### PR TITLE
Fix: remove illegal cast

### DIFF
--- a/drift/lib/src/runtime/types/mapping.dart
+++ b/drift/lib/src/runtime/types/mapping.dart
@@ -134,11 +134,7 @@ class SqlTypes {
     // ignore: unnecessary_cast
     switch (type as DriftSqlType<Object>) {
       case DriftSqlType.bool:
-        if (_dialect == SqlDialect.sqlite) {
-          return (sqlValue != 0) as T;
-        } else {
-          return sqlValue as T;
-        }
+        return (sqlValue != 0) as T;
       case DriftSqlType.string:
         return sqlValue.toString() as T;
       case DriftSqlType.bigInt:

--- a/drift/lib/src/runtime/types/mapping.dart
+++ b/drift/lib/src/runtime/types/mapping.dart
@@ -134,7 +134,7 @@ class SqlTypes {
     // ignore: unnecessary_cast
     switch (type as DriftSqlType<Object>) {
       case DriftSqlType.bool:
-        return (sqlValue != 0) as T;
+        return (sqlValue != 0 && sqlValue != false) as T;
       case DriftSqlType.string:
         return sqlValue.toString() as T;
       case DriftSqlType.bigInt:


### PR DESCRIPTION
Fixes #2221 

Removed illegal cast int as bool:
`return sqlValue as T;`

Also removed _dialect check. I don't think it is needed here. Couldn't really tell what you were trying to archive here.