### PR TITLE
Fix the wrong version number on `migration_test`

### DIFF
--- a/examples/migrations_example/test/migration_test.dart
+++ b/examples/migrations_example/test/migration_test.dart
@@ -32,7 +32,7 @@ void main() {
             targetVersion <= currentSchema;
             targetVersion++) {
           test('to v$targetVersion', () async {
-            final connection = await verifier.startAt(1);
+            final connection = await verifier.startAt(oldVersion);
             final db = Database(connection);
             addTearDown(db.close);
 


### PR DESCRIPTION
It should use `oldVersion` not use `1` on every times.