### PR TITLE
Some minor bug fixes :)

### DIFF
--- a/drift_dev/lib/src/analyzer/sql_queries/nested_queries.dart
+++ b/drift_dev/lib/src/analyzer/sql_queries/nested_queries.dart
@@ -84,6 +84,13 @@ class NestedQueryAnalyzer extends RecursiveVisitor<_AnalyzerState, void> {
   }
 
   @override
+  void visitVariable(Variable e, _AnalyzerState arg) {
+    arg.actualAndAddedVariables.add(e);
+
+    super.visitVariable(e, arg);
+  }
+
+  @override
   void visitReference(Reference e, _AnalyzerState arg) {
     final resultEntity = e.resultEntity;
     final container = arg.container;

--- a/drift_dev/test/writer/queries/query_writer_test.dart
+++ b/drift_dev/test/writer/queries/query_writer_test.dart
@@ -160,7 +160,11 @@ void main() {
             c TEXT
           );
 
-          query: SELECT a, LIST(SELECT b, c FROM tbl WHERE a = :a AND b = :b) FROM tbl WHERE a = :a;
+          query: 
+          SELECT 
+            parent.a, 
+            LIST(SELECT b, c FROM tbl WHERE a = :a OR a = parent.a AND b = :b) 
+          FROM tbl AS parent WHERE parent.a = :a;
         ''',
       });
     });
@@ -204,17 +208,32 @@ void main() {
       );
     });
 
-    test('with the new query generator', () {
+    test('should generate correct queries with variables', () {
       return _runTest(
         const MoorOptions.defaults(newSqlCodeGeneration: true),
         [
-          contains('SELECT a FROM tbl WHERE a = ?1'),
-          contains('SELECT b, c FROM tbl WHERE a = ?1 AND b = ?2'),
-          contains('nestedQuery0: await'),
-          contains('variables: [Variable<String?>(a), Variable<String?>(b)]'),
-          contains('b: row.read<String?>(\'b\')'),
-          contains('c: row.read<String?>(\'c\')'),
-          contains('class QueryNestedQuery0'),
+          contains(
+            r'SELECT parent.a, parent.a AS "\$n_0" FROM tbl AS parent WHERE parent.a = ?1',
+          ),
+          contains(
+            r'[Variable<String?>(a)]',
+          ),
+          contains(
+            r'SELECT b, c FROM tbl WHERE a = ?1 OR a = ?2 AND b = ?3',
+          ),
+          contains(
+            r"[Variable<String?>(a), Variable<String>(row.read('\$n_0')), Variable<String?>(b)]",
+          ),
+        ],
+      );
+    });
+
+    test('should generate correct data class', () {
+      return _runTest(
+        const MoorOptions.defaults(newSqlCodeGeneration: true),
+        [
+          contains('QueryNestedQuery0({this.b,this.c,})'),
+          contains('QueryResult({this.a,required this.nestedQuery0,})'),
         ],
       );
     });

--- a/sqlparser/lib/utils/node_to_text.dart
+++ b/sqlparser/lib/utils/node_to_text.dart
@@ -727,7 +727,6 @@ class NodeSqlBuilder extends AstVisitor<void, void> {
         InsertMode.insertOrFail: TokenType.fail,
         InsertMode.insertOrIgnore: TokenType.ignore,
       }[mode]!);
-      visitNullable(e.returning, arg);
     }
 
     _keyword(TokenType.into);

--- a/sqlparser/test/utils/node_to_text_test.dart
+++ b/sqlparser/test/utils/node_to_text_test.dart
@@ -304,6 +304,10 @@ CREATE UNIQUE INDEX my_idx ON t1 (c1, c2, c3) WHERE c1 < c3;
         testFormat('INSERT INTO foo DEFAULT VALUES RETURNING *');
       });
 
+      test('with returning and insert mode', () {
+        testFormat('INSERT OR IGNORE INTO foo DEFAULT VALUES RETURNING *');
+      });
+
       test('upsert - do nothing', () {
         testFormat(
             'INSERT OR REPLACE INTO foo DEFAULT VALUES ON CONFLICT DO NOTHING');


### PR DESCRIPTION
While using your library I found two bugs and since I am a little bit familiar with your code base, I tried to fix them myself. 

The first bug was related to `RETURNING` insert statements, the following custom select statement was generated from this example:
```sql  
insertTest:
INSERT OR IGNORE INTO profile (uuid, name) VALUES ('test', 'test') RETURNING uuid;
```
Generated:
```dart
return customWriteReturning(
    'INSERT OR IGNORE RETURNING uuid INTO profile (uuid, name) VALUES (\'test\', \'test\') RETURNING uuid',
    variables: [],
    updates: {
      profile
    }).then((rows) =>
    rows.map((QueryRow row) => row.read<String>('uuid')).toList());
```

The second bug was a little bit tricky, because somehow the 'ColonNamedVariable'  could overwrite captured variables in nested queries. I think the following example makes it clear:
```sql  
getProfile(REQUIRED :uuid AS TEXT):
SELECT 
    p.** AS profile,
    LIST(SELECT i.uuid, * FROM image AS i WHERE i.uuid = :uuid OR  i.uuid = p.uuid )
FROM profile AS p;
```
Generated:
```dart
...

nestedQuery0: await customSelect(
       'SELECT i.uuid, * FROM image AS i WHERE i.uuid = ?1 OR i.uuid = ?1',
        variables: [
          Variable<String>(uuid)
        ],

...
```

The fixes I found where quite simple and I hope they can resolve these issues :)