### PR TITLE
Add isInValues and isNotInValues

### DIFF
--- a/drift/CHANGELOG.md
+++ b/drift/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 - Add the `JsonTypeConverter2` mixin. It behaves similar to the existing json
   type converters, but can use a different SQL and JSON type.
+- Add `isInValues` and `isNotInValues` methods to columns with type converters.
+  They can be used to compare the column against a list of Dart expressions that
+  will be mapped through a type converter.
 
 ## 2.2.0
 

--- a/drift/lib/src/runtime/query_builder/schema/column_impl.dart
+++ b/drift/lib/src/runtime/query_builder/schema/column_impl.dart
@@ -287,10 +287,7 @@ class GeneratedColumnWithTypeConverter<D, S extends Object>
           check: check,
         );
 
-  /// Compares this column against the mapped [dartValue].
-  ///
-  /// The value will be mapped using the [converter] applied to this column.
-  Expression<bool> equalsValue(D? dartValue) {
+  S? _mapDartValue(D? dartValue) {
     S? mappedValue;
 
     if ($nullable) {
@@ -311,7 +308,31 @@ class GeneratedColumnWithTypeConverter<D, S extends Object>
           "This non-nullable column can't be equal to `null`.", 'dartValue');
     }
 
+    return mappedValue;
+  }
+
+  /// Compares this column against the mapped [dartValue].
+  ///
+  /// The value will be mapped using the [converter] applied to this column.
+  Expression<bool> equalsValue(D? dartValue) {
+    final mappedValue = _mapDartValue(dartValue);
     return mappedValue == null ? this.isNull() : equals(mappedValue);
+  }
+
+  /// An expression that is true if `this` resolves to any of the values in
+  /// [values].
+  ///
+  /// The values will be mapped using the [converter] applied to this column.
+  Expression<bool> isInValues(Iterable<D> values) {
+    return isIn(values.map(_mapDartValue).whereNotNull());
+  }
+
+  /// An expression that is true if `this` does not resolve to any of the values
+  /// in [values].
+  ///
+  /// The values will be mapped using the [converter] applied to this column.
+  Expression<bool> isNotInValues(Iterable<D> values) {
+    return isNotIn(values.map(_mapDartValue).whereNotNull());
   }
 }
 

--- a/drift/lib/src/runtime/query_builder/schema/column_impl.dart
+++ b/drift/lib/src/runtime/query_builder/schema/column_impl.dart
@@ -323,12 +323,12 @@ class GeneratedColumnWithTypeConverter<D, S extends Object>
   /// [values].
   ///
   /// The values will be mapped using the [converter] applied to this column.
