### PR TITLE
fix DatabaseConnection invoke

### DIFF
--- a/examples/app/lib/database/connection/native.dart
+++ b/examples/app/lib/database/connection/native.dart
@@ -53,7 +53,7 @@ void _entrypointForDriftIsolate(_IsolateStartRequest request) {
   // We can use DriftIsolate.inCurrent because this function is the entrypoint
   // of a background isolate itself.
   final driftServer =
-      DriftIsolate.inCurrent(() => DatabaseConnection(databaseImpl));
+      DriftIsolate.inCurrent(() => DatabaseConnection.fromExecutor(databaseImpl));
 
   // Inform the main isolate about the server we just created.
   request.talkToMain.send(driftServer);


### PR DESCRIPTION
if we call DatabaseConnection( ) it need 3 parameters by default so the compiler report this error . So we need to use the fromExecutor constructor if we want to give it one parameter.