### PR TITLE
Expose fts5 rowid

### DIFF
--- a/drift_dev/lib/src/analyzer/errors.dart
+++ b/drift_dev/lib/src/analyzer/errors.dart
@@ -78,7 +78,7 @@ class ErrorInDartCode extends DriftError {
 }
 
 class ErrorInDriftFile extends DriftError {
-  final FileSpan span;
+  final FileSpan? span;
 
   ErrorInDriftFile(
       {required this.span,
@@ -108,7 +108,12 @@ class ErrorInDriftFile extends DriftError {
 
   @override
   void writeDescription(LogFunction log) {
-    log(span.message(message, color: isError));
+    final errorSpan = span;
+    if (errorSpan != null) {
+      log(errorSpan.message(message, color: isError));
+    } else {
+      log(message);
+    }
   }
 }
 

--- a/drift_dev/lib/src/backends/plugin/services/errors.dart
+++ b/drift_dev/lib/src/backends/plugin/services/errors.dart
@@ -42,11 +42,13 @@ class ErrorService {
   Location _findLocationForError(DriftError error, String path) {
     if (error is ErrorInDriftFile) {
       final span = error.span;
-      final start = span.start;
-      final end = span.end;
-      return Location(
-          path, start.offset, span.length, start.line + 1, start.column + 1,
-          endLine: end.line + 1, endColumn: end.column + 1);
+      if (span != null) {
+        final start = span.start;
+        final end = span.end;
+        return Location(
+            path, start.offset, span.length, start.line + 1, start.column + 1,
+            endLine: end.line + 1, endColumn: end.column + 1);
+      }
     }
 
     return Location(path, 0, 0, 0, 0);

--- a/drift_dev/lib/src/model/base_entity.dart
+++ b/drift_dev/lib/src/model/base_entity.dart
@@ -37,6 +37,9 @@ abstract class DriftEntityWithResultSet extends DriftSchemaEntity {
   @Deprecated('Use dartTypeCode instead')
   String get dartTypeName;
 
+  /// The (unescaped) name of this table when stored in the database
+  String get sqlName;
+
   /// The type name of the Dart row class for this result set.
   ///
   /// This may contain generics.

--- a/drift_dev/lib/src/model/table.dart
+++ b/drift_dev/lib/src/model/table.dart
@@ -44,7 +44,7 @@ class DriftTable extends DriftEntityWithResultSet {
   @override
   final List<DriftColumn> columns;
 
-  /// The (unescaped) name of this table when stored in the database
+  @override
   final String sqlName;
 
   /// The name for the data class associated with this table
@@ -120,7 +120,7 @@ class DriftTable extends DriftEntityWithResultSet {
   final List<String>? overrideTableConstraints;
 
   @override
-  final Set<DriftTable> references = {};
+  final Set<DriftEntityWithResultSet> references = {};
 
   /// Returns whether this table was created from a `CREATE VIRTUAL TABLE`
   /// statement in a moor file

--- a/drift_dev/lib/src/model/view.dart
+++ b/drift_dev/lib/src/model/view.dart
@@ -22,6 +22,9 @@ class MoorView extends DriftEntityWithResultSet {
   final String name;
 
   @override
+  String get sqlName => name;
+
+  @override
   List<DriftSchemaEntity> references = [];
 
   @override

--- a/drift_dev/test/analyzer/drift/create_table_reader_test.dart
+++ b/drift_dev/test/analyzer/drift/create_table_reader_test.dart
@@ -118,7 +118,7 @@ void main() {
               'message',
               allOf(contains('NotAnEnum'), contains('Not an enum')),
             )
-            .having((e) => e.span.text, 'span', 'ENUM(NotAnEnum)'),
+            .having((e) => e.span?.text, 'span', 'ENUM(NotAnEnum)'),
       ),
     );
   });

--- a/drift_dev/test/analyzer/drift/errors_when_importing_part_files_test.dart
+++ b/drift_dev/test/analyzer/drift/errors_when_importing_part_files_test.dart
@@ -43,7 +43,7 @@ void main() {
             'message',
             contains('Is it a part file?'),
           )
-          .having((e) => e.span.text, 'span.text', "import 'tables.dart';"),
+          .having((e) => e.span?.text, 'span.text', "import 'tables.dart';"),
     );
   });
 }

--- a/drift_dev/test/analyzer/drift/fts5_test.dart
+++ b/drift_dev/test/analyzer/drift/fts5_test.dart
@@ -1,0 +1,92 @@
+import 'package:drift_dev/src/analyzer/errors.dart';
+import 'package:drift_dev/src/analyzer/options.dart';
+import 'package:test/test.dart';
+
+import '../utils.dart';
+
+const _options = DriftOptions.defaults(modules: [SqlModule.fts5]);
+
+void main() {
+  group('reports error', () {
+    test('for missing content table', () async {
+      final state = TestState.withContent({
+        'a|lib/main.drift': '''
+CREATE VIRTUAL TABLE fts USING fts5(a, c, content=tbl);
+''',
+      }, options: _options);
+      addTearDown(state.close);
+
+      final result = await state.analyze('package:a/main.drift');
+      expect(result.errors.errors, [
+        const TypeMatcher<ErrorInDriftFile>().having(
+          (e) => e.message,
+          'message',
+          contains('Content table `tbl` could not be found'),
+        ),
+      ]);
+    });
+
+    test('for invalid rowid of content table', () async {
+      final state = TestState.withContent({
+        'a|lib/main.drift': '''
+CREATE TABLE tbl (a, b, c, my_pk INTEGER PRIMARY KEY);
+
+CREATE VIRTUAL TABLE fts USING fts5(a, c, content=tbl, content_rowid=d);
+''',
+      }, options: _options);
+      addTearDown(state.close);
+
+      final result = await state.analyze('package:a/main.drift');
+      expect(result.errors.errors, [
+        const TypeMatcher<ErrorInDriftFile>().having(
+          (e) => e.message,
+          'message',
+          contains(
+            'no column `d`, but this fts5 table is declared to use it as a row '
+            'id',
+          ),
+        ),
+      ]);
+    });
+
+    test('when referencing an unknown column', () async {
+      final state = TestState.withContent({
+        'a|lib/main.drift': '''
+CREATE TABLE tbl (a, b, c, d INTEGER PRIMARY KEY);
+
+CREATE VIRTUAL TABLE fts USING fts5(e, c, content=tbl, content_rowid=d);
+''',
+      }, options: _options);
+      addTearDown(state.close);
+
+      final result = await state.analyze('package:a/main.drift');
+      expect(result.errors.errors, [
+        const TypeMatcher<ErrorInDriftFile>().having(
+          (e) => e.message,
+          'message',
+          contains('no column `e`, but this fts5 table references it'),
+        ),
+      ]);
+    });
+  });
+
+  test('finds referenced table', () async {
+    final state = TestState.withContent({
+      'a|lib/main.drift': '''
+CREATE TABLE tbl (a, b, c, d INTEGER PRIMARY KEY);
+
+CREATE VIRTUAL TABLE fts USING fts5(a, c, content=tbl, content_rowid=d);
+CREATE VIRTUAL TABLE fts2 USING fts5(a, c, content=tbl, content_rowid=rowid);
+''',
+    }, options: _options);
+    addTearDown(state.close);
+
+    final result = await state.analyze('package:a/main.drift');
+    expect(result.errors.errors, isEmpty);
+    final tables = result.currentResult!.declaredTables.toList();
+
+    expect(tables, hasLength(3));
+    expect(tables[1].references, contains(tables[0]));
+    expect(tables[2].references, contains(tables[0]));
+  });
+}

--- a/drift_dev/test/analyzer/drift/moor_ffi_extension_test.dart
+++ b/drift_dev/test/analyzer/drift/moor_ffi_extension_test.dart
@@ -117,7 +117,7 @@ wrongArgs: SELECT sin(oid, foo) FROM numbers;
     final fileB = await state.analyze('package:foo/b.moor');
     expect(fileB.errors.errors, [
       const TypeMatcher<ErrorInDriftFile>()
-          .having((e) => e.span.text, 'span.text', 'sin(oid, foo)')
+          .having((e) => e.span?.text, 'span.text', 'sin(oid, foo)')
     ]);
   });
 }