-  Expression<bool> isInValues(Iterable<D> values, {bool ignoreNulls = false}) {
+  Expression<bool> isInValues(Iterable<D> values) {
     final mappedValues = values.map(_mapDartValue);
     final result = isIn(mappedValues.whereNotNull());
 
     final hasNulls = mappedValues.any((e) => e == null);
-    if (hasNulls && !ignoreNulls) return result | this.isNull();
+    if (hasNulls) return result | this.isNull();
 
     return result & this.isNotNull();
   }
@@ -337,12 +337,12 @@ class GeneratedColumnWithTypeConverter<D, S extends Object>
   /// in [values].
   ///
   /// The values will be mapped using the [converter] applied to this column.
-  Expression<bool> isNotInValues(Iterable<D> values, {bool ignoreNulls = false}) {
+  Expression<bool> isNotInValues(Iterable<D> values) {
     final mappedValues = values.map(_mapDartValue);
     final result = isNotIn(mappedValues.whereNotNull());
 
     final hasNulls = mappedValues.any((e) => e == null);
-    if (hasNulls && !ignoreNulls) return result & this.isNotNull();
+    if (hasNulls) return result & this.isNotNull();
 
     return result | this.isNull();
   }

--- a/drift/lib/src/runtime/query_builder/schema/column_impl.dart
+++ b/drift/lib/src/runtime/query_builder/schema/column_impl.dart
@@ -323,16 +323,28 @@ class GeneratedColumnWithTypeConverter<D, S extends Object>
   /// [values].
   ///
   /// The values will be mapped using the [converter] applied to this column.
-  Expression<bool> isInValues(Iterable<D> values) {
-    return isIn(values.map(_mapDartValue).whereNotNull());
+  Expression<bool> isInValues(Iterable<D> values, {bool ignoreNulls = false}) {
+    final mappedValues = values.map(_mapDartValue);
+    final result = isIn(mappedValues.whereNotNull());
+
+    final hasNulls = mappedValues.any((e) => e == null);
+    if (hasNulls && !ignoreNulls) return result | this.isNull();
+
+    return result & this.isNotNull();
   }
 
   /// An expression that is true if `this` does not resolve to any of the values
   /// in [values].
   ///
   /// The values will be mapped using the [converter] applied to this column.
-  Expression<bool> isNotInValues(Iterable<D> values) {
-    return isNotIn(values.map(_mapDartValue).whereNotNull());
+  Expression<bool> isNotInValues(Iterable<D> values, {bool ignoreNulls = false}) {
+    final mappedValues = values.map(_mapDartValue);
+    final result = isNotIn(mappedValues.whereNotNull());
+
+    final hasNulls = mappedValues.any((e) => e == null);
+    if (hasNulls && !ignoreNulls) return result & this.isNotNull();
+
+    return result | this.isNull();
   }
 }
 

--- a/drift/test/database/expressions/column_test.dart
+++ b/drift/test/database/expressions/column_test.dart
@@ -1,0 +1,84 @@
+import 'package:mockito/mockito.dart';
+import 'package:test/test.dart';
+
+import '../../generated/converter.dart';
+import '../../generated/custom_tables.dart';
+import '../../test_utils/test_utils.dart';
+
+const _createConfig = 'CREATE TABLE IF NOT EXISTS "config" ('
+    '"config_key" TEXT not null primary key, '
+    '"config_value" TEXT, '
+    '"sync_state" INTEGER, '
+    '"sync_state_implicit" INTEGER) STRICT;';
+
+void main() {
+  // see ../data/tables/tables.drift
+  late MockExecutor mock;
+  late CustomTablesDb db;
+
+  setUp(() {
+    mock = MockExecutor();
+    db = CustomTablesDb(mock);
+  });
+
+  tearDown(() => db.close());
+
+  test('creates everything as specified in .drift files', () async {
+    await db.createMigrator().createAll();
+
+    verify(mock.runCustom(_createConfig, []));
+  });
+
+  test('isInValues', () async {
+    expect(
+      db.select(db.config)
+        ..where((tbl) => tbl.syncState.isInValues([
+              SyncType.synchronized,
+              SyncType.locallyCreated,
+            ])),
+      generates('SELECT * FROM "config" WHERE "sync_state" IN (?, ?) AND "sync_state" IS NOT NULL', [
+        ConfigTable.$converter0.toSql(SyncType.synchronized),
+        ConfigTable.$converter0.toSql(SyncType.locallyCreated),
+      ]),
+    );
+    expect(
+      db.select(db.config)
+        ..where((tbl) => tbl.syncState.isInValues([
+              SyncType.synchronized,
+              SyncType.locallyCreated,
+              null,
+            ])),
+      generates('SELECT * FROM "config" WHERE "sync_state" IN (?, ?) OR "sync_state" IS NULL', [
+        ConfigTable.$converter0.toSql(SyncType.synchronized),
+        ConfigTable.$converter0.toSql(SyncType.locallyCreated),
+      ]),
+    );
+  });
+
+  test('isNotInValues', () async {
+    expect(
+      db.select(db.config)
+        ..where((tbl) => tbl.syncState.isNotInValues([
+              SyncType.synchronized,
+              SyncType.locallyCreated,
+            ])),
+      generates('SELECT * FROM "config" WHERE "sync_state" NOT IN (?, ?) OR "sync_state" IS NULL', [
+        ConfigTable.$converter0.toSql(SyncType.synchronized),
+        ConfigTable.$converter0.toSql(SyncType.locallyCreated),
+      ]),
+    );
+
+    expect(
+      db.select(db.config)
+        ..where((tbl) => tbl.syncState.isNotInValues([
+              SyncType.synchronized,
+              SyncType.locallyCreated,
+              null,
+            ])),
+      generates('SELECT * FROM "config" WHERE "sync_state" NOT IN (?, ?) AND "sync_state" IS NOT NULL', [
+        ConfigTable.$converter0.toSql(SyncType.synchronized),
+        ConfigTable.$converter0.toSql(SyncType.locallyCreated),
+      ]),
+    );
+  });
+}

--- a/drift/test/database/expressions/column_test.dart
+++ b/drift/test/database/expressions/column_test.dart
@@ -36,10 +36,12 @@ void main() {
               SyncType.synchronized,
               SyncType.locallyCreated,
             ])),
-      generates('SELECT * FROM "config" WHERE "sync_state" IN (?, ?) AND "sync_state" IS NOT NULL', [
-        ConfigTable.$converter0.toSql(SyncType.synchronized),
-        ConfigTable.$converter0.toSql(SyncType.locallyCreated),
-      ]),
+      generates(
+          'SELECT * FROM "config" WHERE "sync_state" IN (?, ?) AND "sync_state" IS NOT NULL',
+          [
+            ConfigTable.$converter0.toSql(SyncType.synchronized),
+            ConfigTable.$converter0.toSql(SyncType.locallyCreated),
+          ]),
     );
     expect(
       db.select(db.config)
@@ -48,10 +50,12 @@ void main() {
               SyncType.locallyCreated,
               null,
             ])),
