### PR TITLE
Add the `column_name_case` option

### DIFF
--- a/docs/pages/docs/Advanced Features/builder_options.md
+++ b/docs/pages/docs/Advanced Features/builder_options.md
@@ -72,7 +72,7 @@ At the moment, drift supports these options:
 * `store_date_time_values_as_text`: Whether date-time columns should be stored as ISO 8601 string instead of a unix timestamp.
   For more information on these modes, see [datetime options]({{ '../Getting started/advanced_dart_tables#datetime-options' | pageUrl }}).
 * `column_name_case` (defaults to `snake_case`): Controls how the column names are re-cased from the Dart identifiers.
-  The possible values are  `preserve`, `camel_case`, `CONSTANT_CASE`, `snake_case`, `PascalCase`, `lowercase` and `UPPERCASE` (default: `snake_case`).
+  The possible values are  `preserve`, `camelCase`, `CONSTANT_CASE`, `snake_case`, `PascalCase`, `lowercase` and `UPPERCASE` (default: `snake_case`).
 
 ## Assumed SQL environment
 

--- a/docs/pages/docs/Advanced Features/builder_options.md
+++ b/docs/pages/docs/Advanced Features/builder_options.md
@@ -71,7 +71,7 @@ At the moment, drift supports these options:
   Dart placeholders.
 * `store_date_time_values_as_text`: Whether date-time columns should be stored as ISO 8601 string instead of a unix timestamp.
   For more information on these modes, see [datetime options]({{ '../Getting started/advanced_dart_tables#datetime-options' | pageUrl }}).
-* `case_from_dart_to_sql` (defaults to `snake_case`): Controls how the table and column  names are re-cased from the Dart identifiers.
+* `case_from_dart_to_sql` (defaults to `snake_case`): Controls how the table and column names are re-cased from the Dart identifiers.
   The possible values are  `preserve`, `camelCase`, `CONSTANT_CASE`, `snake_case`, `PascalCase`, `lowercase` and `UPPERCASE` (default: `snake_case`).
 
 ## Assumed SQL environment

--- a/docs/pages/docs/Advanced Features/builder_options.md
+++ b/docs/pages/docs/Advanced Features/builder_options.md
@@ -71,7 +71,7 @@ At the moment, drift supports these options:
   Dart placeholders.
 * `store_date_time_values_as_text`: Whether date-time columns should be stored as ISO 8601 string instead of a unix timestamp.
   For more information on these modes, see [datetime options]({{ '../Getting started/advanced_dart_tables#datetime-options' | pageUrl }}).
-* `column_name_case` (defaults to `snake_case`): Controls how the column names are re-cased from the Dart identifiers.
+* `case_from_dart_to_sql` (defaults to `snake_case`): Controls how the table and column  names are re-cased from the Dart identifiers.
   The possible values are  `preserve`, `camelCase`, `CONSTANT_CASE`, `snake_case`, `PascalCase`, `lowercase` and `UPPERCASE` (default: `snake_case`).
 
 ## Assumed SQL environment

--- a/docs/pages/docs/Advanced Features/builder_options.md
+++ b/docs/pages/docs/Advanced Features/builder_options.md
@@ -71,6 +71,8 @@ At the moment, drift supports these options:
   Dart placeholders.
 * `store_date_time_values_as_text`: Whether date-time columns should be stored as ISO 8601 string instead of a unix timestamp.
   For more information on these modes, see [datetime options]({{ '../Getting started/advanced_dart_tables#datetime-options' | pageUrl }}).
+* `column_name_case` (defaults to `snake_case`): Controls how the column names are re-cased from the Dart identifiers.
+  The possible values are  `preserve`, `camel_case`, `CONSTANT_CASE`, `snake_case`, `PascalCase`, `lowercase` and `UPPERCASE` (default: `snake_case`).
 
 ## Assumed SQL environment
 

--- a/drift_dev/CHANGELOG.md
+++ b/drift_dev/CHANGELOG.md
@@ -1,10 +1,7 @@
-## 2.5.0-dev
-
-- Adds the `column_name_case` option with the possible values: `preserve`, `camelCase`, `CONSTANT_CASE`, `snake_case`, `PascalCase`, `lowercase` and `UPPERCASE` (default: `snake_case`).
-
 ## 2.4.0-dev
 
 - Add the support for `textEnum`.
+- Adds the `column_name_case` option with the possible values: `preserve`, `camelCase`, `CONSTANT_CASE`, `snake_case`, `PascalCase`, `lowercase` and `UPPERCASE` (default: `snake_case`).
 
 ## 2.3.2
 

--- a/drift_dev/CHANGELOG.md
+++ b/drift_dev/CHANGELOG.md
@@ -1,6 +1,6 @@
 ## 2.5.0-dev
 
-- Adds the `column_name_case` option with the possible values: `preserve`, `camel_case`, `CONSTANT_CASE`, `snake_case`, `PascalCase`, `lowercase` and `UPPERCASE` (default: `snake_case`).
+- Adds the `column_name_case` option with the possible values: `preserve`, `camelCase`, `CONSTANT_CASE`, `snake_case`, `PascalCase`, `lowercase` and `UPPERCASE` (default: `snake_case`).
 
 ## 2.4.0-dev
 

--- a/drift_dev/CHANGELOG.md
+++ b/drift_dev/CHANGELOG.md
@@ -1,7 +1,7 @@
 ## 2.4.0-dev
 
 - Add the support for `textEnum`.