--- a/sqlparser/lib/sqlparser.dart
+++ b/sqlparser/lib/sqlparser.dart
@@ -4,7 +4,7 @@ library sqlparser;
 export 'src/analysis/analysis.dart';
 export 'src/analysis/types/join_analysis.dart';
 export 'src/ast/ast.dart';
-export 'src/engine/module/fts5.dart' show Fts5Extension;
+export 'src/engine/module/fts5.dart' show Fts5Extension, Fts5Table;
 export 'src/engine/module/json1.dart' show Json1Extension;
 export 'src/engine/module/math.dart' show BuiltInMathExtension;
 export 'src/engine/module/rtree.dart' show RTreeExtension;

--- a/sqlparser/lib/src/analysis/schema/table.dart
+++ b/sqlparser/lib/src/analysis/schema/table.dart
@@ -54,11 +54,16 @@ class Table extends NamedResultSet with HasMetaMixin implements HumanReadable {
     for (final column in resolvedColumns) {
       column.table = this;
 
-      if (_rowIdColumn == null && column.isAliasForRowId()) {
-        _rowIdColumn = column;
-        // By design, the rowid is non-nullable, even if there isn't a NOT NULL
-        // constraint set on the column definition.
-        column._type = const ResolvedType(type: BasicType.int, nullable: false);
+      if (_rowIdColumn == null) {
+        if (column is RowId) {
+          _rowIdColumn = column;
+        } else if (column.isAliasForRowId()) {
+          _rowIdColumn = column;
+          // By design, the rowid is non-nullable, even if there isn't a NOT NULL
+          // constraint set on the column definition.
+          column._type =
+              const ResolvedType(type: BasicType.int, nullable: false);
+        }
       }
     }
   }

--- a/sqlparser/lib/src/engine/module/fts5.dart
+++ b/sqlparser/lib/src/engine/module/fts5.dart
@@ -28,6 +28,8 @@ class _Fts5Module extends Module {
     return _Fts5Table(
       name: stmt.tableName,
       columns: [
+        if (stmt.argumentContent.any((arg) => arg.startsWith('content_rowid')))
+          TableColumn('rowid', const ResolvedType(type: BasicType.int)),
         for (var arg in columnNames)
           TableColumn(arg, const ResolvedType(type: BasicType.text)),
       ],

--- a/sqlparser/test/engine/module/fts5_test.dart
+++ b/sqlparser/test/engine/module/fts5_test.dart
@@ -20,6 +20,19 @@ void main() {
       expect(columns.single.name, 'bar');
     });
 
+    test('can create fts5 tables with content table', () {
+      final result = engine.analyze('CREATE VIRTUAL TABLE foo USING '
+          "fts5(bar , tokenize = 'porter ascii',content=tbl, content_rowid=d)");
+
+      final table = const SchemaFromCreateTable()
+          .read(result.root as TableInducingStatement);
+
+      expect(table.name, 'foo');
+      final columns = table.resultColumns;
+      expect(columns, hasLength(2));
+      expect(columns.first.name, 'rowid');
+    });
+
     group('creating fts5vocab tables', () {
       final engine = SqlEngine(_fts5Options);
 

--- a/sqlparser/test/engine/module/fts5_test.dart
+++ b/sqlparser/test/engine/module/fts5_test.dart
@@ -28,9 +28,16 @@ void main() {
           .read(result.root as TableInducingStatement);
 
       expect(table.name, 'foo');
-      final columns = table.resultColumns;
-      expect(columns, hasLength(2));
-      expect(columns.first.name, 'rowid');
+      expect(table.resultColumns,
+          [isA<Column>().having((c) => c.name, 'name', 'bar')]);
+      expect(table.findColumn('oid'), isA<RowId>());
+
+      expect(
+        table,
+        isA<Fts5Table>()
+            .having((e) => e.contentTable, 'contentTable', 'tbl')
+            .having((e) => e.contentRowId, 'contentRowId', 'd'),
+      );
     });
 
     group('creating fts5vocab tables', () {

--- a/sqlparser/test/engine/module/fts5_test.dart
+++ b/sqlparser/test/engine/module/fts5_test.dart
@@ -18,6 +18,12 @@ void main() {
       final columns = table.resultColumns;
       expect(columns, hasLength(1));
       expect(columns.single.name, 'bar');
+      expect(
+        table,
+        isA<Fts5Table>()
+            .having((e) => e.contentTable, 'contentTable', null)
+            .having((e) => e.contentRowId, 'contentRowId', null),
+      );
     });
 
     test('can create fts5 tables with content table', () {
@@ -37,6 +43,51 @@ void main() {
         isA<Fts5Table>()
             .having((e) => e.contentTable, 'contentTable', 'tbl')
             .having((e) => e.contentRowId, 'contentRowId', 'd'),
+      );
+    });
+
+    test('does clean option values', () {
+      final result = engine.analyze('CREATE VIRTUAL TABLE foo USING '
+          "fts5(bar , tokenize = 'porter ascii', content='tbl', content_rowid='d')");
+
+      final table = const SchemaFromCreateTable()
+          .read(result.root as TableInducingStatement);
+
+      expect(
+        table,
+        isA<Fts5Table>()
+            .having((e) => e.contentTable, 'contentTable', 'tbl')
+            .having((e) => e.contentRowId, 'contentRowId', 'd'),
+      );
+    });
+
+    test('detects empty content table', () {
+      final result = engine.analyze('CREATE VIRTUAL TABLE foo USING '
+          "fts5(bar , tokenize = 'porter ascii',content='', content_rowid='d')");
+
+      final table = const SchemaFromCreateTable()
+          .read(result.root as TableInducingStatement);
+
+      expect(
+        table,
+        isA<Fts5Table>()
+            .having((e) => e.contentTable, 'contentTable', null)
+            .having((e) => e.contentRowId, 'contentRowId', null),
+      );
+    });
+
+    test('content table undefined rowid falls back', () {
+      final result = engine.analyze('CREATE VIRTUAL TABLE foo USING '
+          "fts5(bar , tokenize = 'porter ascii',content='tbl')");
+
+      final table = const SchemaFromCreateTable()
+          .read(result.root as TableInducingStatement);
+
+      expect(
+        table,
+        isA<Fts5Table>()
+            .having((e) => e.contentTable, 'contentTable', 'tbl')
+            .having((e) => e.contentRowId, 'contentRowId', 'rowid'),
       );
     });
 


### PR DESCRIPTION
Expose `rowid` of fts5 table when created with external content table (https://www.sqlite.org/fts5.html#external_content_tables).
We need the `rowid` for every insert here, and probably also for other queries.