### PR TITLE
A couple bugfixes for complex migration

### DIFF
--- a/drift/lib/src/runtime/query_builder/migration.dart
+++ b/drift/lib/src/runtime/query_builder/migration.dart
@@ -203,9 +203,7 @@ class Migrator {
       context.buffer.write('INSERT INTO $temporaryName (');
       var first = true;
       for (final column in table.$columns) {
-        if (column.generatedAs != null) {
-          continue;
-        }
+        if (column.generatedAs != null) continue;
 
         final transformer = migration.columnTransformer[column];
 
@@ -232,7 +230,7 @@ class Migrator {
         first = false;
       }
       context.buffer.write(' FROM ${context.identifier(tableName)};');
-      await _issueCustomQuery(context.sql, context.introducedVariables);
+      await _issueCustomQuery(context.sql, context.boundVariables);
 
       // Step 6: Drop the old table
       await _issueCustomQuery('DROP TABLE ${context.identifier(tableName)}');

--- a/drift/lib/src/runtime/query_builder/migration.dart
+++ b/drift/lib/src/runtime/query_builder/migration.dart
@@ -203,6 +203,10 @@ class Migrator {
       context.buffer.write('INSERT INTO $temporaryName (');
       var first = true;
       for (final column in table.$columns) {
+        if (column.generatedAs != null) {
+          continue;
+        }
+
         final transformer = migration.columnTransformer[column];
 
         if (transformer != null || !migration.newColumns.contains(column)) {

--- a/drift/test/integration_tests/migrations_integration_test.dart
+++ b/drift/test/integration_tests/migrations_integration_test.dart
@@ -240,12 +240,51 @@ void main() {
         ));
       },
     );
+    addTearDown(db.close);
 
     final entry = await db
         .customSelect("SELECT sql FROM sqlite_master WHERE name = 'no_ids'")
         .getSingle();
 
     expect(entry.read<String>('sql'), contains('WITHOUT ROWID'));
+  });
+
+  test('alter table that has a generated column', () async {
+    final db = TodoDb(NativeDatabase.memory());
+    addTearDown(db.close);
+
+    await db.categories.insertOne(
+        CategoriesCompanion.insert(description: 'My Initial Description'));
+
+    final migrator = db.createMigrator();
+    await migrator.alterTable(TableMigration(
+      db.categories,
+      columnTransformer: {
+        db.categories.description: db.categories.description.lower(),
+      },
+    ));
+
+    final value = await db.categories.select().getSingle();
+    expect(value.description, 'my initial description');
+  });
+
+  test('can run migration with variable', () async {
+    final db = TodoDb(NativeDatabase.memory());
+    addTearDown(db.close);
+
+    await db.todosTable
+        .insertOne(TodosTableCompanion.insert(content: 'my content'));
+
+    final migrator = db.createMigrator();
+    await migrator.alterTable(TableMigration(
+      db.todosTable,
+      columnTransformer: {
+        db.todosTable.content: Variable('old: ') + db.todosTable.content,
+      },
+    ));
+
+    final value = await db.todosTable.select().getSingle();
+    expect(value.content, 'old: my content');
   });
 
   group('exceptions in migrations', () {

--- a/drift/test/integration_tests/migrations_integration_test.dart
+++ b/drift/test/integration_tests/migrations_integration_test.dart
@@ -257,12 +257,15 @@ void main() {
         CategoriesCompanion.insert(description: 'My Initial Description'));
 
     final migrator = db.createMigrator();
+    await migrator.drop(db.categoryTodoCountView);
+    await migrator.drop(db.todoWithCategoryView);
     await migrator.alterTable(TableMigration(
       db.categories,
       columnTransformer: {
         db.categories.description: db.categories.description.lower(),
       },
     ));
+    await migrator.recreateAllViews();
 
     final value = await db.categories.select().getSingle();
     expect(value.description, 'my initial description');
@@ -276,12 +279,15 @@ void main() {
         .insertOne(TodosTableCompanion.insert(content: 'my content'));
 
     final migrator = db.createMigrator();
+    await migrator.drop(db.categoryTodoCountView);
+    await migrator.drop(db.todoWithCategoryView);
     await migrator.alterTable(TableMigration(
       db.todosTable,
       columnTransformer: {
         db.todosTable.content: Variable('old: ') + db.todosTable.content,
       },
     ));
+    await migrator.recreateAllViews();
 
     final value = await db.todosTable.select().getSingle();
     expect(value.content, 'old: my content');


### PR DESCRIPTION
I was trying to change a TextColumn to DateTimeColumn and initialize all values with a date 30 days in the past, like this:

```
await m.alterTable(TableMigration(myTable, columnTransformer: {
  myTable.date: Variable<DateTime>(
    DateTime.now().add(const Duration(days: -30)),
  ),
}));
```

This table has a generated column, and it couldn't complete the insert with this exception:

_SqliteException(1): cannot INSERT into generated column "generated", SQL logic error._

Debugging I realized it was actually trying to insert a value to the generated column on the temporary table, so I changed it to skip columns with a not null `generatedAs` property, like this:


```
for (final column in table.$columns) {
  if (column.generatedAs != null) continue;
```

After that, it failed again with this exception:

_ArgumentError (Invalid argument (params[1]): Allowed parameters must either be null or bool, int, num, String or List\<int\>.: Instance of 'Variable\<DateTime\>')_

This was happening because it passed `introducedVariables` to the INSERT statement instead of `boundVariables` like it does in line 119 when creating a table, so it made sense to pass the same argument to the same method and changed it.

Old code:
```
context.buffer.write(' FROM ${context.identifier(tableName)};');
await _issueCustomQuery(context.sql, context.introducedVariables);
```
Line 119:
```
return _issueCustomQuery(context.sql, context.boundVariables);
```

Hope it helps, greetings!