### PR TITLE
Fix DriftSqlType.deserialize for double, dateTime and any

### DIFF
--- a/drift_dev/lib/src/services/schema/schema_files.dart
+++ b/drift_dev/lib/src/services/schema/schema_files.dart
@@ -450,29 +450,26 @@ extension _SerializeSqlType on DriftSqlType {
   static DriftSqlType deserialize(String description) {
     switch (description) {
       case 'ColumnType.boolean':
-      case 'bool':
         return DriftSqlType.bool;
       case 'ColumnType.text':
-      case 'string':
         return DriftSqlType.string;
       case 'ColumnType.bigInt':
-      case 'bigInt':
         return DriftSqlType.bigInt;
       case 'ColumnType.integer':
-      case 'int':
         return DriftSqlType.int;
       case 'ColumnType.datetime':
-      case 'datetime':
         return DriftSqlType.dateTime;
       case 'ColumnType.blob':
-      case 'blob':
         return DriftSqlType.blob;
       case 'ColumnType.real':
-      case 'real':
         return DriftSqlType.double;
-      default:
-        throw ArgumentError.value(
-            description, 'description', 'Not a known column type');
+    }
+
+    try {
+      return DriftSqlType.values.byName(description);
+    } on ArgumentError {
+      throw ArgumentError.value(
+          description, 'description', 'Not a known column type');
     }
   }
 

--- a/examples/app/lib/database/database.g.dart
+++ b/examples/app/lib/database/database.g.dart
@@ -612,8 +612,6 @@ class TextEntries extends Table
   }
 
   @override
-  List<String> get customConstraints => const [];
-  @override
   bool get dontWriteConstraints => true;
   @override
   String get moduleAndArgs =>

--- a/examples/migrations_example/lib/database.g.dart
+++ b/examples/migrations_example/lib/database.g.dart
@@ -727,8 +727,6 @@ class Notes extends Table
   }
 
   @override
-  List<String> get customConstraints => const [];
-  @override
   bool get dontWriteConstraints => true;
   @override
   String get moduleAndArgs =>

--- a/examples/with_built_value/lib/database.drift.dart
+++ b/examples/with_built_value/lib/database.drift.dart
@@ -168,8 +168,6 @@ class Users extends Table with TableInfo<Users, User> {
   }
 
   @override
-  List<String> get customConstraints => const [];
-  @override
   bool get dontWriteConstraints => true;
 }
 


### PR DESCRIPTION
The following values were being deserialized incorrectly:
- `datetime` instead of `dateTime`
- `real` instead of `double`
- `any` was missing

I instead replaced it with `DriftSqlType.values.byName(description);` which fell back to the old `ColumnType.` check