### PR TITLE
Generated functions for returning queries return Iterable<_> instead of List<_>

### DIFF
--- a/drift_dev/lib/src/writer/queries/query_writer.dart
+++ b/drift_dev/lib/src/writer/queries/query_writer.dart
@@ -218,11 +218,11 @@ class QueryWriter {
     if (update.needsAsyncMapping) {
       _buffer.write('Future.wait(rows.map(');
       _writeMappingLambda(update);
-      _buffer.write('))');
+      _buffer.write(')).toList()');
     } else {
       _buffer.write('rows.map(');
       _writeMappingLambda(update);
-      _buffer.write(')');
+      _buffer.write(').toList()');
     }
     _buffer.write(');\n}');
   }

--- a/drift_dev/lib/src/writer/queries/query_writer.dart
+++ b/drift_dev/lib/src/writer/queries/query_writer.dart
@@ -218,7 +218,7 @@ class QueryWriter {
     if (update.needsAsyncMapping) {
       _buffer.write('Future.wait(rows.map(');
       _writeMappingLambda(update);
-      _buffer.write(')).toList()');
+      _buffer.write('))');
     } else {
       _buffer.write('rows.map(');
       _writeMappingLambda(update);

--- a/drift_dev/test/writer/queries/query_writer_test.dart
+++ b/drift_dev/test/writer/queries/query_writer_test.dart
@@ -82,6 +82,27 @@ void main() {
     );
   });
 
+  test('generates correct returning mapping', () async {
+    final state = TestState.withContent({
+      'a|lib/main.moor': '''
+        CREATE TABLE tbl (
+          id INTEGER NULL
+        );
+
+        query: INSERT INTO tbl (id) VALUES(10) RETURNING id;
+      ''',
+    });
+    addTearDown(state.close);
+
+    final file = await state.analyze('package:a/main.moor');
+    final fileState = file.currentResult as ParsedDriftFile;
+
+    final writer = Writer(const DriftOptions.defaults());
+    QueryWriter(writer.child()).write(fileState.resolvedQueries!.single);
+
+    expect(writer.writeGenerated(), contains('.toList()'));
+  });
+
   group('generates correct code for expanded arrays', () {
     late TestState state;
 

--- a/drift_dev/test/writer/queries/query_writer_test.dart
+++ b/drift_dev/test/writer/queries/query_writer_test.dart
@@ -86,10 +86,11 @@ void main() {
     final state = TestState.withContent({
       'a|lib/main.moor': '''
         CREATE TABLE tbl (
-          id INTEGER NULL
+          id INTEGER,
+          text TEXT
         );
 
-        query: INSERT INTO tbl (id) VALUES(10) RETURNING id;
+        query: INSERT INTO tbl (id, text) VALUES(10, "test") RETURNING id;
       ''',
     });
     addTearDown(state.close);


### PR DESCRIPTION
After I upgraded to version 2.1.0 I found the following error:
```
 Error: A value of type 'Iterable<int>' can't be returned from a function with return type 'FutureOr<List<int>>'.
 - 'Iterable' is from 'dart:core'.
 - 'List' is from 'dart:core'.
        }).then((rows) => rows.map((QueryRow row) => row.read<int>('id')));
```

This error is caused by the generated code from returning queries. For example this simple query would generate the following code: 
```
query: INSERT INTO tbl (id) VALUES(10) RETURNING id;
```
```dart 
Future<List<TblData>> query() {
  return customWriteReturning(
    'INSERT INTO tbl (id) VALUES (10) RETURNING id',
    variables: [],
    updates: {tbl}
  ).then((rows) => Future.wait(rows.map(tbl.mapFromRow)));
}
```
And because the `map` function returns an iterable instead of a list the types are not compatible. To fix this I just added a `toList`call in this pull request.

Hope this is helpful :) 