### PR TITLE
Fix typeconverter-depend nullability in DataClass copyWidth

### DIFF
--- a/drift_dev/lib/src/writer/tables/data_class_writer.dart
+++ b/drift_dev/lib/src/writer/tables/data_class_writer.dart
@@ -231,7 +231,7 @@ class DataClassWriter {
       // we can use field.present ? field.value : this.field
       final getter = column.dartGetterName;
 
-      if (wrapNullableInValue && column.nullable) {
+      if (wrapNullableInValue && column.nullableInDart) {
         _buffer
             .write('$getter: $getter.present ? $getter.value : this.$getter,');
       } else {


### PR DESCRIPTION
A small fix to data class writer where copyWidth parameters and class constructor didn't match. 