### PR TITLE
Option to store `DateTime` values as text

### DIFF
--- a/docs/lib/snippets/migrations/datetime_conversion.dart
+++ b/docs/lib/snippets/migrations/datetime_conversion.dart
@@ -1,0 +1,74 @@
+import 'package:drift/drift.dart';
+
+extension MigrateToTextDateTimes on GeneratedDatabase {
+  // #docregion unix-to-text
+  Future<void> migrateFromUnixTimestampsToText(Migrator m) async {
+    for (final table in allTables) {
+      final dateTimeColumns =
+          table.$columns.where((c) => c.type == DriftSqlType.dateTime);
+
+      if (dateTimeColumns.isNotEmpty) {
+        // This table has dateTime columns which need to be migrated.
+        await m.alterTable(TableMigration(
+          table,
+          columnTransformer: {
+            for (final column in dateTimeColumns)
+              // We assume that the column in the database is an int (unix
+              // timestamp), use `fromUnixEpoch` to convert it to a date time.
+              // Note that the resulting value in the database is in UTC.
+              column: DateTimeExpressions.fromUnixEpoch(column.dartCast<int>()),
+          },
+        ));
+      }
+    }
+  }
+  // #enddocregion unix-to-text
+}
+
+extension MigrateToTimestamps on GeneratedDatabase {
+  // #docregion text-to-unix
+  Future<void> migrateFromTextDateTimesToUnixTimestamps(Migrator m) async {
+    for (final table in allTables) {
+      final dateTimeColumns =
+          table.$columns.where((c) => c.type == DriftSqlType.dateTime);
+
+      if (dateTimeColumns.isNotEmpty) {
+        // This table has dateTime columns which need to be migrated.
+        await m.alterTable(TableMigration(
+          table,
+          columnTransformer: {
+            for (final column in dateTimeColumns)
+              // We assume that the column in the database is a string. We want
+              // to parse it to a date in SQL and then get the unix timestamp of
+              // it.
+              // Note that this requires sqlite version 3.38 or above.
+              column: FunctionCallExpression('unixepoch', [column]),
+          },
+        ));
+      }
+    }
+  }
+  // #enddocregion text-to-unix
+
+  Future<void> migrateFromTextDateTimesToUnixTimestampsPre338(
+      Migrator m) async {
+    for (final table in allTables) {
+      final dateTimeColumns =
+          table.$columns.where((c) => c.type == DriftSqlType.dateTime);
+
+      if (dateTimeColumns.isNotEmpty) {
+        await m.alterTable(TableMigration(
+          table,
+          // #docregion text-to-unix-old
+          columnTransformer: {
+            for (final column in dateTimeColumns)
+              // Use this as an alternative to `unixepoch`:
+              column: FunctionCallExpression(
+                  'strftime', [const Constant('%s'), column]).cast<int>(),
+          },
+          // #enddocregion text-to-unix-old
+        ));
+      }
+    }
+  }
+}

--- a/docs/pages/docs/Advanced Features/builder_options.md
+++ b/docs/pages/docs/Advanced Features/builder_options.md
@@ -77,6 +77,8 @@ At the moment, drift supports these options:
 * `scoped_dart_components`: Generates a function parameter for [Dart placeholders]({{ '../Using SQL/drift_files.md#dart-components-in-sql' | pageUrl }}) in SQL.
   The function has a parameter for each table that is available in the query, making it easier to get aliases right when using
   Dart placeholders.
+* `store_date_time_values_as_text`: Whether date-time columns should be stored as ISO 8601 string instead of a unix timestamp.
+  For more information on these modes, see [datetime options]({{ '../Getting started/advanced_dart_tables#datetime-options' | pageUrl }}).
 
 ## Assumed SQL environment
 

--- a/docs/pages/docs/Getting started/advanced_dart_tables.md
+++ b/docs/pages/docs/Getting started/advanced_dart_tables.md
@@ -172,7 +172,7 @@ Drift supports a variety of column types out of the box. You can store custom cl
 | `double`     | `real()`      | `REAL`                                              |
 | `boolean`    | `boolean()`   | `INTEGER`, which a `CHECK` to only allow `0` or `1` |
 | `String`     | `text()`      | `TEXT`                                              |
