### PR TITLE
Depend on analyzer 4.1.0 for 'isNotOptional' -> 'isRequired' deprecation

### DIFF
--- a/drift_dev/pubspec.yaml
+++ b/drift_dev/pubspec.yaml
@@ -30,7 +30,7 @@ dependencies:
   sqlparser: ^0.22.0
 
   # Dart analysis
-  analyzer: "^4.0.0"
+  analyzer: "^4.1.0"
   analyzer_plugin: '^0.10.0'
   source_span: ^1.5.5
   package_config: ^2.0.0


### PR DESCRIPTION
With `dart_code_metrics: ^4.15.2` and `drift_dev: ^1.7.0` in `dev_dependencies`, running build_runner gave the following error:

```
[WARNING] [...] .pub-cache/hosted/pub.dartlang.org/drift_dev-1.7.0/lib/src/analyzer/custom_row_class.dart:127:15: Error: The getter 'isRequired' isn't defined for the class 'ParameterElement'.
 - 'ParameterElement' is from 'package:analyzer/dart/element/element.dart' ('/C:/flutter/.pub-cache/hosted/pub.dartlang.org/analyzer-4.0.0/lib/dart/element/element.dart').
Try correcting the name to the name of an existing getter, or defining a getter or field named 'isRequired'.
      element.isRequired) {
              ^^^^^^^^^^
[INFO] Precompiling build script... completed, took 6.2s

[SEVERE] Failed to precompile build script .dart_tool/build/entrypoint/build.dart.
This is likely caused by a misconfigured builder definition.
```

With this PR I get the expected dependency conflict message: 
> Because every version of drift_dev from path depends on analyzer ^4.1.0 and dart_code_metrics >=4.15.1 depends on analyzer >=2.4.0 <4.1.0, drift_dev from path is incompatible with dart_code_metrics >=4.15.1.