### PR TITLE
Added fts5vocab module

### DIFF
--- a/sqlparser/test/engine/module/fts5_test.dart
+++ b/sqlparser/test/engine/module/fts5_test.dart
@@ -20,6 +20,48 @@ void main() {
       expect(columns.single.name, 'bar');
     });
 
+    group('creating fts5vocab tables', () {
+      final engine = SqlEngine(_fts5Options);
+
+      test('can create fts5vocab instance table', () {
+        final result = engine.analyze('CREATE VIRTUAL TABLE foo USING '
+            'fts5vocab(bar, instance)');
+
+        final table = const SchemaFromCreateTable()
+            .read(result.root as TableInducingStatement);
+
+        expect(table.name, 'foo');
+        final columns = table.resultColumns;
+        expect(columns, hasLength(4));
+        expect(columns.map((e) => e.name), contains('offset'));
+      });
+
+      test('can create fts5vocab row table', () {
+        final result = engine.analyze('CREATE VIRTUAL TABLE foo USING '
+            'fts5vocab(bar, row)');
+
+        final table = const SchemaFromCreateTable()
+            .read(result.root as TableInducingStatement);
+
+        expect(table.name, 'foo');
+        final columns = table.resultColumns;
+        expect(columns, hasLength(3));
+      });
+
+      test('can create fts5vocab col table', () {
+        final result = engine.analyze('CREATE VIRTUAL TABLE foo USING '
+            'fts5vocab(bar, col)');
+
+        final table = const SchemaFromCreateTable()
+            .read(result.root as TableInducingStatement);
+
+        expect(table.name, 'foo');
+        final columns = table.resultColumns;
+        expect(columns, hasLength(4));
+        expect(columns.map((e) => e.name), contains('col'));
+      });
+    });
+
     test('handles the UNINDEXED column option', () {
       final result = engine
           .analyze('CREATE VIRTUAL TABLE foo USING fts5(bar, baz UNINDEXED)');


### PR DESCRIPTION
Added support for the fts5vocab table (https://www.sqlite.org/fts5.html#the_fts5vocab_virtual_table_module).
The fts5vocab module is a part of FTS5 - it is available whenever FTS5 is.

Tests has been added, validating the table structures.

Let me know weather something is missing.