-      generates('SELECT * FROM "config" WHERE "sync_state" IN (?, ?) OR "sync_state" IS NULL', [
-        ConfigTable.$converter0.toSql(SyncType.synchronized),
-        ConfigTable.$converter0.toSql(SyncType.locallyCreated),
-      ]),
+      generates(
+          'SELECT * FROM "config" WHERE "sync_state" IN (?, ?) OR "sync_state" IS NULL',
+          [
+            ConfigTable.$converter0.toSql(SyncType.synchronized),
+            ConfigTable.$converter0.toSql(SyncType.locallyCreated),
+          ]),
     );
   });
 
@@ -62,10 +66,12 @@ void main() {
               SyncType.synchronized,
               SyncType.locallyCreated,
             ])),
-      generates('SELECT * FROM "config" WHERE "sync_state" NOT IN (?, ?) OR "sync_state" IS NULL', [
-        ConfigTable.$converter0.toSql(SyncType.synchronized),
-        ConfigTable.$converter0.toSql(SyncType.locallyCreated),
-      ]),
+      generates(
+          'SELECT * FROM "config" WHERE "sync_state" NOT IN (?, ?) OR "sync_state" IS NULL',
+          [
+            ConfigTable.$converter0.toSql(SyncType.synchronized),
+            ConfigTable.$converter0.toSql(SyncType.locallyCreated),
+          ]),
     );
 
     expect(
@@ -75,10 +81,12 @@ void main() {
               SyncType.locallyCreated,
               null,
             ])),
-      generates('SELECT * FROM "config" WHERE "sync_state" NOT IN (?, ?) AND "sync_state" IS NOT NULL', [
-        ConfigTable.$converter0.toSql(SyncType.synchronized),
-        ConfigTable.$converter0.toSql(SyncType.locallyCreated),
-      ]),
+      generates(
+          'SELECT * FROM "config" WHERE "sync_state" NOT IN (?, ?) AND "sync_state" IS NOT NULL',
+          [
+            ConfigTable.$converter0.toSql(SyncType.synchronized),
+            ConfigTable.$converter0.toSql(SyncType.locallyCreated),
+          ]),
     );
   });
 }

--- a/drift/test/database/expressions/column_test.dart
+++ b/drift/test/database/expressions/column_test.dart
@@ -1,15 +1,8 @@
-import 'package:mockito/mockito.dart';
 import 'package:test/test.dart';
 
 import '../../generated/converter.dart';
 import '../../generated/custom_tables.dart';
 import '../../test_utils/test_utils.dart';
-
-const _createConfig = 'CREATE TABLE IF NOT EXISTS "config" ('
-    '"config_key" TEXT not null primary key, '
-    '"config_value" TEXT, '
-    '"sync_state" INTEGER, '
-    '"sync_state_implicit" INTEGER) STRICT;';
 
 void main() {
   // see ../data/tables/tables.drift
@@ -22,12 +15,6 @@ void main() {
   });
 
   tearDown(() => db.close());
-
-  test('creates everything as specified in .drift files', () async {
-    await db.createMigrator().createAll();
-
-    verify(mock.runCustom(_createConfig, []));
-  });
 
   test('isInValues', () async {
     expect(

--- a/drift/test/integration_tests/drift_files_test.dart
+++ b/drift/test/integration_tests/drift_files_test.dart
@@ -241,7 +241,9 @@ void main() {
           ..where((tbl) => tbl.syncState.equalsValue(SyncType.synchronized)))
         .getSingleOrNull();
 
-    verify(mock.runSelect('SELECT * FROM "config" WHERE "sync_state" = ?;',
+    verify(mock.runSelect(
+        'SELECT * FROM "config" WHERE '
+        '"sync_state" IS NOT NULL AND "sync_state" = ?;',
         [ConfigTable.$converter0.toSql(SyncType.synchronized)]));
   });
 }


### PR DESCRIPTION
Adds `isInValues` and `isNotInValues` extensions.

If the value is `null` it currently gets ignored. I'm not sure of the correct way to handle `null` in that case.