### PR TITLE
TypeConverter mapToDart -> fromSql, mapToSql -> toSql

### DIFF
--- a/docs/lib/snippets/type_converters/converters.dart
+++ b/docs/lib/snippets/type_converters/converters.dart
@@ -27,12 +27,12 @@ class PreferenceConverter extends NullAwareTypeConverter<Preferences, String>
   const PreferenceConverter();
 
   @override
-  Preferences requireMapToDart(String fromDb) {
+  Preferences requireFromSql(String fromDb) {
     return Preferences.fromJson(json.decode(fromDb) as Map<String, dynamic>);
   }
 
   @override
-  String requireMapToSql(Preferences value) {
+  String requireToSql(Preferences value) {
     return json.encode(value.toJson());
   }
 }

--- a/drift/lib/src/dsl/columns.dart
+++ b/drift/lib/src/dsl/columns.dart
@@ -306,12 +306,12 @@ extension BuildGeneralColumn<T> on _BaseColumnBuilder<T> {
   ///   // json or any other method of your choice.
   ///   const CustomConverter();
   ///   @override
-  ///   MyCustomObject mapToDart(String fromDb) {
+  ///   MyCustomObject fromSql(String fromDb) {
   ///     return fromDb == null ? null : MyCustomObject(fromDb);
   ///   }
   ///
   ///   @override
-  ///   String mapToSql(MyCustomObject value) {
+  ///   String toSql(MyCustomObject value) {
   ///     return value?.data;
   ///   }
   /// }

--- a/drift/lib/src/runtime/query_builder/schema/column_impl.dart
+++ b/drift/lib/src/runtime/query_builder/schema/column_impl.dart
@@ -299,14 +299,14 @@ class GeneratedColumnWithTypeConverter<D, S> extends GeneratedColumn<S> {
     if ($nullable) {
       // For nullable columns, the type converter needs to accept null values.
       // ignore: unnecessary_cast, https://github.com/dart-lang/sdk/issues/34150
-      mappedValue = (converter as TypeConverter<D?, S>).mapToSql(dartValue);
+      mappedValue = (converter as TypeConverter<D?, S>).toSql(dartValue);
     } else {
       if (dartValue == null) {
         throw ArgumentError(
             "This non-nullable column can't be equal to `null`.", 'dartValue');
       }
 
-      mappedValue = converter.mapToSql(dartValue);
+      mappedValue = converter.toSql(dartValue);
     }
 
     if (!$nullable && dartValue == null) {

--- a/drift/lib/src/runtime/types/custom_type.dart
+++ b/drift/lib/src/runtime/types/custom_type.dart
@@ -18,10 +18,10 @@ abstract class TypeConverter<D, S> {
 
   /// Map a value from an object in Dart into something that will be understood
   /// by the database.
-  S mapToSql(D value);
+  S toSql(D value);
 
   /// Maps a column from the database back to Dart.
-  D mapToDart(S fromDb);
+  D fromSql(S fromDb);
 }
 
 /// A mixin for [TypeConverter]s that should also apply to drift's builtin
@@ -35,13 +35,13 @@ abstract class TypeConverter<D, S> {
 mixin JsonTypeConverter<D, S> on TypeConverter<D, S> {
   /// Map a value from the Data class to json.
   ///
-  /// Defaults to doing the same conversion as for Dart -> SQL, [mapToSql].
-  S toJson(D value) => mapToSql(value);
+  /// Defaults to doing the same conversion as for Dart -> SQL, [toSql].
+  S toJson(D value) => toSql(value);
 
   /// Map a value from json to something understood by the data class.
   ///
-  /// Defaults to doing the same conversion as for SQL -> Dart, [mapToSql].
-  D fromJson(S json) => mapToDart(json);
+  /// Defaults to doing the same conversion as for SQL -> Dart, [toSql].
+  D fromJson(S json) => fromSql(json);
 
   /// Wraps an [inner] type converter that only considers non-nullable values
   /// as a type converter that handles null values too.
@@ -65,12 +65,12 @@ class EnumIndexConverter<T extends Enum> extends TypeConverter<T, int> {
   const EnumIndexConverter(this.values);
 
   @override
-  T mapToDart(int fromDb) {
+  T fromSql(int fromDb) {
     return values[fromDb];
   }
 
   @override
-  int mapToSql(T value) {
+  int toSql(T value) {
     return value.index;
   }
 }
@@ -78,8 +78,8 @@ class EnumIndexConverter<T extends Enum> extends TypeConverter<T, int> {
 /// A type converter automatically mapping `null` values to `null` in both
 /// directions.
 ///
-/// Instead of overriding  [mapToDart] and [mapToSql], subclasses of this
-/// converter should implement [requireMapToDart] and [requireMapToSql], which
+/// Instead of overriding  [fromSql] and [toSql], subclasses of this
+/// converter should implement [requireFromSql] and [requireToSql], which
 /// are used to map non-null values to and from sql values, respectively.
 ///
 /// Apart from the implementation changes, subclasses of this converter can be
@@ -99,21 +99,21 @@ abstract class NullAwareTypeConverter<D, S extends Object>
       _NullWrappingTypeConverter<D, S>;
 
   @override
-  D? mapToDart(S? fromDb) {
-    return fromDb == null ? null : requireMapToDart(fromDb);
+  D? fromSql(S? fromDb) {
+    return fromDb == null ? null : requireFromSql(fromDb);
   }
 
   /// Maps a non-null column from the database back to Dart.
-  D requireMapToDart(S fromDb);
+  D requireFromSql(S fromDb);
 
   @override
-  S? mapToSql(D? value) {
-    return value == null ? null : requireMapToSql(value);
+  S? toSql(D? value) {
+    return value == null ? null : requireToSql(value);
   }
 
   /// Map a non-null value from an object in Dart into something that will be
   /// understood by the database.
-  S requireMapToSql(D value);
+  S requireToSql(D value);
 }
 
 class _NullWrappingTypeConverter<D, S extends Object>
@@ -123,10 +123,10 @@ class _NullWrappingTypeConverter<D, S extends Object>
   const _NullWrappingTypeConverter(this._inner);
 
   @override
-  D requireMapToDart(S fromDb) => _inner.mapToDart(fromDb);
+  D requireFromSql(S fromDb) => _inner.fromSql(fromDb);
 
   @override
-  S requireMapToSql(D value) => _inner.mapToSql(value);
+  S requireToSql(D value) => _inner.toSql(value);
 }
 
 class _NullWrappingTypeConverterWithJson<D, S extends Object>
@@ -136,8 +136,8 @@ class _NullWrappingTypeConverterWithJson<D, S extends Object>
   const _NullWrappingTypeConverterWithJson(this._inner);
 
   @override
-  D requireMapToDart(S fromDb) => _inner.mapToDart(fromDb);
+  D requireFromSql(S fromDb) => _inner.fromSql(fromDb);
 
   @override
-  S requireMapToSql(D value) => _inner.mapToSql(value);
+  S requireToSql(D value) => _inner.toSql(value);
 }

--- a/drift/test/database/types/enum_index_converter_test.dart
+++ b/drift/test/database/types/enum_index_converter_test.dart
@@ -9,13 +9,13 @@ void main() {
 
   group('encodes', () {
     values.forEach((key, value) {
-      test('$key as $value', () => expect(converter.mapToSql(key), value));
+      test('$key as $value', () => expect(converter.toSql(key), value));
     });
   });
 
   group('decodes', () {
     values.forEach((key, value) {
-      test('$key as $value', () => expect(converter.mapToDart(value), key));
+      test('$key as $value', () => expect(converter.fromSql(value), key));
     });
   });
 }

--- a/drift/test/database/types/non_nullable_type_converter_test.dart
+++ b/drift/test/database/types/non_nullable_type_converter_test.dart
@@ -6,32 +6,32 @@ import '../../generated/converter.dart';
 void main() {
   test('test null in null aware type converters', () {
     const typeConverter = NullAwareSyncTypeConverter();
-    expect(typeConverter.mapToDart(typeConverter.mapToSql(null)), null);
-    expect(typeConverter.mapToSql(typeConverter.mapToDart(null)), null);
+    expect(typeConverter.fromSql(typeConverter.toSql(null)), null);
+    expect(typeConverter.toSql(typeConverter.fromSql(null)), null);
   });
 
   test('test value in null aware type converters', () {
     const typeConverter = NullAwareSyncTypeConverter();
     const value = SyncType.synchronized;
-    expect(typeConverter.mapToDart(typeConverter.mapToSql(value)), value);
-    expect(typeConverter.mapToSql(typeConverter.mapToDart(value.index)),
-        value.index);
+    expect(typeConverter.fromSql(typeConverter.toSql(value)), value);
+    expect(
+        typeConverter.toSql(typeConverter.fromSql(value.index)), value.index);
   });
 
   test('test invalid value in null aware type converters', () {
     const typeConverter = NullAwareSyncTypeConverter();
     const defaultValue = SyncType.locallyCreated;
-    expect(typeConverter.mapToDart(-1), defaultValue);
+    expect(typeConverter.fromSql(-1), defaultValue);
   });
 
   test('can wrap existing type converter', () {
     const converter =
         NullAwareTypeConverter.wrap(EnumIndexConverter(_MyEnum.values));
 
-    expect(converter.mapToDart(null), null);
-    expect(converter.mapToSql(null), null);
-    expect(converter.mapToDart(0), _MyEnum.foo);
-    expect(converter.mapToSql(_MyEnum.foo), 0);
+    expect(converter.fromSql(null), null);
+    expect(converter.toSql(null), null);
+    expect(converter.fromSql(0), _MyEnum.foo);
+    expect(converter.toSql(_MyEnum.foo), 0);
   });
 }
 

--- a/drift/test/generated/converter.dart
+++ b/drift/test/generated/converter.dart
@@ -10,12 +10,12 @@ class SyncTypeConverter extends TypeConverter<SyncType, int> {
   const SyncTypeConverter();
 
   @override
-  SyncType mapToDart(int fromDb) {
+  SyncType fromSql(int fromDb) {
     return SyncType.values[fromDb];
   }
 
   @override
-  int mapToSql(SyncType value) {
+  int toSql(SyncType value) {
     return value.index;
   }
 }
@@ -24,7 +24,7 @@ class NullAwareSyncTypeConverter extends NullAwareTypeConverter<SyncType, int> {
   const NullAwareSyncTypeConverter();
 
   @override
-  SyncType requireMapToDart(int fromDb) {
+  SyncType requireFromSql(int fromDb) {
     const values = SyncType.values;
     if (fromDb < 0 || fromDb >= values.length) {
       return SyncType.locallyCreated;
@@ -33,7 +33,7 @@ class NullAwareSyncTypeConverter extends NullAwareTypeConverter<SyncType, int> {
   }
 
   @override
-  int requireMapToSql(SyncType value) {
+  int requireToSql(SyncType value) {
     return value.index;
   }
 }

--- a/drift/test/generated/custom_tables.g.dart
+++ b/drift/test/generated/custom_tables.g.dart
@@ -24,9 +24,9 @@ class Config extends DataClass implements Insertable<Config> {
           .mapFromDatabaseResponse(data['${effectivePrefix}config_key'])!,
       configValue: const StringType()
           .mapFromDatabaseResponse(data['${effectivePrefix}config_value']),
-      syncState: ConfigTable.$converter0.mapToDart(const IntType()
+      syncState: ConfigTable.$converter0.fromSql(const IntType()
           .mapFromDatabaseResponse(data['${effectivePrefix}sync_state'])),
-      syncStateImplicit: ConfigTable.$converter1.mapToDart(const IntType()
+      syncStateImplicit: ConfigTable.$converter1.fromSql(const IntType()
           .mapFromDatabaseResponse(
               data['${effectivePrefix}sync_state_implicit'])),
     );
@@ -40,12 +40,12 @@ class Config extends DataClass implements Insertable<Config> {
     }
     if (!nullToAbsent || syncState != null) {
       final converter = ConfigTable.$converter0;
-      map['sync_state'] = Variable<int?>(converter.mapToSql(syncState));
+      map['sync_state'] = Variable<int?>(converter.toSql(syncState));
     }
     if (!nullToAbsent || syncStateImplicit != null) {
       final converter = ConfigTable.$converter1;
       map['sync_state_implicit'] =
-          Variable<int?>(converter.mapToSql(syncStateImplicit));
+          Variable<int?>(converter.toSql(syncStateImplicit));
     }
     return map;
   }
@@ -183,12 +183,12 @@ class ConfigCompanion extends UpdateCompanion<Config> {
     }
     if (syncState.present) {
       final converter = ConfigTable.$converter0;
-      map['sync_state'] = Variable<int?>(converter.mapToSql(syncState.value));
+      map['sync_state'] = Variable<int?>(converter.toSql(syncState.value));
     }
     if (syncStateImplicit.present) {
       final converter = ConfigTable.$converter1;
       map['sync_state_implicit'] =
-          Variable<int?>(converter.mapToSql(syncStateImplicit.value));
+          Variable<int?>(converter.toSql(syncStateImplicit.value));
     }
     return map;
   }
@@ -1476,9 +1476,9 @@ class MyViewData extends DataClass {
           .mapFromDatabaseResponse(data['${effectivePrefix}config_key'])!,
       configValue: const StringType()
           .mapFromDatabaseResponse(data['${effectivePrefix}config_value']),
-      syncState: ConfigTable.$converter0.mapToDart(const IntType()
+      syncState: ConfigTable.$converter0.fromSql(const IntType()
           .mapFromDatabaseResponse(data['${effectivePrefix}sync_state'])),
-      syncStateImplicit: ConfigTable.$converter1.mapToDart(const IntType()
+      syncStateImplicit: ConfigTable.$converter1.fromSql(const IntType()
           .mapFromDatabaseResponse(
               data['${effectivePrefix}sync_state_implicit'])),
     );
@@ -1677,10 +1677,9 @@ abstract class _$CustomTablesDb extends GeneratedDatabase {
     return customSelect(
         'SELECT config_key FROM config WHERE ${generatedpred.sql} AND(sync_state = ?1 OR sync_state_implicit IN ($expandedvar2))',
         variables: [
-          Variable<int?>(ConfigTable.$converter0.mapToSql(var1)),
+          Variable<int?>(ConfigTable.$converter0.toSql(var1)),
           ...generatedpred.introducedVariables,
-          for (var $ in var2)
-            Variable<int?>(ConfigTable.$converter1.mapToSql($))
+          for (var $ in var2) Variable<int?>(ConfigTable.$converter1.toSql($))
         ],
         readsFrom: {
           config,
@@ -1777,9 +1776,9 @@ abstract class _$CustomTablesDb extends GeneratedDatabase {
         configKey: row.read<String>('config_key'),
         configValue: row.read<String?>('config_value'),
         syncState:
-            ConfigTable.$converter0.mapToDart(row.read<int?>('sync_state')),
+            ConfigTable.$converter0.fromSql(row.read<int?>('sync_state')),
         syncStateImplicit: ConfigTable.$converter1
-            .mapToDart(row.read<int?>('sync_state_implicit')),
+            .fromSql(row.read<int?>('sync_state_implicit')),
       );
     });
   }

--- a/drift/test/generated/todos.dart
+++ b/drift/test/generated/todos.dart
@@ -126,12 +126,12 @@ class CustomConverter extends TypeConverter<MyCustomObject, String> {
   const CustomConverter();
 
   @override
-  MyCustomObject mapToDart(String fromDb) {
+  MyCustomObject fromSql(String fromDb) {
     return MyCustomObject(fromDb);
   }
 
   @override
-  String mapToSql(MyCustomObject value) {
+  String toSql(MyCustomObject value) {
     return value.data;
   }
 }

--- a/drift/test/generated/todos.g.dart
+++ b/drift/test/generated/todos.g.dart
@@ -24,7 +24,7 @@ class Category extends DataClass implements Insertable<Category> {
           .mapFromDatabaseResponse(data['${effectivePrefix}id'])!,
       description: const StringType()
           .mapFromDatabaseResponse(data['${effectivePrefix}desc'])!,
-      priority: $CategoriesTable.$converter0.mapToDart(const IntType()
+      priority: $CategoriesTable.$converter0.fromSql(const IntType()
           .mapFromDatabaseResponse(data['${effectivePrefix}priority'])!),
       descriptionInUpperCase: const StringType().mapFromDatabaseResponse(
           data['${effectivePrefix}description_in_upper_case'])!,
@@ -37,7 +37,7 @@ class Category extends DataClass implements Insertable<Category> {
     map['desc'] = Variable<String>(description);
     {
       final converter = $CategoriesTable.$converter0;
-      map['priority'] = Variable<int>(converter.mapToSql(priority)!);
+      map['priority'] = Variable<int>(converter.toSql(priority)!);
     }
     return map;
   }
@@ -162,7 +162,7 @@ class CategoriesCompanion extends UpdateCompanion<Category> {
     }
     if (priority.present) {
       final converter = $CategoriesTable.$converter0;
-      map['priority'] = Variable<int>(converter.mapToSql(priority.value)!);
+      map['priority'] = Variable<int>(converter.toSql(priority.value)!);
     }
     return map;
   }
@@ -1109,7 +1109,7 @@ class TableWithoutPKCompanion extends UpdateCompanion<CustomRowClass> {
     }
     if (custom.present) {
       final converter = $TableWithoutPKTable.$converter0;
-      map['custom'] = Variable<String>(converter.mapToSql(custom.value)!);
+      map['custom'] = Variable<String>(converter.toSql(custom.value)!);
     }
     return map;
   }
@@ -1224,7 +1224,7 @@ class $TableWithoutPKTable extends TableWithoutPK
           .mapFromDatabaseResponse(data['${effectivePrefix}not_really_an_id'])!,
       const RealType()
           .mapFromDatabaseResponse(data['${effectivePrefix}some_float'])!,
-      custom: $TableWithoutPKTable.$converter0.mapToDart(const StringType()
+      custom: $TableWithoutPKTable.$converter0.fromSql(const StringType()
           .mapFromDatabaseResponse(data['${effectivePrefix}custom'])!),
       webSafeInt: const BigIntType()
           .mapFromDatabaseResponse(data['${effectivePrefix}web_safe_int']),
@@ -1246,7 +1246,7 @@ class PureDefault extends DataClass implements Insertable<PureDefault> {
   factory PureDefault.fromData(Map<String, dynamic> data, {String? prefix}) {
     final effectivePrefix = prefix ?? '';
     return PureDefault(
-      txt: $PureDefaultsTable.$converter0.mapToDart(const StringType()
+      txt: $PureDefaultsTable.$converter0.fromSql(const StringType()
           .mapFromDatabaseResponse(data['${effectivePrefix}insert'])),
     );
   }
@@ -1255,7 +1255,7 @@ class PureDefault extends DataClass implements Insertable<PureDefault> {
     final map = <String, Expression>{};
     if (!nullToAbsent || txt != null) {
       final converter = $PureDefaultsTable.$converter0;
-      map['insert'] = Variable<String?>(converter.mapToSql(txt));
+      map['insert'] = Variable<String?>(converter.toSql(txt));
     }
     return map;
   }
@@ -1334,7 +1334,7 @@ class PureDefaultsCompanion extends UpdateCompanion<PureDefault> {
     final map = <String, Expression>{};
     if (txt.present) {
       final converter = $PureDefaultsTable.$converter0;
-      map['insert'] = Variable<String?>(converter.mapToSql(txt.value));
+      map['insert'] = Variable<String?>(converter.toSql(txt.value));
     }
     return map;
   }
@@ -1688,8 +1688,8 @@ abstract class _$TodoDb extends GeneratedDatabase {
         variables: [],
         readsFrom: {
           tableWithoutPK,
-        }).map((QueryRow row) => $TableWithoutPKTable.$converter0
-        .mapToDart(row.read<String>('custom'))!);
+        }).map((QueryRow row) =>
+        $TableWithoutPKTable.$converter0.fromSql(row.read<String>('custom'))!);
   }
 
   @override

--- a/drift/test/integration_tests/drift_files_test.dart
+++ b/drift/test/integration_tests/drift_files_test.dart
@@ -242,6 +242,6 @@ void main() {
         .getSingleOrNull();
 
     verify(mock.runSelect('SELECT * FROM config WHERE sync_state = ?;',
-        [ConfigTable.$converter0.mapToSql(SyncType.synchronized)]));
+        [ConfigTable.$converter0.toSql(SyncType.synchronized)]));
   });
 }

--- a/drift_dev/lib/src/writer/queries/query_writer.dart
+++ b/drift_dev/lib/src/writer/queries/query_writer.dart
@@ -187,7 +187,7 @@ class QueryWriter {
       final needsAssert = !nullableDartType && generationOptions.nnbd;
 
       final converter = column.typeConverter;
-      code = '${_converter(converter!)}.mapToDart($code)';
+      code = '${_converter(converter!)}.fromSql($code)';
       if (needsAssert) code += '!';
     }
     return code;
@@ -855,7 +855,7 @@ class _ExpandedVariableWriter {
   void _writeVariable(FoundVariable element) {
     // Variables without type converters are written as:
     // `Variable<int>(x)`. When there's a type converter, we instead use
-    // `Variable<int>(typeConverter.mapToSql(x))`.
+    // `Variable<int>(typeConverter.toSql(x))`.
     // Finally, if we're dealing with a list, we use a collection for to
     // write all the variables sequentially.
     String constructVar(String dartExpr) {
@@ -867,8 +867,7 @@ class _ExpandedVariableWriter {
 
       if (element.typeConverter != null) {
         // Apply the converter
-        buffer
-            .write('${_converter(element.typeConverter!)}.mapToSql($dartExpr)');
+        buffer.write('${_converter(element.typeConverter!)}.toSql($dartExpr)');
 
         final needsNullAssertion =
             !element.nullable && scope.generationOptions.nnbd;

--- a/drift_dev/lib/src/writer/tables/data_class_writer.dart
+++ b/drift_dev/lib/src/writer/tables/data_class_writer.dart
@@ -274,7 +274,7 @@ class DataClassWriter {
         _buffer
           ..write('final converter = $fieldName;\n')
           ..write(mapSetter)
-          ..write('(converter.mapToSql(${column.dartGetterName})');
+          ..write('(converter.toSql(${column.dartGetterName})');
         if (assertNotNull) _buffer.write('!');
         _buffer.write(');');
       } else {
@@ -378,7 +378,7 @@ class RowMappingWriter {
         final converter = column.typeConverter!;
         final loaded =
             '${converter.table!.entityInfoName}.${converter.fieldName}';
-        loadType = '$loaded.mapToDart($loadType)';
+        loadType = '$loaded.fromSql($loadType)';
       }
 
       return loadType;

--- a/drift_dev/lib/src/writer/tables/update_companion_writer.dart
+++ b/drift_dev/lib/src/writer/tables/update_companion_writer.dart
@@ -192,7 +192,7 @@ class UpdateCompanionWriter {
         _buffer
           ..write('final converter = $fieldName;\n')
           ..write(mapSetter)
-          ..write('(converter.mapToSql($getterName.value)');
+          ..write('(converter.toSql($getterName.value)');
 
         if (!column.nullable && scope.generationOptions.nnbd) {
           _buffer.write('!');

--- a/drift_dev/test/analyzer/dart/custom_row_classes_test.dart
+++ b/drift_dev/test/analyzer/dart/custom_row_classes_test.dart
@@ -60,9 +60,9 @@ class MyConverter extends TypeConverter<int, String> {
   const MyConverter();
 
   @override
-  int? mapToDart(String? fromDb) => throw 'stub';
+  int? fromSql(String? fromDb) => throw 'stub';
   @override
-  String? mapToSql(int? value) => throw 'stub';
+  String? toSql(int? value) => throw 'stub';
 }
 
 class RowClass {

--- a/drift_dev/test/backends/build/preprocess_builder_tests.dart
+++ b/drift_dev/test/backends/build/preprocess_builder_tests.dart
@@ -28,9 +28,9 @@ import 'package:drift/drift.dart';
 class MyConverter extends TypeConverter<DateTime, int> {
   const MyConverter();
 
-  int mapToSql(DateTime time) => time?.millisecondsSinceEpoch;
+  int toSql(DateTime time) => time?.millisecondsSinceEpoch;
 
-  DateTime mapToDart(int fromSql) {
+  DateTime fromSql(int fromSql) {
     if (fromSql == null) return null;
     return DateTime.fromMillisecondsSinceEpoch(fromSql);
   }
@@ -76,9 +76,9 @@ import 'package:drift/drift.dart';
 class MyConverter extends TypeConverter<DateTime, int> {
   const MyConverter();
 
-  int mapToSql(DateTime time) => time?.millisecondsSinceEpoch;
+  int toSql(DateTime time) => time?.millisecondsSinceEpoch;
 
-  DateTime mapToDart(int fromSql) {
+  DateTime fromSql(int fromSql) {
     if (fromSql == null) return null;
     return DateTime.fromMillisecondsSinceEpoch(fromSql);
   }

--- a/drift_dev/test/services/schema/writer_test.dart
+++ b/drift_dev/test/services/schema/writer_test.dart
@@ -57,8 +57,8 @@ class Settings {}
 class SettingsConverter extends TypeConverter<Settings, String> {
   const SettingsConverter();
 
-  String mapToSql(Settings s) => '';
-  Settings mapToDart(String db) => Settings();
+  String toSql(Settings s) => '';
+  Settings fromSql(String db) => Settings();
 }
 
 @DriftDatabase(include: {'a.moor'}, tables: [Users])

--- a/examples/app/lib/database/database.g.dart
+++ b/examples/app/lib/database/database.g.dart
@@ -19,7 +19,7 @@ class Category extends DataClass implements Insertable<Category> {
           .mapFromDatabaseResponse(data['${effectivePrefix}id'])!,
       name: const StringType()
           .mapFromDatabaseResponse(data['${effectivePrefix}name'])!,
-      color: $CategoriesTable.$converter0.mapToDart(const IntType()
+      color: $CategoriesTable.$converter0.fromSql(const IntType()
           .mapFromDatabaseResponse(data['${effectivePrefix}color']))!,
     );
   }
@@ -30,7 +30,7 @@ class Category extends DataClass implements Insertable<Category> {
     map['name'] = Variable<String>(name);
     {
       final converter = $CategoriesTable.$converter0;
-      map['color'] = Variable<int>(converter.mapToSql(color)!);
+      map['color'] = Variable<int>(converter.toSql(color)!);
     }
     return map;
   }
@@ -135,7 +135,7 @@ class CategoriesCompanion extends UpdateCompanion<Category> {
     }
     if (color.present) {
       final converter = $CategoriesTable.$converter0;
-      map['color'] = Variable<int>(converter.mapToSql(color.value)!);
+      map['color'] = Variable<int>(converter.toSql(color.value)!);
     }
     return map;
   }
@@ -646,7 +646,7 @@ abstract class _$AppDatabase extends GeneratedDatabase {
       return CategoriesWithCountResult(
         id: row.read<int?>('id'),
         name: row.read<String?>('name'),
-        color: $CategoriesTable.$converter0.mapToDart(row.read<int?>('color')),
+        color: $CategoriesTable.$converter0.fromSql(row.read<int?>('color')),
         amount: row.read<int>('amount'),
       );
     });

--- a/examples/app/lib/database/tables.dart
+++ b/examples/app/lib/database/tables.dart
@@ -39,8 +39,8 @@ class ColorConverter extends NullAwareTypeConverter<Color, int> {
   const ColorConverter();
 
   @override
-  Color requireMapToDart(int fromDb) => Color(fromDb);
+  Color requireFromSql(int fromDb) => Color(fromDb);
 
   @override
-  int requireMapToSql(Color value) => value.value;
+  int requireToSql(Color value) => value.value;
 }

--- a/extras/integration_tests/tests/lib/database/database.dart
+++ b/extras/integration_tests/tests/lib/database/database.dart
@@ -52,12 +52,12 @@ class Preferences {
 class PreferenceConverter extends NullAwareTypeConverter<Preferences, String> {
   const PreferenceConverter();
   @override
-  Preferences requireMapToDart(String fromDb) {
+  Preferences requireFromSql(String fromDb) {
     return Preferences.fromJson(json.decode(fromDb) as Map<String, dynamic>);
   }
 
   @override
-  String requireMapToSql(Preferences value) {
+  String requireToSql(Preferences value) {
     return json.encode(value.toJson());
   }
 }

--- a/extras/integration_tests/tests/lib/database/database.g.dart
+++ b/extras/integration_tests/tests/lib/database/database.g.dart
@@ -48,7 +48,7 @@ class User extends DataClass implements Insertable<User> {
           .mapFromDatabaseResponse(data['${effectivePrefix}birth_date'])!,
       profilePicture: const BlobType()
           .mapFromDatabaseResponse(data['${effectivePrefix}profile_picture']),
-      preferences: $UsersTable.$converter0.mapToDart(const StringType()
+      preferences: $UsersTable.$converter0.fromSql(const StringType()
           .mapFromDatabaseResponse(data['${effectivePrefix}preferences'])),
     );
   }
@@ -63,7 +63,7 @@ class User extends DataClass implements Insertable<User> {
     }
     if (!nullToAbsent || preferences != null) {
       final converter = $UsersTable.$converter0;
-      map['preferences'] = Variable<String?>(converter.mapToSql(preferences));
+      map['preferences'] = Variable<String?>(converter.toSql(preferences));
     }
     return map;
   }
@@ -214,7 +214,7 @@ class UsersCompanion extends UpdateCompanion<User> {
     if (preferences.present) {
       final converter = $UsersTable.$converter0;
       map['preferences'] =
-          Variable<String?>(converter.mapToSql(preferences.value));
+          Variable<String?>(converter.toSql(preferences.value));
     }
     return map;
   }
@@ -603,7 +603,7 @@ abstract class _$Database extends GeneratedDatabase {
         readsFrom: {
           users,
         }).map((QueryRow row) =>
-        $UsersTable.$converter0.mapToDart(row.read<String?>('preferences')));
+        $UsersTable.$converter0.fromSql(row.read<String?>('preferences')));
   }
 
   Selectable<User> usersById(List<int> var1) {


### PR DESCRIPTION
So this is just a change to make TypeConverter and JsonTypeConverter more similar in syntax.

Since 2.0 is a breaking change I thought I'd try to slip this in :P
If you don't want it you can just decline / close it.

I was also considering changing `TypeConverter` to `SqlTypeConverter`