### PR TITLE
Validate enum default value in drift files

### DIFF
--- a/drift_dev/CHANGELOG.md
+++ b/drift_dev/CHANGELOG.md
@@ -3,6 +3,7 @@
 - Add the support for `textEnum`.
 - Adds the `case_from_dart_to_sql` option with the possible values: `preserve`, `camelCase`, `CONSTANT_CASE`, `snake_case`, `PascalCase`, `lowercase` and `UPPERCASE` (default: `snake_case`).
 - `drift_dev schema dump` can now dump the schema of existing sqlite3 database files as well.
+- Warn about suspicious int or text literals being inserted into enum columns.
 
 ## 2.3.3
 

--- a/drift_dev/lib/src/analysis/resolver/drift/table.dart
+++ b/drift_dev/lib/src/analysis/resolver/drift/table.dart
@@ -11,14 +11,15 @@ import 'package:sqlparser/utils/node_to_text.dart';
 import '../../../utils/string_escaper.dart';
 import '../../backend.dart';
 import '../../driver/error.dart';
+import '../../driver/state.dart';
 import '../../results/results.dart';
 import '../intermediate_state.dart';
-import '../resolver.dart';
 import '../shared/dart_types.dart';
 import '../shared/data_class.dart';
-import 'find_dart_class.dart';
+import 'element_resolver.dart';
+import 'sqlparser/drift_lints.dart';
 
