### PR TITLE
Export `SqlStatement`

### DIFF
--- a/drift_core/lib/drift_core.dart
+++ b/drift_core/lib/drift_core.dart
@@ -6,6 +6,7 @@ export 'src/builder/context.dart';
 export 'src/expressions/boolean.dart';
 export 'src/expressions/expression.dart';
 export 'src/schema.dart';
+export 'src/statements/statement.dart' show SqlStatement;
 export 'src/statements/delete.dart';
 export 'src/statements/insert.dart';
 export 'src/statements/select.dart' show SelectStatement, star;


### PR DESCRIPTION
Allows authors to accept statements as types, e.g. `T extends SqlStatement` 