### PR TITLE
Support analyzer 4.x.x

### DIFF
--- a/docs/pubspec.yaml
+++ b/docs/pubspec.yaml
@@ -23,7 +23,8 @@ dev_dependencies:
   shelf: ^1.2.0
   shelf_static: ^1.1.0
   # `dart doc` is missing some options, so we run `dart run dartdoc` instead.
-  dartdoc: ^5.0.1
+  # 5.1.0 release is broken: https://github.com/dart-lang/dartdoc/issues/3041
+  dartdoc: '5.0.1'
   code_snippets:
     hosted: https://simonbinder.eu
     version: ^0.0.4
@@ -41,6 +42,7 @@ dev_dependencies:
   drift_dev:
 
 dependency_overrides:
+  analyzer: ^4.0.0
   moor:
     path: ../moor
   moor_generator:

--- a/drift_dev/lib/src/analyzer/custom_row_class.dart
+++ b/drift_dev/lib/src/analyzer/custom_row_class.dart
@@ -124,7 +124,7 @@ void _checkType(ParameterElement element, MoorColumn column, Step step) {
   if (library.isNonNullableByDefault &&
       nullableDartType &&
       !typesystem.isNullable(type) &&
-      element.isNotOptional) {
+      element.isRequired) {
     error('Expected this parameter to be nullable');
     return;
   }

--- a/drift_dev/pubspec.yaml
+++ b/drift_dev/pubspec.yaml
@@ -30,8 +30,8 @@ dependencies:
   sqlparser: ^0.21.0
 
   # Dart analysis
-  analyzer: ">=2.1.0 <4.0.0"
-  analyzer_plugin: '>=0.8.0 <0.10.0'
+  analyzer: ">=2.1.0 <5.0.0"
+  analyzer_plugin: '>=0.8.0 <0.11.0'
   source_span: ^1.5.5
   package_config: ^2.0.0
   pub_semver: ^2.0.0

--- a/drift_dev/pubspec.yaml
+++ b/drift_dev/pubspec.yaml
@@ -30,8 +30,8 @@ dependencies:
   sqlparser: ^0.21.0
 
   # Dart analysis
-  analyzer: ">=2.1.0 <5.0.0"
-  analyzer_plugin: '>=0.8.0 <0.11.0'
+  analyzer: "^4.0.0"
+  analyzer_plugin: '^0.10.0'
   source_span: ^1.5.5
   package_config: ^2.0.0
   pub_semver: ^2.0.0


### PR DESCRIPTION
With Flutter 3 release, more packages (such as `build_runner`) require analyzer 4.0.0 or above. 