-- Adds the `column_name_case` option with the possible values: `preserve`, `camelCase`, `CONSTANT_CASE`, `snake_case`, `PascalCase`, `lowercase` and `UPPERCASE` (default: `snake_case`).
+- Adds the `case_from_dart_to_sql` option with the possible values: `preserve`, `camelCase`, `CONSTANT_CASE`, `snake_case`, `PascalCase`, `lowercase` and `UPPERCASE` (default: `snake_case`).
 
 ## 2.3.2
 

--- a/drift_dev/CHANGELOG.md
+++ b/drift_dev/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 2.5.0-dev
+
+- Adds the `column_name_case` option with the possible values: `preserve`, `camel_case`, `CONSTANT_CASE`, `snake_case`, `PascalCase`, `lowercase` and `UPPERCASE` (default: `snake_case`).
+
 ## 2.4.0-dev
 
 - Add the support for `textEnum`.

--- a/drift_dev/lib/src/analysis/options.dart
+++ b/drift_dev/lib/src/analysis/options.dart
@@ -87,6 +87,9 @@ class DriftOptions {
   @JsonKey(defaultValue: false)
   final bool storeDateTimeValuesAsText;
 
+  @JsonKey(name: 'column_name_case', defaultValue: ColumnNameCase.snake)
+  final ColumnNameCase columnNameCase;
+
   @internal
   const DriftOptions.defaults({
     this.generateFromJsonStringConstructor = false,
@@ -107,6 +110,7 @@ class DriftOptions {
     this.sqliteAnalysisOptions,
     this.storeDateTimeValuesAsText = false,
     this.dialect = const DialectOptions(SqlDialect.sqlite, null),
+    this.columnNameCase = ColumnNameCase.snake,
   });
 
   DriftOptions({
@@ -127,6 +131,7 @@ class DriftOptions {
     required this.modules,
     required this.sqliteAnalysisOptions,
     required this.storeDateTimeValuesAsText,
+    required this.columnNameCase,
     this.dialect,
   }) {
     // ignore: deprecated_member_use_from_same_package
@@ -281,4 +286,49 @@ enum SqlModule {
   rtree,
 
   spellfix1,
+}
+
+/// The possible values for the case of the column names.
+enum ColumnNameCase {
+  /// Preserves the case of the column name as it is in the dart code.
+  ///
+  /// `myColumn` -> `myColumn`.
+  preserve,
+
+  /// Use camelCase.
+  ///
+  /// `my_column` -> `myColumn`.
+  @JsonValue('camelCase')
+  camel,
+
+  /// Use CONSTANT_CASE.
+  ///
+  /// `myColumn` -> `MY_COLUMN`.
+  @JsonValue('CONSTANT_CASE')
+  constant,
+
+  /// Use snake_case.
+  ///
+  /// `myColumn` -> `my_column`.
+  @JsonValue('snake_case')
+  snake,
+
+  /// Use PascalCase.
+  ///
+  /// `my_column` -> `MyColumn`.
+  // ignore: constant_identifier_names
+  @JsonValue('PascalCase')
+  pascal,
+
+  /// Use lowercase.
+  ///
+  /// `myColumn` -> `mycolumn`.
+  @JsonValue('lowercase')
+  lower,
+
+  /// Use UPPERCASE.
+  ///
+  /// `myColumn` -> `MYCOLUMN`.
+  @JsonValue('UPPERCASE')
+  upper,
 }

--- a/drift_dev/lib/src/analysis/options.dart
+++ b/drift_dev/lib/src/analysis/options.dart
@@ -2,6 +2,7 @@ import 'package:charcode/ascii.dart';
 import 'package:drift/drift.dart' show SqlDialect;
 import 'package:json_annotation/json_annotation.dart';
 import 'package:meta/meta.dart';
+import 'package:recase/recase.dart';
 import 'package:sqlparser/sqlparser.dart'
     show BasicType, ResolvedType, SchemaFromCreateTable, SqliteVersion;
 import 'package:string_scanner/string_scanner.dart';
@@ -406,5 +407,26 @@ enum CaseFromDartToSql {
   ///
   /// `myColumn` -> `MYCOLUMN`.
   @JsonValue('UPPERCASE')
-  upper,
+  upper;
+
+  /// Applies the correct case to the given [name].
+  String apply(String name) {
+    final reCase = ReCase(name);
+    switch (this) {
+      case CaseFromDartToSql.preserve:
+        return name;
+      case CaseFromDartToSql.camel:
+        return reCase.camelCase;
+      case CaseFromDartToSql.constant:
+        return reCase.constantCase;
+      case CaseFromDartToSql.snake:
+        return reCase.snakeCase;
+      case CaseFromDartToSql.pascal:
+        return reCase.pascalCase;
+      case CaseFromDartToSql.lower:
+        return name.toLowerCase();
+      case CaseFromDartToSql.upper:
+        return name.toUpperCase();
+    }
+  }
 }

--- a/drift_dev/lib/src/analysis/options.dart
+++ b/drift_dev/lib/src/analysis/options.dart
@@ -90,8 +90,8 @@ class DriftOptions {
   @JsonKey(defaultValue: false)
   final bool storeDateTimeValuesAsText;
 
-  @JsonKey(name: 'column_name_case', defaultValue: ColumnNameCase.snake)
-  final ColumnNameCase columnNameCase;
+  @JsonKey(name: 'case_from_dart_to_sql', defaultValue: CaseFromDartToSql.snake)
+  final CaseFromDartToSql caseFromDartToSql;
 
   @internal
   const DriftOptions.defaults({
@@ -113,7 +113,7 @@ class DriftOptions {
     this.sqliteAnalysisOptions,
     this.storeDateTimeValuesAsText = false,
     this.dialect = const DialectOptions(SqlDialect.sqlite, null),
-    this.columnNameCase = ColumnNameCase.snake,
+    this.caseFromDartToSql = CaseFromDartToSql.snake,
   });
 
   DriftOptions({
@@ -134,7 +134,7 @@ class DriftOptions {
     required this.modules,
     required this.sqliteAnalysisOptions,
     required this.storeDateTimeValuesAsText,
-    required this.columnNameCase,
+    required this.caseFromDartToSql,
     this.dialect,
   }) {
     // ignore: deprecated_member_use_from_same_package
@@ -364,9 +364,9 @@ enum SqlModule {
   spellfix1,
 }
 
-/// The possible values for the case of the column names.
-enum ColumnNameCase {
-  /// Preserves the case of the column name as it is in the dart code.
+/// The possible values for the case of the table and column names.
+enum CaseFromDartToSql {
+  /// Preserves the case of the name as it is in the dart code.
   ///
   /// `myColumn` -> `myColumn`.
   preserve,

--- a/drift_dev/lib/src/analysis/resolver/dart/column.dart
+++ b/drift_dev/lib/src/analysis/resolver/dart/column.dart
@@ -3,6 +3,7 @@ import 'package:analyzer/dart/element/element.dart';
 import 'package:analyzer/dart/element/type.dart';
 import 'package:collection/collection.dart';
 import 'package:drift/drift.dart' show DriftSqlType;
+import 'package:drift_dev/src/analysis/options.dart';
 import 'package:recase/recase.dart';
 import 'package:sqlparser/sqlparser.dart' show ReferenceAction;
 
@@ -335,7 +336,10 @@ class ColumnParser {
       remainingExpr = inner;
     }
 
-    final sqlName = foundExplicitName ?? ReCase(getter.name.lexeme).snakeCase;
+    _resolver.resolver.driver.options.columnNameCase;
+    final sqlName = foundExplicitName ??
+        _resolver.resolver.driver.options.columnNameCase
+            .apply(getter.name.lexeme);
     final sqlType = _startMethodToColumnType(foundStartMethod);
 
     AppliedTypeConverter? converter;
@@ -483,4 +487,26 @@ class PendingColumnInformation {
   final String? referencesColumnInSameTable;
 
   PendingColumnInformation(this.column, {this.referencesColumnInSameTable});
+}
+
+extension on ColumnNameCase {
+  String apply(String name) {
+    final reCase = ReCase(name);
+    switch (this) {
+      case ColumnNameCase.preserve:
+        return name;
+      case ColumnNameCase.camel:
+        return reCase.camelCase;
+      case ColumnNameCase.constant:
+        return reCase.constantCase;
+      case ColumnNameCase.snake:
+        return reCase.snakeCase;
+      case ColumnNameCase.pascal:
+        return reCase.pascalCase;
+      case ColumnNameCase.lower:
+        return name.toLowerCase();
+      case ColumnNameCase.upper:
+        return name.toUpperCase();
+    }
+  }
 }

--- a/drift_dev/lib/src/analysis/resolver/dart/column.dart
+++ b/drift_dev/lib/src/analysis/resolver/dart/column.dart
@@ -336,9 +336,9 @@ class ColumnParser {
       remainingExpr = inner;
     }
 
-    _resolver.resolver.driver.options.columnNameCase;
+    _resolver.resolver.driver.options.caseFromDartToSql;
     final sqlName = foundExplicitName ??
-        _resolver.resolver.driver.options.columnNameCase
+        _resolver.resolver.driver.options.caseFromDartToSql
             .apply(getter.name.lexeme);
     final sqlType = _startMethodToColumnType(foundStartMethod);
     final helper = await _resolver.resolver.driver.loadKnownTypes();
@@ -492,23 +492,23 @@ class PendingColumnInformation {
   PendingColumnInformation(this.column, {this.referencesColumnInSameTable});
 }
 
-extension on ColumnNameCase {
+extension on CaseFromDartToSql {
   String apply(String name) {
     final reCase = ReCase(name);
     switch (this) {
-      case ColumnNameCase.preserve:
+      case CaseFromDartToSql.preserve:
         return name;
-      case ColumnNameCase.camel:
+      case CaseFromDartToSql.camel:
         return reCase.camelCase;
-      case ColumnNameCase.constant:
+      case CaseFromDartToSql.constant:
         return reCase.constantCase;
-      case ColumnNameCase.snake:
+      case CaseFromDartToSql.snake:
         return reCase.snakeCase;
-      case ColumnNameCase.pascal:
+      case CaseFromDartToSql.pascal:
         return reCase.pascalCase;
-      case ColumnNameCase.lower:
+      case CaseFromDartToSql.lower:
         return name.toLowerCase();
-      case ColumnNameCase.upper:
+      case CaseFromDartToSql.upper:
         return name.toUpperCase();
     }
   }

--- a/drift_dev/lib/src/analysis/resolver/dart/column.dart
+++ b/drift_dev/lib/src/analysis/resolver/dart/column.dart
@@ -3,8 +3,6 @@ import 'package:analyzer/dart/element/element.dart';
 import 'package:analyzer/dart/element/type.dart';
 import 'package:collection/collection.dart';
 import 'package:drift/drift.dart' show DriftSqlType;
-import 'package:drift_dev/src/analysis/options.dart';
-import 'package:recase/recase.dart';
 import 'package:sqlparser/sqlparser.dart' show ReferenceAction;
 
 import '../../driver/error.dart';
@@ -490,26 +488,4 @@ class PendingColumnInformation {
   final String? referencesColumnInSameTable;
 
   PendingColumnInformation(this.column, {this.referencesColumnInSameTable});
-}
-
-extension on CaseFromDartToSql {
-  String apply(String name) {
-    final reCase = ReCase(name);
-    switch (this) {
-      case CaseFromDartToSql.preserve:
-        return name;
-      case CaseFromDartToSql.camel:
-        return reCase.camelCase;
-      case CaseFromDartToSql.constant:
-        return reCase.constantCase;
-      case CaseFromDartToSql.snake:
-        return reCase.snakeCase;
-      case CaseFromDartToSql.pascal:
-        return reCase.pascalCase;
-      case CaseFromDartToSql.lower:
-        return name.toLowerCase();
-      case CaseFromDartToSql.upper:
-        return name.toUpperCase();
-    }
-  }
 }

--- a/drift_dev/lib/src/analysis/resolver/discover.dart
+++ b/drift_dev/lib/src/analysis/resolver/discover.dart
@@ -2,7 +2,6 @@ import 'package:analyzer/dart/ast/ast.dart' as dart;
 import 'package:analyzer/dart/constant/value.dart';
 import 'package:analyzer/dart/element/element.dart';
 import 'package:analyzer/dart/element/visitor.dart';
-import 'package:recase/recase.dart';
 import 'package:source_gen/source_gen.dart';
 import 'package:sqlparser/sqlparser.dart' hide AnalysisError;
 
@@ -217,7 +216,8 @@ class _FindDartElements extends RecursiveElementVisitor<void> {
   }
 
   String _defaultNameForTableOrView(ClassElement definingElement) {
-    return ReCase(definingElement.name).snakeCase;
+    return _discoverStep._driver.options.caseFromDartToSql
+        .apply(definingElement.name);
   }
 
   DartObject? _driftViewAnnotation(ClassElement view) {

--- a/drift_dev/lib/src/generated/analysis/options.g.dart
+++ b/drift_dev/lib/src/generated/analysis/options.g.dart
@@ -31,7 +31,7 @@ DriftOptions _$DriftOptionsFromJson(Map json) => $checkedCreate(
             'named_parameters_always_required',
             'scoped_dart_components',
             'store_date_time_values_as_text',
-            'column_name_case'
+            'case_from_dart_to_sql'
           ],
         );
         final val = DriftOptions(
@@ -78,11 +78,11 @@ DriftOptions _$DriftOptionsFromJson(Map json) => $checkedCreate(
                   v == null ? null : SqliteAnalysisOptions.fromJson(v as Map)),
           storeDateTimeValuesAsText: $checkedConvert(
               'store_date_time_values_as_text', (v) => v as bool? ?? false),
-          columnNameCase: $checkedConvert(
-              'column_name_case',
+          caseFromDartToSql: $checkedConvert(
+              'case_from_dart_to_sql',
               (v) =>
-                  $enumDecodeNullable(_$ColumnNameCaseEnumMap, v) ??
-                  ColumnNameCase.snake),
+                  $enumDecodeNullable(_$CaseFromDartToSqlEnumMap, v) ??
+                  CaseFromDartToSql.snake),
           dialect: $checkedConvert('sql',
               (v) => v == null ? null : DialectOptions.fromJson(v as Map)),
         );
@@ -109,7 +109,7 @@ DriftOptions _$DriftOptionsFromJson(Map json) => $checkedCreate(
         'modules': 'sqlite_modules',
         'sqliteAnalysisOptions': 'sqlite',
         'storeDateTimeValuesAsText': 'store_date_time_values_as_text',
-        'columnNameCase': 'column_name_case',
+        'caseFromDartToSql': 'case_from_dart_to_sql',
         'dialect': 'sql'
       },
     );
@@ -140,7 +140,8 @@ Map<String, dynamic> _$DriftOptionsToJson(DriftOptions instance) =>
           instance.namedParametersAlwaysRequired,
       'scoped_dart_components': instance.scopedDartComponents,
       'store_date_time_values_as_text': instance.storeDateTimeValuesAsText,
-      'column_name_case': _$ColumnNameCaseEnumMap[instance.columnNameCase]!,
+      'case_from_dart_to_sql':
+          _$CaseFromDartToSqlEnumMap[instance.caseFromDartToSql]!,
     };
 
 const _$SqlModuleEnumMap = {
@@ -152,14 +153,14 @@ const _$SqlModuleEnumMap = {
   SqlModule.spellfix1: 'spellfix1',
 };
 
-const _$ColumnNameCaseEnumMap = {
-  ColumnNameCase.preserve: 'preserve',
-  ColumnNameCase.camel: 'camelCase',
-  ColumnNameCase.constant: 'CONSTANT_CASE',
-  ColumnNameCase.snake: 'snake_case',
-  ColumnNameCase.pascal: 'PascalCase',
-  ColumnNameCase.lower: 'lowercase',
-  ColumnNameCase.upper: 'UPPERCASE',
+const _$CaseFromDartToSqlEnumMap = {
+  CaseFromDartToSql.preserve: 'preserve',
+  CaseFromDartToSql.camel: 'camelCase',
+  CaseFromDartToSql.constant: 'CONSTANT_CASE',
+  CaseFromDartToSql.snake: 'snake_case',
+  CaseFromDartToSql.pascal: 'PascalCase',
+  CaseFromDartToSql.lower: 'lowercase',
+  CaseFromDartToSql.upper: 'UPPERCASE',
 };
 
 DialectOptions _$DialectOptionsFromJson(Map json) => $checkedCreate(

--- a/drift_dev/lib/src/generated/analysis/options.g.dart
+++ b/drift_dev/lib/src/generated/analysis/options.g.dart
@@ -153,7 +153,7 @@ const _$SqlModuleEnumMap = {
 };
 
 const _$ColumnNameCaseEnumMap = {
-  ColumnNameCase.none: 'none',
+  ColumnNameCase.preserve: 'preserve',
   ColumnNameCase.camel: 'camelCase',
   ColumnNameCase.constant: 'CONSTANT_CASE',
   ColumnNameCase.snake: 'snake_case',

--- a/drift_dev/lib/src/generated/analysis/options.g.dart
+++ b/drift_dev/lib/src/generated/analysis/options.g.dart
@@ -30,7 +30,8 @@ DriftOptions _$DriftOptionsFromJson(Map json) => $checkedCreate(
             'named_parameters',
             'named_parameters_always_required',
             'scoped_dart_components',
-            'store_date_time_values_as_text'
+            'store_date_time_values_as_text',
+            'column_name_case'
           ],
         );
         final val = DriftOptions(
@@ -77,6 +78,11 @@ DriftOptions _$DriftOptionsFromJson(Map json) => $checkedCreate(
                   v == null ? null : SqliteAnalysisOptions.fromJson(v as Map)),
           storeDateTimeValuesAsText: $checkedConvert(
               'store_date_time_values_as_text', (v) => v as bool? ?? false),
+          columnNameCase: $checkedConvert(
+              'column_name_case',
+              (v) =>
+                  $enumDecodeNullable(_$ColumnNameCaseEnumMap, v) ??
+                  ColumnNameCase.snake),
           dialect: $checkedConvert('sql',
               (v) => v == null ? null : DialectOptions.fromJson(v as Map)),
         );
@@ -103,6 +109,7 @@ DriftOptions _$DriftOptionsFromJson(Map json) => $checkedCreate(
         'modules': 'sqlite_modules',
         'sqliteAnalysisOptions': 'sqlite',
         'storeDateTimeValuesAsText': 'store_date_time_values_as_text',
+        'columnNameCase': 'column_name_case',
         'dialect': 'sql'
       },
     );
@@ -133,6 +140,7 @@ Map<String, dynamic> _$DriftOptionsToJson(DriftOptions instance) =>
           instance.namedParametersAlwaysRequired,
       'scoped_dart_components': instance.scopedDartComponents,
       'store_date_time_values_as_text': instance.storeDateTimeValuesAsText,
+      'column_name_case': _$ColumnNameCaseEnumMap[instance.columnNameCase]!,
     };
 
 const _$SqlModuleEnumMap = {
@@ -142,6 +150,16 @@ const _$SqlModuleEnumMap = {
   SqlModule.math: 'math',
   SqlModule.rtree: 'rtree',
   SqlModule.spellfix1: 'spellfix1',
+};
+
+const _$ColumnNameCaseEnumMap = {
+  ColumnNameCase.none: 'none',
+  ColumnNameCase.camel: 'camelCase',
+  ColumnNameCase.constant: 'CONSTANT_CASE',
+  ColumnNameCase.snake: 'snake_case',
+  ColumnNameCase.pascal: 'PascalCase',
+  ColumnNameCase.lower: 'lowercase',
+  ColumnNameCase.upper: 'UPPERCASE',
 };
 
 DialectOptions _$DialectOptionsFromJson(Map json) => $checkedCreate(

--- a/drift_dev/pubspec.yaml
+++ b/drift_dev/pubspec.yaml
@@ -1,6 +1,6 @@
 name: drift_dev
 description: Dev-dependency for users of drift. Contains a the generator and development tools.
-version: 2.4.0-dev
+version: 2.5.0-dev
 repository: https://github.com/simolus3/drift
 homepage: https://drift.simonbinder.eu/
 issue_tracker: https://github.com/simolus3/drift/issues

--- a/drift_dev/pubspec.yaml
+++ b/drift_dev/pubspec.yaml
@@ -1,6 +1,6 @@
 name: drift_dev
 description: Dev-dependency for users of drift. Contains a the generator and development tools.
-version: 2.5.0-dev
+version: 2.4.0-dev
 repository: https://github.com/simolus3/drift
 homepage: https://drift.simonbinder.eu/
 issue_tracker: https://github.com/simolus3/drift/issues

--- a/drift_dev/test/analysis/resolver/dart/column_test.dart
+++ b/drift_dev/test/analysis/resolver/dart/column_test.dart
@@ -48,7 +48,8 @@ class TestTable extends Table {
 class Database {}
 '''
       },
-      options: DriftOptions.defaults(columnNameCase: ColumnNameCase.snake),
+      options:
+          DriftOptions.defaults(caseFromDartToSql: CaseFromDartToSql.snake),
     );
 
     final file = await state.analyze('package:a/main.dart');
@@ -77,7 +78,8 @@ class TestTable extends Table {
 class Database {}
 '''
       },
-      options: DriftOptions.defaults(columnNameCase: ColumnNameCase.preserve),
+      options:
+          DriftOptions.defaults(caseFromDartToSql: CaseFromDartToSql.preserve),
     );
 
     final file = await state.analyze('package:a/main.dart');
@@ -105,7 +107,8 @@ class TestTable extends Table {
 class Database {}
 '''
       },
-      options: DriftOptions.defaults(columnNameCase: ColumnNameCase.camel),
+      options:
+          DriftOptions.defaults(caseFromDartToSql: CaseFromDartToSql.camel),
     );
 
     final file = await state.analyze('package:a/main.dart');
@@ -134,7 +137,8 @@ class TestTable extends Table {
 class Database {}
 '''
       },
-      options: DriftOptions.defaults(columnNameCase: ColumnNameCase.constant),
+      options:
+          DriftOptions.defaults(caseFromDartToSql: CaseFromDartToSql.constant),
     );
 
     final file = await state.analyze('package:a/main.dart');
@@ -162,7 +166,8 @@ class TestTable extends Table {
 class Database {}
 '''
       },
-      options: DriftOptions.defaults(columnNameCase: ColumnNameCase.pascal),
+      options:
+          DriftOptions.defaults(caseFromDartToSql: CaseFromDartToSql.pascal),
     );
 
     final file = await state.analyze('package:a/main.dart');
@@ -190,7 +195,8 @@ class TestTable extends Table {
 class Database {}
 '''
       },
-      options: DriftOptions.defaults(columnNameCase: ColumnNameCase.lower),
+      options:
+          DriftOptions.defaults(caseFromDartToSql: CaseFromDartToSql.lower),
     );
 
     final file = await state.analyze('package:a/main.dart');
@@ -218,7 +224,8 @@ class TestTable extends Table {
 class Database {}
 '''
       },
-      options: DriftOptions.defaults(columnNameCase: ColumnNameCase.upper),
+      options:
+          DriftOptions.defaults(caseFromDartToSql: CaseFromDartToSql.upper),
     );
 
     final file = await state.analyze('package:a/main.dart');

--- a/drift_dev/test/analysis/resolver/dart/column_test.dart
+++ b/drift_dev/test/analysis/resolver/dart/column_test.dart
@@ -1,0 +1,235 @@
+import 'package:drift_dev/src/analysis/options.dart';
+import 'package:drift_dev/src/analysis/results/table.dart';
+import 'package:test/test.dart';
+
+import '../../test_utils.dart';
+
+void main() {
+  test('It should rename the column name to its snake case version by default',
+      () async {
+    final state = TestBackend.inTest(
+      {
+        'a|lib/main.dart': '''
+import 'package:drift/drift.dart';
+
+class TestTable extends Table {
+  TextColumn get textColumn => text()();
+}
+
+@DriftDatabase(tables: [TestTable])
+class Database {}
+'''
+      },
+    );
+
+    final file = await state.analyze('package:a/main.dart');
+    expect(file.allErrors, isEmpty);
+
+    final table = file.analyzedElements
+        .whereType<DriftTable>()
+        .firstWhere((e) => e.schemaName == 'test_table');
+
+    final column = table.columns.single;
+
+    expect(column.nameInSql, 'text_column');
+  });
+
+  test('It should rename the column name to its snake case version', () async {
+    final state = TestBackend.inTest(
+      {
+        'a|lib/main.dart': '''
+import 'package:drift/drift.dart';
+
+class TestTable extends Table {
+  TextColumn get textColumn => text()();
+}
+
+@DriftDatabase(tables: [TestTable])
+class Database {}
+'''
+      },
+      options: DriftOptions.defaults(columnNameCase: ColumnNameCase.snake),
+    );
+
+    final file = await state.analyze('package:a/main.dart');
+    expect(file.allErrors, isEmpty);
+
+    final table = file.analyzedElements
+        .whereType<DriftTable>()
+        .firstWhere((e) => e.schemaName == 'test_table');
+
+    final column = table.columns.single;
+
+    expect(column.nameInSql, 'text_column');
+  });
+
+  test('It should not rename the column name', () async {
+    final state = TestBackend.inTest(
+      {
+        'a|lib/main.dart': '''
+import 'package:drift/drift.dart';
+
+class TestTable extends Table {
+  TextColumn get tExTcOlUmN => text()();
+}
+
+@DriftDatabase(tables: [TestTable])
+class Database {}
+'''
+      },
+      options: DriftOptions.defaults(columnNameCase: ColumnNameCase.preserve),
+    );
+
+    final file = await state.analyze('package:a/main.dart');
+    expect(file.allErrors, isEmpty);
+
+    final table = file.analyzedElements
+        .whereType<DriftTable>()
+        .firstWhere((e) => e.schemaName == 'test_table');
+
+    final column = table.columns.single;
+
+    expect(column.nameInSql, 'tExTcOlUmN');
+  });
+  test('It should rename the column name to its camel case version', () async {
+    final state = TestBackend.inTest(
+      {
+        'a|lib/main.dart': '''
+import 'package:drift/drift.dart';
+
+class TestTable extends Table {
+  TextColumn get text_column => text()();
+}
+
+@DriftDatabase(tables: [TestTable])
+class Database {}
+'''
+      },
+      options: DriftOptions.defaults(columnNameCase: ColumnNameCase.camel),
+    );
+
+    final file = await state.analyze('package:a/main.dart');
+    expect(file.allErrors, isEmpty);
+
+    final table = file.analyzedElements
+        .whereType<DriftTable>()
+        .firstWhere((e) => e.schemaName == 'test_table');
+
+    final column = table.columns.single;
+
+    expect(column.nameInSql, 'textColumn');
+  });
+  test('It should rename the column name to its constant case version',
+      () async {
+    final state = TestBackend.inTest(
+      {
+        'a|lib/main.dart': '''
+import 'package:drift/drift.dart';
+
+class TestTable extends Table {
+  TextColumn get textColumn => text()();
+}
+
+@DriftDatabase(tables: [TestTable])
+class Database {}
+'''
+      },
+      options: DriftOptions.defaults(columnNameCase: ColumnNameCase.constant),
+    );
+
+    final file = await state.analyze('package:a/main.dart');
+    expect(file.allErrors, isEmpty);
+
+    final table = file.analyzedElements
+        .whereType<DriftTable>()
+        .firstWhere((e) => e.schemaName == 'test_table');
+
+    final column = table.columns.single;
+
+    expect(column.nameInSql, 'TEXT_COLUMN');
+  });
+  test('It should rename the column name to its pascal case version', () async {
+    final state = TestBackend.inTest(
+      {
+        'a|lib/main.dart': '''
+import 'package:drift/drift.dart';
+
+class TestTable extends Table {
+  TextColumn get textColumn => text()();
+}
+
+@DriftDatabase(tables: [TestTable])
+class Database {}
+'''
+      },
+      options: DriftOptions.defaults(columnNameCase: ColumnNameCase.pascal),
+    );
+
+    final file = await state.analyze('package:a/main.dart');
+    expect(file.allErrors, isEmpty);
+
+    final table = file.analyzedElements
+        .whereType<DriftTable>()
+        .firstWhere((e) => e.schemaName == 'test_table');
+
+    final column = table.columns.single;
+
+    expect(column.nameInSql, 'TextColumn');
+  });
+  test('It should rename the column name to its lower case version', () async {
+    final state = TestBackend.inTest(
+      {
+        'a|lib/main.dart': '''
+import 'package:drift/drift.dart';
+
+class TestTable extends Table {
+  TextColumn get textColumn => text()();
+}
+
+@DriftDatabase(tables: [TestTable])
+class Database {}
+'''
+      },
+      options: DriftOptions.defaults(columnNameCase: ColumnNameCase.lower),
+    );
+
+    final file = await state.analyze('package:a/main.dart');
+    expect(file.allErrors, isEmpty);
+
+    final table = file.analyzedElements
+        .whereType<DriftTable>()
+        .firstWhere((e) => e.schemaName == 'test_table');
+
+    final column = table.columns.single;
+
+    expect(column.nameInSql, 'textcolumn');
+  });
+  test('It should rename the column name to its upper case version', () async {
+    final state = TestBackend.inTest(
+      {
+        'a|lib/main.dart': '''
+import 'package:drift/drift.dart';
+
+class TestTable extends Table {
+  TextColumn get textColumn => text()();
+}
+
+@DriftDatabase(tables: [TestTable])
+class Database {}
+'''
+      },
+      options: DriftOptions.defaults(columnNameCase: ColumnNameCase.upper),
+    );
+
+    final file = await state.analyze('package:a/main.dart');
+    expect(file.allErrors, isEmpty);
+
+    final table = file.analyzedElements
+        .whereType<DriftTable>()
+        .firstWhere((e) => e.schemaName == 'test_table');
+
+    final column = table.columns.single;
+
+    expect(column.nameInSql, 'TEXTCOLUMN');
+  });
+}

--- a/drift_dev/test/analysis/resolver/dart/column_test.dart
+++ b/drift_dev/test/analysis/resolver/dart/column_test.dart
@@ -5,7 +5,8 @@ import 'package:test/test.dart';
 import '../../test_utils.dart';
 
 void main() {
-  test('It should rename the column name to its snake case version by default',
+  test(
+      'It should rename the table and column name to its snake case version by default',
       () async {
     final state = TestBackend.inTest(
       {
@@ -25,16 +26,15 @@ class Database {}
     final file = await state.analyze('package:a/main.dart');
     expect(file.allErrors, isEmpty);
 
-    final table = file.analyzedElements
-        .whereType<DriftTable>()
-        .firstWhere((e) => e.schemaName == 'test_table');
+    final table = file.analyzedElements.whereType<DriftTable>().single;
+    expect(table.schemaName, 'test_table');
 
     final column = table.columns.single;
-
     expect(column.nameInSql, 'text_column');
   });
 
-  test('It should rename the column name to its snake case version', () async {
+  test('It should rename the table and column name to its snake case version',
+      () async {
     final state = TestBackend.inTest(
       {
         'a|lib/main.dart': '''
@@ -55,26 +55,24 @@ class Database {}
     final file = await state.analyze('package:a/main.dart');
     expect(file.allErrors, isEmpty);
 
-    final table = file.analyzedElements
-        .whereType<DriftTable>()
-        .firstWhere((e) => e.schemaName == 'test_table');
+    final table = file.analyzedElements.whereType<DriftTable>().single;
+    expect(table.schemaName, 'test_table');
 
     final column = table.columns.single;
-
     expect(column.nameInSql, 'text_column');
   });
 
-  test('It should not rename the column name', () async {
+  test('It should not rename the table and column name', () async {
     final state = TestBackend.inTest(
       {
         'a|lib/main.dart': '''
 import 'package:drift/drift.dart';
 
-class TestTable extends Table {
+class TeStTaBlE extends Table {
   TextColumn get tExTcOlUmN => text()();
 }
 
-@DriftDatabase(tables: [TestTable])
+@DriftDatabase(tables: [TeStTaBlE])
 class Database {}
 '''
       },
@@ -85,15 +83,15 @@ class Database {}
     final file = await state.analyze('package:a/main.dart');
     expect(file.allErrors, isEmpty);
 
-    final table = file.analyzedElements
-        .whereType<DriftTable>()
-        .firstWhere((e) => e.schemaName == 'test_table');
+    final table = file.analyzedElements.whereType<DriftTable>().single;
+    expect(table.schemaName, 'TeStTaBlE');
 
     final column = table.columns.single;
 
     expect(column.nameInSql, 'tExTcOlUmN');
   });
-  test('It should rename the column name to its camel case version', () async {
+  test('It should rename the table and column name to its camel case version',
+      () async {
     final state = TestBackend.inTest(
       {
         'a|lib/main.dart': '''
@@ -114,15 +112,14 @@ class Database {}
     final file = await state.analyze('package:a/main.dart');
     expect(file.allErrors, isEmpty);
 
-    final table = file.analyzedElements
-        .whereType<DriftTable>()
-        .firstWhere((e) => e.schemaName == 'test_table');
+    final table = file.analyzedElements.whereType<DriftTable>().single;
+    expect(table.schemaName, 'testTable');
 
     final column = table.columns.single;
-
     expect(column.nameInSql, 'textColumn');
   });
-  test('It should rename the column name to its constant case version',
+  test(
+      'It should rename the table and column name to its constant case version',
       () async {
     final state = TestBackend.inTest(
       {
@@ -144,25 +141,24 @@ class Database {}
     final file = await state.analyze('package:a/main.dart');
     expect(file.allErrors, isEmpty);
 
-    final table = file.analyzedElements
-        .whereType<DriftTable>()
-        .firstWhere((e) => e.schemaName == 'test_table');
+    final table = file.analyzedElements.whereType<DriftTable>().single;
+    expect(table.schemaName, 'TEST_TABLE');
 
     final column = table.columns.single;
-
     expect(column.nameInSql, 'TEXT_COLUMN');
   });
-  test('It should rename the column name to its pascal case version', () async {
+  test('It should rename the table and column name to its pascal case version',
+      () async {
     final state = TestBackend.inTest(
       {
         'a|lib/main.dart': '''
 import 'package:drift/drift.dart';
 
-class TestTable extends Table {
+class Test_Table extends Table {
   TextColumn get textColumn => text()();
 }
 
-@DriftDatabase(tables: [TestTable])
+@DriftDatabase(tables: [Test_Table])
 class Database {}
 '''
       },
@@ -173,15 +169,14 @@ class Database {}
     final file = await state.analyze('package:a/main.dart');
     expect(file.allErrors, isEmpty);
 
-    final table = file.analyzedElements
-        .whereType<DriftTable>()
-        .firstWhere((e) => e.schemaName == 'test_table');
+    final table = file.analyzedElements.whereType<DriftTable>().single;
+    expect(table.schemaName, 'TestTable');
 
     final column = table.columns.single;
-
     expect(column.nameInSql, 'TextColumn');
   });
-  test('It should rename the column name to its lower case version', () async {
+  test('It should rename the table and column name to its lower case version',
+      () async {
     final state = TestBackend.inTest(
       {
         'a|lib/main.dart': '''
@@ -202,15 +197,15 @@ class Database {}
     final file = await state.analyze('package:a/main.dart');
     expect(file.allErrors, isEmpty);
 
-    final table = file.analyzedElements
-        .whereType<DriftTable>()
-        .firstWhere((e) => e.schemaName == 'test_table');
+    final table = file.analyzedElements.whereType<DriftTable>().single;
+    expect(table.schemaName, 'testtable');
 
     final column = table.columns.single;
 
     expect(column.nameInSql, 'textcolumn');
   });
-  test('It should rename the column name to its upper case version', () async {
+  test('It should rename the table and column name to its upper case version',
+      () async {
     final state = TestBackend.inTest(
       {
         'a|lib/main.dart': '''
@@ -231,12 +226,10 @@ class Database {}
     final file = await state.analyze('package:a/main.dart');
     expect(file.allErrors, isEmpty);
 
-    final table = file.analyzedElements
-        .whereType<DriftTable>()
-        .firstWhere((e) => e.schemaName == 'test_table');
+    final table = file.analyzedElements.whereType<DriftTable>().single;
+    expect(table.schemaName, 'TESTTABLE');
 
     final column = table.columns.single;
-
     expect(column.nameInSql, 'TEXTCOLUMN');
   });
 }


### PR DESCRIPTION
Should close https://github.com/simolus3/drift/issues/1068

Add the `column_name_case` option to the builder
The possible options are 
- `preserve`
- `camel_case`
- `CONSTANT_CASE`
- `snake_case`
- `PascalCase`
- `lowercase`
- `UPPERCASE`