-| `DateTime`   | `dateTime()`  | `INTEGER` (Unix timestamp in seconds)               |
+| `DateTime`   | `dateTime()`  | `INTEGER` (default) or `TEXT` depending on [options](#datetime-options)               |
 | `Uint8List`  | `blob()`      | `BLOB`                                              |
 | `Enum`       | `intEnum()`   | `INTEGER` (more information available [here]({{ "../Advanced Features/type_converters.md#implicit-enum-converters" | pageUrl }})). |
 
@@ -223,6 +223,112 @@ Here are some more pointers on using `BigInt`s in drift:
 - To use `BigInt` support on a `WebDatabase`, set the `readIntsAsBigInt: true`
   flag when instantiating it.
 - Both `NativeDatabase` and `WasmDatabase` have builtin support for bigints.
+
+### `DateTime` options
+
+Drift supports two approaches of storing `DateTime` values in SQL:
+
+1. __As unix timestamp__ (the default): In this mode, drift stores date time
+   values as an SQL `INTEGER` containing the unix timestamp (in seconds).
+   When date times are mapped from SQL back to Dart, drift always returns a
+   non-UTC value. So even when UTC date times are stored, this information is
+   lost when retrieving rows.
+2. __As ISO 8601 string__: In this mode, datetime values are stored in a
+   textual format based on `DateTime.toIso8601String()`: UTC values are stored
+   unchanged (e.g. `2022-07-25 09:28:42.015Z`), while local values have their
+   UTC offset appended (e.g. `2022-07-25T11:28:42.015 +02:00`).
+   Most of sqlite3's date and time functions operate on UTC values, but parsing
+   datetimes in SQL respects the UTC offset added to the value.
+
+   When reading values back from the database, drift will use `DateTime.parse`
+   as following:
+    - If the textual value ends with `Z`, drift will use `DateTime.parse`
+      directly. The `Z` suffix will be recognized and a UTC value is returned.
+    - If the textual value ends with a UTC offset (e.g. `+02:00`), drift first
+      uses `DateTime.parse` which respects the modifier but returns a UTC
+      datetime. Drift then calls `toLocal()` on this intermediate result to
+      return a local value.
+    - If the textual value neither has a `Z` suffix nor a UTC offset, drift
+      will parse it as if it had a `Z` modifier, returning a UTC datetime.
+      The motivation for this is that the `datetime` function in sqlite3 returns
+      values in this format and uses UTC by default.
+
+   This behavior works well with the date functions in sqlite3 while also
+   preserving "UTC-ness" for stored values.
+
+The mode can be changed with the `store_date_time_values_as_text` [build option]({{ '../Advanced Features/builder_options.md' | pageUrl }}).
+
+Regardless of the option used, drift's builtin support for
+[date and time functions]({{ '../Advanced Features/expressions.md#date-and-time' | pageUrl }})
+return an equivalent values. Drift internally inserts the `unixepoch`
+[modifier](https://sqlite.org/lang_datefunc.html#modifiers) when unix timestamps
+are used to make the date functions work. When comparing dates stored as text,
+drift will compare their `julianday` values behind the scenes.
+
+#### Migrating between the two modes
+
+While making drift change the date time modes is as simple as changing a build
+option, toggling this behavior is not compatible with existing database schemas:
+
+1. Depending on the build option, drift expects strings or integers for datetime
+   values. So you need to migrate stored columns to the new format when changing
+   the option.
+2. If you are using SQL statements defined in `.drift` files, use custom SQL
+  at runtime or manually invoke datetime expressions with a direct
+  `FunctionCallExpression` instead of using the higher-level date time APIs, you
+  may have to adapt those usages.
+
+   For instance, comparison operators like `<` work on unix timestamps, but they
+  will compare textual datetime values lexicographically. So depending on the
+  mode used, you will have to wrap the value in `unixepoch` or `julianday` to
+  make them comparable.
+
+As the second point is specific to usages in your app, this documentation only
+describes how to migrate stored columns between the format:
+
+{% assign snippets = "package:drift_docs/snippets/migrations/datetime_conversion.dart.excerpt.json" | readString | json_decode %}
+
+##### Migrating from unix timestamps to text
+
+To migrate from using timestamps (the default option) to storing datetimes as
+text, follow these steps:
+
+1. Enable the `store_date_time_values_as_text` build option.
+2. Add the following method (or an adaption of it suiting your needs) to your
+   database class.
+3. Increment the `schemaVersion` in your database class.
+4. Write a migration step in `onUpgrade` that calls
+  `migrateFromUnixTimestampsToText` for this schema version increase.
+  __Remember that triggers, views or other custom SQL entries in your database
+  will require a custom migration that is not covered by this guide.__
+
+{% include "blocks/snippet" snippets = snippets name = "unix-to-text" %}
+
+##### Migrating from text to unix timestamps
+
+To migrate from datetimes stored as text back to unix timestamps, follow these
+steps:
+
+1. Disable the `store_date_time_values_as_text` build option.
+2. Add the following method (or an adaption of it suiting your needs) to your
+   database class.
+3. Increment the `schemaVersion` in your database class.
+4. Write a migration step in `onUpgrade` that calls
+  `migrateFromTextDateTimesToUnixTimestamps` for this schema version increase.
+  __Remember that triggers, views or other custom SQL entries in your database
+  will require a custom migration that is not covered by this guide.__
+
+{% include "blocks/snippet" snippets = snippets name = "text-to-unix" %}
+
+Note that this snippet uses the `unixepoch` sqlite3 function, which has been
+added in sqlite 3.38. To support older sqlite3 versions, you can use `strftime`
+and cast to an integer instead:
+
+{% include "blocks/snippet" snippets = snippets name = "text-to-unix-old" %}
+
+When using a `NativeDatabase` with a recent dependency on the
+`sqlite3_flutter_libs` package, you can safely assume that you are on a recent
+sqlite3 version with support for `unixepoch`.
 
 ## Custom constraints
 

--- a/docs/pages/docs/Using SQL/drift_files.md
+++ b/docs/pages/docs/Using SQL/drift_files.md
@@ -97,12 +97,16 @@ it. Of course, `id IN ? OR title = ?` will work as expected.
 
 ## Supported column types
 
-We use [this algorithm](https://www.sqlite.org/datatype3.html#determination_of_column_affinity)
+Just like sqlite itself, we use [this algorithm](https://www.sqlite.org/datatype3.html#determination_of_column_affinity)
 to determine the column type based on the declared type name.
 
 Additionally, columns that have the type name `BOOLEAN` or `DATETIME` will have
-`bool` or `DateTime` as their Dart counterpart. Both will be
-written as an `INTEGER` column when the table gets created.
+`bool` or `DateTime` as their Dart counterpart.
+Booleans are stored as `INTEGER` (either `0` or `1`). Datetimes are stored as
+unix timestamps (`INTEGER`) or ISO-8601 (`TEXT`) depending on a configurable
+build option.
+For details on all supported types, and information on how to switch between the
+datetime modes, see [this section]({{ '../Getting started/advanced_dart_tables.md#supported-column-types' | pageUrl }}).
 
 ## Imports
 You can put import statements at the top of a `drift` file:

--- a/docs/pubspec.yaml
+++ b/docs/pubspec.yaml
@@ -12,6 +12,9 @@ dependencies:
   docsy:
     hosted: https://simonbinder.eu
     version: ^0.2.2
+  code_snippets:
+    hosted: https://simonbinder.eu
+    version: ^0.0.7
 
 dev_dependencies:
   build: ^2.1.0
@@ -24,9 +27,6 @@ dev_dependencies:
   json_serializable: ^6.1.6
   shelf: ^1.2.0
   shelf_static: ^1.1.0
-  code_snippets:
-    hosted: https://simonbinder.eu
-    version: ^0.0.7
 
   # Fake path_provider for snippets
   path_provider:

--- a/drift/build.yaml
+++ b/drift/build.yaml
@@ -1,8 +1,45 @@
+# We run drift's builder in two different configurations on this package. The
+# default configuration (in the `$default`) package applies a range of
+# recommended builder options that are unlikely to cause problems.
+# For additional testing, the version of drift_dev generating the custom tables
+# file has `store_date_time_values_as_text` build option enabled.
+# This way, we get to write integration tests for both date time modes.
+
 targets:
   $default:
+    sources:
+      exclude:
+        - "test/generated/custom_tables.dart"
     builders:
       drift_dev:
         options:
+          override_hash_and_equals_in_result_sets: true
+          use_column_name_as_json_key_when_defined_in_moor_file: true
+          generate_connect_constructor: true
+          compact_query_methods: true
+          write_from_json_string_constructor: true
+          raw_result_set_data: true
+          apply_converters_on_variables: true
+          generate_values_in_copy_with: true
+          named_parameters: true
+          scoped_dart_components: true
+          sql:
+            dialect: sqlite
+            options:
+              version: "3.37"
+              modules:
+                - json1
+                - fts5
+
+  custom:
+    auto_apply_builders: false
+    sources:
+     - "test/generated/custom_tables.dart"
+    builders:
+      drift_dev:
+        options:
+          store_date_time_values_as_text: true
+          # Dart doesn't support YAML merge tags yet, https://github.com/dart-lang/yaml/issues/121
           override_hash_and_equals_in_result_sets: true
           use_column_name_as_json_key_when_defined_in_moor_file: true
           generate_connect_constructor: true

--- a/drift/lib/src/runtime/api/db_base.dart
+++ b/drift/lib/src/runtime/api/db_base.dart
@@ -16,7 +16,7 @@ abstract class GeneratedDatabase extends DatabaseConnectionUser
   GeneratedDatabase get attachedDatabase => this;
 
   @override
-  DriftDatabaseOptions get options => DriftDatabaseOptions();
+  DriftDatabaseOptions get options => const DriftDatabaseOptions();
 
   /// Specify the schema version of your database. Whenever you change or add
   /// tables, you should bump this field and provide a [migration] strategy.

--- a/drift/lib/src/runtime/api/options.dart
+++ b/drift/lib/src/runtime/api/options.dart
@@ -14,7 +14,8 @@ class DriftDatabaseOptions {
   /// When [storeDateTimeAsText] is enabled (it defaults to `false` for
   /// backwards-compatibility), drift's datetime columns will be stored as text.
   /// By default, they will be stored as ints.
-  DriftDatabaseOptions({
+  const DriftDatabaseOptions({
     bool storeDateTimeAsText = false,
-  }) : types = SqlTypes(storeDateTimeAsText);
+  }) : types =
+            storeDateTimeAsText ? const SqlTypes(true) : const SqlTypes(false);
 }

--- a/drift/lib/src/runtime/api/options.dart
+++ b/drift/lib/src/runtime/api/options.dart
@@ -13,7 +13,11 @@ class DriftDatabaseOptions {
   ///
   /// When [storeDateTimeAsText] is enabled (it defaults to `false` for
   /// backwards-compatibility), drift's datetime columns will be stored as text.
-  /// By default, they will be stored as ints.
+  /// By default, they will be stored as unix timestamps (integers).
+  ///
+  /// For details on how datetimes can be stored, see [the documentation].
+  ///
+  /// [the documentation]: https://drift.simonbinder.eu/docs/getting-started/advanced_dart_tables/#supported-column-types
   const DriftDatabaseOptions({
     bool storeDateTimeAsText = false,
   }) : types =

--- a/drift/lib/src/runtime/query_builder/expressions/aggregate.dart
+++ b/drift/lib/src/runtime/query_builder/expressions/aggregate.dart
@@ -159,22 +159,28 @@ extension BigIntAggregates on Expression<BigInt> {
 extension DateTimeAggregate on Expression<DateTime> {
   /// Return the average of all non-null values in this group.
   /// {@macro drift_aggregate_filter}
-  Expression<DateTime> avg({Expression<bool>? filter}) =>
-      secondsSinceEpoch.avg(filter: filter).roundToInt().dartCast();
+  Expression<DateTime> avg({Expression<bool>? filter}) {
+    final avgTimestamp = unixepoch.avg(filter: filter).roundToInt();
+    return DateTimeExpressions.fromUnixEpoch(avgTimestamp);
+  }
 
   /// Return the maximum of all non-null values in this group.
   ///
   /// If there are no non-null values in the group, returns null.
   /// {@macro drift_aggregate_filter}
-  Expression<DateTime> max({Expression<bool>? filter}) =>
-      _AggregateExpression('MAX', [this], filter: filter);
+  Expression<DateTime> max({Expression<bool>? filter}) {
+    final maxTimestamp = unixepoch.max(filter: filter);
+    return DateTimeExpressions.fromUnixEpoch(maxTimestamp);
+  }
 
   /// Return the minimum of all non-null values in this group.
   ///
   /// If there are no non-null values in the group, returns null.
   /// {@macro drift_aggregate_filter}
-  Expression<DateTime> min({Expression<bool>? filter}) =>
-      _AggregateExpression('MIN', [this], filter: filter);
+  Expression<DateTime> min({Expression<bool>? filter}) {
+    final minTimestamp = unixepoch.min(filter: filter);
+    return DateTimeExpressions.fromUnixEpoch(minTimestamp);
+  }
 }
 
 class _AggregateExpression<D extends Object> extends Expression<D> {

--- a/drift/lib/src/runtime/query_builder/expressions/comparable.dart
+++ b/drift/lib/src/runtime/query_builder/expressions/comparable.dart
@@ -95,6 +95,18 @@ class _BetweenExpression extends Expression<bool> {
 
   @override
   void writeInto(GenerationContext context) {
+    var target = this.target;
+    var lower = this.lower;
+    var higher = this.higher;
+
+    // We don't want to compare datetime values lexicographically, so we convert
+    // them to a comparable unit
+    if (context.options.types.storeDateTimesAsText) {
+      if (target is Expression<DateTime>) target = target.julianday;
+      if (lower is Expression<DateTime>) lower = lower.julianday;
+      if (higher is Expression<DateTime>) higher = higher.julianday;
+    }
+
     writeInner(context, target);
 
     if (not) context.buffer.write(' NOT');

--- a/drift/lib/src/runtime/query_builder/expressions/datetimes.dart
+++ b/drift/lib/src/runtime/query_builder/expressions/datetimes.dart
@@ -53,6 +53,26 @@ Expression<DateTime> _driftDateTimeFromLiteral(
 /// Provides expressions to extract information from date time values, or to
 /// calculate the difference between datetimes.
 extension DateTimeExpressions on Expression<DateTime> {
+  /// Converts a numeric expression [unixEpoch] into a date time by interpreting
+  /// it as the amount of seconds since 1970-01-01 00:00:00 UTC.
+  ///
+  /// Note that the returned value is in UTC if date times are stored as text.
+  /// If they're stored as unix timestamps, this function is a no-op and the
+  /// returned value is interpreted as a local date time (like all datetime
+  /// values in that mode).
+  static Expression<DateTime> fromUnixEpoch(Expression<int> unixEpoch) {
+    return Expression.withContext((context) {
+      if (context.options.types.storeDateTimesAsText) {
+        return FunctionCallExpression(
+            'datetime', [unixEpoch, const Constant('unixepoch')]);
+      } else {
+        // We use unix timestamps to represent date times, so we just need to
+        // reinterpret.
+        return unixEpoch.dartCast();
+      }
+    });
+  }
+
   /// Extracts the year from `this` datetime expression.
   ///
   /// {@template drift_datetime_timezone}

--- a/drift/lib/src/runtime/types/mapping.dart
+++ b/drift/lib/src/runtime/types/mapping.dart
@@ -15,7 +15,7 @@ class SqlTypes {
 
   /// Creates an [SqlTypes] mapper from the provided options.
   @internal
-  SqlTypes(this._storeDateTimesAsText);
+  const SqlTypes(this._storeDateTimesAsText);
 
   /// Maps a Dart object to a (possibly simpler) object that can be used as a
   /// parameter in raw sql queries.

--- a/drift/lib/src/runtime/types/mapping.dart
+++ b/drift/lib/src/runtime/types/mapping.dart
@@ -7,8 +7,8 @@ import 'package:meta/meta.dart';
 
 import '../query_builder/query_builder.dart';
 
-/// Static helper methods mapping Dart values from and to SQL variables or
-/// literals.
+/// Database-specific helper methods mapping Dart values from and to SQL
+/// variables or literals.
 @sealed
 class SqlTypes {
   // Stolen from DateTime._parseFormat
@@ -21,6 +21,10 @@ class SqlTypes {
   /// When false (the default), date times values are stored as unix timestamps
   /// with second accuracy. When true, date time values are stored as an
   /// ISO-8601 string.
+  ///
+  /// For more details on the mapping, see [the documentation].
+  ///
+  /// [the documentation]: https://drift.simonbinder.eu/docs/getting-started/advanced_dart_tables/#supported-column-types
   final bool storeDateTimesAsText;
 
   /// Creates an [SqlTypes] mapper from the provided options.

--- a/drift/pubspec.yaml
+++ b/drift/pubspec.yaml
@@ -24,6 +24,8 @@ dev_dependencies:
   drift_dev: any
   drift_testcases:
     path: ../extras/integration_tests/drift_testcases
+  drift_docs:
+    path: ../docs/
   http: ^0.13.4
   uuid: ^3.0.0
   path: ^1.8.0

--- a/drift/test/database/expressions/comparable_test.dart
+++ b/drift/test/database/expressions/comparable_test.dart
@@ -73,4 +73,35 @@ void main() {
       expect(ctx.boundVariables, [3, 15]);
     });
   });
+
+  group('special case for date time values as text', () {
+    const a = CustomExpression<DateTime>('a', precedence: Precedence.primary);
+    const b = CustomExpression<DateTime>('b', precedence: Precedence.primary);
+    const c = CustomExpression<DateTime>('c', precedence: Precedence.primary);
+
+    test('disabled for datetimes as timestamps', () {
+      expect(a.isSmallerThan(b), generates('a < b'));
+      expect(a.isBiggerOrEqual(b), generates('a >= b'));
+      expect(a.isBetween(b, c), generates('a BETWEEN b AND c'));
+    });
+
+    test('enabled for datetimes as timestamps', () {
+      const options = DriftDatabaseOptions(storeDateTimeAsText: true);
+
+      expect(
+          a.isSmallerThan(b),
+          generatesWithOptions('JULIANDAY(a) < JULIANDAY(b)',
+              options: options));
+      expect(
+          a.isBiggerOrEqual(b),
+          generatesWithOptions('JULIANDAY(a) >= JULIANDAY(b)',
+              options: options));
+      expect(
+          a.isBetween(b, c),
+          generatesWithOptions(
+            'JULIANDAY(a) BETWEEN JULIANDAY(b) AND JULIANDAY(c)',
+            options: options,
+          ));
+    });
+  });
 }

--- a/drift/test/database/expressions/datetime_expression_test.dart
+++ b/drift/test/database/expressions/datetime_expression_test.dart
@@ -5,45 +5,113 @@ import '../../test_utils/test_utils.dart';
 
 typedef _Extractor = Expression Function(Expression<DateTime> d);
 
+final _expectedResultsTimestamp = <_Extractor, String>{
+  (d) => d.year: "CAST(strftime('%Y', val, 'unixepoch') AS INTEGER)",
+  (d) => d.month: "CAST(strftime('%m', val, 'unixepoch') AS INTEGER)",
+  (d) => d.day: "CAST(strftime('%d', val, 'unixepoch') AS INTEGER)",
+  (d) => d.hour: "CAST(strftime('%H', val, 'unixepoch') AS INTEGER)",
+  (d) => d.minute: "CAST(strftime('%M', val, 'unixepoch') AS INTEGER)",
+  (d) => d.second: "CAST(strftime('%S', val, 'unixepoch') AS INTEGER)",
+  (d) => d.date: "DATE(val, 'unixepoch')",
+  (d) => d.datetime: "DATETIME(val, 'unixepoch')",
+  (d) => d.time: "TIME(val, 'unixepoch')",
+  (d) => d.unixepoch: 'val',
+  (d) => d.julianday: "JULIANDAY(val, 'unixepoch')",
+};
+
+final _expectedResultsText = <_Extractor, String>{
+  (d) => d.year: "CAST(strftime('%Y', val) AS INTEGER)",
+  (d) => d.month: "CAST(strftime('%m', val) AS INTEGER)",
+  (d) => d.day: "CAST(strftime('%d', val) AS INTEGER)",
+  (d) => d.hour: "CAST(strftime('%H', val) AS INTEGER)",
+  (d) => d.minute: "CAST(strftime('%M', val) AS INTEGER)",
+  (d) => d.second: "CAST(strftime('%S', val) AS INTEGER)",
+  (d) => d.date: 'DATE(val)',
+  (d) => d.datetime: 'DATETIME(val)',
+  (d) => d.time: 'TIME(val)',
+  (d) => d.unixepoch: 'UNIXEPOCH(val)',
+  (d) => d.julianday: 'JULIANDAY(val)',
+};
+
 void main() {
   const column =
       CustomExpression<DateTime>('val', precedence: Precedence.primary);
 
-  group('extracting information via top-level method', () {
-    final expectedResults = <_Extractor, String>{
-      (d) => d.year: "CAST(strftime('%Y', val, 'unixepoch') AS INTEGER)",
-      (d) => d.month: "CAST(strftime('%m', val, 'unixepoch') AS INTEGER)",
-      (d) => d.day: "CAST(strftime('%d', val, 'unixepoch') AS INTEGER)",
-      (d) => d.hour: "CAST(strftime('%H', val, 'unixepoch') AS INTEGER)",
-      (d) => d.minute: "CAST(strftime('%M', val, 'unixepoch') AS INTEGER)",
-      (d) => d.second: "CAST(strftime('%S', val, 'unixepoch') AS INTEGER)",
-      (d) => d.date: "DATE(val, 'unixepoch')",
-      (d) => d.datetime: "DATETIME(val, 'unixepoch')",
-      (d) => d.time: "TIME(val, 'unixepoch')",
-    };
+  for (final useText in [false, true]) {
+    final desc = useText ? 'text' : 'timestamp';
 
-    expectedResults.forEach((key, value) {
-      test('should extract field', () {
-        expect(key(column), generates(value));
-        expectEquals(key(column), key(column));
+    group('storing datetime values as $desc', () {
+      final options = DriftDatabaseOptions(storeDateTimeAsText: useText);
+
+      group('extracting information via top-level method', () {
+        final expectedResults =
+            useText ? _expectedResultsText : _expectedResultsTimestamp;
+
+        expectedResults.forEach((key, value) {
+          test('should extract field', () {
+            expect(key(column), generatesWithOptions(value, options: options));
+          });
+        });
+      });
+
+      test('can cast datetimes to unix timestamps without rewriting', () {
+        final expr = currentDateAndTime.unixepoch + const Constant(10);
+        final expectedSql = useText
+            ? 'UNIXEPOCH(CURRENT_TIMESTAMP) + 10'
+            : 'CAST(strftime(\'%s\', CURRENT_TIMESTAMP) AS INTEGER) + 10';
+
+        expect(expr, generatesWithOptions(expectedSql, options: options));
+      });
+
+      test('plus and minus durations', () {
+        final expr = currentDateAndTime +
+            const Duration(days: 3) -
+            const Duration(seconds: 5);
+
+        if (useText) {
+          expect(
+            expr,
+            generatesWithOptions(
+              "datetime(datetime(CURRENT_TIMESTAMP, '259200.0 seconds'), "
+              "'-5.0 seconds')",
+              options: options,
+            ),
+          );
+        } else {
+          expect(
+            expr,
+            generates(
+                'CAST(strftime(\'%s\', CURRENT_TIMESTAMP) AS INTEGER) + ? - ?',
+                [259200, 5]),
+          );
+        }
+      });
+
+      test('can compare', () {
+        final left = Variable(DateTime.utc(2022, 07, 22));
+        final right = Variable(DateTime.utc(2022, 07, 23));
+
+        if (useText) {
+          expect(
+              left.isSmallerThan(right),
+              generatesWithOptions(
+                'JULIANDAY(?) < JULIANDAY(?)',
+                options: options,
+                variables: [
+                  '2022-07-22T00:00:00.000Z',
+                  '2022-07-23T00:00:00.000Z'
+                ],
+              ));
+        } else {
+          expect(
+              left.isSmallerThan(right),
+              generatesWithOptions(
+                '? < ?',
+                options: options,
+                variables: [1658448000, 1658534400],
+              ));
+        }
       });
     });
-  });
-
-  test('can cast datetimes to unix timestamps without rewriting', () {
-    final expr = currentDateAndTime.secondsSinceEpoch + const Constant(10);
-    final ctx = stubContext();
-    expr.writeInto(ctx);
-
-    expect(ctx.sql, 'strftime(\'%s\', CURRENT_TIMESTAMP) + 10');
-  });
-
-  test('plus and minus durations', () {
-    final expr = currentDateAndTime +
-        const Duration(days: 3) -
-        const Duration(seconds: 5);
-
-    expect(expr,
-        generates('strftime(\'%s\', CURRENT_TIMESTAMP) + ? - ?', [259200, 5]));
-  });
+  }
 }

--- a/drift/test/database/expressions/datetime_expression_test.dart
+++ b/drift/test/database/expressions/datetime_expression_test.dart
@@ -112,6 +112,16 @@ void main() {
               ));
         }
       });
+
+      test('from unix epoch', () {
+        expect(
+          DateTimeExpressions.fromUnixEpoch(column.dartCast()),
+          generatesWithOptions(
+            useText ? "datetime(val, 'unixepoch')" : 'val',
+            options: options,
+          ),
+        );
+      });
     });
   }
 }

--- a/drift/test/database/statements/insert_test.dart
+++ b/drift/test/database/statements/insert_test.dart
@@ -196,7 +196,8 @@ void main() {
     verify(
       executor.runInsert(
         'INSERT INTO users (name, is_awesome, profile_picture, creation_time) '
-        "VALUES (?, 1, _custom_, strftime('%s', CURRENT_TIMESTAMP))",
+        'VALUES (?, 1, _custom_, '
+        "CAST(strftime('%s', CURRENT_TIMESTAMP) AS INTEGER))",
         ['User name'],
       ),
     );

--- a/drift/test/database/statements/schema_test.dart
+++ b/drift/test/database/statements/schema_test.dart
@@ -44,7 +44,7 @@ void main() {
           'is_awesome INTEGER NOT NULL DEFAULT 1 CHECK (is_awesome IN (0, 1)), '
           'profile_picture BLOB NOT NULL, '
           'creation_time INTEGER NOT NULL '
-          "DEFAULT (strftime('%s', CURRENT_TIMESTAMP)) "
+          "DEFAULT (CAST(strftime('%s', CURRENT_TIMESTAMP) AS INTEGER)) "
           'CHECK(creation_time > -631152000)'
           ');',
           []));
@@ -101,7 +101,7 @@ void main() {
           'is_awesome INTEGER NOT NULL DEFAULT 1 CHECK (is_awesome IN (0, 1)), '
           'profile_picture BLOB NOT NULL, '
           'creation_time INTEGER NOT NULL '
-          "DEFAULT (strftime('%s', CURRENT_TIMESTAMP)) "
+          "DEFAULT (CAST(strftime('%s', CURRENT_TIMESTAMP) AS INTEGER)) "
           'CHECK(creation_time > -631152000)'
           ');',
           []));

--- a/drift/test/database/statements/update_test.dart
+++ b/drift/test/database/statements/update_test.dart
@@ -76,7 +76,8 @@ void main() {
 
       verify(executor.runUpdate(
           'UPDATE users SET name = ?, profile_picture = ?, is_awesome = 1, '
-          'creation_time = strftime(\'%s\', CURRENT_TIMESTAMP) WHERE id = ?;',
+          'creation_time = CAST(strftime(\'%s\', CURRENT_TIMESTAMP) AS INTEGER)'
+          ' WHERE id = ?;',
           ['Hummingbird', Uint8List(0), 3]));
     });
   });

--- a/drift/test/database/types/blob_test.dart
+++ b/drift/test/database/types/blob_test.dart
@@ -5,7 +5,7 @@ import 'package:test/test.dart';
 
 void main() {
   test('maps without transformation', () {
-    final types = DriftDatabaseOptions().types;
+    final types = const DriftDatabaseOptions().types;
     final data = Uint8List.fromList(List.generate(256, (i) => i));
 
     expect(types.mapToSqlVariable(data), data);
@@ -13,7 +13,7 @@ void main() {
   });
 
   test('writes blob literals', () {
-    final types = DriftDatabaseOptions().types;
+    final types = const DriftDatabaseOptions().types;
     const hex = '67656E6572616C206B656E6F626921';
     final data = Uint8List.fromList(utf8.encode('general kenobi!'));
 
@@ -23,7 +23,7 @@ void main() {
   test('maps of string', () {
     const chars = 'AaBbCcDdEeFfGgHhIiJjKkLlMmNnOoPpQqRrSsTtUuVvWwXxYyZz';
 
-    final types = DriftDatabaseOptions().types;
+    final types = const DriftDatabaseOptions().types;
     final data = List.generate(256, (i) => chars[i % chars.length]);
     final dataString = data.join();
     final dataInt = data.map((e) => e.codeUnits[0]).toList();

--- a/drift/test/database/types/datetime_test.dart
+++ b/drift/test/database/types/datetime_test.dart
@@ -25,4 +25,138 @@ void main() {
 
     expect(ctx.sql, "name < strftime('%s', CURRENT_TIMESTAMP)");
   });
+
+  group('mapping datetime values', () {
+    group('from dart to sql', () {
+      final local = DateTime(2022, 07, 21, 22, 53, 12, 888, 999);
+      final utc = DateTime.utc(2022, 07, 21, 22, 53, 12, 888, 999);
+
+      test('as unix timestamp', () {
+        expect(Variable(local),
+            generates('?', [local.millisecondsSinceEpoch ~/ 1000]));
+        expect(Variable(utc), generates('?', [1658443992]));
+
+        expect(Constant(local),
+            generates('${local.millisecondsSinceEpoch ~/ 1000}'));
+        expect(Constant(utc), generates('1658443992'));
+      });
+
+      test('as text', () {
+        const options = DriftDatabaseOptions(storeDateTimeAsText: true);
+
+        expect(
+          Variable(_MockDateTime(local, const Duration(hours: 1))),
+          generatesWithOptions(
+            '?',
+            variables: ['2022-07-21T22:53:12.888999 +01:00'],
+            options: options,
+          ),
+        );
+        expect(
+          Variable(_MockDateTime(local, const Duration(hours: 1, minutes: 12))),
+          generatesWithOptions(
+            '?',
+            variables: ['2022-07-21T22:53:12.888999 +01:12'],
+            options: options,
+          ),
+        );
+        expect(
+          Variable(
+              _MockDateTime(local, -const Duration(hours: 1, minutes: 29))),
+          generatesWithOptions(
+            '?',
+            variables: ['2022-07-21T22:53:12.888999 -01:29'],
+            options: options,
+          ),
+        );
+
+        expect(
+          Variable(utc),
+          generatesWithOptions(
+            '?',
+            variables: ['2022-07-21T22:53:12.888999Z'],
+            options: options,
+          ),
+        );
+
+        expect(
+          Constant(_MockDateTime(local, const Duration(hours: 1))),
+          generatesWithOptions(
+            "'2022-07-21T22:53:12.888999 +01:00'",
+            options: options,
+          ),
+        );
+        expect(
+          Constant(utc),
+          generatesWithOptions("'2022-07-21T22:53:12.888999Z'",
+              options: options),
+        );
+
+        // Writing date times with an UTC offset that isn't a whole minute
+        // is not supported and should throw.
+        expect(() {
+          final context = stubContext(options: options);
+          Variable(_MockDateTime(local, const Duration(seconds: 30)))
+              .writeInto(context);
+        }, throwsArgumentError);
+
+        expect(() {
+          final context = stubContext(options: options);
+          Constant(_MockDateTime(local, const Duration(seconds: 30)))
+              .writeInto(context);
+        }, throwsArgumentError);
+      });
+    });
+
+    group('from sql to dart', () {
+      test('as unix timestamp', () {
+        const types = SqlTypes(false);
+
+        expect(types.read(DriftSqlType.dateTime, 1658443992),
+            DateTime.utc(2022, 07, 21, 22, 53, 12).toLocal());
+      });
+
+      test('as text', () {
+        const types = SqlTypes(true);
+
+        expect(types.read(DriftSqlType.dateTime, '2022-07-21T22:53:12Z'),
+            DateTime.utc(2022, 07, 21, 22, 53, 12));
+
+        expect(
+          types.read(DriftSqlType.dateTime, '2022-07-21T22:53:12 -03:00'),
+          DateTime.utc(2022, 07, 21, 22, 53, 12)
+              .add(const Duration(hours: 3))
+              .toLocal(),
+        );
+      });
+    });
+  });
+}
+
+class _MockDateTime implements DateTime {
+  final DateTime original;
+  final Duration utcOffset;
+
+  _MockDateTime(this.original, this.utcOffset) : assert(!original.isUtc);
+
+  @override
+  bool get isUtc => false;
+
+  @override
+  Duration get timeZoneOffset => utcOffset;
+
+  @override
+  String toIso8601String() {
+    return original.toIso8601String();
+  }
+
+  @override
+  String toString() {
+    return '${original.toString()} with fake offset $utcOffset';
+  }
+
+  @override
+  dynamic noSuchMethod(Invocation invocation) {
+    return super.noSuchMethod(invocation);
+  }
 }

--- a/drift/test/database/types/datetime_test.dart
+++ b/drift/test/database/types/datetime_test.dart
@@ -19,13 +19,6 @@ void main() {
     expect(nonNullQuery.sql, equals('name INTEGER NOT NULL'));
   });
 
-  test('can compare', () {
-    final ctx = stubContext();
-    nonNull.isSmallerThan(currentDateAndTime).writeInto(ctx);
-
-    expect(ctx.sql, "name < strftime('%s', CURRENT_TIMESTAMP)");
-  });
-
   group('mapping datetime values', () {
     group('from dart to sql', () {
       final local = DateTime(2022, 07, 21, 22, 53, 12, 888, 999);

--- a/drift/test/database/types/real_type_test.dart
+++ b/drift/test/database/types/real_type_test.dart
@@ -2,7 +2,7 @@ import 'package:drift/drift.dart' as drift;
 import 'package:test/test.dart';
 
 void main() {
-  final typeSystem = drift.DriftDatabaseOptions().types;
+  final typeSystem = const drift.DriftDatabaseOptions().types;
 
   group('RealType', () {
     test('can be read from floating point values returned by sql', () {

--- a/drift/test/database/types/sql_type_test.dart
+++ b/drift/test/database/types/sql_type_test.dart
@@ -3,7 +3,7 @@ import 'package:test/test.dart';
 
 void main() {
   test('types map null values to null', () {
-    final options = DriftDatabaseOptions();
+    const options = DriftDatabaseOptions();
     expect(options.types.mapToSqlVariable(null), isNull);
 
     for (final type in DriftSqlType.values) {

--- a/drift/test/documentation_snippet_test.dart
+++ b/drift/test/documentation_snippet_test.dart
@@ -1,0 +1,143 @@
+import 'package:drift/drift.dart';
+import 'package:drift_docs/snippets/migrations/datetime_conversion.dart';
+import 'package:test/test.dart';
+
+import 'generated/custom_tables.dart';
+import 'generated/todos.dart';
+import 'test_utils/test_utils.dart';
+
+/// Test for some snippets embedded on https://drift.simonbinder.eu to make sure
+/// that they are still up to date and work as intended with the latest drift
+/// version.
+void main() {
+  group('changing datetime format', () {
+    test('unix timestamp to text', () async {
+      // Note: CustomTablesDb has been compiled to use datetimes as text by
+      // default.
+      final db = CustomTablesDb.connect(testInMemoryDatabase());
+      addTearDown(db.close);
+
+      final time = DateTime.fromMillisecondsSinceEpoch(
+        1000 * (DateTime.now().millisecondsSinceEpoch ~/ 1000),
+        isUtc: true,
+      );
+
+      // Re-create the `mytable` table (the only one using dates) to use unix
+      // timestamps
+      await db.customStatement('DROP TABLE mytable');
+      await db.customStatement('''
+CREATE TABLE mytable (
+    someid INTEGER NOT NULL,
+    sometext TEXT,
+    is_inserting BOOLEAN,
+    somedate INTEGER,
+    PRIMARY KEY (someid DESC)
+);
+''');
+
+      await db.customStatement('''
+INSERT INTO mytable (someid) VALUES (1); -- nullable value
+INSERT INTO mytable (someid, somedate) VALUES (2, ${time.millisecondsSinceEpoch ~/ 1000});
+''');
+
+      // Run conversion from unix timestamps to text
+      await db.migrateFromUnixTimestampsToText(db.createMigrator());
+
+      // Check that the values are still there!
+      final rows = await (db.select(db.mytable)
+            ..orderBy([(row) => OrderingTerm.asc(row.someid)]))
+          .get();
+
+      expect(rows, [
+        const MytableData(someid: 1),
+        MytableData(someid: 2, somedate: time),
+      ]);
+    });
+
+    test('text to unix timestamp', () async {
+      // First, create all tables using text as datetime
+      final db = TodoDb.connect(testInMemoryDatabase());
+      db.options = const DriftDatabaseOptions(storeDateTimeAsText: true);
+      addTearDown(db.close);
+
+      final time = DateTime.fromMillisecondsSinceEpoch(
+          1000 * (DateTime.now().millisecondsSinceEpoch ~/ 1000));
+
+      await db.into(db.users).insert(
+            UsersCompanion.insert(
+              name: 'Some user',
+              profilePicture: Uint8List(0),
+              creationTime: Value(time),
+            ),
+          );
+
+      await db.into(db.todosTable).insert(TodosTableCompanion.insert(
+            content: 'with null date',
+          ));
+      await db.into(db.todosTable).insert(TodosTableCompanion.insert(
+            content: 'with due date',
+            targetDate: Value(time),
+          ));
+
+      // Next, migrate back to unix timestamps
+      db.options = const DriftDatabaseOptions(storeDateTimeAsText: false);
+      final migrator = db.createMigrator();
+      await migrator.drop(db.categoryTodoCountView);
+      await migrator.drop(db.todoWithCategoryView);
+      await db.migrateFromTextDateTimesToUnixTimestamps(migrator);
+      await migrator.create(db.categoryTodoCountView);
+      await migrator.create(db.todoWithCategoryView);
+
+      expect(await db.users.select().getSingle(),
+          isA<User>().having((e) => e.creationTime, 'creationTime', time));
+
+      expect(await db.todosTable.select().get(), [
+        const TodoEntry(id: 1, content: 'with null date'),
+        TodoEntry(id: 2, content: 'with due date', targetDate: time),
+      ]);
+    });
+
+    test('text to unix timestamp, support old sqlite', () async {
+      // First, create all tables using text as datetime
+      final db = TodoDb.connect(testInMemoryDatabase());
+      db.options = const DriftDatabaseOptions(storeDateTimeAsText: true);
+      addTearDown(db.close);
+
+      final time = DateTime.fromMillisecondsSinceEpoch(
+          1000 * (DateTime.now().millisecondsSinceEpoch ~/ 1000));
+
+      await db.into(db.users).insert(
+            UsersCompanion.insert(
+              name: 'Some user',
+              profilePicture: Uint8List(0),
+              creationTime: Value(time),
+            ),
+          );
+
+      await db.into(db.todosTable).insert(TodosTableCompanion.insert(
+            content: 'with null date',
+          ));
+      await db.into(db.todosTable).insert(TodosTableCompanion.insert(
+            content: 'with due date',
+            targetDate: Value(time),
+          ));
+
+      // Next, migrate back to unix timestamps
+      db.options = const DriftDatabaseOptions(storeDateTimeAsText: false);
+      final migrator = db.createMigrator();
+      await migrator.drop(db.categoryTodoCountView);
+      await migrator.drop(db.todoWithCategoryView);
+      await db.migrateFromTextDateTimesToUnixTimestampsPre338(migrator);
+      await migrator.create(db.categoryTodoCountView);
+      await migrator.create(db.todoWithCategoryView);
+
+      expect(await db.users.select().getSingle(),
+          isA<User>().having((e) => e.creationTime, 'creationTime', time));
+
+      expect(await db.todosTable.select().get(), [
+        const TodoEntry(id: 1, content: 'with null date'),
+        TodoEntry(id: 2, content: 'with due date', targetDate: time),
+      ]);
+    });
+  });
+}

--- a/drift/test/generated/custom_tables.g.dart
+++ b/drift/test/generated/custom_tables.g.dart
@@ -1854,6 +1854,9 @@ abstract class _$CustomTablesDb extends GeneratedDatabase {
           ),
         ],
       );
+  @override
+  DriftDatabaseOptions get options =>
+      const DriftDatabaseOptions(storeDateTimeAsText: true);
 }
 
 OrderBy _$moor$default$0(ConfigTable _) => const OrderBy.nothing();

--- a/drift/test/generated/todos.dart
+++ b/drift/test/generated/todos.dart
@@ -201,6 +201,9 @@ class TodoDb extends _$TodoDb {
   MigrationStrategy migration = MigrationStrategy();
 
   @override
+  DriftDatabaseOptions options = const DriftDatabaseOptions();
+
+  @override
   int get schemaVersion => 1;
 }
 

--- a/drift/test/integration_tests/drift_files_test.dart
+++ b/drift/test/integration_tests/drift_files_test.dart
@@ -28,7 +28,7 @@ const _createMyTable = 'CREATE TABLE IF NOT EXISTS mytable ('
     'someid INTEGER NOT NULL, '
     'sometext TEXT, '
     'is_inserting INTEGER, '
-    'somedate INTEGER, '
+    'somedate TEXT, '
     'PRIMARY KEY (someid DESC)'
     ');';
 

--- a/drift/test/test_utils/matchers.dart
+++ b/drift/test/test_utils/matchers.dart
@@ -16,14 +16,24 @@ void expectNotEquals(dynamic a, dynamic expected) {
 /// Matcher for [Component]-subclasses. Expect that a component generates the
 /// matching [sql] and, optionally, the matching [variables].
 Matcher generates(dynamic sql, [dynamic variables = isEmpty]) {
-  return _GeneratesSqlMatcher(wrapMatcher(sql), wrapMatcher(variables));
+  return _GeneratesSqlMatcher(
+      wrapMatcher(sql), wrapMatcher(variables), const DriftDatabaseOptions());
+}
+
+Matcher generatesWithOptions(dynamic sql,
+    {dynamic variables = isEmpty,
+    DriftDatabaseOptions options = const DriftDatabaseOptions()}) {
+  return _GeneratesSqlMatcher(
+      wrapMatcher(sql), wrapMatcher(variables), options);
 }
 
 class _GeneratesSqlMatcher extends Matcher {
   final Matcher _matchSql;
   final Matcher? _matchVariables;
 
-  _GeneratesSqlMatcher(this._matchSql, this._matchVariables);
+  final DriftDatabaseOptions options;
+
+  _GeneratesSqlMatcher(this._matchSql, this._matchVariables, this.options);
 
   @override
   Description describe(Description description) {
@@ -68,7 +78,7 @@ class _GeneratesSqlMatcher extends Matcher {
       return false;
     }
 
-    final ctx = stubContext();
+    final ctx = stubContext(options: options);
     item.writeInto(ctx);
 
     var matches = true;

--- a/drift/test/test_utils/test_utils.dart
+++ b/drift/test/test_utils/test_utils.dart
@@ -9,7 +9,7 @@ export 'mocks.dart';
 
 GenerationContext stubContext({DriftDatabaseOptions? options}) {
   return GenerationContext(
-      options ?? DriftDatabaseOptions(), _NullDatabase.instance);
+      options ?? const DriftDatabaseOptions(), _NullDatabase.instance);
 }
 
 class _NullDatabase extends GeneratedDatabase {

--- a/drift_dev/lib/src/analyzer/options.dart
+++ b/drift_dev/lib/src/analyzer/options.dart
@@ -98,6 +98,11 @@ class DriftOptions {
   @JsonKey(name: 'scoped_dart_components', defaultValue: false)
   final bool scopedDartComponents;
 
+  /// Whether `DateTime` columns should be stored as text (via
+  /// [DateTime.toIso8601String]) instead of integers (unix timestamp).
+  @JsonKey(defaultValue: false)
+  final bool storeDateTimeValuesAsText;
+
   @internal
   const DriftOptions.defaults({
     this.generateFromJsonStringConstructor = false,
@@ -118,6 +123,7 @@ class DriftOptions {
     this.scopedDartComponents = false,
     this.modules = const [],
     this.sqliteAnalysisOptions,
+    this.storeDateTimeValuesAsText = false,
     this.dialect = const DialectOptions(SqlDialect.sqlite, null),
   });
 
@@ -140,6 +146,7 @@ class DriftOptions {
     required this.scopedDartComponents,
     required this.modules,
     required this.sqliteAnalysisOptions,
+    required this.storeDateTimeValuesAsText,
     this.dialect,
   }) {
     if (sqliteAnalysisOptions != null && modules.isNotEmpty) {

--- a/drift_dev/lib/src/analyzer/options.g.dart
+++ b/drift_dev/lib/src/analyzer/options.g.dart
@@ -31,7 +31,8 @@ DriftOptions _$DriftOptionsFromJson(Map json) => $checkedCreate(
             'generate_values_in_copy_with',
             'named_parameters',
             'named_parameters_always_required',
-            'scoped_dart_components'
+            'scoped_dart_components',
+            'store_date_time_values_as_text'
           ],
         );
         final val = DriftOptions(
@@ -80,6 +81,8 @@ DriftOptions _$DriftOptionsFromJson(Map json) => $checkedCreate(
               'sqlite',
               (v) =>
                   v == null ? null : SqliteAnalysisOptions.fromJson(v as Map)),
+          storeDateTimeValuesAsText: $checkedConvert(
+              'store_date_time_values_as_text', (v) => v as bool? ?? false),
           dialect: $checkedConvert('sql',
               (v) => v == null ? null : DialectOptions.fromJson(v as Map)),
         );
@@ -107,6 +110,7 @@ DriftOptions _$DriftOptionsFromJson(Map json) => $checkedCreate(
         'scopedDartComponents': 'scoped_dart_components',
         'modules': 'sqlite_modules',
         'sqliteAnalysisOptions': 'sqlite',
+        'storeDateTimeValuesAsText': 'store_date_time_values_as_text',
         'dialect': 'sql'
       },
     );

--- a/drift_dev/lib/src/analyzer/runner/steps/parse_moor.dart
+++ b/drift_dev/lib/src/analyzer/runner/steps/parse_moor.dart
@@ -2,9 +2,11 @@ part of '../steps.dart';
 
 class ParseMoorStep extends Step {
   final String content;
-  final TypeMapper mapper = TypeMapper();
+  final TypeMapper mapper;
 
-  ParseMoorStep(Task task, FoundFile file, this.content) : super(task, file);
+  ParseMoorStep(Task task, FoundFile file, this.content)
+      : mapper = TypeMapper(options: task.session.options),
+        super(task, file);
 
   Future<ParsedDriftFile> parseFile() async {
     final parser = MoorParser(this, await task.helper);

--- a/drift_dev/lib/src/analyzer/sql_queries/query_analyzer.dart
+++ b/drift_dev/lib/src/analyzer/sql_queries/query_analyzer.dart
@@ -22,10 +22,7 @@ abstract class BaseAnalyzer {
   SqlEngine? _engine;
 
   BaseAnalyzer(this.tables, this.views, this.step)
-      : mapper = TypeMapper(
-          applyTypeConvertersToVariables:
-              step.task.session.options.applyConvertersOnVariables,
-        );
+      : mapper = TypeMapper(options: step.task.session.options);
 
   @protected
   SqlEngine get engine {

--- a/drift_dev/lib/src/writer/database_writer.dart
+++ b/drift_dev/lib/src/writer/database_writer.dart
@@ -156,6 +156,14 @@ class DatabaseWriter {
         ..writeln('int get schemaVersion => $version;');
     }
 
+    if (scope.options.storeDateTimeValuesAsText) {
+      // Override database options to reflect that DateTimes are stored as text.
+      schemaScope
+        ..writeln('@override')
+        ..writeln('DriftDatabaseOptions get options => '
+            'const DriftDatabaseOptions(storeDateTimeAsText: true);');
+    }
+
     // close the class
     schemaScope.write('}\n');
   }

--- a/drift_dev/test/analyzer/sql_queries/linter_test.dart
+++ b/drift_dev/test/analyzer/sql_queries/linter_test.dart
@@ -1,5 +1,6 @@
 import 'package:drift_dev/moor_generator.dart';
 import 'package:drift_dev/src/analyzer/errors.dart';
+import 'package:drift_dev/src/analyzer/options.dart';
 import 'package:drift_dev/src/analyzer/sql_queries/query_handler.dart';
 import 'package:drift_dev/src/analyzer/sql_queries/type_mapping.dart';
 import 'package:sqlparser/sqlparser.dart';
@@ -10,7 +11,7 @@ import '../utils.dart';
 void main() {
   final engine = SqlEngine(EngineOptions(
       useDriftExtensions: true, enabledExtensions: const [Json1Extension()]));
-  final mapper = TypeMapper();
+  final mapper = TypeMapper(options: const DriftOptions.defaults());
 
   final fakeQuery = DeclaredDartQuery('query', 'sql');
 

--- a/drift_dev/test/analyzer/sql_queries/query_handler_test.dart
+++ b/drift_dev/test/analyzer/sql_queries/query_handler_test.dart
@@ -1,5 +1,6 @@
 import 'package:drift_dev/moor_generator.dart';
 import 'package:drift_dev/src/analyzer/drift/create_table_reader.dart';
+import 'package:drift_dev/src/analyzer/options.dart';
 import 'package:drift_dev/src/analyzer/runner/file_graph.dart';
 import 'package:drift_dev/src/analyzer/runner/results.dart';
 import 'package:drift_dev/src/analyzer/runner/steps.dart';
@@ -25,7 +26,7 @@ CREATE TABLE bar (
 ''';
 
 Future<void> main() async {
-  final mapper = TypeMapper();
+  final mapper = TypeMapper(options: const DriftOptions.defaults());
   final engine = SqlEngine(EngineOptions(useDriftExtensions: true));
   final state = TestState.withContent({'a|lib/foo.drift': 'foo'});
   tearDownAll(state.close);
@@ -209,4 +210,49 @@ query: SELECT foo.**, bar.** FROM my_view foo, my_view bar;
         everyElement(isA<NestedResultTable>().having(
             (e) => e.table.displayName, 'table.displayName', 'my_view')));
   });
+
+  for (final dateTimeAsText in [false, true]) {
+    test('analyzing date times (stored as text: $dateTimeAsText)', () async {
+      final state = TestState.withContent(
+        {
+          'foo|lib/foo.drift': r'''
+CREATE TABLE foo (
+  bar DATETIME NOT NULL
+);
+
+q1: SELECT bar FROM foo;
+q2: SELECT unixepoch('now');
+q3: SELECT datetime('now');
+      ''',
+        },
+        options: DriftOptions.defaults(
+          storeDateTimeValuesAsText: dateTimeAsText,
+          sqliteAnalysisOptions: const SqliteAnalysisOptions(
+            version: SqliteVersion.v3_38,
+          ),
+        ),
+      );
+      addTearDown(state.close);
+
+      final file = await state.analyze('package:foo/foo.drift');
+      expect(file.errors.errors, isEmpty);
+
+      final result = file.currentResult as ParsedDriftFile;
+      expect(result.resolvedQueries, hasLength(3));
+
+      final q1 = result.resolvedQueries![0];
+      expect(q1.resultSet!.columns.single.type, DriftSqlType.dateTime);
+
+      final q2 = result.resolvedQueries![1];
+      final q3 = result.resolvedQueries![2];
+
+      if (dateTimeAsText) {
+        expect(q2.resultSet!.columns.single.type, DriftSqlType.int);
+        expect(q3.resultSet!.columns.single.type, DriftSqlType.dateTime);
+      } else {
+        expect(q2.resultSet!.columns.single.type, DriftSqlType.dateTime);
+        expect(q3.resultSet!.columns.single.type, DriftSqlType.string);
+      }
+    });
+  }
 }

--- a/sqlparser/lib/src/analysis/schema/from_create_table.dart
+++ b/sqlparser/lib/src/analysis/schema/from_create_table.dart
@@ -6,7 +6,14 @@ class SchemaFromCreateTable {
   /// and `DATETIME` columns.
   final bool driftExtensions;
 
-  const SchemaFromCreateTable({this.driftExtensions = false});
+  /// Whether the `DATE` column type (only respected if [driftExtensions] are
+  /// enabled) should be reported as a text column instead of an int column.
+  final bool driftUseTextForDateTime;
+
+  const SchemaFromCreateTable({
+    this.driftExtensions = false,
+    this.driftUseTextForDateTime = false,
+  });
 
   /// Reads a [Table] schema from the [stmt] inducing a table (either a
   /// [CreateTableStatement] or a [CreateVirtualTableStatement]).
@@ -154,7 +161,10 @@ class SchemaFromCreateTable {
         return const ResolvedType.bool();
       }
       if (upper.contains('DATE')) {
-        return const ResolvedType(type: BasicType.int, hint: IsDateTime());
+        return ResolvedType(
+          type: driftUseTextForDateTime ? BasicType.text : BasicType.int,
+          hint: const IsDateTime(),
+        );
       }
 
       if (upper.contains('ENUM')) {

--- a/sqlparser/lib/src/analysis/steps/linting_visitor.dart
+++ b/sqlparser/lib/src/analysis/steps/linting_visitor.dart
@@ -252,8 +252,7 @@ class LintingVisitor extends RecursiveVisitor<void, void> {
           context.reportError(
             AnalysisError(
               type: AnalysisErrorType.notSupportedInDesiredVersion,
-              message: 'The `${e.name}` function is not available in '
-                  '${options.version}.',
+              message: 'The `${e.name}` function requires sqlite 3.38 or later',
               relevantNode: e,
             ),
           );

--- a/sqlparser/lib/src/analysis/types/resolving_visitor.dart
+++ b/sqlparser/lib/src/analysis/types/resolving_visitor.dart
@@ -520,7 +520,6 @@ class TypeResolver extends RecursiveVisitor<TypeExpectation, void> {
         return _textType.withNullable(true);
       case 'date':
       case 'time':
-      case 'datetime':
       case 'julianday':
       case 'strftime':
       case 'char':
@@ -531,6 +530,8 @@ class TypeResolver extends RecursiveVisitor<TypeExpectation, void> {
       case 'sqlite_version':
       case 'typeof':
         return _textType;
+      case 'datetime':
+        return _textType.copyWith(hint: const IsDateTime(), nullable: true);
       case 'changes':
       case 'last_insert_rowid':
       case 'random':

--- a/sqlparser/test/analysis/types2/misc_cases_test.dart
+++ b/sqlparser/test/analysis/types2/misc_cases_test.dart
@@ -54,6 +54,8 @@ const Map<String, ResolvedType?> _types = {
   'SELECT SUM(id = 2) = ? FROM demo': ResolvedType(type: BasicType.int),
   "SELECT unixepoch('now') = ?":
       ResolvedType(type: BasicType.int, nullable: true, hint: IsDateTime()),
+  "SELECT datetime('now') = ?":
+      ResolvedType(type: BasicType.text, nullable: true, hint: IsDateTime()),
 };
 
 SqlEngine _spawnEngine() {


### PR DESCRIPTION
This is not nearly done yet, but this PR's description can serve as a to-do list for me :)

Todos:

- [x] Add build option to store date time values as text for a database
- [x] Support this build option in the generator
  - Infer these columns as text for SQL.
  - Respect a `IsDateTime` type-hint on text values during type inference.
- [x] Respect this option when mapping literals and variables to SQL.
- [x] Adapt the datetime APIs as extension on `Expression<DateTime>` to be aware of this option. 
- [x] Run all existing date-time tests against both modes if applicable
- [x] Documentation
  - Document build option
  - Document storing behavior in page about supported types
  - Document how to migrate between the two storage types (and test the migration snippet!)
- [x] Lint for things like `dateTime1 < dateTime2` in SQL queries when the text mode is active.

Finally fixes https://github.com/simolus3/drift/issues/286.