### PR TITLE
Make `includeJoinedTableColumns` default to false for `selectOnly`

### DIFF
--- a/drift/CHANGELOG.md
+++ b/drift/CHANGELOG.md
@@ -5,6 +5,8 @@
   It is an error to use a non-nullable type converter on a column that is nullable in
   SQL and vice-versa.
 - __Breaking__: Mapping methods on type converters are now called `toSql` and `fromSql`.
+- __Breaking__: The `includeJoinedTableColumns` parameter on `selectOnly()` is now
+  disabled by default.
 - Consistently handle transaction errors like a failing `BEGIN` or `COMMIT`
   across database implementations.
 - Support nested transactions.

--- a/drift/lib/src/runtime/api/connection_user.dart
+++ b/drift/lib/src/runtime/api/connection_user.dart
@@ -259,7 +259,7 @@ abstract class DatabaseConnectionUser {
   JoinedSelectStatement<T, R> selectOnly<T extends HasResultSet, R>(
       ResultSetImplementation<T, R> table,
       {bool distinct = false,
-      bool includeJoinedTableColumns = true}) {
+      bool includeJoinedTableColumns = false}) {
     return JoinedSelectStatement<T, R>(
         resolvedEngine, table, [], distinct, false, includeJoinedTableColumns);
   }
@@ -628,7 +628,7 @@ class TableOrViewOperations<Tbl extends HasResultSet, Row> {
   ///
   /// This is equivalent to calling [DatabaseConnectionUser.selectOnly].
   JoinedSelectStatement<Tbl, Row> selectOnly(
-      {bool distinct = false, bool includeJoinedTableColumns = true}) {
+      {bool distinct = false, bool includeJoinedTableColumns = false}) {
     return _user.selectOnly(_sourceSet,
         distinct: distinct,
         includeJoinedTableColumns: includeJoinedTableColumns);

--- a/drift/lib/src/runtime/query_builder/on_table.dart
+++ b/drift/lib/src/runtime/query_builder/on_table.dart
@@ -15,7 +15,7 @@ extension TableOrViewStatements<Tbl extends HasResultSet, Row>
   ///
   /// This is equivalent to calling [DatabaseConnectionUser.selectOnly].
   JoinedSelectStatement<Tbl, Row> selectOnly(
-      {bool distinct = false, bool includeJoinedTableColumns = true}) {
+      {bool distinct = false, bool includeJoinedTableColumns = false}) {
     return attachedDatabase.selectOnly(this,
         distinct: distinct,
         includeJoinedTableColumns: includeJoinedTableColumns);


### PR DESCRIPTION
This always catches me off guard and I feel like it should default to false when using `selectOnly`. Since 2.0 is breaking I think this is a good time to change it, although it could cause bugs as its a change in behaviour. 