### PR TITLE
Prevent additional checks from failing if nullable value is null

### DIFF
--- a/drift/CHANGELOG.md
+++ b/drift/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 2.0.1
+
+- Fix an error when inserting a null value into a nullable column defined with
+  additional checks in Dart.
+
 ## 2.0.0
 
 💡: More information on how to migrate is available in the [documentation](https://drift.simonbinder.eu/docs/upgrading/).

--- a/drift/lib/src/runtime/query_builder/schema/column_impl.dart
+++ b/drift/lib/src/runtime/query_builder/schema/column_impl.dart
@@ -190,10 +190,11 @@ class GeneratedColumn<T extends Object> extends Column<T> {
     final nullOk = $nullable;
     if (!nullOk && value == null) {
       return _invalidNull;
+    } else if (nullOk && value == null) {
+      return const VerificationResult.success();
     } else {
-      // ignore: null_check_on_nullable_type_parameter
-      return additionalChecks?.call(value!, meta) ??
-          const VerificationResult.success();
+      // ignore: null_check_on_nullable_type_parameter 
+      return additionalChecks?.call(value!, meta) ?? const VerificationResult.success();
     }
   }
 

--- a/drift/lib/src/runtime/query_builder/schema/column_impl.dart
+++ b/drift/lib/src/runtime/query_builder/schema/column_impl.dart
@@ -190,11 +190,8 @@ class GeneratedColumn<T extends Object> extends Column<T> {
     final nullOk = $nullable;
     if (!nullOk && value == null) {
       return _invalidNull;
-    } else if (nullOk && value == null) {
-      return const VerificationResult.success();
     } else {
-      // ignore: null_check_on_nullable_type_parameter
-      return additionalChecks?.call(value!, meta) ??
+      return additionalChecks?.call(value, meta) ??
           const VerificationResult.success();
     }
   }

--- a/drift/lib/src/runtime/query_builder/schema/column_impl.dart
+++ b/drift/lib/src/runtime/query_builder/schema/column_impl.dart
@@ -193,8 +193,9 @@ class GeneratedColumn<T extends Object> extends Column<T> {
     } else if (nullOk && value == null) {
       return const VerificationResult.success();
     } else {
-      // ignore: null_check_on_nullable_type_parameter 
-      return additionalChecks?.call(value!, meta) ?? const VerificationResult.success();
+      // ignore: null_check_on_nullable_type_parameter
+      return additionalChecks?.call(value!, meta) ??
+          const VerificationResult.success();
     }
   }
 

--- a/drift/pubspec.yaml
+++ b/drift/pubspec.yaml
@@ -1,6 +1,6 @@
 name: drift
 description: Drift is a reactive library to store relational data in Dart and Flutter applications.
-version: 2.0.0
+version: 2.0.1
 repository: https://github.com/simolus3/drift
 homepage: https://drift.simonbinder.eu/
 issue_tracker: https://github.com/simolus3/drift/issues

--- a/drift/test/database/statements/insert_test.dart
+++ b/drift/test/database/statements/insert_test.dart
@@ -150,6 +150,14 @@ void main() {
         throwsA(isA<InvalidDataException>()),
       );
     });
+
+    test('can provide null value for column with additional checks', () async {
+      await db.todosTable.insertOne(
+          TodosTableCompanion.insert(content: 'content', title: Value(null)));
+
+      verify(executor.runInsert(
+          'INSERT INTO todos (title, content) VALUES (NULL, ?)', ['content']));
+    });
   });
 
   test('reports auto-increment id', () {


### PR DESCRIPTION
If `isAcceptableValue` is run on a nullable column with an additional check it will fail for null values, e.g.

`TextColumn get description => text().withLength(max: 250).nullable()();`

This behaviour is different from previous versions of Drift


