### PR TITLE
Fix null aware type converter nullability suffix

### DIFF
--- a/drift_dev/lib/src/model/types.dart
+++ b/drift_dev/lib/src/model/types.dart
@@ -111,9 +111,9 @@ extension OperationOnTypes on HasType {
     final converter = typeConverter;
     if (converter != null) {
       final needsSuffix = options.nnbd &&
-          (options.nullAwareTypeConverters
-              ? converter.hasNullableDartType
-              : (nullable && !converter.hasNullableDartType));
+          !options.nullAwareTypeConverters &&
+          nullable &&
+          !converter.hasNullableDartType;
       final baseType = converter.mappedType.codeString(options);
 
       final inner = needsSuffix ? '$baseType?' : baseType;


### PR DESCRIPTION
When using null aware type converters, drift generator doubles the nullability operator in generated data class. In this case not need to append the question mark because type converter's type already have it and field nullability depends on that. 

<img width="672" alt="Képernyőfotó 2022-03-27 - 15 26 43" src="https://user-images.githubusercontent.com/536799/160284019-b8681ea1-db52-4925-86f3-7ffc19c47cb6.png">