-class DriftTableResolver extends LocalElementResolver<DiscoveredDriftTable> {
+class DriftTableResolver extends DriftElementResolver<DiscoveredDriftTable> {
   static final RegExp _enumRegex =
       RegExp(r'^enum(name)?\((\w+)\)$', caseSensitive: false);
 
@@ -61,8 +62,7 @@ class DriftTableResolver extends LocalElementResolver<DiscoveredDriftTable> {
           typeName != null ? _enumRegex.firstMatch(typeName) : null;
       if (enumIndexMatch != null) {
         final dartTypeName = enumIndexMatch.group(2)!;
-        final imports = file.discovery!.importDependencies.toList();
-        final dartClass = await findDartClass(imports, dartTypeName);
+        final dartClass = await findDartClass(dartTypeName);
 
         if (dartClass == null) {
           reportError(DriftAnalysisError.inDriftFile(
@@ -142,35 +142,6 @@ class DriftTableResolver extends LocalElementResolver<DiscoveredDriftTable> {
         } else if (constraint is GeneratedAs) {
           constraints.add(ColumnGeneratedAs.fromParser(constraint));
         } else if (constraint is Default) {
-          final element = converter?.dartType.element;
-          if (element is EnumElement) {
-            final expression = constraint.expression;
-            if (type == DriftSqlType.int) {
-              if (expression is NumericLiteral) {
-                final values = element
-                        .getField('values')
-                        ?.computeConstantValue()
-                        ?.toListValue() ??
-                    const [];
-                if (!expression.isInt ||
-                    expression.value < 0 ||
-                    expression.value > values.length) {
-                  reportError(DriftAnalysisError.inDriftFile(constraint,
-                      '${expression.value} is not a valid index value for ${element.name}.'));
-                  continue;
-                }
-              }
-            } else {
-              if (expression is StringLiteral &&
-                  element.getField(expression.value)?.enclosingElement !=
-                      element) {
-                reportError(DriftAnalysisError.inDriftFile(constraint,
-                    '${expression.value} is not a valid enum value for ${element.name}.'));
-                continue;
-              }
-            }
-          }
-
           defaultArgument = AnnotatedDartCode.build((b) => b
             ..addText('const ')
             ..addSymbol('CustomExpression', AnnotatedDartCode.drift)
@@ -325,8 +296,7 @@ class DriftTableResolver extends LocalElementResolver<DiscoveredDriftTable> {
       final overriddenNames = driftTableInfo.overriddenDataClassName;
 
       if (driftTableInfo.useExistingDartClass) {
-        final imports = file.discovery!.importDependencies.toList();
-        final clazz = await findDartClass(imports, overriddenNames);
+        final clazz = await findDartClass(overriddenNames);
         if (clazz == null) {
           reportError(DriftAnalysisError.inDriftFile(
             stmt.tableNameToken!,
@@ -352,7 +322,7 @@ class DriftTableResolver extends LocalElementResolver<DiscoveredDriftTable> {
     dartTableName ??= ReCase(state.ownId.name).pascalCase;
     dataClassName ??= dataClassNameForClassName(dartTableName);
 
-    return DriftTable(
+    final driftTable = DriftTable(
       discovered.ownId,
       DriftDeclaration(
         state.ownId.libraryUri,
@@ -372,6 +342,18 @@ class DriftTableResolver extends LocalElementResolver<DiscoveredDriftTable> {
       writeDefaultConstraints: false,
       overrideTableConstraints: sqlTableConstraints,
     );
+
+    // Run drift-specific lints on the `CREATE TABLE` statement, which requires
+    // having the resolved table structure first.
+    final engineForAnalysis = resolver.driver.typeMapping
+        .newEngineWithTables([driftTable, ...driftTable.references]);
+    final source = (file.discovery as DiscoveredDriftFile).originalSource;
+    final context = engineForAnalysis.analyzeNode(stmt, source);
+    final linter = DriftSqlLinter(context, references: references)
+      ..collectLints();
+    linter.sqlParserErrors.forEach(reportLint);
+
+    return driftTable;
   }
 
   Future<AppliedTypeConverter?> _readTypeConverter(

--- a/drift_dev/lib/src/analysis/resolver/drift/table.dart
+++ b/drift_dev/lib/src/analysis/resolver/drift/table.dart
@@ -1,5 +1,4 @@
 import 'package:analyzer/dart/ast/ast.dart' as dart;
-import 'package:analyzer/dart/element/element.dart';
 import 'package:collection/collection.dart';
 import 'package:drift/drift.dart' show DriftSqlType;
 import 'package:drift_dev/src/analysis/driver/driver.dart';

--- a/drift_dev/lib/src/analysis/resolver/shared/dart_types.dart
+++ b/drift_dev/lib/src/analysis/resolver/shared/dart_types.dart
@@ -223,6 +223,7 @@ AppliedTypeConverter? readTypeConverter(
     sqlType: columnType,
     dartTypeIsNullable: dartTypeNullable,
     sqlTypeIsNullable: sqlTypeNullable,
+    isDriftEnumTypeConverter: false,
   );
 }
 
@@ -271,6 +272,7 @@ AppliedTypeConverter readEnumConverter(
         : DriftSqlType.string,
     dartTypeIsNullable: false,
     sqlTypeIsNullable: false,
+    isDriftEnumTypeConverter: true,
   );
 }
 

--- a/drift_dev/lib/src/analysis/results/column.dart
+++ b/drift_dev/lib/src/analysis/results/column.dart
@@ -139,6 +139,10 @@ class AppliedTypeConverter {
   /// In other words, [sqlType] is potentially nullable.
   final bool sqlTypeIsNullable;
 
+  /// Whether this converter is one of the enum type converters built into
+  /// drift.
+  final bool isDriftEnumTypeConverter;
+
   /// Whether this type converter should also be used in the generated JSON
   /// serialization.
   bool get alsoAppliesToJsonConversion => jsonType != null;
@@ -178,6 +182,7 @@ class AppliedTypeConverter {
     required this.dartTypeIsNullable,
     required this.sqlTypeIsNullable,
     required this.jsonType,
+    required this.isDriftEnumTypeConverter,
   });
 }
 

--- a/drift_dev/lib/src/analysis/serializer.dart
+++ b/drift_dev/lib/src/analysis/serializer.dart
@@ -273,6 +273,7 @@ class ElementSerializer {
       'sql_type': converter.sqlType.name,
       'dart_type_is_nullable': converter.dartTypeIsNullable,
       'sql_type_is_nullable': converter.sqlTypeIsNullable,
+      'is_drift_enum_converter': converter.isDriftEnumTypeConverter,
       if (converter.owningColumn != appliedTo)
         'owner': _serializeColumnReference(converter.owningColumn),
     };
@@ -725,6 +726,7 @@ class ElementDeserializer {
       sqlType: DriftSqlType.values.byName(json['sql_type'] as String),
       dartTypeIsNullable: json['dart_type_is_nullable'] as bool,
       sqlTypeIsNullable: json['sql_type_is_nullable'] as bool,
+      isDriftEnumTypeConverter: json['is_drift_enum_converter'] as bool,
     );
 
     if (readOwner != null) converter.owningColumn = readOwner;

--- a/drift_dev/test/analysis/resolver/drift/sqlparser/type_converter_lints_test.dart
+++ b/drift_dev/test/analysis/resolver/drift/sqlparser/type_converter_lints_test.dart
@@ -1,0 +1,61 @@
+import 'package:test/test.dart';
+
+import '../../../test_utils.dart';
+
+const _enum = '''
+enum Fruit {
+  apple,
+  banana,
+  melon,
+  strawberry
+}
+''';
+
+void main() {
+  group('warns about invalid type converter value', () {
+    test('in table definition', () async {
+      final backend = TestBackend.inTest({
+        'a|lib/a.drift': '''
+import 'enum.dart';
+
+CREATE TABLE a (
+  a ENUMNAME(Fruit) NOT NULL DEFAULT 'raspberry',
+  b ENUM(Fruit) NOT NULL GENERATED ALWAYS AS (7),
+  c ENUM(Fruit) NOT NULL DEFAULT (-1)
+);
+''',
+        'a|lib/enum.dart': _enum,
+      });
+
+      final file = await backend.analyze('package:a/a.drift');
+      expect(file.allErrors, [
+        isDriftError(contains(
+                '`Fruit`. However, that enum declares no member with this name'))
+            .withSpan("'raspberry'"),
+        isDriftError(contains('the constant index is too large')).withSpan('7'),
+        isDriftError(contains("it can't be negative")).withSpan('-1'),
+      ]);
+    });
+
+    test('for query', () async {
+      final backend = TestBackend.inTest({
+        'a|lib/a.drift': '''
+import 'enum.dart';
+
+CREATE TABLE a (
+  a ENUMNAME(Fruit) NOT NULL
+);
+
+b: INSERT INTO a VALUES ('not a fruit');
+''',
+        'a|lib/enum.dart': _enum,
+      });
+
+      final file = await backend.analyze('package:a/a.drift');
+      expect(file.allErrors, [
+        isDriftError(contains('declares no member with this name'))
+            .withSpan("'not a fruit'")
+      ]);
+    });
+  });
+}

--- a/sqlparser/lib/src/analysis/types/expectation.dart
+++ b/sqlparser/lib/src/analysis/types/expectation.dart
@@ -10,6 +10,17 @@ part of 'types.dart';
 /// statement.
 abstract class TypeExpectation {
   const TypeExpectation();
+
+  int get specificity => 0;
+
+  /// Returns the expectaction from `this` or [other] with a higher specificity.
+  TypeExpectation orMoreSpecific(TypeExpectation other) {
+    if (specificity > other.specificity) {
+      return this;
+    } else {
+      return other;
+    }
+  }
 }
 
 /// Passed along when an ast node makes no assumption on the type of its
@@ -28,6 +39,9 @@ class ExactTypeExpectation extends TypeExpectation {
   /// When false, we can report a compile-time error for a type mismatch.
   final bool lax;
 
+  @override
+  int get specificity => lax ? 50 : 100;
+
   const ExactTypeExpectation._(this.type, this.lax);
 
   const ExactTypeExpectation(this.type) : lax = false;
@@ -45,6 +59,9 @@ class RoughTypeExpectation extends TypeExpectation {
   const RoughTypeExpectation._(this._type);
 
   const RoughTypeExpectation.numeric() : this._(_RoughType.numeric);
+
+  @override
+  int get specificity => 10;
 
   bool accepts(ResolvedType type) {
     final baseType = type.type;

--- a/sqlparser/lib/src/analysis/types/types.dart
+++ b/sqlparser/lib/src/analysis/types/types.dart
@@ -23,7 +23,16 @@ class TypeInferenceSession {
 
   void _checkAndResolve(
       Typeable t, ResolvedType r, TypeExpectation expectation) {
-    _expectIsPossible(r, expectation);
+    if (expectation is ExactTypeExpectation) {
+      final expectedType = expectation.type;
+
+      if (expectedType.hint != null &&
+          r.hint == null &&
+          expectedType.type == r.type) {
+        r = r.copyWith(hint: expectedType.hint);
+      }
+    }
+
     _markTypeResolved(t, r);
   }
 
@@ -35,11 +44,6 @@ class TypeInferenceSession {
   void _addRelation(TypeRelation relationship) {
     graph.addRelation(relationship);
   }
-
-  /// Check that [r] is compatible with [expectation].
-  ///
-  /// This is not currently implemented.
-  void _expectIsPossible(ResolvedType r, TypeExpectation expectation) {}
 
   /// This is not currently implemented.
   void _hintNullability(Typeable t, bool nullable) {

--- a/sqlparser/lib/src/ast/visitor.dart
+++ b/sqlparser/lib/src/ast/visitor.dart
@@ -449,7 +449,7 @@ class RecursiveVisitor<A, R> implements AstVisitor<A, R?> {
   }
 
   @override
-  R? visitNumericLiteral(Literal e, A arg) {
+  R? visitNumericLiteral(NumericLiteral e, A arg) {
     return defaultLiteral(e, arg);
   }
 


### PR DESCRIPTION
For enums in drift files you need to use the converted value. This PR checks if the index (for ENUM) or the field (for ENUMNAME) is a valid value.