### PR TITLE
Rewrite TypeConverter to null aware by default

### DIFF
--- a/drift/lib/src/runtime/query_builder/schema/column_impl.dart
+++ b/drift/lib/src/runtime/query_builder/schema/column_impl.dart
@@ -266,8 +266,8 @@ class GeneratedColumnWithTypeConverter<D, S> extends GeneratedColumn<S> {
   /// Compares this column against the mapped [dartValue].
   ///
   /// The value will be mapped using the [converter] applied to this column.
-  Expression<bool> equalsValue(D? dartValue) {
-    return equals(converter.mapToSql(dartValue) as S);
+  Expression<bool> equalsValue(D dartValue) {
+    return equals(converter.mapToSql(dartValue));
   }
 }
 

--- a/drift/lib/src/runtime/types/custom_type.dart
+++ b/drift/lib/src/runtime/types/custom_type.dart
@@ -14,15 +14,15 @@ abstract class TypeConverter<D, S> {
 
   /// Map a value from an object in Dart into something that will be understood
   /// by the database.
-  S? mapToSql(D? value);
+  S mapToSql(D value);
 
   /// Maps a column from the database back to Dart.
-  D? mapToDart(S? fromDb);
+  D mapToDart(S fromDb);
 }
 
 /// Implementation for an enum to int converter that uses the index of the enum
 /// as the value stored in the database.
-class EnumIndexConverter<T> extends NullAwareTypeConverter<T, int> {
+class EnumIndexConverter<T> extends TypeConverter<T, int> {
   /// All values of the enum.
   final List<T> values;
 
@@ -30,46 +30,36 @@ class EnumIndexConverter<T> extends NullAwareTypeConverter<T, int> {
   const EnumIndexConverter(this.values);
 
   @override
-  T requireMapToDart(int fromDb) {
+  T mapToDart(int fromDb) {
     return values[fromDb];
   }
 
   @override
-  int requireMapToSql(T value) {
+  int mapToSql(T value) {
     // In Dart 2.14: Cast to Enum instead of dynamic. Also add Enum as an upper
     // bound for T.
     return (value as dynamic).index as int;
   }
 }
 
-/// A type converter automatically mapping `null` values to `null` in both
-/// directions.
-///
-/// Instead of overriding  [mapToDart] and [mapToSql], subclasses of this
-/// converter should implement [requireMapToDart] and [requireMapToSql], which
-/// are used to map non-null values to and from sql values, respectively.
-///
-/// Apart from the implementation changes, subclasses of this converter can be
-/// used just like all other type converters.
-abstract class NullAwareTypeConverter<D, S extends Object>
-    extends TypeConverter<D, S> {
+/// Implementation for a nullable enum to int converter that uses the index of
+/// the enum as the value stored in the database.
+class NullableEnumIndexConverter<T> extends TypeConverter<T?, int?> {
+  /// All values of the enum.
+  final List<T> values;
+
   /// Constant default constructor.
-  const NullAwareTypeConverter();
+  const NullableEnumIndexConverter(this.values);
 
   @override
-  D? mapToDart(S? fromDb) {
-    return fromDb == null ? null : requireMapToDart(fromDb);
+  T? mapToDart(int? fromDb) {
+    return fromDb == null ? null : values[fromDb];
   }
-
-  /// Maps a non-null column from the database back to Dart.
-  D requireMapToDart(S fromDb);
 
   @override
-  S? mapToSql(D? value) {
-    return value == null ? null : requireMapToSql(value);
+  int? mapToSql(T? value) {
+    // In Dart 2.14: Cast to Enum instead of dynamic. Also add Enum as an upper
+    // bound for T.
+    return value == null ? null : (value as dynamic).index as int;
   }
-
-  /// Map a non-null value from an object in Dart into something that will be
-  /// understood by the database.
-  S requireMapToSql(D value);
 }

--- a/drift/test/data/tables/converter.dart
+++ b/drift/test/data/tables/converter.dart
@@ -6,8 +6,8 @@ enum SyncType {
   synchronized,
 }
 
-class SyncTypeConverter extends TypeConverter<SyncType, int> {
-  const SyncTypeConverter();
+class NullableSyncTypeConverter extends TypeConverter<SyncType?, int?> {
+  const NullableSyncTypeConverter();
 
   @override
   SyncType? mapToDart(int? fromDb) {
@@ -22,11 +22,11 @@ class SyncTypeConverter extends TypeConverter<SyncType, int> {
   }
 }
 
-class NullAwareSyncTypeConverter extends NullAwareTypeConverter<SyncType, int> {
-  const NullAwareSyncTypeConverter();
+class SyncTypeConverter extends TypeConverter<SyncType, int> {
+  const SyncTypeConverter();
 
   @override
-  SyncType requireMapToDart(int fromDb) {
+  SyncType mapToDart(int fromDb) {
     const values = SyncType.values;
     if (fromDb < 0 || fromDb >= values.length) {
       return SyncType.locallyCreated;
@@ -35,7 +35,7 @@ class NullAwareSyncTypeConverter extends NullAwareTypeConverter<SyncType, int> {
   }
 
   @override
-  int requireMapToSql(SyncType value) {
+  int mapToSql(SyncType value) {
     return value.index;
   }
 }

--- a/drift/test/data/tables/custom_tables.g.dart
+++ b/drift/test/data/tables/custom_tables.g.dart
@@ -223,12 +223,12 @@ class ConfigTable extends Table with TableInfo<ConfigTable, Config> {
       requiredDuringInsert: false,
       $customConstraints: '');
   final VerificationMeta _syncStateMeta = const VerificationMeta('syncState');
-  late final GeneratedColumnWithTypeConverter<SyncType, int?> syncState =
+  late final GeneratedColumnWithTypeConverter<SyncType?, int?> syncState =
       GeneratedColumn<int?>('sync_state', aliasedName, true,
               type: const IntType(),
               requiredDuringInsert: false,
               $customConstraints: '')
-          .withConverter<SyncType>(ConfigTable.$converter0);
+          .withConverter<SyncType?>(ConfigTable.$converter0);
   final VerificationMeta _syncStateImplicitMeta =
       const VerificationMeta('syncStateImplicit');
   late final GeneratedColumnWithTypeConverter<SyncType?, int?>
@@ -280,9 +280,10 @@ class ConfigTable extends Table with TableInfo<ConfigTable, Config> {
     return ConfigTable(_db, alias);
   }
 
-  static TypeConverter<SyncType, int> $converter0 = const SyncTypeConverter();
-  static TypeConverter<SyncType?, int> $converter1 =
-      const EnumIndexConverter<SyncType>(SyncType.values);
+  static TypeConverter<SyncType?, int?> $converter0 =
+      const NullableSyncTypeConverter();
+  static TypeConverter<SyncType?, int?> $converter1 =
+      const NullableEnumIndexConverter<SyncType>(SyncType.values);
   @override
   bool get dontWriteConstraints => true;
 }
@@ -1557,10 +1558,10 @@ class MyView extends View<MyView, MyViewData> {
   late final GeneratedColumn<String?> configValue = GeneratedColumn<String?>(
       'config_value', aliasedName, true,
       type: const StringType());
-  late final GeneratedColumnWithTypeConverter<SyncType, int?> syncState =
+  late final GeneratedColumnWithTypeConverter<SyncType?, int?> syncState =
       GeneratedColumn<int?>('sync_state', aliasedName, true,
               type: const IntType())
-          .withConverter<SyncType>(ConfigTable.$converter0);
+          .withConverter<SyncType?>(ConfigTable.$converter0);
   late final GeneratedColumnWithTypeConverter<SyncType?, int?>
       syncStateImplicit = GeneratedColumn<int?>(
               'sync_state_implicit', aliasedName, true,

--- a/drift/test/data/tables/tables.drift
+++ b/drift/test/data/tables/tables.drift
@@ -21,7 +21,7 @@ CREATE TABLE with_constraints (
 create table config (
     config_key TEXT not null primary key,
     config_value TEXT,
-    sync_state INTEGER MAPPED BY `const SyncTypeConverter()`,
+    sync_state INTEGER MAPPED BY `const NullableSyncTypeConverter()`,
     sync_state_implicit ENUM(SyncType)
 ) AS "Config";
 

--- a/drift/test/data/tables/todos.dart
+++ b/drift/test/data/tables/todos.dart
@@ -17,6 +17,7 @@ class TodosTable extends Table with AutoIncrement {
 
   TextColumn get title => text().withLength(min: 4, max: 16).nullable()();
   TextColumn get content => text()();
+
   @JsonKey('target_date')
   DateTimeColumn get targetDate => dateTime().nullable()();
 
@@ -107,13 +108,13 @@ class CustomConverter extends TypeConverter<MyCustomObject, String> {
   const CustomConverter();
 
   @override
-  MyCustomObject? mapToDart(String? fromDb) {
-    return fromDb == null ? null : MyCustomObject(fromDb);
+  MyCustomObject mapToDart(String fromDb) {
+    return MyCustomObject(fromDb);
   }
 
   @override
-  String? mapToSql(MyCustomObject? value) {
-    return value?.data;
+  String mapToSql(MyCustomObject value) {
+    return value.data;
   }
 }
 

--- a/drift/test/data/tables/todos.g.dart
+++ b/drift/test/data/tables/todos.g.dart
@@ -25,7 +25,7 @@ class Category extends DataClass implements Insertable<Category> {
       description: const StringType()
           .mapFromDatabaseResponse(data['${effectivePrefix}desc'])!,
       priority: $CategoriesTable.$converter0.mapToDart(const IntType()
-          .mapFromDatabaseResponse(data['${effectivePrefix}priority']))!,
+          .mapFromDatabaseResponse(data['${effectivePrefix}priority'])!),
       descriptionInUpperCase: const StringType().mapFromDatabaseResponse(
           data['${effectivePrefix}description_in_upper_case'])!,
     );
@@ -1168,7 +1168,7 @@ class $TableWithoutPKTable extends TableWithoutPK
       const RealType()
           .mapFromDatabaseResponse(data['${effectivePrefix}some_float'])!,
       custom: $TableWithoutPKTable.$converter0.mapToDart(const StringType()
-          .mapFromDatabaseResponse(data['${effectivePrefix}custom']))!,
+          .mapFromDatabaseResponse(data['${effectivePrefix}custom'])!),
     );
   }
 

--- a/drift/test/integration_tests/cancellation_test.dart
+++ b/drift/test/integration_tests/cancellation_test.dart
@@ -105,7 +105,7 @@ void main() {
 
     for (var i = 0; i < 4; i++) {
       filter.add(i);
-      await pumpEventQueue(times: 10);
+      await pumpEventQueue(times: 5);
     }
 
     final values = await db

--- a/drift/test/types/enum_index_converter_test.dart
+++ b/drift/test/types/enum_index_converter_test.dart
@@ -4,7 +4,7 @@ import 'package:test/test.dart';
 enum _MyEnum { one, two, three }
 
 void main() {
-  const converter = EnumIndexConverter(_MyEnum.values);
+  const converter = NullableEnumIndexConverter<_MyEnum>(_MyEnum.values);
   const values = {_MyEnum.one: 0, _MyEnum.two: 1, _MyEnum.three: 2, null: null};
 
   group('encodes', () {

--- a/drift/test/types/non_nullable_type_converter_test.dart
+++ b/drift/test/types/non_nullable_type_converter_test.dart
@@ -3,14 +3,8 @@ import 'package:test/test.dart';
 import '../data/tables/converter.dart';
 
 void main() {
-  test('test null in null aware type converters', () {
-    const typeConverter = NullAwareSyncTypeConverter();
-    expect(typeConverter.mapToDart(typeConverter.mapToSql(null)), null);
-    expect(typeConverter.mapToSql(typeConverter.mapToDart(null)), null);
-  });
-
   test('test value in null aware type converters', () {
-    const typeConverter = NullAwareSyncTypeConverter();
+    const typeConverter = SyncTypeConverter();
     const value = SyncType.synchronized;
     expect(typeConverter.mapToDart(typeConverter.mapToSql(value)), value);
     expect(typeConverter.mapToSql(typeConverter.mapToDart(value.index)),
@@ -18,7 +12,7 @@ void main() {
   });
 
   test('test invalid value in null aware type converters', () {
-    const typeConverter = NullAwareSyncTypeConverter();
+    const typeConverter = SyncTypeConverter();
     const defaultValue = SyncType.locallyCreated;
     expect(typeConverter.mapToDart(-1), defaultValue);
   });

--- a/drift_dev/lib/src/analyzer/dart/column_parser.dart
+++ b/drift_dev/lib/src/analyzer/dart/column_parser.dart
@@ -298,7 +298,8 @@ class ColumnParser {
       converter = UsedTypeConverter(
           expression: createdTypeConverter.toSource(),
           mappedType: typeConverterRuntime,
-          sqlType: columnType);
+          sqlType: columnType,
+          nullable: nullable);
     }
 
     if (foundStartMethod == startEnum) {

--- a/drift_dev/lib/src/analyzer/dart/table_parser.dart
+++ b/drift_dev/lib/src/analyzer/dart/table_parser.dart
@@ -99,7 +99,7 @@ class TableParser {
     final verified = existingClass == null
         ? null
         : validateExistingClass(columns, existingClass,
-            constructorInExistingClass!, generateInsertable!, base.step);
+            constructorInExistingClass!, generateInsertable!, base.step.errors);
     return _DataClassInformation(name, verified);
   }
 

--- a/drift_dev/lib/src/analyzer/moor/create_table_reader.dart
+++ b/drift_dev/lib/src/analyzer/moor/create_table_reader.dart
@@ -264,7 +264,18 @@ class CreateTableReader {
         (type) => isFromMoor(type) && type.element.name == 'TypeConverter');
 
     // TypeConverter<D, S>, where D is the type in Dart
-    final typeInDart = asTypeConverter.typeArguments.first;
+    final typeInDart = asTypeConverter.typeArguments[0];
+    final typeInSql = asTypeConverter.typeArguments[1];
+
+    if (!nullable && typeInSql.nullabilitySuffix != NullabilitySuffix.none) {
+      step.reportError(
+        ErrorInMoorFile(
+            span: mapper.span!,
+            message: 'The column declared as not null, '
+                'but TypeConverter SQL type argument is nullable'),
+      );
+      return null;
+    }
 
     return UsedTypeConverter(
         expression: code,

--- a/drift_dev/lib/src/analyzer/moor/create_table_reader.dart
+++ b/drift_dev/lib/src/analyzer/moor/create_table_reader.dart
@@ -117,7 +117,8 @@ class CreateTableReader {
             continue;
           }
 
-          converter = await _readTypeConverter(moorType, constraint);
+          converter = await _readTypeConverter(
+              moorType, constraint, column.type.nullable != false);
           // don't write MAPPED BY constraints when creating the table, they're
           // a convenience feature by the compiler
           continue;
@@ -183,7 +184,7 @@ class CreateTableReader {
           ));
         } else {
           existingRowClass = validateExistingClass(
-              foundColumns.values, clazz, '', false, step);
+              foundColumns.values, clazz, '', false, step.errors);
           dataClassName = existingRowClass?.targetClass.name;
         }
       } else if (overriddenNames.contains('/')) {
@@ -238,7 +239,7 @@ class CreateTableReader {
   }
 
   Future<UsedTypeConverter?> _readTypeConverter(
-      ColumnType sqlType, MappedBy mapper) async {
+      ColumnType sqlType, MappedBy mapper, bool nullable) async {
     final code = mapper.mapper.dartCode;
 
     DartType type;
@@ -266,7 +267,10 @@ class CreateTableReader {
     final typeInDart = asTypeConverter.typeArguments.first;
 
     return UsedTypeConverter(
-        expression: code, mappedType: typeInDart, sqlType: sqlType);
+        expression: code,
+        mappedType: typeInDart,
+        sqlType: sqlType,
+        nullable: nullable);
   }
 
   Future<DartType?> _readDartType(String typeIdentifier) async {

--- a/drift_dev/lib/src/analyzer/options.dart
+++ b/drift_dev/lib/src/analyzer/options.dart
@@ -101,9 +101,6 @@ class MoorOptions {
   @JsonKey(name: 'scoped_dart_components', defaultValue: false)
   final bool scopedDartComponents;
 
-  @JsonKey(name: 'null_aware_type_converters', defaultValue: false)
-  final bool nullAwareTypeConverters;
-
   @internal
   const MoorOptions.defaults({
     this.generateFromJsonStringConstructor = false,
@@ -126,7 +123,6 @@ class MoorOptions {
     this.modules = const [],
     this.sqliteAnalysisOptions,
     this.dialect = const DialectOptions(SqlDialect.sqlite, null),
-    this.nullAwareTypeConverters = false,
   });
 
   MoorOptions({
@@ -149,7 +145,6 @@ class MoorOptions {
     required this.scopedDartComponents,
     required this.modules,
     required this.sqliteAnalysisOptions,
-    required this.nullAwareTypeConverters,
     this.dialect,
   }) {
     if (sqliteAnalysisOptions != null && modules.isNotEmpty) {

--- a/drift_dev/lib/src/analyzer/options.g.dart
+++ b/drift_dev/lib/src/analyzer/options.g.dart
@@ -33,7 +33,6 @@ MoorOptions _$MoorOptionsFromJson(Map json) => $checkedCreate(
             'named_parameters_always_required',
             'new_sql_code_generation',
             'scoped_dart_components',
-            'null_aware_type_converters',
           ],
         );
         final val = MoorOptions(
@@ -86,8 +85,6 @@ MoorOptions _$MoorOptionsFromJson(Map json) => $checkedCreate(
                   v == null ? null : SqliteAnalysisOptions.fromJson(v as Map)),
           dialect: $checkedConvert('sql',
               (v) => v == null ? null : DialectOptions.fromJson(v as Map)),
-          nullAwareTypeConverters: $checkedConvert(
-              'null_aware_type_converters', (v) => v as bool? ?? false),
         );
         return val;
       },
@@ -111,7 +108,6 @@ MoorOptions _$MoorOptionsFromJson(Map json) => $checkedCreate(
         'generateNamedParameters': 'named_parameters',
         'namedParametersAlwaysRequired': 'named_parameters_always_required',
         'newSqlCodeGeneration': 'new_sql_code_generation',
-        'nullAwareTypeConverters': 'null_aware_type_converters',
         'scopedDartComponents': 'scoped_dart_components',
         'modules': 'sqlite_modules',
         'sqliteAnalysisOptions': 'sqlite',

--- a/drift_dev/lib/src/analyzer/view/view_analyzer.dart
+++ b/drift_dev/lib/src/analyzer/view/view_analyzer.dart
@@ -64,7 +64,7 @@ class ViewAnalyzer extends BaseAnalyzer {
             ));
           } else {
             final rowClass = view.existingRowClass =
-                validateExistingClass(columns, clazz, '', false, step);
+                validateExistingClass(columns, clazz, '', false, step.errors);
             final newName = rowClass?.targetClass.name;
             if (newName != null) {
               view.dartTypeName = rowClass!.targetClass.name;

--- a/drift_dev/lib/src/backends/build/moor_builder.dart
+++ b/drift_dev/lib/src/backends/build/moor_builder.dart
@@ -23,9 +23,7 @@ mixin MoorBuilder on Builder {
   Writer createWriter({bool nnbd = false}) {
     return Writer(options,
         generationOptions: GenerationOptions(
-            nnbd: nnbd,
-            writeForMoorPackage: !isForNewDriftPackage,
-            nullAwareTypeConverters: options.nullAwareTypeConverters));
+            nnbd: nnbd, writeForMoorPackage: !isForNewDriftPackage));
   }
 
   Future<ParsedDartFile> analyzeDartFile(BuildStep step) async {

--- a/drift_dev/lib/src/cli/commands/schema/generate_utils.dart
+++ b/drift_dev/lib/src/cli/commands/schema/generate_utils.dart
@@ -153,8 +153,6 @@ class GenerateUtilsCommand extends Command {
         writeCompanions: companions,
         writeDataClasses: dataClasses,
         writeForMoorPackage: isForMoor,
-        nullAwareTypeConverters:
-            cli.project.moorOptions.nullAwareTypeConverters,
       ),
     );
     final file = File(p.join(output.path, _filenameForVersion(version)));

--- a/drift_dev/lib/src/model/types.dart
+++ b/drift_dev/lib/src/model/types.dart
@@ -60,14 +60,8 @@ extension OperationOnTypes on HasType {
   String dartTypeCode([GenerationOptions options = const GenerationOptions()]) {
     final converter = typeConverter;
     if (converter != null) {
-      final needsSuffix = options.nnbd &&
-          (options.nullAwareTypeConverters
-              ? converter.hasNullableDartType
-              : (nullable && !converter.hasNullableDartType));
       final baseType = converter.mappedType.codeString(options);
-
-      final inner = needsSuffix ? '$baseType?' : baseType;
-      return isArray ? 'List<$inner>' : inner;
+      return isArray ? 'List<$baseType>' : baseType;
     }
 
     return variableTypeCode(options);

--- a/drift_dev/lib/src/model/used_type_converter.dart
+++ b/drift_dev/lib/src/model/used_type_converter.dart
@@ -26,6 +26,9 @@ class UsedTypeConverter {
   /// The type that will be written to the database.
   final ColumnType sqlType;
 
+  /// Is column nullable?
+  final bool nullable;
+
   /// Type converters are stored as static fields in the table that created
   /// them. This will be the field name for this converter.
   String get fieldName => '\$converter$index';
@@ -37,6 +40,7 @@ class UsedTypeConverter {
     required this.expression,
     required this.mappedType,
     required this.sqlType,
+    required this.nullable,
   });
 
   bool get hasNullableDartType =>
@@ -53,21 +57,26 @@ class UsedTypeConverter {
     }
 
     final className = creatingClass.name;
+    final nullablePrefix = nullable ? 'Nullable' : '';
 
     return UsedTypeConverter(
-      expression: 'const EnumIndexConverter<$className>($className.values)',
+      expression: 'const ${nullablePrefix}EnumIndexConverter<$className>'
+          '($className.values)',
       mappedType: creatingClass.instantiate(
           typeArguments: const [],
           nullabilitySuffix:
               nullable ? NullabilitySuffix.question : NullabilitySuffix.none),
       sqlType: ColumnType.integer,
+      nullable: nullable,
     );
   }
 
   /// A suitable typename to store an instance of the type converter used here.
   String converterNameInCode(GenerationOptions options) {
     final sqlDartType = dartTypeNames[sqlType];
-    return 'TypeConverter<${mappedType.codeString(options)}, $sqlDartType>';
+    final needSuffix = nullable ? '?' : '';
+    return 'TypeConverter<${mappedType.codeString(options)}, '
+        '$sqlDartType$needSuffix>';
   }
 }
 

--- a/drift_dev/lib/src/writer/queries/query_writer.dart
+++ b/drift_dev/lib/src/writer/queries/query_writer.dart
@@ -94,7 +94,7 @@ class QueryWriter {
     if (resultSet.singleColumn) {
       final column = resultSet.columns.single;
       _buffer.write('(QueryRow row) => '
-          '${readingCode(column, scope.generationOptions, options)}');
+          '${readingCode(column, scope.generationOptions)}');
     } else if (resultSet.matchingTable != null) {
       // note that, even if the result set has a matching table, we can't just
       // use the mapFromRow() function of that table - the column names might
@@ -128,8 +128,8 @@ class QueryWriter {
 
       for (final column in resultSet.columns) {
         final fieldName = resultSet.dartNameFor(column);
-        _buffer.write('$fieldName: '
-            '${readingCode(column, scope.generationOptions, options)},');
+        _buffer.write(
+            '$fieldName: ${readingCode(column, scope.generationOptions)},');
       }
       for (final nested in resultSet.nestedResults) {
         final prefix = resultSet.nestedPrefixFor(nested);
@@ -151,8 +151,7 @@ class QueryWriter {
   /// Returns Dart code that, given a variable of type `QueryRow` named `row`
   /// in the same scope, reads the [column] from that row and brings it into a
   /// suitable type.
-  String readingCode(ResultColumn column, GenerationOptions generationOptions,
-      MoorOptions moorOptions) {
+  String readingCode(ResultColumn column, GenerationOptions generationOptions) {
     var rawDartType = dartTypeNames[column.type];
     if (column.nullable && generationOptions.nnbd) {
       rawDartType = '$rawDartType?';
@@ -167,11 +166,8 @@ class QueryWriter {
     var code = 'row.read<$rawDartType>($dartLiteral)';
 
     if (column.typeConverter != null) {
-      final nullableDartType = moorOptions.nullAwareTypeConverters
-          ? column.typeConverter!.hasNullableDartType
-          : column.nullable;
-      final needsAssert = !nullableDartType && generationOptions.nnbd;
-
+      final needsAssert =
+          !column.typeConverter!.hasNullableDartType && generationOptions.nnbd;
       final converter = column.typeConverter;
       code = '${_converter(converter!)}.mapToDart($code)';
       if (needsAssert) code += '!';

--- a/drift_dev/lib/src/writer/tables/table_writer.dart
+++ b/drift_dev/lib/src/writer/tables/table_writer.dart
@@ -194,12 +194,7 @@ abstract class TableOrViewWriter {
             (a, b) => positionalToIndex[a]!.compareTo(positionalToIndex[b]!));
 
       final writer = RowMappingWriter(
-        positional,
-        named,
-        tableOrView,
-        scope.generationOptions,
-        scope.options,
-      );
+          positional, named, tableOrView, scope.generationOptions);
 
       final classElement = info.targetClass;
       final ctor = info.constructor;

--- a/drift_dev/lib/src/writer/writer.dart
+++ b/drift_dev/lib/src/writer/writer.dart
@@ -121,15 +121,12 @@ class GenerationOptions {
   /// new `drift` package.
   final bool writeForMoorPackage;
 
-  final bool nullAwareTypeConverters;
-
   const GenerationOptions({
     this.forSchema,
     this.nnbd = false,
     this.writeDataClasses = true,
     this.writeCompanions = true,
     this.writeForMoorPackage = false,
-    this.nullAwareTypeConverters = false,
   });
 
   /// Whether, instead of generating the full database code, we're only

--- a/extras/integration_tests/tests/lib/database/database.dart
+++ b/extras/integration_tests/tests/lib/database/database.dart
@@ -23,7 +23,7 @@ class Users extends Table {
   BlobColumn get profilePicture => blob().nullable()();
 
   TextColumn get preferences =>
-      text().map(const PreferenceConverter()).nullable()();
+      text().nullable().map(const PreferenceConverter())();
 }
 
 class Friendships extends Table {
@@ -49,8 +49,9 @@ class Preferences {
   Map<String, dynamic> toJson() => _$PreferencesToJson(this);
 }
 
-class PreferenceConverter extends TypeConverter<Preferences, String> {
+class PreferenceConverter extends TypeConverter<Preferences?, String?> {
   const PreferenceConverter();
+
   @override
   Preferences? mapToDart(String? fromDb) {
     if (fromDb == null) {
@@ -151,7 +152,7 @@ class Database extends _$Database {
           .go();
 
       if (fail) {
-        throw Exception('oh no, the query misteriously failed!');
+        throw Exception('oh no, hquery misteriously failed!');
       }
 
       await delete(users).delete(user);

--- a/extras/integration_tests/tests/lib/database/database.g.dart
+++ b/extras/integration_tests/tests/lib/database/database.g.dart
@@ -257,10 +257,10 @@ class $UsersTable extends Users with TableInfo<$UsersTable, User> {
           type: const BlobType(), requiredDuringInsert: false);
   final VerificationMeta _preferencesMeta =
       const VerificationMeta('preferences');
-  late final GeneratedColumnWithTypeConverter<Preferences, String?>
+  late final GeneratedColumnWithTypeConverter<Preferences?, String?>
       preferences = GeneratedColumn<String?>('preferences', aliasedName, true,
               type: const StringType(), requiredDuringInsert: false)
-          .withConverter<Preferences>($UsersTable.$converter0);
+          .withConverter<Preferences?>($UsersTable.$converter0);
   @override
   List<GeneratedColumn> get $columns =>
       [id, name, birthDate, profilePicture, preferences];
@@ -311,7 +311,7 @@ class $UsersTable extends Users with TableInfo<$UsersTable, User> {
     return $UsersTable(_db, alias);
   }
 
-  static TypeConverter<Preferences, String> $converter0 =
+  static TypeConverter<Preferences?, String?> $converter0 =
       const PreferenceConverter();
 }
 


### PR DESCRIPTION
DSL table declaration is type safe by default. You can't use nullable (sql) type converter on a not null column, but you can use non-nullable (sql) type converter on null column. With `UseRowClass` the generator will display warning when you use nullable converter on non-nullable field. Generated data class is always match the type converter (dart) type.

For Drift files there is a warning when you want to use nullable TypeConverter on not null column. Vice versa is working. You can use a nullable TypeConverter on a not null column.

```
line 24, column 33: The column declared as not null, but TypeConverter SQL type argument is nullable
   ╷
24 │     sync_state INTEGER not null MAPPED BY `const NullableSyncTypeConverter()`,
   │                                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

```