### PR TITLE
Logging long debug messages

### DIFF
--- a/drift/lib/src/runtime/api/runtime_api.dart
+++ b/drift/lib/src/runtime/api/runtime_api.dart
@@ -26,7 +26,8 @@ class DriftRuntimeOptions {
   ///
   /// This is the function used with `logStatements: true` on databases and
   /// `debugLog` on isolates.
-  void Function(String) debugPrint = print;
+  void Function(String) debugPrint = (text) =>
+      RegExp('.{1,300}').allMatches(text).map((m) => m.group(0)).forEach(print);
 }
 
 /// Stores the [DriftRuntimeOptions] describing global drift behavior across


### PR DESCRIPTION
print method does not allow for very long messages, proposed fix by splitting debug messages into 300 character lines