### PR TITLE
New implementation for reference scopes

### DIFF
--- a/drift_dev/lib/src/analyzer/moor/create_table_reader.dart
+++ b/drift_dev/lib/src/analyzer/moor/create_table_reader.dart
@@ -34,7 +34,8 @@ class CreateTableReader {
     Table table;
     try {
       table = _schemaReader.read(stmt);
-    } catch (e) {
+    } catch (e, s) {
+      print(s);
       step.reportError(ErrorInMoorFile(
         span: stmt.tableNameToken!.span,
         message: 'Could not extract schema information for this table: $e',

--- a/drift_dev/lib/src/analyzer/sql_queries/type_mapping.dart
+++ b/drift_dev/lib/src/analyzer/sql_queries/type_mapping.dart
@@ -304,8 +304,7 @@ class TypeMapper {
       },
     );
 
-    final availableResults =
-        placeholder.scope.allOf<ResultSetAvailableInStatement>();
+    final availableResults = placeholder.statementScope.allAvailableResultSets;
     final availableMoorResults = <AvailableMoorResultSet>[];
     for (final available in availableResults) {
       final aliasedResultSet = available.resultSet.resultSet;

--- a/sqlparser/CHANGELOG.md
+++ b/sqlparser/CHANGELOG.md
@@ -1,5 +1,6 @@
-## 0.21.1-dev
+## 0.22.0-dev
 
+- Refactor how tables and columns are resolved internally.
 - Lint for `DISTINCT` misuse in aggregate function calls.
 
 ## 0.21.0

--- a/sqlparser/lib/src/analysis/analysis.dart
+++ b/sqlparser/lib/src/analysis/analysis.dart
@@ -7,6 +7,8 @@ import 'package:source_span/source_span.dart';
 import 'package:sqlparser/sqlparser.dart' hide ExpandParameters;
 import 'package:sqlparser/src/utils/meta.dart';
 
+import '../../utils/case_insensitive_map.dart';
+
 export 'types/data.dart';
 export 'types/types.dart' show TypeInferenceResults;
 

--- a/sqlparser/lib/src/analysis/context.dart
+++ b/sqlparser/lib/src/analysis/context.dart
@@ -13,6 +13,11 @@ class AnalysisContext {
   /// The raw sql statement that was used to construct this [AnalysisContext].
   final String sql;
 
+  /// The root scope used when analyzing SQL statements.
+  ///
+  /// This contains information about known tables and modules.
+  final RootScope rootScope;
+
   /// Additional information about variables in this context, passed from the
   /// outside.
   final AnalyzeStatementOptions stmtOptions;
@@ -34,7 +39,7 @@ class AnalysisContext {
   late final TypeInferenceResults types2;
 
   /// Constructs a new analysis context from the AST and the source sql.
-  AnalysisContext(this.root, this.sql, this.engineOptions,
+  AnalysisContext(this.root, this.sql, this.rootScope, this.engineOptions,
       {AnalyzeStatementOptions? stmtOptions, required this.schemaSupport})
       : stmtOptions = stmtOptions ?? const AnalyzeStatementOptions();
 

--- a/sqlparser/lib/src/analysis/schema/from_create_table.dart
+++ b/sqlparser/lib/src/analysis/schema/from_create_table.dart
@@ -16,7 +16,7 @@ class SchemaFromCreateTable {
     if (stmt is CreateTableStatement) {
       return _readCreateTable(stmt);
     } else if (stmt is CreateVirtualTableStatement) {
-      final module = stmt.scope.resolve<Module>(stmt.moduleName);
+      final module = stmt.scope.rootScope.knownModules[stmt.moduleName];
 
       if (module == null) {
         throw CantReadSchemaException('Unknown module "${stmt.moduleName}", '

--- a/sqlparser/lib/src/analysis/schema/references.dart
+++ b/sqlparser/lib/src/analysis/schema/references.dart
@@ -20,126 +20,263 @@ mixin Referencable {
   bool get visibleToChildren => false;
 }
 
-/// Class which keeps track of references for tables, columns and functions in a
-/// query.
-class ReferenceScope {
-  final ReferenceScope? parent;
-  final ReferenceScope? root;
+abstract class ReferenceScope {
+  RootScope get rootScope;
 
-  /// Whether the [availableColumns] of the [parent] are available in this scope
-  /// as well.
-  final bool inheritAvailableColumns;
+  List<Column>? get expansionOfStarColumn => null;
 
-  /// Gets the effective root scope. If no [root] scope has been set, this
-  /// scope is assumed to be the root scope.
-  ReferenceScope get effectiveRoot => root ?? this;
+  /// Attempts to find a result set that has been added to this scope, for
+  /// instance because it was introduced in a `FROM` clause.
+  ///
+  /// This is useful to resolve qualified references (e.g. to resolve `foo.bar`
+  /// the resolver would call [resolveResultSet]("foo") and then look up the
+  /// `bar` column in that result set).
+  ResultSetAvailableInStatement? resolveResultSet(String name) => null;
 
-  final Map<String, List<Referencable>> _references = {};
+  void addResolvedResultSet(
+      String? name, ResultSetAvailableInStatement resultSet) {
+    throw StateError('Result set cannot be added in this scope: $this');
+  }
 
-  List<Column>? _availableColumns;
+  /// Registers a [ResultSetAvailableInStatement] to a [TableAlias] for the
+  /// given [resultSet].
+  void addAlias(AstNode origin, ResultSet resultSet, String alias) {
+    final createdAlias = TableAlias(resultSet, alias);
+    addResolvedResultSet(
+        alias, ResultSetAvailableInStatement(origin, createdAlias));
+  }
 
-  /// All columns that would be available in this scope. Can be used to resolve
-  /// a '*' expression for function calls or result columns
-  List<Column> get availableColumns {
-    if (_availableColumns != null) return _availableColumns!;
-    if (inheritAvailableColumns) return parent!.availableColumns;
+  /// Attempts to find a result set that _can_ be added to a scope.
+  ///
+  /// This is used to resolve table references. Usually, after a result set to
+  /// add has been resolve,d a [ResultSetAvailableInStatement] is added to the
+  /// scope and [resolveResultSet] will find that afterwards.
+  ResultSet? resolveResultSetToAdd(String name) => rootScope.knownTables[name];
+
+  List<Column> resolveUnqualifiedReference(String columnName,
+          {bool allowReferenceToResultColumn = false}) =>
+      const [];
+}
+
+class RootScope extends ReferenceScope {
+  @override
+  RootScope get rootScope => this;
+
+  final Map<String, ResultSet> knownTables = CaseInsensitiveMap();
+  final Map<String, Module> knownModules = CaseInsensitiveMap();
+}
+
+class StatementScope extends ReferenceScope {
+  final ReferenceScope parent;
+
+  final Map<String, ResultSet> additionalKnownTables = CaseInsensitiveMap();
+  final Map<String?, ResultSetAvailableInStatement> resultSets =
+      CaseInsensitiveMap();
+  final List<Column> namedResultColumns = [];
+
+  final Map<String, NamedWindowDeclaration> windowDeclarations =
+      CaseInsensitiveMap();
+
+  /// All columns that a (unqualified) `*` in a select statement or function
+  /// call argument would expand to.
+  @override
+  List<Column>? expansionOfStarColumn;
+
+  StatementScope(this.parent);
+
+  StatementScope? get parentStatementScope {
+    final parent = this.parent;
+    if (parent is StatementScope) {
+      return parent;
+    } else if (parent is SubqueryInFromScope) {
+      return parent.enclosingStatement;
+    } else if (parent is MiscStatementSubScope) {
+      return parent.parent;
+    } else {
+      return null;
+    }
+  }
+
+  /// All result sets available in this and parent scopes.
+  Iterable<ResultSetAvailableInStatement> get allAvailableResultSets {
+    final here = resultSets.values;
+    final parent = parentStatementScope;
+    return parent != null
+        ? here.followedBy(parent.allAvailableResultSets)
+        : here;
+  }
+
+  @override
+  RootScope get rootScope => parent.rootScope;
+
+  @override
+  void addAlias(AstNode origin, ResultSet resultSet, String alias) {
+    final createdAlias = TableAlias(resultSet, alias);
+    additionalKnownTables[alias] = createdAlias;
+    resultSets[alias] = ResultSetAvailableInStatement(origin, createdAlias);
+  }
+
+  @override
+  ResultSetAvailableInStatement? resolveResultSet(String name) {
+    return resultSets[name] ?? parentStatementScope?.resolveResultSet(name);
+  }
+
+  @override
+  void addResolvedResultSet(
+      String? name, ResultSetAvailableInStatement resultSet) {
+    resultSets[name] = resultSet;
+  }
+
+  @override
+  ResultSet? resolveResultSetToAdd(String name) {
+    return additionalKnownTables[name] ??
+        parentStatementScope?.resolveResultSetToAdd(name) ??
+        rootScope.knownTables[name];
+  }
+
+  @override
+  List<Column> resolveUnqualifiedReference(String columnName,
+      {bool allowReferenceToResultColumn = false}) {
+    if (allowReferenceToResultColumn) {
+      final foundColumn = namedResultColumns.firstWhereOrNull(
+          (c) => c.name.toLowerCase() == columnName.toLowerCase());
+      if (foundColumn != null) {
+        return [foundColumn];
+      }
+    }
+
+    StatementScope? currentScope = this;
+
+    // Search scopes for a matching column in an added result set. If a column
+    // reference is found in a closer scope, it takes precedence over outer
+    // scopes. However, it's an error if two columns with the same name are
+    // found in the same scope.
+    while (currentScope != null) {
+      final available = currentScope.resultSets.values;
+      final sourceColumns = <Column>{};
+      final availableColumns = <AvailableColumn>[];
+
+      for (final availableSource in available) {
+        final resolvedColumns =
+            availableSource.resultSet.resultSet?.resolvedColumns;
+        if (resolvedColumns == null) continue;
+
+        for (final column in resolvedColumns) {
+          if (column.name.toLowerCase() == columnName.toLowerCase() &&
+              sourceColumns.add(column)) {
+            availableColumns.add(AvailableColumn(column, availableSource));
+          }
+        }
+      }
+
+      if (availableColumns.isEmpty) {
+        currentScope = currentScope.parentStatementScope;
+        if (currentScope == null) {
+          // Reached the outermost scope without finding a reference target.
+          return const [];
+        }
+        continue;
+      } else {
+        return availableColumns;
+      }
+    }
 
     return const [];
   }
 
-  set availableColumns(List<Column>? value) {
-    // guard against lists of subtype of column
-    if (value != null) {
-      _availableColumns = <Column>[...value];
+  factory StatementScope.forStatement(RootScope root, Statement statement) {
+    return StatementScope(statement.optionalScope ?? root);
+  }
+
+  static StatementScope cast(ReferenceScope other) {
+    if (other is StatementScope) {
+      return other;
+    } else if (other is MiscStatementSubScope) {
+      return other.parent;
     } else {
-      _availableColumns = null;
+      throw ArgumentError.value(
+          other, 'other', 'Not resolvable to a statement scope');
+    }
+  }
+}
+
+class SubqueryInFromScope extends ReferenceScope {
+  final StatementScope enclosingStatement;
+
+  SubqueryInFromScope(this.enclosingStatement);
+
+  @override
+  RootScope get rootScope => enclosingStatement.rootScope;
+}
+
+class MiscStatementSubScope extends ReferenceScope {
+  final StatementScope parent;
+
+  final Map<String?, ResultSetAvailableInStatement> additionalResultSets =
+      CaseInsensitiveMap();
+
+  MiscStatementSubScope(this.parent);
+
+  @override
+  RootScope get rootScope => parent.rootScope;
+
+  @override
+  ResultSetAvailableInStatement? resolveResultSet(String name) {
+    return additionalResultSets[name] ?? parent.resolveResultSet(name);
+  }
+
+  @override
+  void addResolvedResultSet(
+      String? name, ResultSetAvailableInStatement resultSet) {
+    additionalResultSets[name] = resultSet;
+  }
+
+  @override
+  List<Column> resolveUnqualifiedReference(String columnName,
+      {bool allowReferenceToResultColumn = false}) {
+    return parent.resolveUnqualifiedReference(columnName);
+  }
+}
+
+/// A reference scope that only allows a single added result set.
+///
+/// This is used for e.g. foreign key clauses (`REFERENCES table (a, b, c)`),
+/// where `a`, `b` and `c` can only refer to `table`.
+class SingleTableReferenceScope extends ReferenceScope {
+  final ReferenceScope parent;
+
+  String? addedTableName;
+  ResultSetAvailableInStatement? addedTable;
+
+  SingleTableReferenceScope(this.parent);
+
+  @override
+  RootScope get rootScope => parent.rootScope;
+
+  @override
+  ResultSetAvailableInStatement? resolveResultSet(String name) {
+    if (name == addedTableName) {
+      return addedTable;
+    } else {
+      return null;
     }
   }
 
-  ReferenceScope(this.parent,
-      {this.root, this.inheritAvailableColumns = false});
-
-  void addAvailableColumn(Column column) {
-    // make sure _availableColumns is resolved and mutable
-    final ownColumns = _availableColumns ??= <Column>[...availableColumns];
-    ownColumns.add(column);
+  @override
+  void addResolvedResultSet(
+      String? name, ResultSetAvailableInStatement resultSet) {
+    addedTableName = null;
+    addedTable = null;
   }
 
-  ReferenceScope createChild({bool? inheritAvailableColumns}) {
-    // wonder why we're creating a linked list of reference scopes instead of
-    // just passing down a copy of [_references]? In sql, some variables can be
-    // used before they're defined, even in child scopes:
-    // SELECT *, (SELECT * FROM table2 WHERE id = t1.a) FROM table2 t1
-    return ReferenceScope(
-      this,
-      root: effectiveRoot,
-      inheritAvailableColumns: inheritAvailableColumns ?? false,
-    );
-  }
-
-  ReferenceScope createSibling() {
-    return parent!.createChild();
-  }
-
-  /// Registers something that can be referenced in this and child scopes.
-  void register(String identifier, Referencable ref) {
-    _references.putIfAbsent(identifier.toUpperCase(), () => []).add(ref);
-  }
-
-  /// Registers both a [TableAlias] and a [ResultSetAvailableInStatement] so
-  /// that the alias can be used in expressions without being selected.
-  void registerUsableAlias(AstNode origin, ResultSet resultSet, String alias) {
-    final createdAlias = TableAlias(resultSet, alias);
-    register(alias, createdAlias);
-    register(alias, ResultSetAvailableInStatement(origin, createdAlias));
-  }
-
-  /// Resolves to a [Referencable] with the given [name] and of the type [T].
-  /// If the reference couldn't be found, null is returned and [orElse] will be
-  /// called.
-  T? resolve<T extends Referencable>(String name, {Function()? orElse}) {
-    ReferenceScope? scope = this;
-    var isAtParent = false;
-    final upper = name.toUpperCase();
-
-    while (scope != null) {
-      if (scope._references.containsKey(upper)) {
-        final candidates = scope._references[upper]!;
-        final resolved = candidates.whereType<T>().where((x) {
-          return x.visibleToChildren || !isAtParent;
-        });
-        if (resolved.isNotEmpty) {
-          return resolved.first;
-        }
-      }
-
-      scope = scope.parent;
-      isAtParent = true;
+  @override
+  List<Column> resolveUnqualifiedReference(String columnName,
+      {bool allowReferenceToResultColumn = false}) {
+    final column = addedTable?.resultSet.resultSet?.findColumn(columnName);
+    if (column != null) {
+      return [AvailableColumn(column, addedTable!)];
+    } else {
+      return const [];
     }
-
-    if (orElse != null) orElse();
-    return null; // not found in any parent scope
-  }
-
-  /// Returns everything that is in scope and a subtype of [T].
-  List<T> allOf<T extends Referencable>() {
-    ReferenceScope? scope = this;
-    var isInCurrentScope = true;
-    final collected = <T>[];
-
-    while (scope != null) {
-      var foundValues =
-          scope._references.values.expand((list) => list).whereType<T>();
-
-      if (!isInCurrentScope) {
-        foundValues =
-            foundValues.where((element) => element.visibleToChildren).cast();
-      }
-
-      collected.addAll(foundValues);
-      scope = scope.parent;
-      isInCurrentScope = false;
-    }
-    return collected;
   }
 }

--- a/sqlparser/lib/src/analysis/schema/table.dart
+++ b/sqlparser/lib/src/analysis/schema/table.dart
@@ -80,6 +80,9 @@ class Table extends NamedResultSet with HasMetaMixin implements HumanReadable {
   String humanReadableDescription() {
     return name;
   }
+
+  @override
+  String toString() => 'Table $name';
 }
 
 class TableAlias extends NamedResultSet implements HumanReadable {

--- a/sqlparser/lib/src/analysis/steps/column_resolver.dart
+++ b/sqlparser/lib/src/analysis/steps/column_resolver.dart
@@ -429,23 +429,27 @@ class ColumnResolver extends RecursiveVisitor<void, void> {
           ? TableAlias(resolvedInSchema, createdName)
           : resolvedInSchema;
     } else {
-      final available = StatementScope.cast(scope)
-          .allAvailableResultSets
-          .where((e) => e.resultSet.resultSet != null)
-          .map((t) {
-        final resultSet = t.resultSet.resultSet;
-        if (resultSet is HumanReadable) {
-          return (resultSet as HumanReadable).humanReadableDescription();
-        }
+      Iterable<String>? available;
 
-        return t.toString();
-      });
+      if (scope is StatementScope) {
+        available = StatementScope.cast(scope)
+            .allAvailableResultSets
+            .where((e) => e.resultSet.resultSet != null)
+            .map((t) {
+          final resultSet = t.resultSet.resultSet;
+          if (resultSet is HumanReadable) {
+            return (resultSet as HumanReadable).humanReadableDescription();
+          }
+
+          return t.toString();
+        });
+      }
 
       context.reportError(UnresolvedReferenceError(
         type: AnalysisErrorType.referencedUnknownTable,
         relevantNode: r,
         reference: r.tableName,
-        available: available,
+        available: available ?? const Iterable.empty(),
       ));
     }
 

--- a/sqlparser/lib/src/analysis/utils/expand_function_parameters.dart
+++ b/sqlparser/lib/src/analysis/utils/expand_function_parameters.dart
@@ -6,7 +6,7 @@ extension ExpandParameters on SqlInvocation {
   /// Returns the expanded parameters of a function call.
   ///
   /// When a [StarFunctionParameter] is used, it's expanded to the
-  /// [ReferenceScope.availableColumns].
+  /// [ReferenceScope.expansionOfStarColumn].
   /// Elements of the result are either an [Expression] or a [Column].
   List<Typeable> expandParameters() {
     final sqlParameters = parameters;
@@ -16,7 +16,8 @@ extension ExpandParameters on SqlInvocation {
     } else if (sqlParameters is StarFunctionParameter) {
       // if * is used as a parameter, it refers to all columns in all tables
       // that are available in the current scope.
-      final allColumns = scope.availableColumns;
+      final allColumns = scope.expansionOfStarColumn;
+      if (allColumns == null) return const [];
 
       // When we look at `SELECT SUM(*), foo FROM ...`, the star in `SUM`
       // shouldn't expand to include itself.

--- a/sqlparser/lib/src/ast/node.dart
+++ b/sqlparser/lib/src/ast/node.dart
@@ -93,9 +93,7 @@ abstract class AstNode with HasMetaMixin implements SyntacticEntity {
     return null;
   }
 
-  /// The [ReferenceScope], which contains available tables, column references
-  /// and functions for this node.
-  ReferenceScope get scope {
+  ReferenceScope? get optionalScope {
     AstNode? node = this;
 
     while (node != null) {
@@ -104,8 +102,19 @@ abstract class AstNode with HasMetaMixin implements SyntacticEntity {
       node = node.parent;
     }
 
+    return null;
+  }
+
+  /// The [ReferenceScope], which contains available tables, column references
+  /// and functions for this node.
+  ReferenceScope get scope {
+    final resolved = optionalScope;
+    if (resolved != null) return resolved;
+
     throw StateError('No reference scope found in this or any parent node');
   }
+
+  StatementScope get statementScope => StatementScope.cast(scope);
 
   /// Applies a [ReferenceScope] to this node. Variables declared in [scope]
   /// will be visible to this node and to [allDescendants].

--- a/sqlparser/lib/src/engine/sql_engine.dart
+++ b/sqlparser/lib/src/engine/sql_engine.dart
@@ -186,7 +186,6 @@ class SqlEngine {
       {AnalyzeStatementOptions? stmtOptions}) {
     final context = _createContext(node, file, stmtOptions);
     _analyzeContext(context);
-    node.scope = context.rootScope;
     return context;
   }
 

--- a/sqlparser/lib/src/engine/sql_engine.dart
+++ b/sqlparser/lib/src/engine/sql_engine.dart
@@ -75,14 +75,15 @@ class SqlEngine {
     options.addTableValuedFunctionHandler(handler);
   }
 
-  ReferenceScope _constructRootScope({ReferenceScope? parent}) {
-    final scope = parent == null ? ReferenceScope(null) : parent.createChild();
+  RootScope _constructRootScope() {
+    final scope = RootScope();
+
     for (final resultSet in knownResultSets) {
-      scope.register(resultSet.name, resultSet);
+      scope.knownTables[resultSet.name] = resultSet;
     }
 
     for (final module in _knownModules) {
-      scope.register(module.name, module);
+      scope.knownModules[module.name] = module;
     }
 
     return scope;
@@ -127,7 +128,7 @@ class SqlEngine {
         Parser(tokensForParser, useDrift: true, autoComplete: autoComplete);
 
     final driftFile = parser.driftFile();
-    _attachRootScope(driftFile);
+    driftFile.scope = _constructRootScope();
 
     return ParseResult._(
         driftFile, tokens, parser.errors, content, autoComplete);
@@ -185,18 +186,19 @@ class SqlEngine {
       {AnalyzeStatementOptions? stmtOptions}) {
     final context = _createContext(node, file, stmtOptions);
     _analyzeContext(context);
+    node.scope = context.rootScope;
     return context;
   }
 
   AnalysisContext _createContext(
       AstNode node, String sql, AnalyzeStatementOptions? stmtOptions) {
-    return AnalysisContext(node, sql, options,
+    return AnalysisContext(node, sql, _constructRootScope(), options,
         stmtOptions: stmtOptions, schemaSupport: schemaReader);
   }
 
   void _analyzeContext(AnalysisContext context) {
     final node = context.root;
-    _attachRootScope(node);
+    node.scope = context.rootScope;
 
     try {
       AstPreparingVisitor(context: context).start(node);
@@ -214,16 +216,6 @@ class SqlEngine {
     } catch (_) {
       rethrow;
     }
-  }
-
-  void _attachRootScope(AstNode root) {
-    // calling node.referenceScope throws when no scope is set, we use the
-    // nullable variant here
-    final safeScope = root.selfAndParents
-        .map((node) => node.meta<ReferenceScope>())
-        .firstWhere((e) => e != null, orElse: () => null);
-
-    root.scope = _constructRootScope(parent: safeScope);
   }
 }
 

--- a/sqlparser/lib/utils/case_insensitive_map.dart
+++ b/sqlparser/lib/utils/case_insensitive_map.dart
@@ -1,0 +1,36 @@
+import 'dart:collection';
+
+/// A map from strings to [T] where keys are compared without case sensitivity.
+class CaseInsensitiveMap<K extends String?, T> extends MapBase<K, T> {
+  final Map<K, T> _normalized = {};
+
+  @override
+  T? operator [](Object? key) {
+    if (key is String?) {
+      return _normalized[key?.toLowerCase()];
+    } else {
+      return null;
+    }
+  }
+
+  @override
+  void operator []=(K key, T value) {
+    _normalized[key?.toLowerCase() as K] = value;
+  }
+
+  @override
+  void clear() {
+    _normalized.clear();
+  }
+
+  @override
+  Iterable<K> get keys => _normalized.keys;
+
+  @override
+  T? remove(Object? key) {
+    if (key is String?) {
+      return _normalized.remove(key?.toLowerCase());
+    }
+    return null;
+  }
+}

--- a/sqlparser/test/analysis/available_tables_test.dart
+++ b/sqlparser/test/analysis/available_tables_test.dart
@@ -43,14 +43,14 @@ void main() {
         );
       ''');
 
-    final result = engine.analyze(r''' 
+    final result = engine.analyze(r'''
       SELECT d.*, c.** FROM with_defaults d
       LEFT OUTER JOIN with_constraints c
         ON d.a = c.a AND d.b = c.b
       WHERE $predicate;
     ''');
 
-    final scope = result.root.scope;
-    expect(scope.allOf<ResultSetAvailableInStatement>(), hasLength(2));
+    final scope = result.root.statementScope;
+    expect(scope.resultSets, hasLength(2));
   });
 }

--- a/sqlparser/test/analysis/types2/join_analysis_test.dart
+++ b/sqlparser/test/analysis/types2/join_analysis_test.dart
@@ -18,24 +18,18 @@ void main() {
 
     final model = JoinModel.of(stmt)!;
     expect(
-      model.isNullableTable(stmt.scope
-          .resolve<ResultSetAvailableInStatement>('a1')!
-          .resultSet
-          .resultSet!),
+      model.isNullableTable(
+          stmt.scope.resolveResultSet('a1')!.resultSet.resultSet!),
       isFalse,
     );
     expect(
-      model.isNullableTable(stmt.scope
-          .resolve<ResultSetAvailableInStatement>('a2')!
-          .resultSet
-          .resultSet!),
+      model.isNullableTable(
+          stmt.scope.resolveResultSet('a2')!.resultSet.resultSet!),
       isTrue,
     );
     expect(
-      model.isNullableTable(stmt.scope
-          .resolve<ResultSetAvailableInStatement>('a3')!
-          .resultSet
-          .resultSet!),
+      model.isNullableTable(
+          stmt.scope.resolveResultSet('a3')!.resultSet.resultSet!),
       isFalse,
     );
   });

--- a/sqlparser/test/utils/find_referenced_tables_test.dart
+++ b/sqlparser/test/utils/find_referenced_tables_test.dart
@@ -67,6 +67,7 @@ void main() {
         INSERT INTO logins (user, timestamp) VALUES (new.id, 0);
       END;
     ''');
+    expect(ctx.errors, isEmpty);
     final body = (ctx.root as CreateTriggerStatement).action;
 
     // Users referenced via "new" in body.


### PR DESCRIPTION
Previously, `sqlparser` had a single scope implementation for all kinds of lookups. But SQL's complex rules of what is visible where is hard to map onto that system. The implementation was kind of hacky and fails in very subtle cases sometimes.
Now, the decision of what's visible where is moved into different scope classes which can better deal with the delicate scoping rules around subqueries.

Todo:

- document the new scoping classes and some relevant lookups!
- refactor `drift_dev` special's column handling
- check that things like `SELECT * FROM demo d1, (SELECT * FROM demo i WHERE i.id = d1.id) d2` are properly rejected
- check that things like `SELECT * FROM demo d1 WHERE EXISTS (SELECT * FROM demo i WHERE i.id = d1.id)` still work

Closes https://github.com/simolus3/drift/issues/1858.