### PR TITLE
Prepare for separating ClassElement, EnumElement, and MixinElement.

### DIFF
--- a/drift_dev/lib/src/analyzer/drift/find_dart_class.dart
+++ b/drift_dev/lib/src/analyzer/drift/find_dart_class.dart
@@ -23,7 +23,7 @@ Future<FoundDartClass?> findDartClass(
     }
 
     final foundElement = library.exportNamespace.get(identifier);
-    if (foundElement is ClassElement) {
+    if (foundElement is InterfaceElement) {
       return FoundDartClass(foundElement, null);
     } else if (foundElement is TypeAliasElement) {
       final innerType = foundElement.aliasedType;

--- a/drift_dev/lib/src/analyzer/helper.dart
+++ b/drift_dev/lib/src/analyzer/helper.dart
@@ -22,13 +22,13 @@ class HelperLibrary {
   /// Returns `null` if [type] is not a subtype of `TypeConverter`.
   InterfaceType? asTypeConverter(DartType type) {
     final converter =
-        helperLibrary.exportNamespace.get('TypeConverter') as ClassElement;
+        helperLibrary.exportNamespace.get('TypeConverter') as InterfaceElement;
     return type.asInstanceOf(converter);
   }
 
   bool isJsonAwareTypeConverter(DartType? type, LibraryElement context) {
-    final jsonMixin =
-        helperLibrary.exportNamespace.get('JsonTypeConverter') as ClassElement;
+    final jsonMixin = helperLibrary.exportNamespace.get('JsonTypeConverter')
+        as InterfaceElement;
     final jsonConverterType = jsonMixin.instantiate(
       typeArguments: [
         context.typeProvider.dynamicType,

--- a/drift_dev/lib/src/analyzer/runner/steps/parse_dart.dart
+++ b/drift_dev/lib/src/analyzer/runner/steps/parse_dart.dart
@@ -122,15 +122,18 @@ class ParseDartStep extends Step {
   Future<List<DriftTable>> parseTables(
       Iterable<DartType> types, Element initializedBy) {
     return Future.wait(types.map((type) {
-      if (!_tableTypeChecker.isAssignableFromType(type)) {
+      final element = type is InterfaceType ? type.element2 : null;
+
+      if (!_tableTypeChecker.isAssignableFromType(type) ||
+          element is! ClassElement) {
         reportError(ErrorInDartCode(
           severity: Severity.criticalError,
-          message: 'The type $type is not a moor table',
+          message: 'The type $type is not a drift table class.',
           affectedElement: initializedBy,
         ));
         return Future.value(null);
       } else {
-        return _parseTable((type as InterfaceType).element2 as ClassElement);
+        return _parseTable(element);
       }
     })).then((list) {
       // only keep tables that were resolved successfully
@@ -145,16 +148,18 @@ class ParseDartStep extends Step {
   Future<List<MoorView>> parseViews(Iterable<DartType> types,
       Element initializedBy, List<DriftTable> tables) {
     return Future.wait(types.map((type) {
-      if (!_viewTypeChecker.isAssignableFromType(type)) {
+      final element = type is InterfaceType ? type.element2 : null;
+
+      if (!_viewTypeChecker.isAssignableFromType(type) ||
+          element is! ClassElement) {
         reportError(ErrorInDartCode(
           severity: Severity.criticalError,
-          message: 'The type $type is not a drift view',
+          message: 'The type $type is not a drift view class.',
           affectedElement: initializedBy,
         ));
         return Future.value(null);
       } else {
-        return _parseView(
-            (type as InterfaceType).element2 as ClassElement, tables);
+        return _parseView(element, tables);
       }
     })).then((list) {
       // only keep tables that were resolved successfully


### PR DESCRIPTION
All three implement InterfaceElement, but in the breaking change for analyzer we will stop implementing ClassElement in EnumElement and MixinElement. This is a minimal change necessary to make google3 green, the might be need for more changes that are not exercised there.