### PR TITLE
Add toColumns mixin when using user generated classes

### DIFF
--- a/docs/pages/docs/Advanced Features/builder_options.md
+++ b/docs/pages/docs/Advanced Features/builder_options.md
@@ -73,6 +73,8 @@ At the moment, drift supports these options:
   For more information on these modes, see [datetime options]({{ '../Getting started/advanced_dart_tables#datetime-options' | pageUrl }}).
 * `case_from_dart_to_sql` (defaults to `snake_case`): Controls how the table and column names are re-cased from the Dart identifiers.
   The possible values are  `preserve`, `camelCase`, `CONSTANT_CASE`, `snake_case`, `PascalCase`, `lowercase` and `UPPERCASE` (default: `snake_case`).
+* `write_to_columns_mixins`: Whether the `toColumns` method should be written as a mixin instead of being added directly to the data class.
+   This is useful when using [existing row classes]({{ 'custom_row_classes.md' | pageUrl }}), as the mixin is generated for those as well.
 
 ## Assumed SQL environment
 

--- a/drift/example/main.g.dart
+++ b/drift/example/main.g.dart
@@ -3,6 +3,68 @@
 part of 'main.dart';
 
 // ignore_for_file: type=lint
+class $TodoCategoriesTable extends TodoCategories
+    with TableInfo<$TodoCategoriesTable, TodoCategory> {
+  @override
+  final GeneratedDatabase attachedDatabase;
+  final String? _alias;
+  $TodoCategoriesTable(this.attachedDatabase, [this._alias]);
+  static const VerificationMeta _idMeta = const VerificationMeta('id');
+  @override
+  late final GeneratedColumn<int> id = GeneratedColumn<int>(
+      'id', aliasedName, false,
+      hasAutoIncrement: true,
+      type: DriftSqlType.int,
+      requiredDuringInsert: false,
+      defaultConstraints:
+          GeneratedColumn.constraintIsAlways('PRIMARY KEY AUTOINCREMENT'));
+  static const VerificationMeta _nameMeta = const VerificationMeta('name');
+  @override
+  late final GeneratedColumn<String> name = GeneratedColumn<String>(
+      'name', aliasedName, false,
+      type: DriftSqlType.string, requiredDuringInsert: true);
+  @override
+  List<GeneratedColumn> get $columns => [id, name];
+  @override
+  String get aliasedName => _alias ?? 'todo_categories';
+  @override
+  String get actualTableName => 'todo_categories';
+  @override
+  VerificationContext validateIntegrity(Insertable<TodoCategory> instance,
+      {bool isInserting = false}) {
+    final context = VerificationContext();
+    final data = instance.toColumns(true);
+    if (data.containsKey('id')) {
+      context.handle(_idMeta, id.isAcceptableOrUnknown(data['id']!, _idMeta));
+    }
+    if (data.containsKey('name')) {
+      context.handle(
+          _nameMeta, name.isAcceptableOrUnknown(data['name']!, _nameMeta));
+    } else if (isInserting) {
+      context.missing(_nameMeta);
+    }
+    return context;
+  }
+
+  @override
+  Set<GeneratedColumn> get $primaryKey => {id};
+  @override
+  TodoCategory map(Map<String, dynamic> data, {String? tablePrefix}) {
+    final effectivePrefix = tablePrefix != null ? '$tablePrefix.' : '';
+    return TodoCategory(
+      id: attachedDatabase.typeMapping
+          .read(DriftSqlType.int, data['${effectivePrefix}id'])!,
+      name: attachedDatabase.typeMapping
+          .read(DriftSqlType.string, data['${effectivePrefix}name'])!,
+    );
+  }
+
+  @override
+  $TodoCategoriesTable createAlias(String alias) {
+    return $TodoCategoriesTable(attachedDatabase, alias);
+  }
+}
+
 class TodoCategory extends DataClass implements Insertable<TodoCategory> {
   final int id;
   final String name;
@@ -115,12 +177,12 @@ class TodoCategoriesCompanion extends UpdateCompanion<TodoCategory> {
   }
 }
 
-class $TodoCategoriesTable extends TodoCategories
-    with TableInfo<$TodoCategoriesTable, TodoCategory> {
+class $TodoItemsTable extends TodoItems
+    with TableInfo<$TodoItemsTable, TodoItem> {
   @override
   final GeneratedDatabase attachedDatabase;
   final String? _alias;
-  $TodoCategoriesTable(this.attachedDatabase, [this._alias]);
+  $TodoItemsTable(this.attachedDatabase, [this._alias]);
   static const VerificationMeta _idMeta = const VerificationMeta('id');
   @override
   late final GeneratedColumn<int> id = GeneratedColumn<int>(
@@ -130,30 +192,73 @@ class $TodoCategoriesTable extends TodoCategories
       requiredDuringInsert: false,
       defaultConstraints:
           GeneratedColumn.constraintIsAlways('PRIMARY KEY AUTOINCREMENT'));
-  static const VerificationMeta _nameMeta = const VerificationMeta('name');
+  static const VerificationMeta _titleMeta = const VerificationMeta('title');
   @override
-  late final GeneratedColumn<String> name = GeneratedColumn<String>(
-      'name', aliasedName, false,
+  late final GeneratedColumn<String> title = GeneratedColumn<String>(
+      'title', aliasedName, false,
       type: DriftSqlType.string, requiredDuringInsert: true);
+  static const VerificationMeta _contentMeta =
+      const VerificationMeta('content');
   @override
-  List<GeneratedColumn> get $columns => [id, name];
+  late final GeneratedColumn<String> content = GeneratedColumn<String>(
+      'content', aliasedName, true,
+      type: DriftSqlType.string, requiredDuringInsert: false);
+  static const VerificationMeta _categoryIdMeta =
+      const VerificationMeta('categoryId');
   @override
-  String get aliasedName => _alias ?? 'todo_categories';
+  late final GeneratedColumn<int> categoryId = GeneratedColumn<int>(
+      'category_id', aliasedName, false,
+      type: DriftSqlType.int,
+      requiredDuringInsert: true,
+      defaultConstraints: GeneratedColumn.constraintIsAlways(
+          'REFERENCES todo_categories (id)'));
+  static const VerificationMeta _generatedTextMeta =
+      const VerificationMeta('generatedText');
   @override
-  String get actualTableName => 'todo_categories';
+  late final GeneratedColumn<String> generatedText = GeneratedColumn<String>(
+      'generated_text', aliasedName, true,
+      generatedAs: GeneratedAs(
+          title + const Constant(' (') + content + const Constant(')'), false),
+      type: DriftSqlType.string,
+      requiredDuringInsert: false);
   @override
-  VerificationContext validateIntegrity(Insertable<TodoCategory> instance,
+  List<GeneratedColumn> get $columns =>
+      [id, title, content, categoryId, generatedText];
+  @override
+  String get aliasedName => _alias ?? 'todo_items';
+  @override
+  String get actualTableName => 'todo_items';
+  @override
+  VerificationContext validateIntegrity(Insertable<TodoItem> instance,
       {bool isInserting = false}) {
     final context = VerificationContext();
     final data = instance.toColumns(true);
     if (data.containsKey('id')) {
       context.handle(_idMeta, id.isAcceptableOrUnknown(data['id']!, _idMeta));
     }
-    if (data.containsKey('name')) {
+    if (data.containsKey('title')) {
       context.handle(
-          _nameMeta, name.isAcceptableOrUnknown(data['name']!, _nameMeta));
+          _titleMeta, title.isAcceptableOrUnknown(data['title']!, _titleMeta));
     } else if (isInserting) {
-      context.missing(_nameMeta);
+      context.missing(_titleMeta);
+    }
+    if (data.containsKey('content')) {
+      context.handle(_contentMeta,
+          content.isAcceptableOrUnknown(data['content']!, _contentMeta));
+    }
+    if (data.containsKey('category_id')) {
+      context.handle(
+          _categoryIdMeta,
+          categoryId.isAcceptableOrUnknown(
+              data['category_id']!, _categoryIdMeta));
+    } else if (isInserting) {
+      context.missing(_categoryIdMeta);
+    }
+    if (data.containsKey('generated_text')) {
+      context.handle(
+          _generatedTextMeta,
+          generatedText.isAcceptableOrUnknown(
+              data['generated_text']!, _generatedTextMeta));
     }
     return context;
   }
@@ -161,19 +266,25 @@ class $TodoCategoriesTable extends TodoCategories
   @override
   Set<GeneratedColumn> get $primaryKey => {id};
   @override
-  TodoCategory map(Map<String, dynamic> data, {String? tablePrefix}) {
+  TodoItem map(Map<String, dynamic> data, {String? tablePrefix}) {
     final effectivePrefix = tablePrefix != null ? '$tablePrefix.' : '';
-    return TodoCategory(
+    return TodoItem(
       id: attachedDatabase.typeMapping
           .read(DriftSqlType.int, data['${effectivePrefix}id'])!,
-      name: attachedDatabase.typeMapping
-          .read(DriftSqlType.string, data['${effectivePrefix}name'])!,
+      title: attachedDatabase.typeMapping
+          .read(DriftSqlType.string, data['${effectivePrefix}title'])!,
+      content: attachedDatabase.typeMapping
+          .read(DriftSqlType.string, data['${effectivePrefix}content']),
+      categoryId: attachedDatabase.typeMapping
+          .read(DriftSqlType.int, data['${effectivePrefix}category_id'])!,
+      generatedText: attachedDatabase.typeMapping
+          .read(DriftSqlType.string, data['${effectivePrefix}generated_text']),
     );
   }
 
   @override
-  $TodoCategoriesTable createAlias(String alias) {
-    return $TodoCategoriesTable(attachedDatabase, alias);
+  $TodoItemsTable createAlias(String alias) {
+    return $TodoItemsTable(attachedDatabase, alias);
   }
 }
 
@@ -352,117 +463,6 @@ class TodoItemsCompanion extends UpdateCompanion<TodoItem> {
           ..write('categoryId: $categoryId')
           ..write(')'))
         .toString();
-  }
-}
-
-class $TodoItemsTable extends TodoItems
-    with TableInfo<$TodoItemsTable, TodoItem> {
-  @override
-  final GeneratedDatabase attachedDatabase;
-  final String? _alias;
-  $TodoItemsTable(this.attachedDatabase, [this._alias]);
-  static const VerificationMeta _idMeta = const VerificationMeta('id');
-  @override
-  late final GeneratedColumn<int> id = GeneratedColumn<int>(
-      'id', aliasedName, false,
-      hasAutoIncrement: true,
-      type: DriftSqlType.int,
-      requiredDuringInsert: false,
-      defaultConstraints:
-          GeneratedColumn.constraintIsAlways('PRIMARY KEY AUTOINCREMENT'));
-  static const VerificationMeta _titleMeta = const VerificationMeta('title');
-  @override
-  late final GeneratedColumn<String> title = GeneratedColumn<String>(
-      'title', aliasedName, false,
-      type: DriftSqlType.string, requiredDuringInsert: true);
-  static const VerificationMeta _contentMeta =
-      const VerificationMeta('content');
-  @override
-  late final GeneratedColumn<String> content = GeneratedColumn<String>(
-      'content', aliasedName, true,
-      type: DriftSqlType.string, requiredDuringInsert: false);
-  static const VerificationMeta _categoryIdMeta =
-      const VerificationMeta('categoryId');
-  @override
-  late final GeneratedColumn<int> categoryId = GeneratedColumn<int>(
-      'category_id', aliasedName, false,
-      type: DriftSqlType.int,
-      requiredDuringInsert: true,
-      defaultConstraints: GeneratedColumn.constraintIsAlways(
-          'REFERENCES todo_categories (id)'));
-  static const VerificationMeta _generatedTextMeta =
-      const VerificationMeta('generatedText');
-  @override
-  late final GeneratedColumn<String> generatedText = GeneratedColumn<String>(
-      'generated_text', aliasedName, true,
-      generatedAs: GeneratedAs(
-          title + const Constant(' (') + content + const Constant(')'), false),
-      type: DriftSqlType.string,
-      requiredDuringInsert: false);
-  @override
-  List<GeneratedColumn> get $columns =>
-      [id, title, content, categoryId, generatedText];
-  @override
-  String get aliasedName => _alias ?? 'todo_items';
-  @override
-  String get actualTableName => 'todo_items';
-  @override
-  VerificationContext validateIntegrity(Insertable<TodoItem> instance,
-      {bool isInserting = false}) {
-    final context = VerificationContext();
-    final data = instance.toColumns(true);
-    if (data.containsKey('id')) {
-      context.handle(_idMeta, id.isAcceptableOrUnknown(data['id']!, _idMeta));
-    }
-    if (data.containsKey('title')) {
-      context.handle(
-          _titleMeta, title.isAcceptableOrUnknown(data['title']!, _titleMeta));
-    } else if (isInserting) {
-      context.missing(_titleMeta);
-    }
-    if (data.containsKey('content')) {
-      context.handle(_contentMeta,
-          content.isAcceptableOrUnknown(data['content']!, _contentMeta));
-    }
-    if (data.containsKey('category_id')) {
-      context.handle(
-          _categoryIdMeta,
-          categoryId.isAcceptableOrUnknown(
-              data['category_id']!, _categoryIdMeta));
-    } else if (isInserting) {
-      context.missing(_categoryIdMeta);
-    }
-    if (data.containsKey('generated_text')) {
-      context.handle(
-          _generatedTextMeta,
-          generatedText.isAcceptableOrUnknown(
-              data['generated_text']!, _generatedTextMeta));
-    }
-    return context;
-  }
-
-  @override
-  Set<GeneratedColumn> get $primaryKey => {id};
-  @override
-  TodoItem map(Map<String, dynamic> data, {String? tablePrefix}) {
-    final effectivePrefix = tablePrefix != null ? '$tablePrefix.' : '';
-    return TodoItem(
-      id: attachedDatabase.typeMapping
-          .read(DriftSqlType.int, data['${effectivePrefix}id'])!,
-      title: attachedDatabase.typeMapping
-          .read(DriftSqlType.string, data['${effectivePrefix}title'])!,
-      content: attachedDatabase.typeMapping
-          .read(DriftSqlType.string, data['${effectivePrefix}content']),
-      categoryId: attachedDatabase.typeMapping
-          .read(DriftSqlType.int, data['${effectivePrefix}category_id'])!,
-      generatedText: attachedDatabase.typeMapping
-          .read(DriftSqlType.string, data['${effectivePrefix}generated_text']),
-    );
-  }
-
-  @override
-  $TodoItemsTable createAlias(String alias) {
-    return $TodoItemsTable(attachedDatabase, alias);
   }
 }
 

--- a/drift/lib/src/dsl/table.dart
+++ b/drift/lib/src/dsl/table.dart
@@ -314,6 +314,7 @@ class UseRowClass {
   ///
   /// This can be useful when a custom data class should be used for inserts or
   /// updates.
+  @Deprecated('Use `write_to_columns_mixins` build option instead')
   final bool generateInsertable;
 
   /// Customize the class used by drift to hold an instance of an annotated

--- a/drift/test/generated/custom_tables.g.dart
+++ b/drift/test/generated/custom_tables.g.dart
@@ -3,46 +3,6 @@
 part of 'custom_tables.dart';
 
 // ignore_for_file: type=lint
-class NoIdsCompanion extends UpdateCompanion<NoIdRow> {
-  final Value<Uint8List> payload;
-  const NoIdsCompanion({
-    this.payload = const Value.absent(),
-  });
-  NoIdsCompanion.insert({
-    required Uint8List payload,
-  }) : payload = Value(payload);
-  static Insertable<NoIdRow> custom({
-    Expression<Uint8List>? payload,
-  }) {
-    return RawValuesInsertable({
-      if (payload != null) 'payload': payload,
-    });
-  }
-
-  NoIdsCompanion copyWith({Value<Uint8List>? payload}) {
-    return NoIdsCompanion(
-      payload: payload ?? this.payload,
-    );
-  }
-
-  @override
-  Map<String, Expression> toColumns(bool nullToAbsent) {
-    final map = <String, Expression>{};
-    if (payload.present) {
-      map['payload'] = Variable<Uint8List>(payload.value);
-    }
-    return map;
-  }
-
-  @override
-  String toString() {
-    return (StringBuffer('NoIdsCompanion(')
-          ..write('payload: $payload')
-          ..write(')'))
-        .toString();
-  }
-}
-
 class NoIds extends Table with TableInfo<NoIds, NoIdRow> {
   @override
   final GeneratedDatabase attachedDatabase;
@@ -93,6 +53,106 @@ class NoIds extends Table with TableInfo<NoIds, NoIdRow> {
 
   @override
   bool get withoutRowId => true;
+  @override
+  bool get dontWriteConstraints => true;
+}
+
+class NoIdsCompanion extends UpdateCompanion<NoIdRow> {
+  final Value<Uint8List> payload;
+  const NoIdsCompanion({
+    this.payload = const Value.absent(),
+  });
+  NoIdsCompanion.insert({
+    required Uint8List payload,
+  }) : payload = Value(payload);
+  static Insertable<NoIdRow> custom({
+    Expression<Uint8List>? payload,
+  }) {
+    return RawValuesInsertable({
+      if (payload != null) 'payload': payload,
+    });
+  }
+
+  NoIdsCompanion copyWith({Value<Uint8List>? payload}) {
+    return NoIdsCompanion(
+      payload: payload ?? this.payload,
+    );
+  }
+
+  @override
+  Map<String, Expression> toColumns(bool nullToAbsent) {
+    final map = <String, Expression>{};
+    if (payload.present) {
+      map['payload'] = Variable<Uint8List>(payload.value);
+    }
+    return map;
+  }
+
+  @override
+  String toString() {
+    return (StringBuffer('NoIdsCompanion(')
+          ..write('payload: $payload')
+          ..write(')'))
+        .toString();
+  }
+}
+
+class WithDefaults extends Table with TableInfo<WithDefaults, WithDefault> {
+  @override
+  final GeneratedDatabase attachedDatabase;
+  final String? _alias;
+  WithDefaults(this.attachedDatabase, [this._alias]);
+  static const VerificationMeta _aMeta = const VerificationMeta('a');
+  late final GeneratedColumn<String> a = GeneratedColumn<String>(
+      'a', aliasedName, true,
+      type: DriftSqlType.string,
+      requiredDuringInsert: false,
+      $customConstraints: 'DEFAULT \'something\'',
+      defaultValue: const CustomExpression('\'something\''));
+  static const VerificationMeta _bMeta = const VerificationMeta('b');
+  late final GeneratedColumn<int> b = GeneratedColumn<int>(
+      'b', aliasedName, true,
+      type: DriftSqlType.int,
+      requiredDuringInsert: false,
+      $customConstraints: 'UNIQUE');
+  @override
+  List<GeneratedColumn> get $columns => [a, b];
+  @override
+  String get aliasedName => _alias ?? 'with_defaults';
+  @override
+  String get actualTableName => 'with_defaults';
+  @override
+  VerificationContext validateIntegrity(Insertable<WithDefault> instance,
+      {bool isInserting = false}) {
+    final context = VerificationContext();
+    final data = instance.toColumns(true);
+    if (data.containsKey('a')) {
+      context.handle(_aMeta, a.isAcceptableOrUnknown(data['a']!, _aMeta));
+    }
+    if (data.containsKey('b')) {
+      context.handle(_bMeta, b.isAcceptableOrUnknown(data['b']!, _bMeta));
+    }
+    return context;
+  }
+
+  @override
+  Set<GeneratedColumn> get $primaryKey => const {};
+  @override
+  WithDefault map(Map<String, dynamic> data, {String? tablePrefix}) {
+    final effectivePrefix = tablePrefix != null ? '$tablePrefix.' : '';
+    return WithDefault(
+      a: attachedDatabase.typeMapping
+          .read(DriftSqlType.string, data['${effectivePrefix}a']),
+      b: attachedDatabase.typeMapping
+          .read(DriftSqlType.int, data['${effectivePrefix}b']),
+    );
+  }
+
+  @override
+  WithDefaults createAlias(String alias) {
+    return WithDefaults(attachedDatabase, alias);
+  }
+
   @override
   bool get dontWriteConstraints => true;
 }
@@ -216,32 +276,38 @@ class WithDefaultsCompanion extends UpdateCompanion<WithDefault> {
   }
 }
 
-class WithDefaults extends Table with TableInfo<WithDefaults, WithDefault> {
+class WithConstraints extends Table
+    with TableInfo<WithConstraints, WithConstraint> {
   @override
   final GeneratedDatabase attachedDatabase;
   final String? _alias;
-  WithDefaults(this.attachedDatabase, [this._alias]);
+  WithConstraints(this.attachedDatabase, [this._alias]);
   static const VerificationMeta _aMeta = const VerificationMeta('a');
   late final GeneratedColumn<String> a = GeneratedColumn<String>(
       'a', aliasedName, true,
       type: DriftSqlType.string,
       requiredDuringInsert: false,
-      $customConstraints: 'DEFAULT \'something\'',
-      defaultValue: const CustomExpression('\'something\''));
+      $customConstraints: '');
   static const VerificationMeta _bMeta = const VerificationMeta('b');
   late final GeneratedColumn<int> b = GeneratedColumn<int>(
-      'b', aliasedName, true,
+      'b', aliasedName, false,
       type: DriftSqlType.int,
+      requiredDuringInsert: true,
+      $customConstraints: 'NOT NULL');
+  static const VerificationMeta _cMeta = const VerificationMeta('c');
+  late final GeneratedColumn<double> c = GeneratedColumn<double>(
+      'c', aliasedName, true,
+      type: DriftSqlType.double,
       requiredDuringInsert: false,
-      $customConstraints: 'UNIQUE');
+      $customConstraints: '');
   @override
-  List<GeneratedColumn> get $columns => [a, b];
+  List<GeneratedColumn> get $columns => [a, b, c];
   @override
-  String get aliasedName => _alias ?? 'with_defaults';
+  String get aliasedName => _alias ?? 'with_constraints';
   @override
-  String get actualTableName => 'with_defaults';
+  String get actualTableName => 'with_constraints';
   @override
-  VerificationContext validateIntegrity(Insertable<WithDefault> instance,
+  VerificationContext validateIntegrity(Insertable<WithConstraint> instance,
       {bool isInserting = false}) {
     final context = VerificationContext();
     final data = instance.toColumns(true);
@@ -250,6 +316,11 @@ class WithDefaults extends Table with TableInfo<WithDefaults, WithDefault> {
     }
     if (data.containsKey('b')) {
       context.handle(_bMeta, b.isAcceptableOrUnknown(data['b']!, _bMeta));
+    } else if (isInserting) {
+      context.missing(_bMeta);
+    }
+    if (data.containsKey('c')) {
+      context.handle(_cMeta, c.isAcceptableOrUnknown(data['c']!, _cMeta));
     }
     return context;
   }
@@ -257,21 +328,26 @@ class WithDefaults extends Table with TableInfo<WithDefaults, WithDefault> {
   @override
   Set<GeneratedColumn> get $primaryKey => const {};
   @override
-  WithDefault map(Map<String, dynamic> data, {String? tablePrefix}) {
+  WithConstraint map(Map<String, dynamic> data, {String? tablePrefix}) {
     final effectivePrefix = tablePrefix != null ? '$tablePrefix.' : '';
-    return WithDefault(
+    return WithConstraint(
       a: attachedDatabase.typeMapping
           .read(DriftSqlType.string, data['${effectivePrefix}a']),
       b: attachedDatabase.typeMapping
-          .read(DriftSqlType.int, data['${effectivePrefix}b']),
+          .read(DriftSqlType.int, data['${effectivePrefix}b'])!,
+      c: attachedDatabase.typeMapping
+          .read(DriftSqlType.double, data['${effectivePrefix}c']),
     );
   }
 
   @override
-  WithDefaults createAlias(String alias) {
-    return WithDefaults(attachedDatabase, alias);
+  WithConstraints createAlias(String alias) {
+    return WithConstraints(attachedDatabase, alias);
   }
 
+  @override
+  List<String> get customConstraints =>
+      const ['FOREIGN KEY(a, b)REFERENCES with_defaults(a, b)'];
   @override
   bool get dontWriteConstraints => true;
 }
@@ -417,78 +493,106 @@ class WithConstraintsCompanion extends UpdateCompanion<WithConstraint> {
   }
 }
 
-class WithConstraints extends Table
-    with TableInfo<WithConstraints, WithConstraint> {
+class ConfigTable extends Table with TableInfo<ConfigTable, Config> {
   @override
   final GeneratedDatabase attachedDatabase;
   final String? _alias;
-  WithConstraints(this.attachedDatabase, [this._alias]);
-  static const VerificationMeta _aMeta = const VerificationMeta('a');
-  late final GeneratedColumn<String> a = GeneratedColumn<String>(
-      'a', aliasedName, true,
+  ConfigTable(this.attachedDatabase, [this._alias]);
+  static const VerificationMeta _configKeyMeta =
+      const VerificationMeta('configKey');
+  late final GeneratedColumn<String> configKey = GeneratedColumn<String>(
+      'config_key', aliasedName, false,
       type: DriftSqlType.string,
-      requiredDuringInsert: false,
-      $customConstraints: '');
-  static const VerificationMeta _bMeta = const VerificationMeta('b');
-  late final GeneratedColumn<int> b = GeneratedColumn<int>(
-      'b', aliasedName, false,
-      type: DriftSqlType.int,
       requiredDuringInsert: true,
-      $customConstraints: 'NOT NULL');
-  static const VerificationMeta _cMeta = const VerificationMeta('c');
-  late final GeneratedColumn<double> c = GeneratedColumn<double>(
-      'c', aliasedName, true,
-      type: DriftSqlType.double,
+      $customConstraints: 'NOT NULL PRIMARY KEY');
+  static const VerificationMeta _configValueMeta =
+      const VerificationMeta('configValue');
+  late final GeneratedColumn<DriftAny> configValue = GeneratedColumn<DriftAny>(
+      'config_value', aliasedName, true,
+      type: DriftSqlType.any,
       requiredDuringInsert: false,
       $customConstraints: '');
+  static const VerificationMeta _syncStateMeta =
+      const VerificationMeta('syncState');
+  late final GeneratedColumnWithTypeConverter<SyncType?, int> syncState =
+      GeneratedColumn<int>('sync_state', aliasedName, true,
+              type: DriftSqlType.int,
+              requiredDuringInsert: false,
+              $customConstraints: '')
+          .withConverter<SyncType?>(ConfigTable.$convertersyncStaten);
+  static const VerificationMeta _syncStateImplicitMeta =
+      const VerificationMeta('syncStateImplicit');
+  late final GeneratedColumnWithTypeConverter<SyncType?, int>
+      syncStateImplicit = GeneratedColumn<int>(
+              'sync_state_implicit', aliasedName, true,
+              type: DriftSqlType.int,
+              requiredDuringInsert: false,
+              $customConstraints: '')
+          .withConverter<SyncType?>(ConfigTable.$convertersyncStateImplicitn);
   @override
-  List<GeneratedColumn> get $columns => [a, b, c];
+  List<GeneratedColumn> get $columns =>
+      [configKey, configValue, syncState, syncStateImplicit];
   @override
-  String get aliasedName => _alias ?? 'with_constraints';
+  String get aliasedName => _alias ?? 'config';
   @override
-  String get actualTableName => 'with_constraints';
+  String get actualTableName => 'config';
   @override
-  VerificationContext validateIntegrity(Insertable<WithConstraint> instance,
+  VerificationContext validateIntegrity(Insertable<Config> instance,
       {bool isInserting = false}) {
     final context = VerificationContext();
     final data = instance.toColumns(true);
-    if (data.containsKey('a')) {
-      context.handle(_aMeta, a.isAcceptableOrUnknown(data['a']!, _aMeta));
-    }
-    if (data.containsKey('b')) {
-      context.handle(_bMeta, b.isAcceptableOrUnknown(data['b']!, _bMeta));
+    if (data.containsKey('config_key')) {
+      context.handle(_configKeyMeta,
+          configKey.isAcceptableOrUnknown(data['config_key']!, _configKeyMeta));
     } else if (isInserting) {
-      context.missing(_bMeta);
+      context.missing(_configKeyMeta);
     }
-    if (data.containsKey('c')) {
-      context.handle(_cMeta, c.isAcceptableOrUnknown(data['c']!, _cMeta));
+    if (data.containsKey('config_value')) {
+      context.handle(
+          _configValueMeta,
+          configValue.isAcceptableOrUnknown(
+              data['config_value']!, _configValueMeta));
     }
+    context.handle(_syncStateMeta, const VerificationResult.success());
+    context.handle(_syncStateImplicitMeta, const VerificationResult.success());
     return context;
   }
 
   @override
-  Set<GeneratedColumn> get $primaryKey => const {};
+  Set<GeneratedColumn> get $primaryKey => {configKey};
   @override
-  WithConstraint map(Map<String, dynamic> data, {String? tablePrefix}) {
+  Config map(Map<String, dynamic> data, {String? tablePrefix}) {
     final effectivePrefix = tablePrefix != null ? '$tablePrefix.' : '';
-    return WithConstraint(
-      a: attachedDatabase.typeMapping
-          .read(DriftSqlType.string, data['${effectivePrefix}a']),
-      b: attachedDatabase.typeMapping
-          .read(DriftSqlType.int, data['${effectivePrefix}b'])!,
-      c: attachedDatabase.typeMapping
-          .read(DriftSqlType.double, data['${effectivePrefix}c']),
+    return Config(
+      configKey: attachedDatabase.typeMapping
+          .read(DriftSqlType.string, data['${effectivePrefix}config_key'])!,
+      configValue: attachedDatabase.typeMapping
+          .read(DriftSqlType.any, data['${effectivePrefix}config_value']),
+      syncState: ConfigTable.$convertersyncStaten.fromSql(attachedDatabase
+          .typeMapping
+          .read(DriftSqlType.int, data['${effectivePrefix}sync_state'])),
+      syncStateImplicit: ConfigTable.$convertersyncStateImplicitn.fromSql(
+          attachedDatabase.typeMapping.read(
+              DriftSqlType.int, data['${effectivePrefix}sync_state_implicit'])),
     );
   }
 
   @override
-  WithConstraints createAlias(String alias) {
-    return WithConstraints(attachedDatabase, alias);
+  ConfigTable createAlias(String alias) {
+    return ConfigTable(attachedDatabase, alias);
   }
 
+  static TypeConverter<SyncType, int> $convertersyncState =
+      const SyncTypeConverter();
+  static TypeConverter<SyncType?, int?> $convertersyncStaten =
+      NullAwareTypeConverter.wrap($convertersyncState);
+  static JsonTypeConverter2<SyncType, int, int> $convertersyncStateImplicit =
+      const EnumIndexConverter<SyncType>(SyncType.values);
+  static JsonTypeConverter2<SyncType?, int?, int?>
+      $convertersyncStateImplicitn =
+      JsonTypeConverter2.asNullable($convertersyncStateImplicit);
   @override
-  List<String> get customConstraints =>
-      const ['FOREIGN KEY(a, b)REFERENCES with_defaults(a, b)'];
+  bool get isStrict => true;
   @override
   bool get dontWriteConstraints => true;
 }
@@ -678,106 +782,101 @@ class ConfigCompanion extends UpdateCompanion<Config> {
   }
 }
 
-class ConfigTable extends Table with TableInfo<ConfigTable, Config> {
+class Mytable extends Table with TableInfo<Mytable, MytableData> {
   @override
   final GeneratedDatabase attachedDatabase;
   final String? _alias;
-  ConfigTable(this.attachedDatabase, [this._alias]);
-  static const VerificationMeta _configKeyMeta =
-      const VerificationMeta('configKey');
-  late final GeneratedColumn<String> configKey = GeneratedColumn<String>(
-      'config_key', aliasedName, false,
+  Mytable(this.attachedDatabase, [this._alias]);
+  static const VerificationMeta _someidMeta = const VerificationMeta('someid');
+  late final GeneratedColumn<int> someid = GeneratedColumn<int>(
+      'someid', aliasedName, false,
+      type: DriftSqlType.int,
+      requiredDuringInsert: false,
+      $customConstraints: 'NOT NULL');
+  static const VerificationMeta _sometextMeta =
+      const VerificationMeta('sometext');
+  late final GeneratedColumn<String> sometext = GeneratedColumn<String>(
+      'sometext', aliasedName, true,
       type: DriftSqlType.string,
-      requiredDuringInsert: true,
-      $customConstraints: 'NOT NULL PRIMARY KEY');
-  static const VerificationMeta _configValueMeta =
-      const VerificationMeta('configValue');
-  late final GeneratedColumn<DriftAny> configValue = GeneratedColumn<DriftAny>(
-      'config_value', aliasedName, true,
-      type: DriftSqlType.any,
       requiredDuringInsert: false,
       $customConstraints: '');
-  static const VerificationMeta _syncStateMeta =
-      const VerificationMeta('syncState');
-  late final GeneratedColumnWithTypeConverter<SyncType?, int> syncState =
-      GeneratedColumn<int>('sync_state', aliasedName, true,
-              type: DriftSqlType.int,
-              requiredDuringInsert: false,
-              $customConstraints: '')
-          .withConverter<SyncType?>(ConfigTable.$convertersyncStaten);
-  static const VerificationMeta _syncStateImplicitMeta =
-      const VerificationMeta('syncStateImplicit');
-  late final GeneratedColumnWithTypeConverter<SyncType?, int>
-      syncStateImplicit = GeneratedColumn<int>(
-              'sync_state_implicit', aliasedName, true,
-              type: DriftSqlType.int,
-              requiredDuringInsert: false,
-              $customConstraints: '')
-          .withConverter<SyncType?>(ConfigTable.$convertersyncStateImplicitn);
+  static const VerificationMeta _isInsertingMeta =
+      const VerificationMeta('isInserting');
+  late final GeneratedColumn<bool> isInserting = GeneratedColumn<bool>(
+      'is_inserting', aliasedName, true,
+      type: DriftSqlType.bool,
+      requiredDuringInsert: false,
+      $customConstraints: '');
+  static const VerificationMeta _somedateMeta =
+      const VerificationMeta('somedate');
+  late final GeneratedColumn<DateTime> somedate = GeneratedColumn<DateTime>(
+      'somedate', aliasedName, true,
+      type: DriftSqlType.dateTime,
+      requiredDuringInsert: false,
+      $customConstraints: '');
   @override
   List<GeneratedColumn> get $columns =>
-      [configKey, configValue, syncState, syncStateImplicit];
+      [someid, sometext, isInserting, somedate];
   @override
-  String get aliasedName => _alias ?? 'config';
+  String get aliasedName => _alias ?? 'mytable';
   @override
-  String get actualTableName => 'config';
+  String get actualTableName => 'mytable';
   @override
-  VerificationContext validateIntegrity(Insertable<Config> instance,
+  VerificationContext validateIntegrity(Insertable<MytableData> instance,
       {bool isInserting = false}) {
     final context = VerificationContext();
     final data = instance.toColumns(true);
-    if (data.containsKey('config_key')) {
-      context.handle(_configKeyMeta,
-          configKey.isAcceptableOrUnknown(data['config_key']!, _configKeyMeta));
-    } else if (isInserting) {
-      context.missing(_configKeyMeta);
+    if (data.containsKey('someid')) {
+      context.handle(_someidMeta,
+          someid.isAcceptableOrUnknown(data['someid']!, _someidMeta));
     }
-    if (data.containsKey('config_value')) {
+    if (data.containsKey('sometext')) {
+      context.handle(_sometextMeta,
+          sometext.isAcceptableOrUnknown(data['sometext']!, _sometextMeta));
+    }
+    if (data.containsKey('is_inserting')) {
       context.handle(
-          _configValueMeta,
-          configValue.isAcceptableOrUnknown(
-              data['config_value']!, _configValueMeta));
+          _isInsertingMeta,
+          this
+              .isInserting
+              .isAcceptableOrUnknown(data['is_inserting']!, _isInsertingMeta));
     }
-    context.handle(_syncStateMeta, const VerificationResult.success());
-    context.handle(_syncStateImplicitMeta, const VerificationResult.success());
+    if (data.containsKey('somedate')) {
+      context.handle(_somedateMeta,
+          somedate.isAcceptableOrUnknown(data['somedate']!, _somedateMeta));
+    }
     return context;
   }
 
   @override
-  Set<GeneratedColumn> get $primaryKey => {configKey};
+  Set<GeneratedColumn> get $primaryKey => {someid};
   @override
-  Config map(Map<String, dynamic> data, {String? tablePrefix}) {
+  List<Set<GeneratedColumn>> get uniqueKeys => [
+        {sometext, isInserting},
+      ];
+  @override
+  MytableData map(Map<String, dynamic> data, {String? tablePrefix}) {
     final effectivePrefix = tablePrefix != null ? '$tablePrefix.' : '';
-    return Config(
-      configKey: attachedDatabase.typeMapping
-          .read(DriftSqlType.string, data['${effectivePrefix}config_key'])!,
-      configValue: attachedDatabase.typeMapping
-          .read(DriftSqlType.any, data['${effectivePrefix}config_value']),
-      syncState: ConfigTable.$convertersyncStaten.fromSql(attachedDatabase
-          .typeMapping
-          .read(DriftSqlType.int, data['${effectivePrefix}sync_state'])),
-      syncStateImplicit: ConfigTable.$convertersyncStateImplicitn.fromSql(
-          attachedDatabase.typeMapping.read(
-              DriftSqlType.int, data['${effectivePrefix}sync_state_implicit'])),
+    return MytableData(
+      someid: attachedDatabase.typeMapping
+          .read(DriftSqlType.int, data['${effectivePrefix}someid'])!,
+      sometext: attachedDatabase.typeMapping
+          .read(DriftSqlType.string, data['${effectivePrefix}sometext']),
+      isInserting: attachedDatabase.typeMapping
+          .read(DriftSqlType.bool, data['${effectivePrefix}is_inserting']),
+      somedate: attachedDatabase.typeMapping
+          .read(DriftSqlType.dateTime, data['${effectivePrefix}somedate']),
     );
   }
 
   @override
-  ConfigTable createAlias(String alias) {
-    return ConfigTable(attachedDatabase, alias);
+  Mytable createAlias(String alias) {
+    return Mytable(attachedDatabase, alias);
   }
 
-  static TypeConverter<SyncType, int> $convertersyncState =
-      const SyncTypeConverter();
-  static TypeConverter<SyncType?, int?> $convertersyncStaten =
-      NullAwareTypeConverter.wrap($convertersyncState);
-  static JsonTypeConverter2<SyncType, int, int> $convertersyncStateImplicit =
-      const EnumIndexConverter<SyncType>(SyncType.values);
-  static JsonTypeConverter2<SyncType?, int?, int?>
-      $convertersyncStateImplicitn =
-      JsonTypeConverter2.asNullable($convertersyncStateImplicit);
   @override
-  bool get isStrict => true;
+  List<String> get customConstraints =>
+      const ['PRIMARY KEY(someid DESC)', 'UNIQUE(sometext, is_inserting)'];
   @override
   bool get dontWriteConstraints => true;
 }
@@ -954,103 +1053,86 @@ class MytableCompanion extends UpdateCompanion<MytableData> {
   }
 }
 
-class Mytable extends Table with TableInfo<Mytable, MytableData> {
+class Email extends Table
+    with TableInfo<Email, EMail>, VirtualTableInfo<Email, EMail> {
   @override
   final GeneratedDatabase attachedDatabase;
   final String? _alias;
-  Mytable(this.attachedDatabase, [this._alias]);
-  static const VerificationMeta _someidMeta = const VerificationMeta('someid');
-  late final GeneratedColumn<int> someid = GeneratedColumn<int>(
-      'someid', aliasedName, false,
-      type: DriftSqlType.int,
-      requiredDuringInsert: false,
-      $customConstraints: 'NOT NULL');
-  static const VerificationMeta _sometextMeta =
-      const VerificationMeta('sometext');
-  late final GeneratedColumn<String> sometext = GeneratedColumn<String>(
-      'sometext', aliasedName, true,
+  Email(this.attachedDatabase, [this._alias]);
+  static const VerificationMeta _senderMeta = const VerificationMeta('sender');
+  late final GeneratedColumn<String> sender = GeneratedColumn<String>(
+      'sender', aliasedName, false,
       type: DriftSqlType.string,
-      requiredDuringInsert: false,
+      requiredDuringInsert: true,
       $customConstraints: '');
-  static const VerificationMeta _isInsertingMeta =
-      const VerificationMeta('isInserting');
-  late final GeneratedColumn<bool> isInserting = GeneratedColumn<bool>(
-      'is_inserting', aliasedName, true,
-      type: DriftSqlType.bool,
-      requiredDuringInsert: false,
+  static const VerificationMeta _titleMeta = const VerificationMeta('title');
+  late final GeneratedColumn<String> title = GeneratedColumn<String>(
+      'title', aliasedName, false,
+      type: DriftSqlType.string,
+      requiredDuringInsert: true,
       $customConstraints: '');
-  static const VerificationMeta _somedateMeta =
-      const VerificationMeta('somedate');
-  late final GeneratedColumn<DateTime> somedate = GeneratedColumn<DateTime>(
-      'somedate', aliasedName, true,
-      type: DriftSqlType.dateTime,
-      requiredDuringInsert: false,
+  static const VerificationMeta _bodyMeta = const VerificationMeta('body');
+  late final GeneratedColumn<String> body = GeneratedColumn<String>(
+      'body', aliasedName, false,
+      type: DriftSqlType.string,
+      requiredDuringInsert: true,
       $customConstraints: '');
   @override
-  List<GeneratedColumn> get $columns =>
-      [someid, sometext, isInserting, somedate];
+  List<GeneratedColumn> get $columns => [sender, title, body];
   @override
-  String get aliasedName => _alias ?? 'mytable';
+  String get aliasedName => _alias ?? 'email';
   @override
-  String get actualTableName => 'mytable';
+  String get actualTableName => 'email';
   @override
-  VerificationContext validateIntegrity(Insertable<MytableData> instance,
+  VerificationContext validateIntegrity(Insertable<EMail> instance,
       {bool isInserting = false}) {
     final context = VerificationContext();
     final data = instance.toColumns(true);
-    if (data.containsKey('someid')) {
-      context.handle(_someidMeta,
-          someid.isAcceptableOrUnknown(data['someid']!, _someidMeta));
+    if (data.containsKey('sender')) {
+      context.handle(_senderMeta,
+          sender.isAcceptableOrUnknown(data['sender']!, _senderMeta));
+    } else if (isInserting) {
+      context.missing(_senderMeta);
     }
-    if (data.containsKey('sometext')) {
-      context.handle(_sometextMeta,
-          sometext.isAcceptableOrUnknown(data['sometext']!, _sometextMeta));
-    }
-    if (data.containsKey('is_inserting')) {
+    if (data.containsKey('title')) {
       context.handle(
-          _isInsertingMeta,
-          this
-              .isInserting
-              .isAcceptableOrUnknown(data['is_inserting']!, _isInsertingMeta));
+          _titleMeta, title.isAcceptableOrUnknown(data['title']!, _titleMeta));
+    } else if (isInserting) {
+      context.missing(_titleMeta);
     }
-    if (data.containsKey('somedate')) {
-      context.handle(_somedateMeta,
-          somedate.isAcceptableOrUnknown(data['somedate']!, _somedateMeta));
+    if (data.containsKey('body')) {
+      context.handle(
+          _bodyMeta, body.isAcceptableOrUnknown(data['body']!, _bodyMeta));
+    } else if (isInserting) {
+      context.missing(_bodyMeta);
     }
     return context;
   }
 
   @override
-  Set<GeneratedColumn> get $primaryKey => {someid};
+  Set<GeneratedColumn> get $primaryKey => const {};
   @override
-  List<Set<GeneratedColumn>> get uniqueKeys => [
-        {sometext, isInserting},
-      ];
-  @override
-  MytableData map(Map<String, dynamic> data, {String? tablePrefix}) {
+  EMail map(Map<String, dynamic> data, {String? tablePrefix}) {
     final effectivePrefix = tablePrefix != null ? '$tablePrefix.' : '';
-    return MytableData(
-      someid: attachedDatabase.typeMapping
-          .read(DriftSqlType.int, data['${effectivePrefix}someid'])!,
-      sometext: attachedDatabase.typeMapping
-          .read(DriftSqlType.string, data['${effectivePrefix}sometext']),
-      isInserting: attachedDatabase.typeMapping
-          .read(DriftSqlType.bool, data['${effectivePrefix}is_inserting']),
-      somedate: attachedDatabase.typeMapping
-          .read(DriftSqlType.dateTime, data['${effectivePrefix}somedate']),
+    return EMail(
+      sender: attachedDatabase.typeMapping
+          .read(DriftSqlType.string, data['${effectivePrefix}sender'])!,
+      title: attachedDatabase.typeMapping
+          .read(DriftSqlType.string, data['${effectivePrefix}title'])!,
+      body: attachedDatabase.typeMapping
+          .read(DriftSqlType.string, data['${effectivePrefix}body'])!,
     );
   }
 
   @override
-  Mytable createAlias(String alias) {
-    return Mytable(attachedDatabase, alias);
+  Email createAlias(String alias) {
+    return Email(attachedDatabase, alias);
   }
 
   @override
-  List<String> get customConstraints =>
-      const ['PRIMARY KEY(someid DESC)', 'UNIQUE(sometext, is_inserting)'];
-  @override
   bool get dontWriteConstraints => true;
+  @override
+  String get moduleAndArgs => 'fts5(sender, title, body)';
 }
 
 class EMail extends DataClass implements Insertable<EMail> {
@@ -1187,58 +1269,47 @@ class EmailCompanion extends UpdateCompanion<EMail> {
   }
 }
 
-class Email extends Table
-    with TableInfo<Email, EMail>, VirtualTableInfo<Email, EMail> {
+class WeirdTable extends Table with TableInfo<WeirdTable, WeirdData> {
   @override
   final GeneratedDatabase attachedDatabase;
   final String? _alias;
-  Email(this.attachedDatabase, [this._alias]);
-  static const VerificationMeta _senderMeta = const VerificationMeta('sender');
-  late final GeneratedColumn<String> sender = GeneratedColumn<String>(
-      'sender', aliasedName, false,
+  WeirdTable(this.attachedDatabase, [this._alias]);
+  static const VerificationMeta _sqlClassMeta =
+      const VerificationMeta('sqlClass');
+  late final GeneratedColumn<int> sqlClass = GeneratedColumn<int>(
+      'class', aliasedName, false,
+      type: DriftSqlType.int,
+      requiredDuringInsert: true,
+      $customConstraints: 'NOT NULL');
+  static const VerificationMeta _textColumnMeta =
+      const VerificationMeta('textColumn');
+  late final GeneratedColumn<String> textColumn = GeneratedColumn<String>(
+      'text', aliasedName, false,
       type: DriftSqlType.string,
       requiredDuringInsert: true,
-      $customConstraints: '');
-  static const VerificationMeta _titleMeta = const VerificationMeta('title');
-  late final GeneratedColumn<String> title = GeneratedColumn<String>(
-      'title', aliasedName, false,
-      type: DriftSqlType.string,
-      requiredDuringInsert: true,
-      $customConstraints: '');
-  static const VerificationMeta _bodyMeta = const VerificationMeta('body');
-  late final GeneratedColumn<String> body = GeneratedColumn<String>(
-      'body', aliasedName, false,
-      type: DriftSqlType.string,
-      requiredDuringInsert: true,
-      $customConstraints: '');
+      $customConstraints: 'NOT NULL');
   @override
-  List<GeneratedColumn> get $columns => [sender, title, body];
+  List<GeneratedColumn> get $columns => [sqlClass, textColumn];
   @override
-  String get aliasedName => _alias ?? 'email';
+  String get aliasedName => _alias ?? 'Expression';
   @override
-  String get actualTableName => 'email';
+  String get actualTableName => 'Expression';
   @override
-  VerificationContext validateIntegrity(Insertable<EMail> instance,
+  VerificationContext validateIntegrity(Insertable<WeirdData> instance,
       {bool isInserting = false}) {
     final context = VerificationContext();
     final data = instance.toColumns(true);
-    if (data.containsKey('sender')) {
-      context.handle(_senderMeta,
-          sender.isAcceptableOrUnknown(data['sender']!, _senderMeta));
+    if (data.containsKey('class')) {
+      context.handle(_sqlClassMeta,
+          sqlClass.isAcceptableOrUnknown(data['class']!, _sqlClassMeta));
     } else if (isInserting) {
-      context.missing(_senderMeta);
+      context.missing(_sqlClassMeta);
     }
-    if (data.containsKey('title')) {
-      context.handle(
-          _titleMeta, title.isAcceptableOrUnknown(data['title']!, _titleMeta));
+    if (data.containsKey('text')) {
+      context.handle(_textColumnMeta,
+          textColumn.isAcceptableOrUnknown(data['text']!, _textColumnMeta));
     } else if (isInserting) {
-      context.missing(_titleMeta);
-    }
-    if (data.containsKey('body')) {
-      context.handle(
-          _bodyMeta, body.isAcceptableOrUnknown(data['body']!, _bodyMeta));
-    } else if (isInserting) {
-      context.missing(_bodyMeta);
+      context.missing(_textColumnMeta);
     }
     return context;
   }
@@ -1246,27 +1317,23 @@ class Email extends Table
   @override
   Set<GeneratedColumn> get $primaryKey => const {};
   @override
-  EMail map(Map<String, dynamic> data, {String? tablePrefix}) {
+  WeirdData map(Map<String, dynamic> data, {String? tablePrefix}) {
     final effectivePrefix = tablePrefix != null ? '$tablePrefix.' : '';
-    return EMail(
-      sender: attachedDatabase.typeMapping
-          .read(DriftSqlType.string, data['${effectivePrefix}sender'])!,
-      title: attachedDatabase.typeMapping
-          .read(DriftSqlType.string, data['${effectivePrefix}title'])!,
-      body: attachedDatabase.typeMapping
-          .read(DriftSqlType.string, data['${effectivePrefix}body'])!,
+    return WeirdData(
+      sqlClass: attachedDatabase.typeMapping
+          .read(DriftSqlType.int, data['${effectivePrefix}class'])!,
+      textColumn: attachedDatabase.typeMapping
+          .read(DriftSqlType.string, data['${effectivePrefix}text'])!,
     );
   }
 
   @override
-  Email createAlias(String alias) {
-    return Email(attachedDatabase, alias);
+  WeirdTable createAlias(String alias) {
+    return WeirdTable(attachedDatabase, alias);
   }
 
   @override
   bool get dontWriteConstraints => true;
-  @override
-  String get moduleAndArgs => 'fts5(sender, title, body)';
 }
 
 class WeirdData extends DataClass implements Insertable<WeirdData> {
@@ -1383,73 +1450,6 @@ class WeirdTableCompanion extends UpdateCompanion<WeirdData> {
           ..write(')'))
         .toString();
   }
-}
-
-class WeirdTable extends Table with TableInfo<WeirdTable, WeirdData> {
-  @override
-  final GeneratedDatabase attachedDatabase;
-  final String? _alias;
-  WeirdTable(this.attachedDatabase, [this._alias]);
-  static const VerificationMeta _sqlClassMeta =
-      const VerificationMeta('sqlClass');
-  late final GeneratedColumn<int> sqlClass = GeneratedColumn<int>(
-      'class', aliasedName, false,
-      type: DriftSqlType.int,
-      requiredDuringInsert: true,
-      $customConstraints: 'NOT NULL');
-  static const VerificationMeta _textColumnMeta =
-      const VerificationMeta('textColumn');
-  late final GeneratedColumn<String> textColumn = GeneratedColumn<String>(
-      'text', aliasedName, false,
-      type: DriftSqlType.string,
-      requiredDuringInsert: true,
-      $customConstraints: 'NOT NULL');
-  @override
-  List<GeneratedColumn> get $columns => [sqlClass, textColumn];
-  @override
-  String get aliasedName => _alias ?? 'Expression';
-  @override
-  String get actualTableName => 'Expression';
-  @override
-  VerificationContext validateIntegrity(Insertable<WeirdData> instance,
-      {bool isInserting = false}) {
-    final context = VerificationContext();
-    final data = instance.toColumns(true);
-    if (data.containsKey('class')) {
-      context.handle(_sqlClassMeta,
-          sqlClass.isAcceptableOrUnknown(data['class']!, _sqlClassMeta));
-    } else if (isInserting) {
-      context.missing(_sqlClassMeta);
-    }
-    if (data.containsKey('text')) {
-      context.handle(_textColumnMeta,
-          textColumn.isAcceptableOrUnknown(data['text']!, _textColumnMeta));
-    } else if (isInserting) {
-      context.missing(_textColumnMeta);
-    }
-    return context;
-  }
-
-  @override
-  Set<GeneratedColumn> get $primaryKey => const {};
-  @override
-  WeirdData map(Map<String, dynamic> data, {String? tablePrefix}) {
-    final effectivePrefix = tablePrefix != null ? '$tablePrefix.' : '';
-    return WeirdData(
-      sqlClass: attachedDatabase.typeMapping
-          .read(DriftSqlType.int, data['${effectivePrefix}class'])!,
-      textColumn: attachedDatabase.typeMapping
-          .read(DriftSqlType.string, data['${effectivePrefix}text'])!,
-    );
-  }
-
-  @override
-  WeirdTable createAlias(String alias) {
-    return WeirdTable(attachedDatabase, alias);
-  }
-
-  @override
-  bool get dontWriteConstraints => true;
 }
 
 class MyViewData extends DataClass {

--- a/drift/test/generated/todos.g.dart
+++ b/drift/test/generated/todos.g.dart
@@ -3,6 +3,105 @@
 part of 'todos.dart';
 
 // ignore_for_file: type=lint
+class $CategoriesTable extends Categories
+    with TableInfo<$CategoriesTable, Category> {
+  @override
+  final GeneratedDatabase attachedDatabase;
+  final String? _alias;
+  $CategoriesTable(this.attachedDatabase, [this._alias]);
+  static const VerificationMeta _idMeta = const VerificationMeta('id');
+  @override
+  late final GeneratedColumn<int> id = GeneratedColumn<int>(
+      'id', aliasedName, false,
+      hasAutoIncrement: true,
+      type: DriftSqlType.int,
+      requiredDuringInsert: false,
+      defaultConstraints:
+          GeneratedColumn.constraintIsAlways('PRIMARY KEY AUTOINCREMENT'));
+  static const VerificationMeta _descriptionMeta =
+      const VerificationMeta('description');
+  @override
+  late final GeneratedColumn<String> description = GeneratedColumn<String>(
+      'desc', aliasedName, false,
+      type: DriftSqlType.string,
+      requiredDuringInsert: true,
+      $customConstraints: 'NOT NULL UNIQUE');
+  static const VerificationMeta _priorityMeta =
+      const VerificationMeta('priority');
+  @override
+  late final GeneratedColumnWithTypeConverter<CategoryPriority, int> priority =
+      GeneratedColumn<int>('priority', aliasedName, false,
+              type: DriftSqlType.int,
+              requiredDuringInsert: false,
+              defaultValue: const Constant(0))
+          .withConverter<CategoryPriority>($CategoriesTable.$converterpriority);
+  static const VerificationMeta _descriptionInUpperCaseMeta =
+      const VerificationMeta('descriptionInUpperCase');
+  @override
+  late final GeneratedColumn<String> descriptionInUpperCase =
+      GeneratedColumn<String>('description_in_upper_case', aliasedName, false,
+          generatedAs: GeneratedAs(description.upper(), false),
+          type: DriftSqlType.string,
+          requiredDuringInsert: false);
+  @override
+  List<GeneratedColumn> get $columns =>
+      [id, description, priority, descriptionInUpperCase];
+  @override
+  String get aliasedName => _alias ?? 'categories';
+  @override
+  String get actualTableName => 'categories';
+  @override
+  VerificationContext validateIntegrity(Insertable<Category> instance,
+      {bool isInserting = false}) {
+    final context = VerificationContext();
+    final data = instance.toColumns(true);
+    if (data.containsKey('id')) {
+      context.handle(_idMeta, id.isAcceptableOrUnknown(data['id']!, _idMeta));
+    }
+    if (data.containsKey('desc')) {
+      context.handle(_descriptionMeta,
+          description.isAcceptableOrUnknown(data['desc']!, _descriptionMeta));
+    } else if (isInserting) {
+      context.missing(_descriptionMeta);
+    }
+    context.handle(_priorityMeta, const VerificationResult.success());
+    if (data.containsKey('description_in_upper_case')) {
+      context.handle(
+          _descriptionInUpperCaseMeta,
+          descriptionInUpperCase.isAcceptableOrUnknown(
+              data['description_in_upper_case']!, _descriptionInUpperCaseMeta));
+    }
+    return context;
+  }
+
+  @override
+  Set<GeneratedColumn> get $primaryKey => {id};
+  @override
+  Category map(Map<String, dynamic> data, {String? tablePrefix}) {
+    final effectivePrefix = tablePrefix != null ? '$tablePrefix.' : '';
+    return Category(
+      id: attachedDatabase.typeMapping
+          .read(DriftSqlType.int, data['${effectivePrefix}id'])!,
+      description: attachedDatabase.typeMapping
+          .read(DriftSqlType.string, data['${effectivePrefix}desc'])!,
+      priority: $CategoriesTable.$converterpriority.fromSql(attachedDatabase
+          .typeMapping
+          .read(DriftSqlType.int, data['${effectivePrefix}priority'])!),
+      descriptionInUpperCase: attachedDatabase.typeMapping.read(
+          DriftSqlType.string,
+          data['${effectivePrefix}description_in_upper_case'])!,
+    );
+  }
+
+  @override
+  $CategoriesTable createAlias(String alias) {
+    return $CategoriesTable(attachedDatabase, alias);
+  }
+
+  static JsonTypeConverter2<CategoryPriority, int, int> $converterpriority =
+      const EnumIndexConverter<CategoryPriority>(CategoryPriority.values);
+}
+
 class Category extends DataClass implements Insertable<Category> {
   final int id;
   final String description;
@@ -163,12 +262,12 @@ class CategoriesCompanion extends UpdateCompanion<Category> {
   }
 }
 
-class $CategoriesTable extends Categories
-    with TableInfo<$CategoriesTable, Category> {
+class $TodosTableTable extends TodosTable
+    with TableInfo<$TodosTableTable, TodoEntry> {
   @override
   final GeneratedDatabase attachedDatabase;
   final String? _alias;
-  $CategoriesTable(this.attachedDatabase, [this._alias]);
+  $TodosTableTable(this.attachedDatabase, [this._alias]);
   static const VerificationMeta _idMeta = const VerificationMeta('id');
   @override
   late final GeneratedColumn<int> id = GeneratedColumn<int>(
@@ -178,88 +277,118 @@ class $CategoriesTable extends Categories
       requiredDuringInsert: false,
       defaultConstraints:
           GeneratedColumn.constraintIsAlways('PRIMARY KEY AUTOINCREMENT'));
-  static const VerificationMeta _descriptionMeta =
-      const VerificationMeta('description');
+  static const VerificationMeta _titleMeta = const VerificationMeta('title');
   @override
-  late final GeneratedColumn<String> description = GeneratedColumn<String>(
-      'desc', aliasedName, false,
+  late final GeneratedColumn<String> title = GeneratedColumn<String>(
+      'title', aliasedName, true,
+      additionalChecks:
+          GeneratedColumn.checkTextLength(minTextLength: 4, maxTextLength: 16),
       type: DriftSqlType.string,
-      requiredDuringInsert: true,
-      $customConstraints: 'NOT NULL UNIQUE');
-  static const VerificationMeta _priorityMeta =
-      const VerificationMeta('priority');
+      requiredDuringInsert: false);
+  static const VerificationMeta _contentMeta =
+      const VerificationMeta('content');
   @override
-  late final GeneratedColumnWithTypeConverter<CategoryPriority, int> priority =
-      GeneratedColumn<int>('priority', aliasedName, false,
-              type: DriftSqlType.int,
-              requiredDuringInsert: false,
-              defaultValue: const Constant(0))
-          .withConverter<CategoryPriority>($CategoriesTable.$converterpriority);
-  static const VerificationMeta _descriptionInUpperCaseMeta =
-      const VerificationMeta('descriptionInUpperCase');
+  late final GeneratedColumn<String> content = GeneratedColumn<String>(
+      'content', aliasedName, false,
+      type: DriftSqlType.string, requiredDuringInsert: true);
+  static const VerificationMeta _targetDateMeta =
+      const VerificationMeta('targetDate');
   @override
-  late final GeneratedColumn<String> descriptionInUpperCase =
-      GeneratedColumn<String>('description_in_upper_case', aliasedName, false,
-          generatedAs: GeneratedAs(description.upper(), false),
-          type: DriftSqlType.string,
-          requiredDuringInsert: false);
+  late final GeneratedColumn<DateTime> targetDate = GeneratedColumn<DateTime>(
+      'target_date', aliasedName, true,
+      type: DriftSqlType.dateTime,
+      requiredDuringInsert: false,
+      defaultConstraints: GeneratedColumn.constraintIsAlways('UNIQUE'));
+  static const VerificationMeta _categoryMeta =
+      const VerificationMeta('category');
+  @override
+  late final GeneratedColumn<int> category = GeneratedColumn<int>(
+      'category', aliasedName, true,
+      type: DriftSqlType.int,
+      requiredDuringInsert: false,
+      defaultConstraints:
+          GeneratedColumn.constraintIsAlways('REFERENCES categories (id)'));
+  static const VerificationMeta _statusMeta = const VerificationMeta('status');
+  @override
+  late final GeneratedColumnWithTypeConverter<TodoStatus?, String> status =
+      GeneratedColumn<String>('status', aliasedName, true,
+              type: DriftSqlType.string, requiredDuringInsert: false)
+          .withConverter<TodoStatus?>($TodosTableTable.$converterstatusn);
   @override
   List<GeneratedColumn> get $columns =>
-      [id, description, priority, descriptionInUpperCase];
+      [id, title, content, targetDate, category, status];
   @override
-  String get aliasedName => _alias ?? 'categories';
+  String get aliasedName => _alias ?? 'todos';
   @override
-  String get actualTableName => 'categories';
+  String get actualTableName => 'todos';
   @override
-  VerificationContext validateIntegrity(Insertable<Category> instance,
+  VerificationContext validateIntegrity(Insertable<TodoEntry> instance,
       {bool isInserting = false}) {
     final context = VerificationContext();
     final data = instance.toColumns(true);
     if (data.containsKey('id')) {
       context.handle(_idMeta, id.isAcceptableOrUnknown(data['id']!, _idMeta));
     }
-    if (data.containsKey('desc')) {
-      context.handle(_descriptionMeta,
-          description.isAcceptableOrUnknown(data['desc']!, _descriptionMeta));
-    } else if (isInserting) {
-      context.missing(_descriptionMeta);
-    }
-    context.handle(_priorityMeta, const VerificationResult.success());
-    if (data.containsKey('description_in_upper_case')) {
+    if (data.containsKey('title')) {
       context.handle(
-          _descriptionInUpperCaseMeta,
-          descriptionInUpperCase.isAcceptableOrUnknown(
-              data['description_in_upper_case']!, _descriptionInUpperCaseMeta));
+          _titleMeta, title.isAcceptableOrUnknown(data['title']!, _titleMeta));
     }
+    if (data.containsKey('content')) {
+      context.handle(_contentMeta,
+          content.isAcceptableOrUnknown(data['content']!, _contentMeta));
+    } else if (isInserting) {
+      context.missing(_contentMeta);
+    }
+    if (data.containsKey('target_date')) {
+      context.handle(
+          _targetDateMeta,
+          targetDate.isAcceptableOrUnknown(
+              data['target_date']!, _targetDateMeta));
+    }
+    if (data.containsKey('category')) {
+      context.handle(_categoryMeta,
+          category.isAcceptableOrUnknown(data['category']!, _categoryMeta));
+    }
+    context.handle(_statusMeta, const VerificationResult.success());
     return context;
   }
 
   @override
   Set<GeneratedColumn> get $primaryKey => {id};
   @override
-  Category map(Map<String, dynamic> data, {String? tablePrefix}) {
+  List<Set<GeneratedColumn>> get uniqueKeys => [
+        {title, category},
+        {title, targetDate},
+      ];
+  @override
+  TodoEntry map(Map<String, dynamic> data, {String? tablePrefix}) {
     final effectivePrefix = tablePrefix != null ? '$tablePrefix.' : '';
-    return Category(
+    return TodoEntry(
       id: attachedDatabase.typeMapping
           .read(DriftSqlType.int, data['${effectivePrefix}id'])!,
-      description: attachedDatabase.typeMapping
-          .read(DriftSqlType.string, data['${effectivePrefix}desc'])!,
-      priority: $CategoriesTable.$converterpriority.fromSql(attachedDatabase
+      title: attachedDatabase.typeMapping
+          .read(DriftSqlType.string, data['${effectivePrefix}title']),
+      content: attachedDatabase.typeMapping
+          .read(DriftSqlType.string, data['${effectivePrefix}content'])!,
+      targetDate: attachedDatabase.typeMapping
+          .read(DriftSqlType.dateTime, data['${effectivePrefix}target_date']),
+      category: attachedDatabase.typeMapping
+          .read(DriftSqlType.int, data['${effectivePrefix}category']),
+      status: $TodosTableTable.$converterstatusn.fromSql(attachedDatabase
           .typeMapping
-          .read(DriftSqlType.int, data['${effectivePrefix}priority'])!),
-      descriptionInUpperCase: attachedDatabase.typeMapping.read(
-          DriftSqlType.string,
-          data['${effectivePrefix}description_in_upper_case'])!,
+          .read(DriftSqlType.string, data['${effectivePrefix}status'])),
     );
   }
 
   @override
-  $CategoriesTable createAlias(String alias) {
-    return $CategoriesTable(attachedDatabase, alias);
+  $TodosTableTable createAlias(String alias) {
+    return $TodosTableTable(attachedDatabase, alias);
   }
 
-  static JsonTypeConverter2<CategoryPriority, int, int> $converterpriority =
-      const EnumIndexConverter<CategoryPriority>(CategoryPriority.values);
+  static JsonTypeConverter2<TodoStatus, String, String> $converterstatus =
+      const EnumNameConverter<TodoStatus>(TodoStatus.values);
+  static JsonTypeConverter2<TodoStatus?, String?, String?> $converterstatusn =
+      JsonTypeConverter2.asNullable($converterstatus);
 }
 
 class TodoEntry extends DataClass implements Insertable<TodoEntry> {
@@ -486,12 +615,11 @@ class TodosTableCompanion extends UpdateCompanion<TodoEntry> {
   }
 }
 
-class $TodosTableTable extends TodosTable
-    with TableInfo<$TodosTableTable, TodoEntry> {
+class $UsersTable extends Users with TableInfo<$UsersTable, User> {
   @override
   final GeneratedDatabase attachedDatabase;
   final String? _alias;
-  $TodosTableTable(this.attachedDatabase, [this._alias]);
+  $UsersTable(this.attachedDatabase, [this._alias]);
   static const VerificationMeta _idMeta = const VerificationMeta('id');
   @override
   late final GeneratedColumn<int> id = GeneratedColumn<int>(
@@ -501,118 +629,108 @@ class $TodosTableTable extends TodosTable
       requiredDuringInsert: false,
       defaultConstraints:
           GeneratedColumn.constraintIsAlways('PRIMARY KEY AUTOINCREMENT'));
-  static const VerificationMeta _titleMeta = const VerificationMeta('title');
+  static const VerificationMeta _nameMeta = const VerificationMeta('name');
   @override
-  late final GeneratedColumn<String> title = GeneratedColumn<String>(
-      'title', aliasedName, true,
+  late final GeneratedColumn<String> name = GeneratedColumn<String>(
+      'name', aliasedName, false,
       additionalChecks:
-          GeneratedColumn.checkTextLength(minTextLength: 4, maxTextLength: 16),
+          GeneratedColumn.checkTextLength(minTextLength: 6, maxTextLength: 32),
       type: DriftSqlType.string,
-      requiredDuringInsert: false);
-  static const VerificationMeta _contentMeta =
-      const VerificationMeta('content');
+      requiredDuringInsert: true,
+      defaultConstraints: GeneratedColumn.constraintIsAlways('UNIQUE'));
+  static const VerificationMeta _isAwesomeMeta =
+      const VerificationMeta('isAwesome');
   @override
-  late final GeneratedColumn<String> content = GeneratedColumn<String>(
-      'content', aliasedName, false,
-      type: DriftSqlType.string, requiredDuringInsert: true);
-  static const VerificationMeta _targetDateMeta =
-      const VerificationMeta('targetDate');
+  late final GeneratedColumn<bool> isAwesome =
+      GeneratedColumn<bool>('is_awesome', aliasedName, false,
+          type: DriftSqlType.bool,
+          requiredDuringInsert: false,
+          defaultConstraints: GeneratedColumn.constraintsDependsOnDialect({
+            SqlDialect.sqlite: 'CHECK ("is_awesome" IN (0, 1))',
+            SqlDialect.mysql: '',
+            SqlDialect.postgres: '',
+          }),
+          defaultValue: const Constant(true));
+  static const VerificationMeta _profilePictureMeta =
+      const VerificationMeta('profilePicture');
   @override
-  late final GeneratedColumn<DateTime> targetDate = GeneratedColumn<DateTime>(
-      'target_date', aliasedName, true,
+  late final GeneratedColumn<Uint8List> profilePicture =
+      GeneratedColumn<Uint8List>('profile_picture', aliasedName, false,
+          type: DriftSqlType.blob, requiredDuringInsert: true);
+  static const VerificationMeta _creationTimeMeta =
+      const VerificationMeta('creationTime');
+  @override
+  late final GeneratedColumn<DateTime> creationTime = GeneratedColumn<DateTime>(
+      'creation_time', aliasedName, false,
+      check: () => creationTime.isBiggerThan(Constant(DateTime.utc(1950))),
       type: DriftSqlType.dateTime,
       requiredDuringInsert: false,
-      defaultConstraints: GeneratedColumn.constraintIsAlways('UNIQUE'));
-  static const VerificationMeta _categoryMeta =
-      const VerificationMeta('category');
-  @override
-  late final GeneratedColumn<int> category = GeneratedColumn<int>(
-      'category', aliasedName, true,
-      type: DriftSqlType.int,
-      requiredDuringInsert: false,
-      defaultConstraints:
-          GeneratedColumn.constraintIsAlways('REFERENCES categories (id)'));
-  static const VerificationMeta _statusMeta = const VerificationMeta('status');
-  @override
-  late final GeneratedColumnWithTypeConverter<TodoStatus?, String> status =
-      GeneratedColumn<String>('status', aliasedName, true,
-              type: DriftSqlType.string, requiredDuringInsert: false)
-          .withConverter<TodoStatus?>($TodosTableTable.$converterstatusn);
+      defaultValue: currentDateAndTime);
   @override
   List<GeneratedColumn> get $columns =>
-      [id, title, content, targetDate, category, status];
+      [id, name, isAwesome, profilePicture, creationTime];
   @override
-  String get aliasedName => _alias ?? 'todos';
+  String get aliasedName => _alias ?? 'users';
   @override
-  String get actualTableName => 'todos';
+  String get actualTableName => 'users';
   @override
-  VerificationContext validateIntegrity(Insertable<TodoEntry> instance,
+  VerificationContext validateIntegrity(Insertable<User> instance,
       {bool isInserting = false}) {
     final context = VerificationContext();
     final data = instance.toColumns(true);
     if (data.containsKey('id')) {
       context.handle(_idMeta, id.isAcceptableOrUnknown(data['id']!, _idMeta));
     }
-    if (data.containsKey('title')) {
+    if (data.containsKey('name')) {
       context.handle(
-          _titleMeta, title.isAcceptableOrUnknown(data['title']!, _titleMeta));
-    }
-    if (data.containsKey('content')) {
-      context.handle(_contentMeta,
-          content.isAcceptableOrUnknown(data['content']!, _contentMeta));
+          _nameMeta, name.isAcceptableOrUnknown(data['name']!, _nameMeta));
     } else if (isInserting) {
-      context.missing(_contentMeta);
+      context.missing(_nameMeta);
     }
-    if (data.containsKey('target_date')) {
+    if (data.containsKey('is_awesome')) {
+      context.handle(_isAwesomeMeta,
+          isAwesome.isAcceptableOrUnknown(data['is_awesome']!, _isAwesomeMeta));
+    }
+    if (data.containsKey('profile_picture')) {
       context.handle(
-          _targetDateMeta,
-          targetDate.isAcceptableOrUnknown(
-              data['target_date']!, _targetDateMeta));
+          _profilePictureMeta,
+          profilePicture.isAcceptableOrUnknown(
+              data['profile_picture']!, _profilePictureMeta));
+    } else if (isInserting) {
+      context.missing(_profilePictureMeta);
     }
-    if (data.containsKey('category')) {
-      context.handle(_categoryMeta,
-          category.isAcceptableOrUnknown(data['category']!, _categoryMeta));
+    if (data.containsKey('creation_time')) {
+      context.handle(
+          _creationTimeMeta,
+          creationTime.isAcceptableOrUnknown(
+              data['creation_time']!, _creationTimeMeta));
     }
-    context.handle(_statusMeta, const VerificationResult.success());
     return context;
   }
 
   @override
   Set<GeneratedColumn> get $primaryKey => {id};
   @override
-  List<Set<GeneratedColumn>> get uniqueKeys => [
-        {title, category},
-        {title, targetDate},
-      ];
-  @override
-  TodoEntry map(Map<String, dynamic> data, {String? tablePrefix}) {
+  User map(Map<String, dynamic> data, {String? tablePrefix}) {
     final effectivePrefix = tablePrefix != null ? '$tablePrefix.' : '';
-    return TodoEntry(
+    return User(
       id: attachedDatabase.typeMapping
           .read(DriftSqlType.int, data['${effectivePrefix}id'])!,
-      title: attachedDatabase.typeMapping
-          .read(DriftSqlType.string, data['${effectivePrefix}title']),
-      content: attachedDatabase.typeMapping
-          .read(DriftSqlType.string, data['${effectivePrefix}content'])!,
-      targetDate: attachedDatabase.typeMapping
-          .read(DriftSqlType.dateTime, data['${effectivePrefix}target_date']),
-      category: attachedDatabase.typeMapping
-          .read(DriftSqlType.int, data['${effectivePrefix}category']),
-      status: $TodosTableTable.$converterstatusn.fromSql(attachedDatabase
-          .typeMapping
-          .read(DriftSqlType.string, data['${effectivePrefix}status'])),
+      name: attachedDatabase.typeMapping
+          .read(DriftSqlType.string, data['${effectivePrefix}name'])!,
+      isAwesome: attachedDatabase.typeMapping
+          .read(DriftSqlType.bool, data['${effectivePrefix}is_awesome'])!,
+      profilePicture: attachedDatabase.typeMapping
+          .read(DriftSqlType.blob, data['${effectivePrefix}profile_picture'])!,
+      creationTime: attachedDatabase.typeMapping.read(
+          DriftSqlType.dateTime, data['${effectivePrefix}creation_time'])!,
     );
   }
 
   @override
-  $TodosTableTable createAlias(String alias) {
-    return $TodosTableTable(attachedDatabase, alias);
+  $UsersTable createAlias(String alias) {
+    return $UsersTable(attachedDatabase, alias);
   }
-
-  static JsonTypeConverter2<TodoStatus, String, String> $converterstatus =
-      const EnumNameConverter<TodoStatus>(TodoStatus.values);
-  static JsonTypeConverter2<TodoStatus?, String?, String?> $converterstatusn =
-      JsonTypeConverter2.asNullable($converterstatus);
 }
 
 class User extends DataClass implements Insertable<User> {
@@ -801,121 +919,64 @@ class UsersCompanion extends UpdateCompanion<User> {
   }
 }
 
-class $UsersTable extends Users with TableInfo<$UsersTable, User> {
+class $SharedTodosTable extends SharedTodos
+    with TableInfo<$SharedTodosTable, SharedTodo> {
   @override
   final GeneratedDatabase attachedDatabase;
   final String? _alias;
-  $UsersTable(this.attachedDatabase, [this._alias]);
-  static const VerificationMeta _idMeta = const VerificationMeta('id');
+  $SharedTodosTable(this.attachedDatabase, [this._alias]);
+  static const VerificationMeta _todoMeta = const VerificationMeta('todo');
   @override
-  late final GeneratedColumn<int> id = GeneratedColumn<int>(
-      'id', aliasedName, false,
-      hasAutoIncrement: true,
-      type: DriftSqlType.int,
-      requiredDuringInsert: false,
-      defaultConstraints:
-          GeneratedColumn.constraintIsAlways('PRIMARY KEY AUTOINCREMENT'));
-  static const VerificationMeta _nameMeta = const VerificationMeta('name');
+  late final GeneratedColumn<int> todo = GeneratedColumn<int>(
+      'todo', aliasedName, false,
+      type: DriftSqlType.int, requiredDuringInsert: true);
+  static const VerificationMeta _userMeta = const VerificationMeta('user');
   @override
-  late final GeneratedColumn<String> name = GeneratedColumn<String>(
-      'name', aliasedName, false,
-      additionalChecks:
-          GeneratedColumn.checkTextLength(minTextLength: 6, maxTextLength: 32),
-      type: DriftSqlType.string,
-      requiredDuringInsert: true,
-      defaultConstraints: GeneratedColumn.constraintIsAlways('UNIQUE'));
-  static const VerificationMeta _isAwesomeMeta =
-      const VerificationMeta('isAwesome');
+  late final GeneratedColumn<int> user = GeneratedColumn<int>(
+      'user', aliasedName, false,
+      type: DriftSqlType.int, requiredDuringInsert: true);
   @override
-  late final GeneratedColumn<bool> isAwesome =
-      GeneratedColumn<bool>('is_awesome', aliasedName, false,
-          type: DriftSqlType.bool,
-          requiredDuringInsert: false,
-          defaultConstraints: GeneratedColumn.constraintsDependsOnDialect({
-            SqlDialect.sqlite: 'CHECK ("is_awesome" IN (0, 1))',
-            SqlDialect.mysql: '',
-            SqlDialect.postgres: '',
-          }),
-          defaultValue: const Constant(true));
-  static const VerificationMeta _profilePictureMeta =
-      const VerificationMeta('profilePicture');
+  List<GeneratedColumn> get $columns => [todo, user];
   @override
-  late final GeneratedColumn<Uint8List> profilePicture =
-      GeneratedColumn<Uint8List>('profile_picture', aliasedName, false,
-          type: DriftSqlType.blob, requiredDuringInsert: true);
-  static const VerificationMeta _creationTimeMeta =
-      const VerificationMeta('creationTime');
+  String get aliasedName => _alias ?? 'shared_todos';
   @override
-  late final GeneratedColumn<DateTime> creationTime = GeneratedColumn<DateTime>(
-      'creation_time', aliasedName, false,
-      check: () => creationTime.isBiggerThan(Constant(DateTime.utc(1950))),
-      type: DriftSqlType.dateTime,
-      requiredDuringInsert: false,
-      defaultValue: currentDateAndTime);
+  String get actualTableName => 'shared_todos';
   @override
-  List<GeneratedColumn> get $columns =>
-      [id, name, isAwesome, profilePicture, creationTime];
-  @override
-  String get aliasedName => _alias ?? 'users';
-  @override
-  String get actualTableName => 'users';
-  @override
-  VerificationContext validateIntegrity(Insertable<User> instance,
+  VerificationContext validateIntegrity(Insertable<SharedTodo> instance,
       {bool isInserting = false}) {
     final context = VerificationContext();
     final data = instance.toColumns(true);
-    if (data.containsKey('id')) {
-      context.handle(_idMeta, id.isAcceptableOrUnknown(data['id']!, _idMeta));
-    }
-    if (data.containsKey('name')) {
+    if (data.containsKey('todo')) {
       context.handle(
-          _nameMeta, name.isAcceptableOrUnknown(data['name']!, _nameMeta));
+          _todoMeta, todo.isAcceptableOrUnknown(data['todo']!, _todoMeta));
     } else if (isInserting) {
-      context.missing(_nameMeta);
+      context.missing(_todoMeta);
     }
-    if (data.containsKey('is_awesome')) {
-      context.handle(_isAwesomeMeta,
-          isAwesome.isAcceptableOrUnknown(data['is_awesome']!, _isAwesomeMeta));
-    }
-    if (data.containsKey('profile_picture')) {
+    if (data.containsKey('user')) {
       context.handle(
-          _profilePictureMeta,
-          profilePicture.isAcceptableOrUnknown(
-              data['profile_picture']!, _profilePictureMeta));
+          _userMeta, user.isAcceptableOrUnknown(data['user']!, _userMeta));
     } else if (isInserting) {
-      context.missing(_profilePictureMeta);
-    }
-    if (data.containsKey('creation_time')) {
-      context.handle(
-          _creationTimeMeta,
-          creationTime.isAcceptableOrUnknown(
-              data['creation_time']!, _creationTimeMeta));
+      context.missing(_userMeta);
     }
     return context;
   }
 
   @override
-  Set<GeneratedColumn> get $primaryKey => {id};
+  Set<GeneratedColumn> get $primaryKey => {todo, user};
   @override
-  User map(Map<String, dynamic> data, {String? tablePrefix}) {
+  SharedTodo map(Map<String, dynamic> data, {String? tablePrefix}) {
     final effectivePrefix = tablePrefix != null ? '$tablePrefix.' : '';
-    return User(
-      id: attachedDatabase.typeMapping
-          .read(DriftSqlType.int, data['${effectivePrefix}id'])!,
-      name: attachedDatabase.typeMapping
-          .read(DriftSqlType.string, data['${effectivePrefix}name'])!,
-      isAwesome: attachedDatabase.typeMapping
-          .read(DriftSqlType.bool, data['${effectivePrefix}is_awesome'])!,
-      profilePicture: attachedDatabase.typeMapping
-          .read(DriftSqlType.blob, data['${effectivePrefix}profile_picture'])!,
-      creationTime: attachedDatabase.typeMapping.read(
-          DriftSqlType.dateTime, data['${effectivePrefix}creation_time'])!,
+    return SharedTodo(
+      todo: attachedDatabase.typeMapping
+          .read(DriftSqlType.int, data['${effectivePrefix}todo'])!,
+      user: attachedDatabase.typeMapping
+          .read(DriftSqlType.int, data['${effectivePrefix}user'])!,
     );
   }
 
   @override
-  $UsersTable createAlias(String alias) {
-    return $UsersTable(attachedDatabase, alias);
+  $SharedTodosTable createAlias(String alias) {
+    return $SharedTodosTable(attachedDatabase, alias);
   }
 }
 
@@ -1034,65 +1095,99 @@ class SharedTodosCompanion extends UpdateCompanion<SharedTodo> {
   }
 }
 
-class $SharedTodosTable extends SharedTodos
-    with TableInfo<$SharedTodosTable, SharedTodo> {
+class $TableWithoutPKTable extends TableWithoutPK
+    with TableInfo<$TableWithoutPKTable, CustomRowClass> {
   @override
   final GeneratedDatabase attachedDatabase;
   final String? _alias;
-  $SharedTodosTable(this.attachedDatabase, [this._alias]);
-  static const VerificationMeta _todoMeta = const VerificationMeta('todo');
+  $TableWithoutPKTable(this.attachedDatabase, [this._alias]);
+  static const VerificationMeta _notReallyAnIdMeta =
+      const VerificationMeta('notReallyAnId');
   @override
-  late final GeneratedColumn<int> todo = GeneratedColumn<int>(
-      'todo', aliasedName, false,
+  late final GeneratedColumn<int> notReallyAnId = GeneratedColumn<int>(
+      'not_really_an_id', aliasedName, false,
       type: DriftSqlType.int, requiredDuringInsert: true);
-  static const VerificationMeta _userMeta = const VerificationMeta('user');
+  static const VerificationMeta _someFloatMeta =
+      const VerificationMeta('someFloat');
   @override
-  late final GeneratedColumn<int> user = GeneratedColumn<int>(
-      'user', aliasedName, false,
-      type: DriftSqlType.int, requiredDuringInsert: true);
+  late final GeneratedColumn<double> someFloat = GeneratedColumn<double>(
+      'some_float', aliasedName, false,
+      type: DriftSqlType.double, requiredDuringInsert: true);
+  static const VerificationMeta _webSafeIntMeta =
+      const VerificationMeta('webSafeInt');
   @override
-  List<GeneratedColumn> get $columns => [todo, user];
+  late final GeneratedColumn<BigInt> webSafeInt = GeneratedColumn<BigInt>(
+      'web_safe_int', aliasedName, true,
+      type: DriftSqlType.bigInt, requiredDuringInsert: false);
+  static const VerificationMeta _customMeta = const VerificationMeta('custom');
   @override
-  String get aliasedName => _alias ?? 'shared_todos';
+  late final GeneratedColumnWithTypeConverter<MyCustomObject, String> custom =
+      GeneratedColumn<String>('custom', aliasedName, false,
+              type: DriftSqlType.string,
+              requiredDuringInsert: false,
+              clientDefault: _uuid.v4)
+          .withConverter<MyCustomObject>($TableWithoutPKTable.$convertercustom);
   @override
-  String get actualTableName => 'shared_todos';
+  List<GeneratedColumn> get $columns =>
+      [notReallyAnId, someFloat, webSafeInt, custom];
   @override
-  VerificationContext validateIntegrity(Insertable<SharedTodo> instance,
+  String get aliasedName => _alias ?? 'table_without_p_k';
+  @override
+  String get actualTableName => 'table_without_p_k';
+  @override
+  VerificationContext validateIntegrity(Insertable<CustomRowClass> instance,
       {bool isInserting = false}) {
     final context = VerificationContext();
     final data = instance.toColumns(true);
-    if (data.containsKey('todo')) {
+    if (data.containsKey('not_really_an_id')) {
       context.handle(
-          _todoMeta, todo.isAcceptableOrUnknown(data['todo']!, _todoMeta));
+          _notReallyAnIdMeta,
+          notReallyAnId.isAcceptableOrUnknown(
+              data['not_really_an_id']!, _notReallyAnIdMeta));
     } else if (isInserting) {
-      context.missing(_todoMeta);
+      context.missing(_notReallyAnIdMeta);
     }
-    if (data.containsKey('user')) {
+    if (data.containsKey('some_float')) {
+      context.handle(_someFloatMeta,
+          someFloat.isAcceptableOrUnknown(data['some_float']!, _someFloatMeta));
+    } else if (isInserting) {
+      context.missing(_someFloatMeta);
+    }
+    if (data.containsKey('web_safe_int')) {
       context.handle(
-          _userMeta, user.isAcceptableOrUnknown(data['user']!, _userMeta));
-    } else if (isInserting) {
-      context.missing(_userMeta);
+          _webSafeIntMeta,
+          webSafeInt.isAcceptableOrUnknown(
+              data['web_safe_int']!, _webSafeIntMeta));
     }
+    context.handle(_customMeta, const VerificationResult.success());
     return context;
   }
 
   @override
-  Set<GeneratedColumn> get $primaryKey => {todo, user};
+  Set<GeneratedColumn> get $primaryKey => const {};
   @override
-  SharedTodo map(Map<String, dynamic> data, {String? tablePrefix}) {
+  CustomRowClass map(Map<String, dynamic> data, {String? tablePrefix}) {
     final effectivePrefix = tablePrefix != null ? '$tablePrefix.' : '';
-    return SharedTodo(
-      todo: attachedDatabase.typeMapping
-          .read(DriftSqlType.int, data['${effectivePrefix}todo'])!,
-      user: attachedDatabase.typeMapping
-          .read(DriftSqlType.int, data['${effectivePrefix}user'])!,
+    return CustomRowClass.map(
+      attachedDatabase.typeMapping
+          .read(DriftSqlType.int, data['${effectivePrefix}not_really_an_id'])!,
+      attachedDatabase.typeMapping
+          .read(DriftSqlType.double, data['${effectivePrefix}some_float'])!,
+      custom: $TableWithoutPKTable.$convertercustom.fromSql(attachedDatabase
+          .typeMapping
+          .read(DriftSqlType.string, data['${effectivePrefix}custom'])!),
+      webSafeInt: attachedDatabase.typeMapping
+          .read(DriftSqlType.bigInt, data['${effectivePrefix}web_safe_int']),
     );
   }
 
   @override
-  $SharedTodosTable createAlias(String alias) {
-    return $SharedTodosTable(attachedDatabase, alias);
+  $TableWithoutPKTable createAlias(String alias) {
+    return $TableWithoutPKTable(attachedDatabase, alias);
   }
+
+  static TypeConverter<MyCustomObject, String> $convertercustom =
+      const CustomConverter();
 }
 
 class TableWithoutPKCompanion extends UpdateCompanion<CustomRowClass> {
@@ -1193,99 +1288,54 @@ extension CustomRowClassToInsertable on CustomRowClass {
   }
 }
 
-class $TableWithoutPKTable extends TableWithoutPK
-    with TableInfo<$TableWithoutPKTable, CustomRowClass> {
+class $PureDefaultsTable extends PureDefaults
+    with TableInfo<$PureDefaultsTable, PureDefault> {
   @override
   final GeneratedDatabase attachedDatabase;
   final String? _alias;
-  $TableWithoutPKTable(this.attachedDatabase, [this._alias]);
-  static const VerificationMeta _notReallyAnIdMeta =
-      const VerificationMeta('notReallyAnId');
+  $PureDefaultsTable(this.attachedDatabase, [this._alias]);
+  static const VerificationMeta _txtMeta = const VerificationMeta('txt');
   @override
-  late final GeneratedColumn<int> notReallyAnId = GeneratedColumn<int>(
-      'not_really_an_id', aliasedName, false,
-      type: DriftSqlType.int, requiredDuringInsert: true);
-  static const VerificationMeta _someFloatMeta =
-      const VerificationMeta('someFloat');
+  late final GeneratedColumnWithTypeConverter<MyCustomObject?, String> txt =
+      GeneratedColumn<String>('insert', aliasedName, true,
+              type: DriftSqlType.string, requiredDuringInsert: false)
+          .withConverter<MyCustomObject?>($PureDefaultsTable.$convertertxtn);
   @override
-  late final GeneratedColumn<double> someFloat = GeneratedColumn<double>(
-      'some_float', aliasedName, false,
-      type: DriftSqlType.double, requiredDuringInsert: true);
-  static const VerificationMeta _webSafeIntMeta =
-      const VerificationMeta('webSafeInt');
+  List<GeneratedColumn> get $columns => [txt];
   @override
-  late final GeneratedColumn<BigInt> webSafeInt = GeneratedColumn<BigInt>(
-      'web_safe_int', aliasedName, true,
-      type: DriftSqlType.bigInt, requiredDuringInsert: false);
-  static const VerificationMeta _customMeta = const VerificationMeta('custom');
+  String get aliasedName => _alias ?? 'pure_defaults';
   @override
-  late final GeneratedColumnWithTypeConverter<MyCustomObject, String> custom =
-      GeneratedColumn<String>('custom', aliasedName, false,
-              type: DriftSqlType.string,
-              requiredDuringInsert: false,
-              clientDefault: _uuid.v4)
-          .withConverter<MyCustomObject>($TableWithoutPKTable.$convertercustom);
+  String get actualTableName => 'pure_defaults';
   @override
-  List<GeneratedColumn> get $columns =>
-      [notReallyAnId, someFloat, webSafeInt, custom];
-  @override
-  String get aliasedName => _alias ?? 'table_without_p_k';
-  @override
-  String get actualTableName => 'table_without_p_k';
-  @override
-  VerificationContext validateIntegrity(Insertable<CustomRowClass> instance,
+  VerificationContext validateIntegrity(Insertable<PureDefault> instance,
       {bool isInserting = false}) {
     final context = VerificationContext();
     final data = instance.toColumns(true);
-    if (data.containsKey('not_really_an_id')) {
-      context.handle(
-          _notReallyAnIdMeta,
-          notReallyAnId.isAcceptableOrUnknown(
-              data['not_really_an_id']!, _notReallyAnIdMeta));
-    } else if (isInserting) {
-      context.missing(_notReallyAnIdMeta);
-    }
-    if (data.containsKey('some_float')) {
-      context.handle(_someFloatMeta,
-          someFloat.isAcceptableOrUnknown(data['some_float']!, _someFloatMeta));
-    } else if (isInserting) {
-      context.missing(_someFloatMeta);
-    }
-    if (data.containsKey('web_safe_int')) {
-      context.handle(
-          _webSafeIntMeta,
-          webSafeInt.isAcceptableOrUnknown(
-              data['web_safe_int']!, _webSafeIntMeta));
-    }
-    context.handle(_customMeta, const VerificationResult.success());
+    context.handle(_txtMeta, const VerificationResult.success());
     return context;
   }
 
   @override
-  Set<GeneratedColumn> get $primaryKey => const {};
+  Set<GeneratedColumn> get $primaryKey => {txt};
   @override
-  CustomRowClass map(Map<String, dynamic> data, {String? tablePrefix}) {
+  PureDefault map(Map<String, dynamic> data, {String? tablePrefix}) {
     final effectivePrefix = tablePrefix != null ? '$tablePrefix.' : '';
-    return CustomRowClass.map(
-      attachedDatabase.typeMapping
-          .read(DriftSqlType.int, data['${effectivePrefix}not_really_an_id'])!,
-      attachedDatabase.typeMapping
-          .read(DriftSqlType.double, data['${effectivePrefix}some_float'])!,
-      custom: $TableWithoutPKTable.$convertercustom.fromSql(attachedDatabase
+    return PureDefault(
+      txt: $PureDefaultsTable.$convertertxtn.fromSql(attachedDatabase
           .typeMapping
-          .read(DriftSqlType.string, data['${effectivePrefix}custom'])!),
-      webSafeInt: attachedDatabase.typeMapping
-          .read(DriftSqlType.bigInt, data['${effectivePrefix}web_safe_int']),
+          .read(DriftSqlType.string, data['${effectivePrefix}insert'])),
     );
   }
 
   @override
-  $TableWithoutPKTable createAlias(String alias) {
-    return $TableWithoutPKTable(attachedDatabase, alias);
+  $PureDefaultsTable createAlias(String alias) {
+    return $PureDefaultsTable(attachedDatabase, alias);
   }
 
-  static TypeConverter<MyCustomObject, String> $convertercustom =
-      const CustomConverter();
+  static JsonTypeConverter2<MyCustomObject, String, Map<dynamic, dynamic>>
+      $convertertxt = const CustomJsonConverter();
+  static JsonTypeConverter2<MyCustomObject?, String?, Map<dynamic, dynamic>?>
+      $convertertxtn = JsonTypeConverter2.asNullable($convertertxt);
 }
 
 class PureDefault extends DataClass implements Insertable<PureDefault> {
@@ -1387,56 +1437,6 @@ class PureDefaultsCompanion extends UpdateCompanion<PureDefault> {
           ..write(')'))
         .toString();
   }
-}
-
-class $PureDefaultsTable extends PureDefaults
-    with TableInfo<$PureDefaultsTable, PureDefault> {
-  @override
-  final GeneratedDatabase attachedDatabase;
-  final String? _alias;
-  $PureDefaultsTable(this.attachedDatabase, [this._alias]);
-  static const VerificationMeta _txtMeta = const VerificationMeta('txt');
-  @override
-  late final GeneratedColumnWithTypeConverter<MyCustomObject?, String> txt =
-      GeneratedColumn<String>('insert', aliasedName, true,
-              type: DriftSqlType.string, requiredDuringInsert: false)
-          .withConverter<MyCustomObject?>($PureDefaultsTable.$convertertxtn);
-  @override
-  List<GeneratedColumn> get $columns => [txt];
-  @override
-  String get aliasedName => _alias ?? 'pure_defaults';
-  @override
-  String get actualTableName => 'pure_defaults';
-  @override
-  VerificationContext validateIntegrity(Insertable<PureDefault> instance,
-      {bool isInserting = false}) {
-    final context = VerificationContext();
-    final data = instance.toColumns(true);
-    context.handle(_txtMeta, const VerificationResult.success());
-    return context;
-  }
-
-  @override
-  Set<GeneratedColumn> get $primaryKey => {txt};
-  @override
-  PureDefault map(Map<String, dynamic> data, {String? tablePrefix}) {
-    final effectivePrefix = tablePrefix != null ? '$tablePrefix.' : '';
-    return PureDefault(
-      txt: $PureDefaultsTable.$convertertxtn.fromSql(attachedDatabase
-          .typeMapping
-          .read(DriftSqlType.string, data['${effectivePrefix}insert'])),
-    );
-  }
-
-  @override
-  $PureDefaultsTable createAlias(String alias) {
-    return $PureDefaultsTable(attachedDatabase, alias);
-  }
-
-  static JsonTypeConverter2<MyCustomObject, String, Map<dynamic, dynamic>>
-      $convertertxt = const CustomJsonConverter();
-  static JsonTypeConverter2<MyCustomObject?, String?, Map<dynamic, dynamic>?>
-      $convertertxtn = JsonTypeConverter2.asNullable($convertertxt);
 }
 
 class CategoryTodoCountViewData extends DataClass {

--- a/drift/test/integration_tests/regress_2166_test.g.dart
+++ b/drift/test/integration_tests/regress_2166_test.g.dart
@@ -3,6 +3,66 @@
 part of 'regress_2166_test.dart';
 
 // ignore_for_file: type=lint
+class $_SomeTableTable extends _SomeTable
+    with TableInfo<$_SomeTableTable, _SomeTableData> {
+  @override
+  final GeneratedDatabase attachedDatabase;
+  final String? _alias;
+  $_SomeTableTable(this.attachedDatabase, [this._alias]);
+  static const VerificationMeta _idMeta = const VerificationMeta('id');
+  @override
+  late final GeneratedColumn<int> id = GeneratedColumn<int>(
+      'id', aliasedName, false,
+      hasAutoIncrement: true,
+      type: DriftSqlType.int,
+      requiredDuringInsert: false,
+      defaultConstraints:
+          GeneratedColumn.constraintIsAlways('PRIMARY KEY AUTOINCREMENT'));
+  static const VerificationMeta _nameMeta = const VerificationMeta('name');
+  @override
+  late final GeneratedColumn<String> name = GeneratedColumn<String>(
+      'name', aliasedName, true,
+      type: DriftSqlType.string, requiredDuringInsert: false);
+  @override
+  List<GeneratedColumn> get $columns => [id, name];
+  @override
+  String get aliasedName => _alias ?? 'some_table';
+  @override
+  String get actualTableName => 'some_table';
+  @override
+  VerificationContext validateIntegrity(Insertable<_SomeTableData> instance,
+      {bool isInserting = false}) {
+    final context = VerificationContext();
+    final data = instance.toColumns(true);
+    if (data.containsKey('id')) {
+      context.handle(_idMeta, id.isAcceptableOrUnknown(data['id']!, _idMeta));
+    }
+    if (data.containsKey('name')) {
+      context.handle(
+          _nameMeta, name.isAcceptableOrUnknown(data['name']!, _nameMeta));
+    }
+    return context;
+  }
+
+  @override
+  Set<GeneratedColumn> get $primaryKey => {id};
+  @override
+  _SomeTableData map(Map<String, dynamic> data, {String? tablePrefix}) {
+    final effectivePrefix = tablePrefix != null ? '$tablePrefix.' : '';
+    return _SomeTableData(
+      id: attachedDatabase.typeMapping
+          .read(DriftSqlType.int, data['${effectivePrefix}id'])!,
+      name: attachedDatabase.typeMapping
+          .read(DriftSqlType.string, data['${effectivePrefix}name']),
+    );
+  }
+
+  @override
+  $_SomeTableTable createAlias(String alias) {
+    return $_SomeTableTable(attachedDatabase, alias);
+  }
+}
+
 class _SomeTableData extends DataClass implements Insertable<_SomeTableData> {
   final int id;
   final String? name;
@@ -118,66 +178,6 @@ class _SomeTableCompanion extends UpdateCompanion<_SomeTableData> {
           ..write('name: $name')
           ..write(')'))
         .toString();
-  }
-}
-
-class $_SomeTableTable extends _SomeTable
-    with TableInfo<$_SomeTableTable, _SomeTableData> {
-  @override
-  final GeneratedDatabase attachedDatabase;
-  final String? _alias;
-  $_SomeTableTable(this.attachedDatabase, [this._alias]);
-  static const VerificationMeta _idMeta = const VerificationMeta('id');
-  @override
-  late final GeneratedColumn<int> id = GeneratedColumn<int>(
-      'id', aliasedName, false,
-      hasAutoIncrement: true,
-      type: DriftSqlType.int,
-      requiredDuringInsert: false,
-      defaultConstraints:
-          GeneratedColumn.constraintIsAlways('PRIMARY KEY AUTOINCREMENT'));
-  static const VerificationMeta _nameMeta = const VerificationMeta('name');
-  @override
-  late final GeneratedColumn<String> name = GeneratedColumn<String>(
-      'name', aliasedName, true,
-      type: DriftSqlType.string, requiredDuringInsert: false);
-  @override
-  List<GeneratedColumn> get $columns => [id, name];
-  @override
-  String get aliasedName => _alias ?? 'some_table';
-  @override
-  String get actualTableName => 'some_table';
-  @override
-  VerificationContext validateIntegrity(Insertable<_SomeTableData> instance,
-      {bool isInserting = false}) {
-    final context = VerificationContext();
-    final data = instance.toColumns(true);
-    if (data.containsKey('id')) {
-      context.handle(_idMeta, id.isAcceptableOrUnknown(data['id']!, _idMeta));
-    }
-    if (data.containsKey('name')) {
-      context.handle(
-          _nameMeta, name.isAcceptableOrUnknown(data['name']!, _nameMeta));
-    }
-    return context;
-  }
-
-  @override
-  Set<GeneratedColumn> get $primaryKey => {id};
-  @override
-  _SomeTableData map(Map<String, dynamic> data, {String? tablePrefix}) {
-    final effectivePrefix = tablePrefix != null ? '$tablePrefix.' : '';
-    return _SomeTableData(
-      id: attachedDatabase.typeMapping
-          .read(DriftSqlType.int, data['${effectivePrefix}id'])!,
-      name: attachedDatabase.typeMapping
-          .read(DriftSqlType.string, data['${effectivePrefix}name']),
-    );
-  }
-
-  @override
-  $_SomeTableTable createAlias(String alias) {
-    return $_SomeTableTable(attachedDatabase, alias);
   }
 }
 

--- a/drift_dev/lib/src/analysis/options.dart
+++ b/drift_dev/lib/src/analysis/options.dart
@@ -94,6 +94,9 @@ class DriftOptions {
   @JsonKey(name: 'case_from_dart_to_sql', defaultValue: CaseFromDartToSql.snake)
   final CaseFromDartToSql caseFromDartToSql;
 
+  @JsonKey(name: 'write_to_columns_mixins', defaultValue: false)
+  final bool writeToColumnsMixins;
+
   @internal
   const DriftOptions.defaults({
     this.generateFromJsonStringConstructor = false,
@@ -115,6 +118,7 @@ class DriftOptions {
     this.storeDateTimeValuesAsText = false,
     this.dialect = const DialectOptions(SqlDialect.sqlite, null),
     this.caseFromDartToSql = CaseFromDartToSql.snake,
+    this.writeToColumnsMixins = false,
   });
 
   DriftOptions({
@@ -136,6 +140,7 @@ class DriftOptions {
     required this.sqliteAnalysisOptions,
     required this.storeDateTimeValuesAsText,
     required this.caseFromDartToSql,
+    required this.writeToColumnsMixins,
     this.dialect,
   }) {
     // ignore: deprecated_member_use_from_same_package

--- a/drift_dev/lib/src/generated/analysis/options.g.dart
+++ b/drift_dev/lib/src/generated/analysis/options.g.dart
@@ -31,7 +31,8 @@ DriftOptions _$DriftOptionsFromJson(Map json) => $checkedCreate(
             'named_parameters_always_required',
             'scoped_dart_components',
             'store_date_time_values_as_text',
-            'case_from_dart_to_sql'
+            'case_from_dart_to_sql',
+            'write_to_columns_mixins'
           ],
         );
         final val = DriftOptions(
@@ -83,6 +84,8 @@ DriftOptions _$DriftOptionsFromJson(Map json) => $checkedCreate(
               (v) =>
                   $enumDecodeNullable(_$CaseFromDartToSqlEnumMap, v) ??
                   CaseFromDartToSql.snake),
+          writeToColumnsMixins: $checkedConvert(
+              'write_to_columns_mixins', (v) => v as bool? ?? false),
           dialect: $checkedConvert('sql',
               (v) => v == null ? null : DialectOptions.fromJson(v as Map)),
         );
@@ -110,6 +113,7 @@ DriftOptions _$DriftOptionsFromJson(Map json) => $checkedCreate(
         'sqliteAnalysisOptions': 'sqlite',
         'storeDateTimeValuesAsText': 'store_date_time_values_as_text',
         'caseFromDartToSql': 'case_from_dart_to_sql',
+        'writeToColumnsMixins': 'write_to_columns_mixins',
         'dialect': 'sql'
       },
     );
@@ -142,6 +146,7 @@ Map<String, dynamic> _$DriftOptionsToJson(DriftOptions instance) =>
       'store_date_time_values_as_text': instance.storeDateTimeValuesAsText,
       'case_from_dart_to_sql':
           _$CaseFromDartToSqlEnumMap[instance.caseFromDartToSql]!,
+      'write_to_columns_mixins': instance.writeToColumnsMixins,
     };
 
 const _$SqlModuleEnumMap = {

--- a/drift_dev/lib/src/writer/tables/data_class_writer.dart
+++ b/drift_dev/lib/src/writer/tables/data_class_writer.dart
@@ -48,11 +48,15 @@ class DataClassWriter {
     _buffer.write('class ${table.nameOfRowClass} extends $parentClass ');
 
     if (isInsertable) {
-      // The data class is only an insertable if we can actually insert rows
-      // into the target entity.
-      final type = _emitter.dartCode(_emitter.writer.rowType(table));
+      if (scope.options.writeToColumnsMixins) {
+        _buffer.writeln('with ${table.entityInfoName}ToColumns {');
+      } else {
+        // The data class is only an insertable if we can actually insert rows
+        // into the target entity.
+        final type = _emitter.dartCode(_emitter.writer.rowType(table));
 
-      _buffer.writeln('implements ${_emitter.drift('Insertable')}<$type> {');
+        _buffer.writeln('implements ${_emitter.drift('Insertable')}<$type> {');
+      }
     } else {
       _buffer.writeln('{');
     }
@@ -88,7 +92,9 @@ class DataClassWriter {
       ..write('});');
 
     if (isInsertable) {
-      _writeToColumnsOverride();
+      if (!scope.options.writeToColumnsMixins) {
+        _writeToColumnsOverride();
+      }
       if (scope.options.dataClassToCompanions) {
         _writeToCompanion();
       }

--- a/drift_dev/lib/src/writer/tables/update_companion_writer.dart
+++ b/drift_dev/lib/src/writer/tables/update_companion_writer.dart
@@ -271,7 +271,7 @@ class UpdateCompanionWriter {
     final info = table.existingRowClass;
     if (info == null) return;
 
-    _buffer.write('mixin ${table.nameOfRowClass}Columns ');
+    _buffer.write('mixin ${table.baseDartName}ToColumns ');
 
     final type = _emitter.dartCode(_emitter.writer.rowType(table));
     _buffer.writeln('implements ${_emitter.drift('Insertable')}<$type> {');

--- a/drift_dev/lib/src/writer/tables/update_companion_writer.dart
+++ b/drift_dev/lib/src/writer/tables/update_companion_writer.dart
@@ -46,9 +46,6 @@ class UpdateCompanionWriter {
     if (table.existingRowClass?.generateInsertable ?? false) {
       _writeToCompanionExtension();
     }
-    if (scope.options.writeToColumnsMixins) {
-      _writeToColumnsMixin();
-    }
   }
 
   void _writeFields() {
@@ -265,83 +262,5 @@ class UpdateCompanionWriter {
       ..write('$insertableClass toInsertable() {\n')
       ..write('return $insertableClass(this);\n')
       ..write('}\n}\n');
-  }
-
-  void _writeToColumnsMixin() {
-    final info = table.existingRowClass;
-    if (info == null) return;
-
-    _buffer.write('mixin ${table.baseDartName}ToColumns ');
-
-    final type = _emitter.dartCode(_emitter.writer.rowType(table));
-    _buffer.writeln('implements ${_emitter.drift('Insertable')}<$type> {');
-
-    for (final column in columns) {
-      if (column.documentationComment != null) {
-        _buffer.write('${column.documentationComment}\n');
-      }
-      final typeName = _emitter.dartCode(_emitter.dartType(column));
-      _buffer.writeln('$typeName get ${column.nameInDart};');
-    }
-
-    _writeTableToColumnsOverride();
-    _buffer.write('}');
-  }
-
-  void _writeTableToColumnsOverride() {
-    final expression = _emitter.drift('Expression');
-    final variable = _emitter.drift('Variable');
-
-    _buffer
-      ..write('@override\nMap<String, $expression> toColumns'
-          '(bool nullToAbsent) {\n')
-      ..write('final map = <String, $expression> {};');
-
-    for (final column in columns) {
-      // Generated column - cannot be used for inserts or updates
-      if (column.isGenerated) continue;
-
-      // We include all columns that are not null. If nullToAbsent is false, we
-      // also include null columns. When generating NNBD code, we can include
-      // non-nullable columns without an additional null check since we know
-      // the values aren't going to be null.
-      final needsNullCheck = column.nullableInDart;
-      final needsScope = needsNullCheck || column.typeConverter != null;
-      if (needsNullCheck) {
-        _buffer.write('if (!nullToAbsent || ${column.nameInDart} != null)');
-      }
-      if (needsScope) _buffer.write('{');
-
-      final typeName =
-          _emitter.dartCode(_emitter.variableTypeCode(column, nullable: false));
-      final mapSetter = 'map[${asDartLiteral(column.nameInSql)}] = '
-          '$variable<$typeName>';
-
-      if (column.typeConverter != null) {
-        // apply type converter before writing the variable
-        final converter = column.typeConverter!;
-
-        _emitter
-          ..write('final converter = ')
-          ..writeDart(_emitter.writer
-              .readConverter(converter, forNullable: column.nullable))
-          ..writeln(';')
-          ..write(mapSetter)
-          ..write('(converter.toSql(${column.nameInDart})');
-        _buffer.write(');');
-      } else {
-        // no type converter. Write variable directly
-        _buffer
-          ..write(mapSetter)
-          ..write('(')
-          ..write(column.nameInDart)
-          ..write(');');
-      }
-
-      // This one closes the optional if from before.
-      if (needsScope) _buffer.write('}');
-    }
-
-    _buffer.write('return map; \n}\n');
   }
 }

--- a/examples/app/lib/database/database.g.dart
+++ b/examples/app/lib/database/database.g.dart
@@ -3,6 +3,80 @@
 part of 'database.dart';
 
 // ignore_for_file: type=lint
+class $CategoriesTable extends Categories
+    with TableInfo<$CategoriesTable, Category> {
+  @override
+  final GeneratedDatabase attachedDatabase;
+  final String? _alias;
+  $CategoriesTable(this.attachedDatabase, [this._alias]);
+  static const VerificationMeta _idMeta = const VerificationMeta('id');
+  @override
+  late final GeneratedColumn<int> id = GeneratedColumn<int>(
+      'id', aliasedName, false,
+      hasAutoIncrement: true,
+      type: DriftSqlType.int,
+      requiredDuringInsert: false,
+      defaultConstraints:
+          GeneratedColumn.constraintIsAlways('PRIMARY KEY AUTOINCREMENT'));
+  static const VerificationMeta _nameMeta = const VerificationMeta('name');
+  @override
+  late final GeneratedColumn<String> name = GeneratedColumn<String>(
+      'name', aliasedName, false,
+      type: DriftSqlType.string, requiredDuringInsert: true);
+  static const VerificationMeta _colorMeta = const VerificationMeta('color');
+  @override
+  late final GeneratedColumnWithTypeConverter<Color, int> color =
+      GeneratedColumn<int>('color', aliasedName, false,
+              type: DriftSqlType.int, requiredDuringInsert: true)
+          .withConverter<Color>($CategoriesTable.$convertercolor);
+  @override
+  List<GeneratedColumn> get $columns => [id, name, color];
+  @override
+  String get aliasedName => _alias ?? 'categories';
+  @override
+  String get actualTableName => 'categories';
+  @override
+  VerificationContext validateIntegrity(Insertable<Category> instance,
+      {bool isInserting = false}) {
+    final context = VerificationContext();
+    final data = instance.toColumns(true);
+    if (data.containsKey('id')) {
+      context.handle(_idMeta, id.isAcceptableOrUnknown(data['id']!, _idMeta));
+    }
+    if (data.containsKey('name')) {
+      context.handle(
+          _nameMeta, name.isAcceptableOrUnknown(data['name']!, _nameMeta));
+    } else if (isInserting) {
+      context.missing(_nameMeta);
+    }
+    context.handle(_colorMeta, const VerificationResult.success());
+    return context;
+  }
+
+  @override
+  Set<GeneratedColumn> get $primaryKey => {id};
+  @override
+  Category map(Map<String, dynamic> data, {String? tablePrefix}) {
+    final effectivePrefix = tablePrefix != null ? '$tablePrefix.' : '';
+    return Category(
+      id: attachedDatabase.typeMapping
+          .read(DriftSqlType.int, data['${effectivePrefix}id'])!,
+      name: attachedDatabase.typeMapping
+          .read(DriftSqlType.string, data['${effectivePrefix}name'])!,
+      color: $CategoriesTable.$convertercolor.fromSql(attachedDatabase
+          .typeMapping
+          .read(DriftSqlType.int, data['${effectivePrefix}color'])!),
+    );
+  }
+
+  @override
+  $CategoriesTable createAlias(String alias) {
+    return $CategoriesTable(attachedDatabase, alias);
+  }
+
+  static TypeConverter<Color, int> $convertercolor = const ColorConverter();
+}
+
 class Category extends DataClass implements Insertable<Category> {
   final int id;
   final String name;
@@ -136,12 +210,12 @@ class CategoriesCompanion extends UpdateCompanion<Category> {
   }
 }
 
-class $CategoriesTable extends Categories
-    with TableInfo<$CategoriesTable, Category> {
+class $TodoEntriesTable extends TodoEntries
+    with TableInfo<$TodoEntriesTable, TodoEntry> {
   @override
   final GeneratedDatabase attachedDatabase;
   final String? _alias;
-  $CategoriesTable(this.attachedDatabase, [this._alias]);
+  $TodoEntriesTable(this.attachedDatabase, [this._alias]);
   static const VerificationMeta _idMeta = const VerificationMeta('id');
   @override
   late final GeneratedColumn<int> id = GeneratedColumn<int>(
@@ -151,63 +225,81 @@ class $CategoriesTable extends Categories
       requiredDuringInsert: false,
       defaultConstraints:
           GeneratedColumn.constraintIsAlways('PRIMARY KEY AUTOINCREMENT'));
-  static const VerificationMeta _nameMeta = const VerificationMeta('name');
+  static const VerificationMeta _descriptionMeta =
+      const VerificationMeta('description');
   @override
-  late final GeneratedColumn<String> name = GeneratedColumn<String>(
-      'name', aliasedName, false,
+  late final GeneratedColumn<String> description = GeneratedColumn<String>(
+      'description', aliasedName, false,
       type: DriftSqlType.string, requiredDuringInsert: true);
-  static const VerificationMeta _colorMeta = const VerificationMeta('color');
+  static const VerificationMeta _categoryMeta =
+      const VerificationMeta('category');
   @override
-  late final GeneratedColumnWithTypeConverter<Color, int> color =
-      GeneratedColumn<int>('color', aliasedName, false,
-              type: DriftSqlType.int, requiredDuringInsert: true)
-          .withConverter<Color>($CategoriesTable.$convertercolor);
+  late final GeneratedColumn<int> category = GeneratedColumn<int>(
+      'category', aliasedName, true,
+      type: DriftSqlType.int,
+      requiredDuringInsert: false,
+      defaultConstraints:
+          GeneratedColumn.constraintIsAlways('REFERENCES categories (id)'));
+  static const VerificationMeta _dueDateMeta =
+      const VerificationMeta('dueDate');
   @override
-  List<GeneratedColumn> get $columns => [id, name, color];
+  late final GeneratedColumn<DateTime> dueDate = GeneratedColumn<DateTime>(
+      'due_date', aliasedName, true,
+      type: DriftSqlType.dateTime, requiredDuringInsert: false);
   @override
-  String get aliasedName => _alias ?? 'categories';
+  List<GeneratedColumn> get $columns => [id, description, category, dueDate];
   @override
-  String get actualTableName => 'categories';
+  String get aliasedName => _alias ?? 'todo_entries';
   @override
-  VerificationContext validateIntegrity(Insertable<Category> instance,
+  String get actualTableName => 'todo_entries';
+  @override
+  VerificationContext validateIntegrity(Insertable<TodoEntry> instance,
       {bool isInserting = false}) {
     final context = VerificationContext();
     final data = instance.toColumns(true);
     if (data.containsKey('id')) {
       context.handle(_idMeta, id.isAcceptableOrUnknown(data['id']!, _idMeta));
     }
-    if (data.containsKey('name')) {
+    if (data.containsKey('description')) {
       context.handle(
-          _nameMeta, name.isAcceptableOrUnknown(data['name']!, _nameMeta));
+          _descriptionMeta,
+          description.isAcceptableOrUnknown(
+              data['description']!, _descriptionMeta));
     } else if (isInserting) {
-      context.missing(_nameMeta);
+      context.missing(_descriptionMeta);
     }
-    context.handle(_colorMeta, const VerificationResult.success());
+    if (data.containsKey('category')) {
+      context.handle(_categoryMeta,
+          category.isAcceptableOrUnknown(data['category']!, _categoryMeta));
+    }
+    if (data.containsKey('due_date')) {
+      context.handle(_dueDateMeta,
+          dueDate.isAcceptableOrUnknown(data['due_date']!, _dueDateMeta));
+    }
     return context;
   }
 
   @override
   Set<GeneratedColumn> get $primaryKey => {id};
   @override
-  Category map(Map<String, dynamic> data, {String? tablePrefix}) {
+  TodoEntry map(Map<String, dynamic> data, {String? tablePrefix}) {
     final effectivePrefix = tablePrefix != null ? '$tablePrefix.' : '';
-    return Category(
+    return TodoEntry(
       id: attachedDatabase.typeMapping
           .read(DriftSqlType.int, data['${effectivePrefix}id'])!,
-      name: attachedDatabase.typeMapping
-          .read(DriftSqlType.string, data['${effectivePrefix}name'])!,
-      color: $CategoriesTable.$convertercolor.fromSql(attachedDatabase
-          .typeMapping
-          .read(DriftSqlType.int, data['${effectivePrefix}color'])!),
+      description: attachedDatabase.typeMapping
+          .read(DriftSqlType.string, data['${effectivePrefix}description'])!,
+      category: attachedDatabase.typeMapping
+          .read(DriftSqlType.int, data['${effectivePrefix}category']),
+      dueDate: attachedDatabase.typeMapping
+          .read(DriftSqlType.dateTime, data['${effectivePrefix}due_date']),
     );
   }
 
   @override
-  $CategoriesTable createAlias(String alias) {
-    return $CategoriesTable(attachedDatabase, alias);
+  $TodoEntriesTable createAlias(String alias) {
+    return $TodoEntriesTable(attachedDatabase, alias);
   }
-
-  static TypeConverter<Color, int> $convertercolor = const ColorConverter();
 }
 
 class TodoEntry extends DataClass implements Insertable<TodoEntry> {
@@ -376,56 +468,32 @@ class TodoEntriesCompanion extends UpdateCompanion<TodoEntry> {
   }
 }
 
-class $TodoEntriesTable extends TodoEntries
-    with TableInfo<$TodoEntriesTable, TodoEntry> {
+class TextEntries extends Table
+    with
+        TableInfo<TextEntries, TextEntrie>,
+        VirtualTableInfo<TextEntries, TextEntrie> {
   @override
   final GeneratedDatabase attachedDatabase;
   final String? _alias;
-  $TodoEntriesTable(this.attachedDatabase, [this._alias]);
-  static const VerificationMeta _idMeta = const VerificationMeta('id');
-  @override
-  late final GeneratedColumn<int> id = GeneratedColumn<int>(
-      'id', aliasedName, false,
-      hasAutoIncrement: true,
-      type: DriftSqlType.int,
-      requiredDuringInsert: false,
-      defaultConstraints:
-          GeneratedColumn.constraintIsAlways('PRIMARY KEY AUTOINCREMENT'));
+  TextEntries(this.attachedDatabase, [this._alias]);
   static const VerificationMeta _descriptionMeta =
       const VerificationMeta('description');
-  @override
   late final GeneratedColumn<String> description = GeneratedColumn<String>(
       'description', aliasedName, false,
-      type: DriftSqlType.string, requiredDuringInsert: true);
-  static const VerificationMeta _categoryMeta =
-      const VerificationMeta('category');
+      type: DriftSqlType.string,
+      requiredDuringInsert: true,
+      $customConstraints: '');
   @override
-  late final GeneratedColumn<int> category = GeneratedColumn<int>(
-      'category', aliasedName, true,
-      type: DriftSqlType.int,
-      requiredDuringInsert: false,
-      defaultConstraints:
-          GeneratedColumn.constraintIsAlways('REFERENCES categories (id)'));
-  static const VerificationMeta _dueDateMeta =
-      const VerificationMeta('dueDate');
+  List<GeneratedColumn> get $columns => [description];
   @override
-  late final GeneratedColumn<DateTime> dueDate = GeneratedColumn<DateTime>(
-      'due_date', aliasedName, true,
-      type: DriftSqlType.dateTime, requiredDuringInsert: false);
+  String get aliasedName => _alias ?? 'text_entries';
   @override
-  List<GeneratedColumn> get $columns => [id, description, category, dueDate];
+  String get actualTableName => 'text_entries';
   @override
-  String get aliasedName => _alias ?? 'todo_entries';
-  @override
-  String get actualTableName => 'todo_entries';
-  @override
-  VerificationContext validateIntegrity(Insertable<TodoEntry> instance,
+  VerificationContext validateIntegrity(Insertable<TextEntrie> instance,
       {bool isInserting = false}) {
     final context = VerificationContext();
     final data = instance.toColumns(true);
-    if (data.containsKey('id')) {
-      context.handle(_idMeta, id.isAcceptableOrUnknown(data['id']!, _idMeta));
-    }
     if (data.containsKey('description')) {
       context.handle(
           _descriptionMeta,
@@ -434,38 +502,30 @@ class $TodoEntriesTable extends TodoEntries
     } else if (isInserting) {
       context.missing(_descriptionMeta);
     }
-    if (data.containsKey('category')) {
-      context.handle(_categoryMeta,
-          category.isAcceptableOrUnknown(data['category']!, _categoryMeta));
-    }
-    if (data.containsKey('due_date')) {
-      context.handle(_dueDateMeta,
-          dueDate.isAcceptableOrUnknown(data['due_date']!, _dueDateMeta));
-    }
     return context;
   }
 
   @override
-  Set<GeneratedColumn> get $primaryKey => {id};
+  Set<GeneratedColumn> get $primaryKey => const {};
   @override
-  TodoEntry map(Map<String, dynamic> data, {String? tablePrefix}) {
+  TextEntrie map(Map<String, dynamic> data, {String? tablePrefix}) {
     final effectivePrefix = tablePrefix != null ? '$tablePrefix.' : '';
-    return TodoEntry(
-      id: attachedDatabase.typeMapping
-          .read(DriftSqlType.int, data['${effectivePrefix}id'])!,
+    return TextEntrie(
       description: attachedDatabase.typeMapping
           .read(DriftSqlType.string, data['${effectivePrefix}description'])!,
-      category: attachedDatabase.typeMapping
-          .read(DriftSqlType.int, data['${effectivePrefix}category']),
-      dueDate: attachedDatabase.typeMapping
-          .read(DriftSqlType.dateTime, data['${effectivePrefix}due_date']),
     );
   }
 
   @override
-  $TodoEntriesTable createAlias(String alias) {
-    return $TodoEntriesTable(attachedDatabase, alias);
+  TextEntries createAlias(String alias) {
+    return TextEntries(attachedDatabase, alias);
   }
+
+  @override
+  bool get dontWriteConstraints => true;
+  @override
+  String get moduleAndArgs =>
+      'fts5(description, content=todo_entries, content_rowid=id)';
 }
 
 class TextEntrie extends DataClass implements Insertable<TextEntrie> {
@@ -556,66 +616,6 @@ class TextEntriesCompanion extends UpdateCompanion<TextEntrie> {
           ..write(')'))
         .toString();
   }
-}
-
-class TextEntries extends Table
-    with
-        TableInfo<TextEntries, TextEntrie>,
-        VirtualTableInfo<TextEntries, TextEntrie> {
-  @override
-  final GeneratedDatabase attachedDatabase;
-  final String? _alias;
-  TextEntries(this.attachedDatabase, [this._alias]);
-  static const VerificationMeta _descriptionMeta =
-      const VerificationMeta('description');
-  late final GeneratedColumn<String> description = GeneratedColumn<String>(
-      'description', aliasedName, false,
-      type: DriftSqlType.string,
-      requiredDuringInsert: true,
-      $customConstraints: '');
-  @override
-  List<GeneratedColumn> get $columns => [description];
-  @override
-  String get aliasedName => _alias ?? 'text_entries';
-  @override
-  String get actualTableName => 'text_entries';
-  @override
-  VerificationContext validateIntegrity(Insertable<TextEntrie> instance,
-      {bool isInserting = false}) {
-    final context = VerificationContext();
-    final data = instance.toColumns(true);
-    if (data.containsKey('description')) {
-      context.handle(
-          _descriptionMeta,
-          description.isAcceptableOrUnknown(
-              data['description']!, _descriptionMeta));
-    } else if (isInserting) {
-      context.missing(_descriptionMeta);
-    }
-    return context;
-  }
-
-  @override
-  Set<GeneratedColumn> get $primaryKey => const {};
-  @override
-  TextEntrie map(Map<String, dynamic> data, {String? tablePrefix}) {
-    final effectivePrefix = tablePrefix != null ? '$tablePrefix.' : '';
-    return TextEntrie(
-      description: attachedDatabase.typeMapping
-          .read(DriftSqlType.string, data['${effectivePrefix}description'])!,
-    );
-  }
-
-  @override
-  TextEntries createAlias(String alias) {
-    return TextEntries(attachedDatabase, alias);
-  }
-
-  @override
-  bool get dontWriteConstraints => true;
-  @override
-  String get moduleAndArgs =>
-      'fts5(description, content=todo_entries, content_rowid=id)';
 }
 
 abstract class _$AppDatabase extends GeneratedDatabase {

--- a/examples/encryption/lib/database.g.dart
+++ b/examples/encryption/lib/database.g.dart
@@ -3,6 +3,68 @@
 part of 'database.dart';
 
 // ignore_for_file: type=lint
+class $NotesTable extends Notes with TableInfo<$NotesTable, Note> {
+  @override
+  final GeneratedDatabase attachedDatabase;
+  final String? _alias;
+  $NotesTable(this.attachedDatabase, [this._alias]);
+  static const VerificationMeta _idMeta = const VerificationMeta('id');
+  @override
+  late final GeneratedColumn<int> id = GeneratedColumn<int>(
+      'id', aliasedName, false,
+      hasAutoIncrement: true,
+      type: DriftSqlType.int,
+      requiredDuringInsert: false,
+      defaultConstraints:
+          GeneratedColumn.constraintIsAlways('PRIMARY KEY AUTOINCREMENT'));
+  static const VerificationMeta _contentMeta =
+      const VerificationMeta('content');
+  @override
+  late final GeneratedColumn<String> content = GeneratedColumn<String>(
+      'content', aliasedName, false,
+      type: DriftSqlType.string, requiredDuringInsert: true);
+  @override
+  List<GeneratedColumn> get $columns => [id, content];
+  @override
+  String get aliasedName => _alias ?? 'notes';
+  @override
+  String get actualTableName => 'notes';
+  @override
+  VerificationContext validateIntegrity(Insertable<Note> instance,
+      {bool isInserting = false}) {
+    final context = VerificationContext();
+    final data = instance.toColumns(true);
+    if (data.containsKey('id')) {
+      context.handle(_idMeta, id.isAcceptableOrUnknown(data['id']!, _idMeta));
+    }
+    if (data.containsKey('content')) {
+      context.handle(_contentMeta,
+          content.isAcceptableOrUnknown(data['content']!, _contentMeta));
+    } else if (isInserting) {
+      context.missing(_contentMeta);
+    }
+    return context;
+  }
+
+  @override
+  Set<GeneratedColumn> get $primaryKey => {id};
+  @override
+  Note map(Map<String, dynamic> data, {String? tablePrefix}) {
+    final effectivePrefix = tablePrefix != null ? '$tablePrefix.' : '';
+    return Note(
+      id: attachedDatabase.typeMapping
+          .read(DriftSqlType.int, data['${effectivePrefix}id'])!,
+      content: attachedDatabase.typeMapping
+          .read(DriftSqlType.string, data['${effectivePrefix}content'])!,
+    );
+  }
+
+  @override
+  $NotesTable createAlias(String alias) {
+    return $NotesTable(attachedDatabase, alias);
+  }
+}
+
 class Note extends DataClass implements Insertable<Note> {
   final int id;
   final String content;
@@ -107,68 +169,6 @@ class NotesCompanion extends UpdateCompanion<Note> {
           ..write('content: $content')
           ..write(')'))
         .toString();
-  }
-}
-
-class $NotesTable extends Notes with TableInfo<$NotesTable, Note> {
-  @override
-  final GeneratedDatabase attachedDatabase;
-  final String? _alias;
-  $NotesTable(this.attachedDatabase, [this._alias]);
-  static const VerificationMeta _idMeta = const VerificationMeta('id');
-  @override
-  late final GeneratedColumn<int> id = GeneratedColumn<int>(
-      'id', aliasedName, false,
-      hasAutoIncrement: true,
-      type: DriftSqlType.int,
-      requiredDuringInsert: false,
-      defaultConstraints:
-          GeneratedColumn.constraintIsAlways('PRIMARY KEY AUTOINCREMENT'));
-  static const VerificationMeta _contentMeta =
-      const VerificationMeta('content');
-  @override
-  late final GeneratedColumn<String> content = GeneratedColumn<String>(
-      'content', aliasedName, false,
-      type: DriftSqlType.string, requiredDuringInsert: true);
-  @override
-  List<GeneratedColumn> get $columns => [id, content];
-  @override
-  String get aliasedName => _alias ?? 'notes';
-  @override
-  String get actualTableName => 'notes';
-  @override
-  VerificationContext validateIntegrity(Insertable<Note> instance,
-      {bool isInserting = false}) {
-    final context = VerificationContext();
-    final data = instance.toColumns(true);
-    if (data.containsKey('id')) {
-      context.handle(_idMeta, id.isAcceptableOrUnknown(data['id']!, _idMeta));
-    }
-    if (data.containsKey('content')) {
-      context.handle(_contentMeta,
-          content.isAcceptableOrUnknown(data['content']!, _contentMeta));
-    } else if (isInserting) {
-      context.missing(_contentMeta);
-    }
-    return context;
-  }
-
-  @override
-  Set<GeneratedColumn> get $primaryKey => {id};
-  @override
-  Note map(Map<String, dynamic> data, {String? tablePrefix}) {
-    final effectivePrefix = tablePrefix != null ? '$tablePrefix.' : '';
-    return Note(
-      id: attachedDatabase.typeMapping
-          .read(DriftSqlType.int, data['${effectivePrefix}id'])!,
-      content: attachedDatabase.typeMapping
-          .read(DriftSqlType.string, data['${effectivePrefix}content'])!,
-    );
-  }
-
-  @override
-  $NotesTable createAlias(String alias) {
-    return $NotesTable(attachedDatabase, alias);
   }
 }
 

--- a/examples/flutter_web_worker_example/lib/src/database/database.g.dart
+++ b/examples/flutter_web_worker_example/lib/src/database/database.g.dart
@@ -3,6 +3,68 @@
 part of 'database.dart';
 
 // ignore_for_file: type=lint
+class Entries extends Table with TableInfo<Entries, Entrie> {
+  @override
+  final GeneratedDatabase attachedDatabase;
+  final String? _alias;
+  Entries(this.attachedDatabase, [this._alias]);
+  static const VerificationMeta _idMeta = const VerificationMeta('id');
+  late final GeneratedColumn<int> id = GeneratedColumn<int>(
+      'id', aliasedName, false,
+      type: DriftSqlType.int,
+      requiredDuringInsert: false,
+      $customConstraints: 'PRIMARY KEY');
+  static const VerificationMeta _valueMeta = const VerificationMeta('value');
+  late final GeneratedColumn<String> value = GeneratedColumn<String>(
+      'text', aliasedName, false,
+      type: DriftSqlType.string,
+      requiredDuringInsert: true,
+      $customConstraints: 'NOT NULL');
+  @override
+  List<GeneratedColumn> get $columns => [id, value];
+  @override
+  String get aliasedName => _alias ?? 'entries';
+  @override
+  String get actualTableName => 'entries';
+  @override
+  VerificationContext validateIntegrity(Insertable<Entrie> instance,
+      {bool isInserting = false}) {
+    final context = VerificationContext();
+    final data = instance.toColumns(true);
+    if (data.containsKey('id')) {
+      context.handle(_idMeta, id.isAcceptableOrUnknown(data['id']!, _idMeta));
+    }
+    if (data.containsKey('text')) {
+      context.handle(
+          _valueMeta, value.isAcceptableOrUnknown(data['text']!, _valueMeta));
+    } else if (isInserting) {
+      context.missing(_valueMeta);
+    }
+    return context;
+  }
+
+  @override
+  Set<GeneratedColumn> get $primaryKey => {id};
+  @override
+  Entrie map(Map<String, dynamic> data, {String? tablePrefix}) {
+    final effectivePrefix = tablePrefix != null ? '$tablePrefix.' : '';
+    return Entrie(
+      id: attachedDatabase.typeMapping
+          .read(DriftSqlType.int, data['${effectivePrefix}id'])!,
+      value: attachedDatabase.typeMapping
+          .read(DriftSqlType.string, data['${effectivePrefix}text'])!,
+    );
+  }
+
+  @override
+  Entries createAlias(String alias) {
+    return Entries(attachedDatabase, alias);
+  }
+
+  @override
+  bool get dontWriteConstraints => true;
+}
+
 class Entrie extends DataClass implements Insertable<Entrie> {
   final int id;
   final String value;
@@ -108,68 +170,6 @@ class EntriesCompanion extends UpdateCompanion<Entrie> {
           ..write(')'))
         .toString();
   }
-}
-
-class Entries extends Table with TableInfo<Entries, Entrie> {
-  @override
-  final GeneratedDatabase attachedDatabase;
-  final String? _alias;
-  Entries(this.attachedDatabase, [this._alias]);
-  static const VerificationMeta _idMeta = const VerificationMeta('id');
-  late final GeneratedColumn<int> id = GeneratedColumn<int>(
-      'id', aliasedName, false,
-      type: DriftSqlType.int,
-      requiredDuringInsert: false,
-      $customConstraints: 'PRIMARY KEY');
-  static const VerificationMeta _valueMeta = const VerificationMeta('value');
-  late final GeneratedColumn<String> value = GeneratedColumn<String>(
-      'text', aliasedName, false,
-      type: DriftSqlType.string,
-      requiredDuringInsert: true,
-      $customConstraints: 'NOT NULL');
-  @override
-  List<GeneratedColumn> get $columns => [id, value];
-  @override
-  String get aliasedName => _alias ?? 'entries';
-  @override
-  String get actualTableName => 'entries';
-  @override
-  VerificationContext validateIntegrity(Insertable<Entrie> instance,
-      {bool isInserting = false}) {
-    final context = VerificationContext();
-    final data = instance.toColumns(true);
-    if (data.containsKey('id')) {
-      context.handle(_idMeta, id.isAcceptableOrUnknown(data['id']!, _idMeta));
-    }
-    if (data.containsKey('text')) {
-      context.handle(
-          _valueMeta, value.isAcceptableOrUnknown(data['text']!, _valueMeta));
-    } else if (isInserting) {
-      context.missing(_valueMeta);
-    }
-    return context;
-  }
-
-  @override
-  Set<GeneratedColumn> get $primaryKey => {id};
-  @override
-  Entrie map(Map<String, dynamic> data, {String? tablePrefix}) {
-    final effectivePrefix = tablePrefix != null ? '$tablePrefix.' : '';
-    return Entrie(
-      id: attachedDatabase.typeMapping
-          .read(DriftSqlType.int, data['${effectivePrefix}id'])!,
-      value: attachedDatabase.typeMapping
-          .read(DriftSqlType.string, data['${effectivePrefix}text'])!,
-    );
-  }
-
-  @override
-  Entries createAlias(String alias) {
-    return Entries(attachedDatabase, alias);
-  }
-
-  @override
-  bool get dontWriteConstraints => true;
 }
 
 abstract class _$MyDatabase extends GeneratedDatabase {

--- a/examples/migrations_example/lib/database.g.dart
+++ b/examples/migrations_example/lib/database.g.dart
@@ -3,6 +3,98 @@
 part of 'database.dart';
 
 // ignore_for_file: type=lint
+class $UsersTable extends Users with TableInfo<$UsersTable, User> {
+  @override
+  final GeneratedDatabase attachedDatabase;
+  final String? _alias;
+  $UsersTable(this.attachedDatabase, [this._alias]);
+  static const VerificationMeta _idMeta = const VerificationMeta('id');
+  @override
+  late final GeneratedColumn<int> id = GeneratedColumn<int>(
+      'id', aliasedName, false,
+      hasAutoIncrement: true,
+      type: DriftSqlType.int,
+      requiredDuringInsert: false,
+      defaultConstraints:
+          GeneratedColumn.constraintIsAlways('PRIMARY KEY AUTOINCREMENT'));
+  static const VerificationMeta _nameMeta = const VerificationMeta('name');
+  @override
+  late final GeneratedColumn<String> name = GeneratedColumn<String>(
+      'name', aliasedName, false,
+      type: DriftSqlType.string,
+      requiredDuringInsert: false,
+      defaultValue: const Constant('name'));
+  static const VerificationMeta _birthdayMeta =
+      const VerificationMeta('birthday');
+  @override
+  late final GeneratedColumn<DateTime> birthday = GeneratedColumn<DateTime>(
+      'birthday', aliasedName, true,
+      type: DriftSqlType.dateTime, requiredDuringInsert: false);
+  static const VerificationMeta _nextUserMeta =
+      const VerificationMeta('nextUser');
+  @override
+  late final GeneratedColumn<int> nextUser = GeneratedColumn<int>(
+      'next_user', aliasedName, true,
+      type: DriftSqlType.int,
+      requiredDuringInsert: false,
+      defaultConstraints:
+          GeneratedColumn.constraintIsAlways('REFERENCES users (id)'));
+  @override
+  List<GeneratedColumn> get $columns => [id, name, birthday, nextUser];
+  @override
+  String get aliasedName => _alias ?? 'users';
+  @override
+  String get actualTableName => 'users';
+  @override
+  VerificationContext validateIntegrity(Insertable<User> instance,
+      {bool isInserting = false}) {
+    final context = VerificationContext();
+    final data = instance.toColumns(true);
+    if (data.containsKey('id')) {
+      context.handle(_idMeta, id.isAcceptableOrUnknown(data['id']!, _idMeta));
+    }
+    if (data.containsKey('name')) {
+      context.handle(
+          _nameMeta, name.isAcceptableOrUnknown(data['name']!, _nameMeta));
+    }
+    if (data.containsKey('birthday')) {
+      context.handle(_birthdayMeta,
+          birthday.isAcceptableOrUnknown(data['birthday']!, _birthdayMeta));
+    }
+    if (data.containsKey('next_user')) {
+      context.handle(_nextUserMeta,
+          nextUser.isAcceptableOrUnknown(data['next_user']!, _nextUserMeta));
+    }
+    return context;
+  }
+
+  @override
+  Set<GeneratedColumn> get $primaryKey => {id};
+  @override
+  List<Set<GeneratedColumn>> get uniqueKeys => [
+        {name, birthday},
+      ];
+  @override
+  User map(Map<String, dynamic> data, {String? tablePrefix}) {
+    final effectivePrefix = tablePrefix != null ? '$tablePrefix.' : '';
+    return User(
+      id: attachedDatabase.typeMapping
+          .read(DriftSqlType.int, data['${effectivePrefix}id'])!,
+      name: attachedDatabase.typeMapping
+          .read(DriftSqlType.string, data['${effectivePrefix}name'])!,
+      birthday: attachedDatabase.typeMapping
+          .read(DriftSqlType.dateTime, data['${effectivePrefix}birthday']),
+      nextUser: attachedDatabase.typeMapping
+          .read(DriftSqlType.int, data['${effectivePrefix}next_user']),
+    );
+  }
+
+  @override
+  $UsersTable createAlias(String alias) {
+    return $UsersTable(attachedDatabase, alias);
+  }
+}
+
 class User extends DataClass implements Insertable<User> {
   final int id;
   final String name;
@@ -166,67 +258,66 @@ class UsersCompanion extends UpdateCompanion<User> {
   }
 }
 
-class $UsersTable extends Users with TableInfo<$UsersTable, User> {
+class Groups extends Table with TableInfo<Groups, Group> {
   @override
   final GeneratedDatabase attachedDatabase;
   final String? _alias;
-  $UsersTable(this.attachedDatabase, [this._alias]);
+  Groups(this.attachedDatabase, [this._alias]);
   static const VerificationMeta _idMeta = const VerificationMeta('id');
-  @override
   late final GeneratedColumn<int> id = GeneratedColumn<int>(
       'id', aliasedName, false,
-      hasAutoIncrement: true,
       type: DriftSqlType.int,
       requiredDuringInsert: false,
-      defaultConstraints:
-          GeneratedColumn.constraintIsAlways('PRIMARY KEY AUTOINCREMENT'));
-  static const VerificationMeta _nameMeta = const VerificationMeta('name');
-  @override
-  late final GeneratedColumn<String> name = GeneratedColumn<String>(
-      'name', aliasedName, false,
+      $customConstraints: 'NOT NULL');
+  static const VerificationMeta _titleMeta = const VerificationMeta('title');
+  late final GeneratedColumn<String> title = GeneratedColumn<String>(
+      'title', aliasedName, false,
       type: DriftSqlType.string,
+      requiredDuringInsert: true,
+      $customConstraints: 'NOT NULL');
+  static const VerificationMeta _deletedMeta =
+      const VerificationMeta('deleted');
+  late final GeneratedColumn<bool> deleted = GeneratedColumn<bool>(
+      'deleted', aliasedName, true,
+      type: DriftSqlType.bool,
       requiredDuringInsert: false,
-      defaultValue: const Constant('name'));
-  static const VerificationMeta _birthdayMeta =
-      const VerificationMeta('birthday');
-  @override
-  late final GeneratedColumn<DateTime> birthday = GeneratedColumn<DateTime>(
-      'birthday', aliasedName, true,
-      type: DriftSqlType.dateTime, requiredDuringInsert: false);
-  static const VerificationMeta _nextUserMeta =
-      const VerificationMeta('nextUser');
-  @override
-  late final GeneratedColumn<int> nextUser = GeneratedColumn<int>(
-      'next_user', aliasedName, true,
+      $customConstraints: 'DEFAULT FALSE',
+      defaultValue: const CustomExpression('FALSE'));
+  static const VerificationMeta _ownerMeta = const VerificationMeta('owner');
+  late final GeneratedColumn<int> owner = GeneratedColumn<int>(
+      'owner', aliasedName, false,
       type: DriftSqlType.int,
-      requiredDuringInsert: false,
-      defaultConstraints:
-          GeneratedColumn.constraintIsAlways('REFERENCES users (id)'));
+      requiredDuringInsert: true,
+      $customConstraints: 'NOT NULL REFERENCES users(id)');
   @override
-  List<GeneratedColumn> get $columns => [id, name, birthday, nextUser];
+  List<GeneratedColumn> get $columns => [id, title, deleted, owner];
   @override
-  String get aliasedName => _alias ?? 'users';
+  String get aliasedName => _alias ?? 'groups';
   @override
-  String get actualTableName => 'users';
+  String get actualTableName => 'groups';
   @override
-  VerificationContext validateIntegrity(Insertable<User> instance,
+  VerificationContext validateIntegrity(Insertable<Group> instance,
       {bool isInserting = false}) {
     final context = VerificationContext();
     final data = instance.toColumns(true);
     if (data.containsKey('id')) {
       context.handle(_idMeta, id.isAcceptableOrUnknown(data['id']!, _idMeta));
     }
-    if (data.containsKey('name')) {
+    if (data.containsKey('title')) {
       context.handle(
-          _nameMeta, name.isAcceptableOrUnknown(data['name']!, _nameMeta));
+          _titleMeta, title.isAcceptableOrUnknown(data['title']!, _titleMeta));
+    } else if (isInserting) {
+      context.missing(_titleMeta);
     }
-    if (data.containsKey('birthday')) {
-      context.handle(_birthdayMeta,
-          birthday.isAcceptableOrUnknown(data['birthday']!, _birthdayMeta));
+    if (data.containsKey('deleted')) {
+      context.handle(_deletedMeta,
+          deleted.isAcceptableOrUnknown(data['deleted']!, _deletedMeta));
     }
-    if (data.containsKey('next_user')) {
-      context.handle(_nextUserMeta,
-          nextUser.isAcceptableOrUnknown(data['next_user']!, _nextUserMeta));
+    if (data.containsKey('owner')) {
+      context.handle(
+          _ownerMeta, owner.isAcceptableOrUnknown(data['owner']!, _ownerMeta));
+    } else if (isInserting) {
+      context.missing(_ownerMeta);
     }
     return context;
   }
@@ -234,28 +325,29 @@ class $UsersTable extends Users with TableInfo<$UsersTable, User> {
   @override
   Set<GeneratedColumn> get $primaryKey => {id};
   @override
-  List<Set<GeneratedColumn>> get uniqueKeys => [
-        {name, birthday},
-      ];
-  @override
-  User map(Map<String, dynamic> data, {String? tablePrefix}) {
+  Group map(Map<String, dynamic> data, {String? tablePrefix}) {
     final effectivePrefix = tablePrefix != null ? '$tablePrefix.' : '';
-    return User(
+    return Group(
       id: attachedDatabase.typeMapping
           .read(DriftSqlType.int, data['${effectivePrefix}id'])!,
-      name: attachedDatabase.typeMapping
-          .read(DriftSqlType.string, data['${effectivePrefix}name'])!,
-      birthday: attachedDatabase.typeMapping
-          .read(DriftSqlType.dateTime, data['${effectivePrefix}birthday']),
-      nextUser: attachedDatabase.typeMapping
-          .read(DriftSqlType.int, data['${effectivePrefix}next_user']),
+      title: attachedDatabase.typeMapping
+          .read(DriftSqlType.string, data['${effectivePrefix}title'])!,
+      deleted: attachedDatabase.typeMapping
+          .read(DriftSqlType.bool, data['${effectivePrefix}deleted']),
+      owner: attachedDatabase.typeMapping
+          .read(DriftSqlType.int, data['${effectivePrefix}owner'])!,
     );
   }
 
   @override
-  $UsersTable createAlias(String alias) {
-    return $UsersTable(attachedDatabase, alias);
+  Groups createAlias(String alias) {
+    return Groups(attachedDatabase, alias);
   }
+
+  @override
+  List<String> get customConstraints => const ['PRIMARY KEY(id)'];
+  @override
+  bool get dontWriteConstraints => true;
 }
 
 class Group extends DataClass implements Insertable<Group> {
@@ -421,96 +513,91 @@ class GroupsCompanion extends UpdateCompanion<Group> {
   }
 }
 
-class Groups extends Table with TableInfo<Groups, Group> {
+class Notes extends Table
+    with TableInfo<Notes, Note>, VirtualTableInfo<Notes, Note> {
   @override
   final GeneratedDatabase attachedDatabase;
   final String? _alias;
-  Groups(this.attachedDatabase, [this._alias]);
-  static const VerificationMeta _idMeta = const VerificationMeta('id');
-  late final GeneratedColumn<int> id = GeneratedColumn<int>(
-      'id', aliasedName, false,
-      type: DriftSqlType.int,
-      requiredDuringInsert: false,
-      $customConstraints: 'NOT NULL');
+  Notes(this.attachedDatabase, [this._alias]);
   static const VerificationMeta _titleMeta = const VerificationMeta('title');
   late final GeneratedColumn<String> title = GeneratedColumn<String>(
       'title', aliasedName, false,
       type: DriftSqlType.string,
       requiredDuringInsert: true,
-      $customConstraints: 'NOT NULL');
-  static const VerificationMeta _deletedMeta =
-      const VerificationMeta('deleted');
-  late final GeneratedColumn<bool> deleted = GeneratedColumn<bool>(
-      'deleted', aliasedName, true,
-      type: DriftSqlType.bool,
-      requiredDuringInsert: false,
-      $customConstraints: 'DEFAULT FALSE',
-      defaultValue: const CustomExpression('FALSE'));
-  static const VerificationMeta _ownerMeta = const VerificationMeta('owner');
-  late final GeneratedColumn<int> owner = GeneratedColumn<int>(
-      'owner', aliasedName, false,
-      type: DriftSqlType.int,
+      $customConstraints: '');
+  static const VerificationMeta _contentMeta =
+      const VerificationMeta('content');
+  late final GeneratedColumn<String> content = GeneratedColumn<String>(
+      'content', aliasedName, false,
+      type: DriftSqlType.string,
       requiredDuringInsert: true,
-      $customConstraints: 'NOT NULL REFERENCES users(id)');
+      $customConstraints: '');
+  static const VerificationMeta _searchTermsMeta =
+      const VerificationMeta('searchTerms');
+  late final GeneratedColumn<String> searchTerms = GeneratedColumn<String>(
+      'search_terms', aliasedName, false,
+      type: DriftSqlType.string,
+      requiredDuringInsert: true,
+      $customConstraints: '');
   @override
-  List<GeneratedColumn> get $columns => [id, title, deleted, owner];
+  List<GeneratedColumn> get $columns => [title, content, searchTerms];
   @override
-  String get aliasedName => _alias ?? 'groups';
+  String get aliasedName => _alias ?? 'notes';
   @override
-  String get actualTableName => 'groups';
+  String get actualTableName => 'notes';
   @override
-  VerificationContext validateIntegrity(Insertable<Group> instance,
+  VerificationContext validateIntegrity(Insertable<Note> instance,
       {bool isInserting = false}) {
     final context = VerificationContext();
     final data = instance.toColumns(true);
-    if (data.containsKey('id')) {
-      context.handle(_idMeta, id.isAcceptableOrUnknown(data['id']!, _idMeta));
-    }
     if (data.containsKey('title')) {
       context.handle(
           _titleMeta, title.isAcceptableOrUnknown(data['title']!, _titleMeta));
     } else if (isInserting) {
       context.missing(_titleMeta);
     }
-    if (data.containsKey('deleted')) {
-      context.handle(_deletedMeta,
-          deleted.isAcceptableOrUnknown(data['deleted']!, _deletedMeta));
-    }
-    if (data.containsKey('owner')) {
-      context.handle(
-          _ownerMeta, owner.isAcceptableOrUnknown(data['owner']!, _ownerMeta));
+    if (data.containsKey('content')) {
+      context.handle(_contentMeta,
+          content.isAcceptableOrUnknown(data['content']!, _contentMeta));
     } else if (isInserting) {
-      context.missing(_ownerMeta);
+      context.missing(_contentMeta);
+    }
+    if (data.containsKey('search_terms')) {
+      context.handle(
+          _searchTermsMeta,
+          searchTerms.isAcceptableOrUnknown(
+              data['search_terms']!, _searchTermsMeta));
+    } else if (isInserting) {
+      context.missing(_searchTermsMeta);
     }
     return context;
   }
 
   @override
-  Set<GeneratedColumn> get $primaryKey => {id};
+  Set<GeneratedColumn> get $primaryKey => const {};
   @override
-  Group map(Map<String, dynamic> data, {String? tablePrefix}) {
+  Note map(Map<String, dynamic> data, {String? tablePrefix}) {
     final effectivePrefix = tablePrefix != null ? '$tablePrefix.' : '';
-    return Group(
-      id: attachedDatabase.typeMapping
-          .read(DriftSqlType.int, data['${effectivePrefix}id'])!,
+    return Note(
       title: attachedDatabase.typeMapping
           .read(DriftSqlType.string, data['${effectivePrefix}title'])!,
-      deleted: attachedDatabase.typeMapping
-          .read(DriftSqlType.bool, data['${effectivePrefix}deleted']),
-      owner: attachedDatabase.typeMapping
-          .read(DriftSqlType.int, data['${effectivePrefix}owner'])!,
+      content: attachedDatabase.typeMapping
+          .read(DriftSqlType.string, data['${effectivePrefix}content'])!,
+      searchTerms: attachedDatabase.typeMapping
+          .read(DriftSqlType.string, data['${effectivePrefix}search_terms'])!,
     );
   }
 
   @override
-  Groups createAlias(String alias) {
-    return Groups(attachedDatabase, alias);
+  Notes createAlias(String alias) {
+    return Notes(attachedDatabase, alias);
   }
 
   @override
-  List<String> get customConstraints => const ['PRIMARY KEY(id)'];
-  @override
   bool get dontWriteConstraints => true;
+  @override
+  String get moduleAndArgs =>
+      'fts5(title, content, search_terms, tokenize = "unicode61 tokenchars \'.\'")';
 }
 
 class Note extends DataClass implements Insertable<Note> {
@@ -644,93 +731,6 @@ class NotesCompanion extends UpdateCompanion<Note> {
           ..write(')'))
         .toString();
   }
-}
-
-class Notes extends Table
-    with TableInfo<Notes, Note>, VirtualTableInfo<Notes, Note> {
-  @override
-  final GeneratedDatabase attachedDatabase;
-  final String? _alias;
-  Notes(this.attachedDatabase, [this._alias]);
-  static const VerificationMeta _titleMeta = const VerificationMeta('title');
-  late final GeneratedColumn<String> title = GeneratedColumn<String>(
-      'title', aliasedName, false,
-      type: DriftSqlType.string,
-      requiredDuringInsert: true,
-      $customConstraints: '');
-  static const VerificationMeta _contentMeta =
-      const VerificationMeta('content');
-  late final GeneratedColumn<String> content = GeneratedColumn<String>(
-      'content', aliasedName, false,
-      type: DriftSqlType.string,
-      requiredDuringInsert: true,
-      $customConstraints: '');
-  static const VerificationMeta _searchTermsMeta =
-      const VerificationMeta('searchTerms');
-  late final GeneratedColumn<String> searchTerms = GeneratedColumn<String>(
-      'search_terms', aliasedName, false,
-      type: DriftSqlType.string,
-      requiredDuringInsert: true,
-      $customConstraints: '');
-  @override
-  List<GeneratedColumn> get $columns => [title, content, searchTerms];
-  @override
-  String get aliasedName => _alias ?? 'notes';
-  @override
-  String get actualTableName => 'notes';
-  @override
-  VerificationContext validateIntegrity(Insertable<Note> instance,
-      {bool isInserting = false}) {
-    final context = VerificationContext();
-    final data = instance.toColumns(true);
-    if (data.containsKey('title')) {
-      context.handle(
-          _titleMeta, title.isAcceptableOrUnknown(data['title']!, _titleMeta));
-    } else if (isInserting) {
-      context.missing(_titleMeta);
-    }
-    if (data.containsKey('content')) {
-      context.handle(_contentMeta,
-          content.isAcceptableOrUnknown(data['content']!, _contentMeta));
-    } else if (isInserting) {
-      context.missing(_contentMeta);
-    }
-    if (data.containsKey('search_terms')) {
-      context.handle(
-          _searchTermsMeta,
-          searchTerms.isAcceptableOrUnknown(
-              data['search_terms']!, _searchTermsMeta));
-    } else if (isInserting) {
-      context.missing(_searchTermsMeta);
-    }
-    return context;
-  }
-
-  @override
-  Set<GeneratedColumn> get $primaryKey => const {};
-  @override
-  Note map(Map<String, dynamic> data, {String? tablePrefix}) {
-    final effectivePrefix = tablePrefix != null ? '$tablePrefix.' : '';
-    return Note(
-      title: attachedDatabase.typeMapping
-          .read(DriftSqlType.string, data['${effectivePrefix}title'])!,
-      content: attachedDatabase.typeMapping
-          .read(DriftSqlType.string, data['${effectivePrefix}content'])!,
-      searchTerms: attachedDatabase.typeMapping
-          .read(DriftSqlType.string, data['${effectivePrefix}search_terms'])!,
-    );
-  }
-
-  @override
-  Notes createAlias(String alias) {
-    return Notes(attachedDatabase, alias);
-  }
-
-  @override
-  bool get dontWriteConstraints => true;
-  @override
-  String get moduleAndArgs =>
-      'fts5(title, content, search_terms, tokenize = "unicode61 tokenchars \'.\'")';
 }
 
 class GroupCountData extends DataClass {

--- a/examples/modular/lib/src/posts.drift.dart
+++ b/examples/modular/lib/src/posts.drift.dart
@@ -2,6 +2,82 @@
 import 'package:drift/drift.dart' as i0;
 import 'package:modular/src/posts.drift.dart' as i1;
 
+class Posts extends i0.Table with i0.TableInfo<Posts, i1.Post> {
+  @override
+  final i0.GeneratedDatabase attachedDatabase;
+  final String? _alias;
+  Posts(this.attachedDatabase, [this._alias]);
+  static const i0.VerificationMeta _idMeta = const i0.VerificationMeta('id');
+  late final i0.GeneratedColumn<int> id = i0.GeneratedColumn<int>(
+      'id', aliasedName, false,
+      type: i0.DriftSqlType.int,
+      requiredDuringInsert: false,
+      $customConstraints: 'PRIMARY KEY');
+  static const i0.VerificationMeta _authorMeta =
+      const i0.VerificationMeta('author');
+  late final i0.GeneratedColumn<int> author = i0.GeneratedColumn<int>(
+      'author', aliasedName, false,
+      type: i0.DriftSqlType.int,
+      requiredDuringInsert: true,
+      $customConstraints: 'NOT NULL REFERENCES users(id)');
+  static const i0.VerificationMeta _contentMeta =
+      const i0.VerificationMeta('content');
+  late final i0.GeneratedColumn<String> content = i0.GeneratedColumn<String>(
+      'content', aliasedName, true,
+      type: i0.DriftSqlType.string,
+      requiredDuringInsert: false,
+      $customConstraints: '');
+  @override
+  List<i0.GeneratedColumn> get $columns => [id, author, content];
+  @override
+  String get aliasedName => _alias ?? 'posts';
+  @override
+  String get actualTableName => 'posts';
+  @override
+  i0.VerificationContext validateIntegrity(i0.Insertable<i1.Post> instance,
+      {bool isInserting = false}) {
+    final context = i0.VerificationContext();
+    final data = instance.toColumns(true);
+    if (data.containsKey('id')) {
+      context.handle(_idMeta, id.isAcceptableOrUnknown(data['id']!, _idMeta));
+    }
+    if (data.containsKey('author')) {
+      context.handle(_authorMeta,
+          author.isAcceptableOrUnknown(data['author']!, _authorMeta));
+    } else if (isInserting) {
+      context.missing(_authorMeta);
+    }
+    if (data.containsKey('content')) {
+      context.handle(_contentMeta,
+          content.isAcceptableOrUnknown(data['content']!, _contentMeta));
+    }
+    return context;
+  }
+
+  @override
+  Set<i0.GeneratedColumn> get $primaryKey => {id};
+  @override
+  i1.Post map(Map<String, dynamic> data, {String? tablePrefix}) {
+    final effectivePrefix = tablePrefix != null ? '$tablePrefix.' : '';
+    return i1.Post(
+      id: attachedDatabase.typeMapping
+          .read(i0.DriftSqlType.int, data['${effectivePrefix}id'])!,
+      author: attachedDatabase.typeMapping
+          .read(i0.DriftSqlType.int, data['${effectivePrefix}author'])!,
+      content: attachedDatabase.typeMapping
+          .read(i0.DriftSqlType.string, data['${effectivePrefix}content']),
+    );
+  }
+
+  @override
+  Posts createAlias(String alias) {
+    return Posts(attachedDatabase, alias);
+  }
+
+  @override
+  bool get dontWriteConstraints => true;
+}
+
 class Post extends i0.DataClass implements i0.Insertable<i1.Post> {
   final int id;
   final int author;
@@ -138,76 +214,67 @@ class PostsCompanion extends i0.UpdateCompanion<i1.Post> {
   }
 }
 
-class Posts extends i0.Table with i0.TableInfo<Posts, i1.Post> {
+class Likes extends i0.Table with i0.TableInfo<Likes, i1.Like> {
   @override
   final i0.GeneratedDatabase attachedDatabase;
   final String? _alias;
-  Posts(this.attachedDatabase, [this._alias]);
-  static const i0.VerificationMeta _idMeta = const i0.VerificationMeta('id');
-  late final i0.GeneratedColumn<int> id = i0.GeneratedColumn<int>(
-      'id', aliasedName, false,
+  Likes(this.attachedDatabase, [this._alias]);
+  static const i0.VerificationMeta _postMeta =
+      const i0.VerificationMeta('post');
+  late final i0.GeneratedColumn<int> post = i0.GeneratedColumn<int>(
+      'post', aliasedName, false,
       type: i0.DriftSqlType.int,
-      requiredDuringInsert: false,
-      $customConstraints: 'PRIMARY KEY');
-  static const i0.VerificationMeta _authorMeta =
-      const i0.VerificationMeta('author');
-  late final i0.GeneratedColumn<int> author = i0.GeneratedColumn<int>(
-      'author', aliasedName, false,
+      requiredDuringInsert: true,
+      $customConstraints: 'NOT NULL REFERENCES posts(id)');
+  static const i0.VerificationMeta _likedByMeta =
+      const i0.VerificationMeta('likedBy');
+  late final i0.GeneratedColumn<int> likedBy = i0.GeneratedColumn<int>(
+      'liked_by', aliasedName, false,
       type: i0.DriftSqlType.int,
       requiredDuringInsert: true,
       $customConstraints: 'NOT NULL REFERENCES users(id)');
-  static const i0.VerificationMeta _contentMeta =
-      const i0.VerificationMeta('content');
-  late final i0.GeneratedColumn<String> content = i0.GeneratedColumn<String>(
-      'content', aliasedName, true,
-      type: i0.DriftSqlType.string,
-      requiredDuringInsert: false,
-      $customConstraints: '');
   @override
-  List<i0.GeneratedColumn> get $columns => [id, author, content];
+  List<i0.GeneratedColumn> get $columns => [post, likedBy];
   @override
-  String get aliasedName => _alias ?? 'posts';
+  String get aliasedName => _alias ?? 'likes';
   @override
-  String get actualTableName => 'posts';
+  String get actualTableName => 'likes';
   @override
-  i0.VerificationContext validateIntegrity(i0.Insertable<i1.Post> instance,
+  i0.VerificationContext validateIntegrity(i0.Insertable<i1.Like> instance,
       {bool isInserting = false}) {
     final context = i0.VerificationContext();
     final data = instance.toColumns(true);
-    if (data.containsKey('id')) {
-      context.handle(_idMeta, id.isAcceptableOrUnknown(data['id']!, _idMeta));
-    }
-    if (data.containsKey('author')) {
-      context.handle(_authorMeta,
-          author.isAcceptableOrUnknown(data['author']!, _authorMeta));
+    if (data.containsKey('post')) {
+      context.handle(
+          _postMeta, post.isAcceptableOrUnknown(data['post']!, _postMeta));
     } else if (isInserting) {
-      context.missing(_authorMeta);
+      context.missing(_postMeta);
     }
-    if (data.containsKey('content')) {
-      context.handle(_contentMeta,
-          content.isAcceptableOrUnknown(data['content']!, _contentMeta));
+    if (data.containsKey('liked_by')) {
+      context.handle(_likedByMeta,
+          likedBy.isAcceptableOrUnknown(data['liked_by']!, _likedByMeta));
+    } else if (isInserting) {
+      context.missing(_likedByMeta);
     }
     return context;
   }
 
   @override
-  Set<i0.GeneratedColumn> get $primaryKey => {id};
+  Set<i0.GeneratedColumn> get $primaryKey => const {};
   @override
-  i1.Post map(Map<String, dynamic> data, {String? tablePrefix}) {
+  i1.Like map(Map<String, dynamic> data, {String? tablePrefix}) {
     final effectivePrefix = tablePrefix != null ? '$tablePrefix.' : '';
-    return i1.Post(
-      id: attachedDatabase.typeMapping
-          .read(i0.DriftSqlType.int, data['${effectivePrefix}id'])!,
-      author: attachedDatabase.typeMapping
-          .read(i0.DriftSqlType.int, data['${effectivePrefix}author'])!,
-      content: attachedDatabase.typeMapping
-          .read(i0.DriftSqlType.string, data['${effectivePrefix}content']),
+    return i1.Like(
+      post: attachedDatabase.typeMapping
+          .read(i0.DriftSqlType.int, data['${effectivePrefix}post'])!,
+      likedBy: attachedDatabase.typeMapping
+          .read(i0.DriftSqlType.int, data['${effectivePrefix}liked_by'])!,
     );
   }
 
   @override
-  Posts createAlias(String alias) {
-    return Posts(attachedDatabase, alias);
+  Likes createAlias(String alias) {
+    return Likes(attachedDatabase, alias);
   }
 
   @override
@@ -322,71 +389,4 @@ class LikesCompanion extends i0.UpdateCompanion<i1.Like> {
           ..write(')'))
         .toString();
   }
-}
-
-class Likes extends i0.Table with i0.TableInfo<Likes, i1.Like> {
-  @override
-  final i0.GeneratedDatabase attachedDatabase;
-  final String? _alias;
-  Likes(this.attachedDatabase, [this._alias]);
-  static const i0.VerificationMeta _postMeta =
-      const i0.VerificationMeta('post');
-  late final i0.GeneratedColumn<int> post = i0.GeneratedColumn<int>(
-      'post', aliasedName, false,
-      type: i0.DriftSqlType.int,
-      requiredDuringInsert: true,
-      $customConstraints: 'NOT NULL REFERENCES posts(id)');
-  static const i0.VerificationMeta _likedByMeta =
-      const i0.VerificationMeta('likedBy');
-  late final i0.GeneratedColumn<int> likedBy = i0.GeneratedColumn<int>(
-      'liked_by', aliasedName, false,
-      type: i0.DriftSqlType.int,
-      requiredDuringInsert: true,
-      $customConstraints: 'NOT NULL REFERENCES users(id)');
-  @override
-  List<i0.GeneratedColumn> get $columns => [post, likedBy];
-  @override
-  String get aliasedName => _alias ?? 'likes';
-  @override
-  String get actualTableName => 'likes';
-  @override
-  i0.VerificationContext validateIntegrity(i0.Insertable<i1.Like> instance,
-      {bool isInserting = false}) {
-    final context = i0.VerificationContext();
-    final data = instance.toColumns(true);
-    if (data.containsKey('post')) {
-      context.handle(
-          _postMeta, post.isAcceptableOrUnknown(data['post']!, _postMeta));
-    } else if (isInserting) {
-      context.missing(_postMeta);
-    }
-    if (data.containsKey('liked_by')) {
-      context.handle(_likedByMeta,
-          likedBy.isAcceptableOrUnknown(data['liked_by']!, _likedByMeta));
-    } else if (isInserting) {
-      context.missing(_likedByMeta);
-    }
-    return context;
-  }
-
-  @override
-  Set<i0.GeneratedColumn> get $primaryKey => const {};
-  @override
-  i1.Like map(Map<String, dynamic> data, {String? tablePrefix}) {
-    final effectivePrefix = tablePrefix != null ? '$tablePrefix.' : '';
-    return i1.Like(
-      post: attachedDatabase.typeMapping
-          .read(i0.DriftSqlType.int, data['${effectivePrefix}post'])!,
-      likedBy: attachedDatabase.typeMapping
-          .read(i0.DriftSqlType.int, data['${effectivePrefix}liked_by'])!,
-    );
-  }
-
-  @override
-  Likes createAlias(String alias) {
-    return Likes(attachedDatabase, alias);
-  }
-
-  @override
-  bool get dontWriteConstraints => true;
 }

--- a/examples/modular/lib/src/search.drift.dart
+++ b/examples/modular/lib/src/search.drift.dart
@@ -4,6 +4,80 @@ import 'package:modular/src/search.drift.dart' as i1;
 import 'package:drift/internal/modular.dart' as i2;
 import 'package:modular/src/posts.drift.dart' as i3;
 
+class SearchInPosts extends i0.Table
+    with
+        i0.TableInfo<SearchInPosts, i1.SearchInPost>,
+        i0.VirtualTableInfo<SearchInPosts, i1.SearchInPost> {
+  @override
+  final i0.GeneratedDatabase attachedDatabase;
+  final String? _alias;
+  SearchInPosts(this.attachedDatabase, [this._alias]);
+  static const i0.VerificationMeta _authorMeta =
+      const i0.VerificationMeta('author');
+  late final i0.GeneratedColumn<String> author = i0.GeneratedColumn<String>(
+      'author', aliasedName, false,
+      type: i0.DriftSqlType.string,
+      requiredDuringInsert: true,
+      $customConstraints: '');
+  static const i0.VerificationMeta _contentMeta =
+      const i0.VerificationMeta('content');
+  late final i0.GeneratedColumn<String> content = i0.GeneratedColumn<String>(
+      'content', aliasedName, false,
+      type: i0.DriftSqlType.string,
+      requiredDuringInsert: true,
+      $customConstraints: '');
+  @override
+  List<i0.GeneratedColumn> get $columns => [author, content];
+  @override
+  String get aliasedName => _alias ?? 'search_in_posts';
+  @override
+  String get actualTableName => 'search_in_posts';
+  @override
+  i0.VerificationContext validateIntegrity(
+      i0.Insertable<i1.SearchInPost> instance,
+      {bool isInserting = false}) {
+    final context = i0.VerificationContext();
+    final data = instance.toColumns(true);
+    if (data.containsKey('author')) {
+      context.handle(_authorMeta,
+          author.isAcceptableOrUnknown(data['author']!, _authorMeta));
+    } else if (isInserting) {
+      context.missing(_authorMeta);
+    }
+    if (data.containsKey('content')) {
+      context.handle(_contentMeta,
+          content.isAcceptableOrUnknown(data['content']!, _contentMeta));
+    } else if (isInserting) {
+      context.missing(_contentMeta);
+    }
+    return context;
+  }
+
+  @override
+  Set<i0.GeneratedColumn> get $primaryKey => const {};
+  @override
+  i1.SearchInPost map(Map<String, dynamic> data, {String? tablePrefix}) {
+    final effectivePrefix = tablePrefix != null ? '$tablePrefix.' : '';
+    return i1.SearchInPost(
+      author: attachedDatabase.typeMapping
+          .read(i0.DriftSqlType.string, data['${effectivePrefix}author'])!,
+      content: attachedDatabase.typeMapping
+          .read(i0.DriftSqlType.string, data['${effectivePrefix}content'])!,
+    );
+  }
+
+  @override
+  SearchInPosts createAlias(String alias) {
+    return SearchInPosts(attachedDatabase, alias);
+  }
+
+  @override
+  bool get dontWriteConstraints => true;
+  @override
+  String get moduleAndArgs =>
+      'fts5(author, content, content=posts, content_rowid=id)';
+}
+
 class SearchInPost extends i0.DataClass
     implements i0.Insertable<i1.SearchInPost> {
   final String author;
@@ -115,80 +189,6 @@ class SearchInPostsCompanion extends i0.UpdateCompanion<i1.SearchInPost> {
           ..write(')'))
         .toString();
   }
-}
-
-class SearchInPosts extends i0.Table
-    with
-        i0.TableInfo<SearchInPosts, i1.SearchInPost>,
-        i0.VirtualTableInfo<SearchInPosts, i1.SearchInPost> {
-  @override
-  final i0.GeneratedDatabase attachedDatabase;
-  final String? _alias;
-  SearchInPosts(this.attachedDatabase, [this._alias]);
-  static const i0.VerificationMeta _authorMeta =
-      const i0.VerificationMeta('author');
-  late final i0.GeneratedColumn<String> author = i0.GeneratedColumn<String>(
-      'author', aliasedName, false,
-      type: i0.DriftSqlType.string,
-      requiredDuringInsert: true,
-      $customConstraints: '');
-  static const i0.VerificationMeta _contentMeta =
-      const i0.VerificationMeta('content');
-  late final i0.GeneratedColumn<String> content = i0.GeneratedColumn<String>(
-      'content', aliasedName, false,
-      type: i0.DriftSqlType.string,
-      requiredDuringInsert: true,
-      $customConstraints: '');
-  @override
-  List<i0.GeneratedColumn> get $columns => [author, content];
-  @override
-  String get aliasedName => _alias ?? 'search_in_posts';
-  @override
-  String get actualTableName => 'search_in_posts';
-  @override
-  i0.VerificationContext validateIntegrity(
-      i0.Insertable<i1.SearchInPost> instance,
-      {bool isInserting = false}) {
-    final context = i0.VerificationContext();
-    final data = instance.toColumns(true);
-    if (data.containsKey('author')) {
-      context.handle(_authorMeta,
-          author.isAcceptableOrUnknown(data['author']!, _authorMeta));
-    } else if (isInserting) {
-      context.missing(_authorMeta);
-    }
-    if (data.containsKey('content')) {
-      context.handle(_contentMeta,
-          content.isAcceptableOrUnknown(data['content']!, _contentMeta));
-    } else if (isInserting) {
-      context.missing(_contentMeta);
-    }
-    return context;
-  }
-
-  @override
-  Set<i0.GeneratedColumn> get $primaryKey => const {};
-  @override
-  i1.SearchInPost map(Map<String, dynamic> data, {String? tablePrefix}) {
-    final effectivePrefix = tablePrefix != null ? '$tablePrefix.' : '';
-    return i1.SearchInPost(
-      author: attachedDatabase.typeMapping
-          .read(i0.DriftSqlType.string, data['${effectivePrefix}author'])!,
-      content: attachedDatabase.typeMapping
-          .read(i0.DriftSqlType.string, data['${effectivePrefix}content'])!,
-    );
-  }
-
-  @override
-  SearchInPosts createAlias(String alias) {
-    return SearchInPosts(attachedDatabase, alias);
-  }
-
-  @override
-  bool get dontWriteConstraints => true;
-  @override
-  String get moduleAndArgs =>
-      'fts5(author, content, content=posts, content_rowid=id)';
 }
 
 i0.Trigger get postsInsert => i0.Trigger(

--- a/examples/modular/lib/src/users.drift.dart
+++ b/examples/modular/lib/src/users.drift.dart
@@ -3,6 +3,99 @@ import 'package:drift/drift.dart' as i0;
 import 'package:modular/src/users.drift.dart' as i1;
 import 'package:modular/src/preferences.dart' as i2;
 
+class Users extends i0.Table with i0.TableInfo<Users, i1.User> {
+  @override
+  final i0.GeneratedDatabase attachedDatabase;
+  final String? _alias;
+  Users(this.attachedDatabase, [this._alias]);
+  static const i0.VerificationMeta _idMeta = const i0.VerificationMeta('id');
+  late final i0.GeneratedColumn<int> id = i0.GeneratedColumn<int>(
+      'id', aliasedName, false,
+      type: i0.DriftSqlType.int,
+      requiredDuringInsert: false,
+      $customConstraints: 'NOT NULL PRIMARY KEY');
+  static const i0.VerificationMeta _nameMeta =
+      const i0.VerificationMeta('name');
+  late final i0.GeneratedColumn<String> name = i0.GeneratedColumn<String>(
+      'name', aliasedName, false,
+      type: i0.DriftSqlType.string,
+      requiredDuringInsert: true,
+      $customConstraints: 'NOT NULL');
+  static const i0.VerificationMeta _biographyMeta =
+      const i0.VerificationMeta('biography');
+  late final i0.GeneratedColumn<String> biography = i0.GeneratedColumn<String>(
+      'biography', aliasedName, true,
+      type: i0.DriftSqlType.string,
+      requiredDuringInsert: false,
+      $customConstraints: '');
+  static const i0.VerificationMeta _preferencesMeta =
+      const i0.VerificationMeta('preferences');
+  late final i0.GeneratedColumnWithTypeConverter<i2.Preferences?, String>
+      preferences = i0.GeneratedColumn<String>('preferences', aliasedName, true,
+              type: i0.DriftSqlType.string,
+              requiredDuringInsert: false,
+              $customConstraints: '')
+          .withConverter<i2.Preferences?>(i1.Users.$converterpreferencesn);
+  @override
+  List<i0.GeneratedColumn> get $columns => [id, name, biography, preferences];
+  @override
+  String get aliasedName => _alias ?? 'users';
+  @override
+  String get actualTableName => 'users';
+  @override
+  i0.VerificationContext validateIntegrity(i0.Insertable<i1.User> instance,
+      {bool isInserting = false}) {
+    final context = i0.VerificationContext();
+    final data = instance.toColumns(true);
+    if (data.containsKey('id')) {
+      context.handle(_idMeta, id.isAcceptableOrUnknown(data['id']!, _idMeta));
+    }
+    if (data.containsKey('name')) {
+      context.handle(
+          _nameMeta, name.isAcceptableOrUnknown(data['name']!, _nameMeta));
+    } else if (isInserting) {
+      context.missing(_nameMeta);
+    }
+    if (data.containsKey('biography')) {
+      context.handle(_biographyMeta,
+          biography.isAcceptableOrUnknown(data['biography']!, _biographyMeta));
+    }
+    context.handle(_preferencesMeta, const i0.VerificationResult.success());
+    return context;
+  }
+
+  @override
+  Set<i0.GeneratedColumn> get $primaryKey => {id};
+  @override
+  i1.User map(Map<String, dynamic> data, {String? tablePrefix}) {
+    final effectivePrefix = tablePrefix != null ? '$tablePrefix.' : '';
+    return i1.User(
+      id: attachedDatabase.typeMapping
+          .read(i0.DriftSqlType.int, data['${effectivePrefix}id'])!,
+      name: attachedDatabase.typeMapping
+          .read(i0.DriftSqlType.string, data['${effectivePrefix}name'])!,
+      biography: attachedDatabase.typeMapping
+          .read(i0.DriftSqlType.string, data['${effectivePrefix}biography']),
+      preferences: i1.Users.$converterpreferencesn.fromSql(attachedDatabase
+          .typeMapping
+          .read(i0.DriftSqlType.string, data['${effectivePrefix}preferences'])),
+    );
+  }
+
+  @override
+  Users createAlias(String alias) {
+    return Users(attachedDatabase, alias);
+  }
+
+  static i0.JsonTypeConverter2<i2.Preferences, String, Map<String, Object?>>
+      $converterpreferences = const i2.PreferencesConverter();
+  static i0.JsonTypeConverter2<i2.Preferences?, String?, Map<String, Object?>?>
+      $converterpreferencesn =
+      i0.JsonTypeConverter2.asNullable($converterpreferences);
+  @override
+  bool get dontWriteConstraints => true;
+}
+
 class User extends i0.DataClass implements i0.Insertable<i1.User> {
   final int id;
   final String name;
@@ -171,101 +264,78 @@ class UsersCompanion extends i0.UpdateCompanion<i1.User> {
   }
 }
 
-class Users extends i0.Table with i0.TableInfo<Users, i1.User> {
+i0.Index get usersName =>
+    i0.Index('users_name', 'CREATE INDEX users_name ON users (name)');
+
+class Follows extends i0.Table with i0.TableInfo<Follows, i1.Follow> {
   @override
   final i0.GeneratedDatabase attachedDatabase;
   final String? _alias;
-  Users(this.attachedDatabase, [this._alias]);
-  static const i0.VerificationMeta _idMeta = const i0.VerificationMeta('id');
-  late final i0.GeneratedColumn<int> id = i0.GeneratedColumn<int>(
-      'id', aliasedName, false,
+  Follows(this.attachedDatabase, [this._alias]);
+  static const i0.VerificationMeta _followedMeta =
+      const i0.VerificationMeta('followed');
+  late final i0.GeneratedColumn<int> followed = i0.GeneratedColumn<int>(
+      'followed', aliasedName, false,
       type: i0.DriftSqlType.int,
-      requiredDuringInsert: false,
-      $customConstraints: 'NOT NULL PRIMARY KEY');
-  static const i0.VerificationMeta _nameMeta =
-      const i0.VerificationMeta('name');
-  late final i0.GeneratedColumn<String> name = i0.GeneratedColumn<String>(
-      'name', aliasedName, false,
-      type: i0.DriftSqlType.string,
       requiredDuringInsert: true,
-      $customConstraints: 'NOT NULL');
-  static const i0.VerificationMeta _biographyMeta =
-      const i0.VerificationMeta('biography');
-  late final i0.GeneratedColumn<String> biography = i0.GeneratedColumn<String>(
-      'biography', aliasedName, true,
-      type: i0.DriftSqlType.string,
-      requiredDuringInsert: false,
-      $customConstraints: '');
-  static const i0.VerificationMeta _preferencesMeta =
-      const i0.VerificationMeta('preferences');
-  late final i0.GeneratedColumnWithTypeConverter<i2.Preferences?, String>
-      preferences = i0.GeneratedColumn<String>('preferences', aliasedName, true,
-              type: i0.DriftSqlType.string,
-              requiredDuringInsert: false,
-              $customConstraints: '')
-          .withConverter<i2.Preferences?>(i1.Users.$converterpreferencesn);
+      $customConstraints: 'NOT NULL REFERENCES users(id)');
+  static const i0.VerificationMeta _followerMeta =
+      const i0.VerificationMeta('follower');
+  late final i0.GeneratedColumn<int> follower = i0.GeneratedColumn<int>(
+      'follower', aliasedName, false,
+      type: i0.DriftSqlType.int,
+      requiredDuringInsert: true,
+      $customConstraints: 'NOT NULL REFERENCES users(id)');
   @override
-  List<i0.GeneratedColumn> get $columns => [id, name, biography, preferences];
+  List<i0.GeneratedColumn> get $columns => [followed, follower];
   @override
-  String get aliasedName => _alias ?? 'users';
+  String get aliasedName => _alias ?? 'follows';
   @override
-  String get actualTableName => 'users';
+  String get actualTableName => 'follows';
   @override
-  i0.VerificationContext validateIntegrity(i0.Insertable<i1.User> instance,
+  i0.VerificationContext validateIntegrity(i0.Insertable<i1.Follow> instance,
       {bool isInserting = false}) {
     final context = i0.VerificationContext();
     final data = instance.toColumns(true);
-    if (data.containsKey('id')) {
-      context.handle(_idMeta, id.isAcceptableOrUnknown(data['id']!, _idMeta));
-    }
-    if (data.containsKey('name')) {
-      context.handle(
-          _nameMeta, name.isAcceptableOrUnknown(data['name']!, _nameMeta));
+    if (data.containsKey('followed')) {
+      context.handle(_followedMeta,
+          followed.isAcceptableOrUnknown(data['followed']!, _followedMeta));
     } else if (isInserting) {
-      context.missing(_nameMeta);
+      context.missing(_followedMeta);
     }
-    if (data.containsKey('biography')) {
-      context.handle(_biographyMeta,
-          biography.isAcceptableOrUnknown(data['biography']!, _biographyMeta));
+    if (data.containsKey('follower')) {
+      context.handle(_followerMeta,
+          follower.isAcceptableOrUnknown(data['follower']!, _followerMeta));
+    } else if (isInserting) {
+      context.missing(_followerMeta);
     }
-    context.handle(_preferencesMeta, const i0.VerificationResult.success());
     return context;
   }
 
   @override
-  Set<i0.GeneratedColumn> get $primaryKey => {id};
+  Set<i0.GeneratedColumn> get $primaryKey => {followed, follower};
   @override
-  i1.User map(Map<String, dynamic> data, {String? tablePrefix}) {
+  i1.Follow map(Map<String, dynamic> data, {String? tablePrefix}) {
     final effectivePrefix = tablePrefix != null ? '$tablePrefix.' : '';
-    return i1.User(
-      id: attachedDatabase.typeMapping
-          .read(i0.DriftSqlType.int, data['${effectivePrefix}id'])!,
-      name: attachedDatabase.typeMapping
-          .read(i0.DriftSqlType.string, data['${effectivePrefix}name'])!,
-      biography: attachedDatabase.typeMapping
-          .read(i0.DriftSqlType.string, data['${effectivePrefix}biography']),
-      preferences: i1.Users.$converterpreferencesn.fromSql(attachedDatabase
-          .typeMapping
-          .read(i0.DriftSqlType.string, data['${effectivePrefix}preferences'])),
+    return i1.Follow(
+      followed: attachedDatabase.typeMapping
+          .read(i0.DriftSqlType.int, data['${effectivePrefix}followed'])!,
+      follower: attachedDatabase.typeMapping
+          .read(i0.DriftSqlType.int, data['${effectivePrefix}follower'])!,
     );
   }
 
   @override
-  Users createAlias(String alias) {
-    return Users(attachedDatabase, alias);
+  Follows createAlias(String alias) {
+    return Follows(attachedDatabase, alias);
   }
 
-  static i0.JsonTypeConverter2<i2.Preferences, String, Map<String, Object?>>
-      $converterpreferences = const i2.PreferencesConverter();
-  static i0.JsonTypeConverter2<i2.Preferences?, String?, Map<String, Object?>?>
-      $converterpreferencesn =
-      i0.JsonTypeConverter2.asNullable($converterpreferences);
+  @override
+  List<String> get customConstraints =>
+      const ['PRIMARY KEY(followed, follower)'];
   @override
   bool get dontWriteConstraints => true;
 }
-
-i0.Index get usersName =>
-    i0.Index('users_name', 'CREATE INDEX users_name ON users (name)');
 
 class Follow extends i0.DataClass implements i0.Insertable<i1.Follow> {
   final int followed;
@@ -376,76 +446,6 @@ class FollowsCompanion extends i0.UpdateCompanion<i1.Follow> {
           ..write(')'))
         .toString();
   }
-}
-
-class Follows extends i0.Table with i0.TableInfo<Follows, i1.Follow> {
-  @override
-  final i0.GeneratedDatabase attachedDatabase;
-  final String? _alias;
-  Follows(this.attachedDatabase, [this._alias]);
-  static const i0.VerificationMeta _followedMeta =
-      const i0.VerificationMeta('followed');
-  late final i0.GeneratedColumn<int> followed = i0.GeneratedColumn<int>(
-      'followed', aliasedName, false,
-      type: i0.DriftSqlType.int,
-      requiredDuringInsert: true,
-      $customConstraints: 'NOT NULL REFERENCES users(id)');
-  static const i0.VerificationMeta _followerMeta =
-      const i0.VerificationMeta('follower');
-  late final i0.GeneratedColumn<int> follower = i0.GeneratedColumn<int>(
-      'follower', aliasedName, false,
-      type: i0.DriftSqlType.int,
-      requiredDuringInsert: true,
-      $customConstraints: 'NOT NULL REFERENCES users(id)');
-  @override
-  List<i0.GeneratedColumn> get $columns => [followed, follower];
-  @override
-  String get aliasedName => _alias ?? 'follows';
-  @override
-  String get actualTableName => 'follows';
-  @override
-  i0.VerificationContext validateIntegrity(i0.Insertable<i1.Follow> instance,
-      {bool isInserting = false}) {
-    final context = i0.VerificationContext();
-    final data = instance.toColumns(true);
-    if (data.containsKey('followed')) {
-      context.handle(_followedMeta,
-          followed.isAcceptableOrUnknown(data['followed']!, _followedMeta));
-    } else if (isInserting) {
-      context.missing(_followedMeta);
-    }
-    if (data.containsKey('follower')) {
-      context.handle(_followerMeta,
-          follower.isAcceptableOrUnknown(data['follower']!, _followerMeta));
-    } else if (isInserting) {
-      context.missing(_followerMeta);
-    }
-    return context;
-  }
-
-  @override
-  Set<i0.GeneratedColumn> get $primaryKey => {followed, follower};
-  @override
-  i1.Follow map(Map<String, dynamic> data, {String? tablePrefix}) {
-    final effectivePrefix = tablePrefix != null ? '$tablePrefix.' : '';
-    return i1.Follow(
-      followed: attachedDatabase.typeMapping
-          .read(i0.DriftSqlType.int, data['${effectivePrefix}followed'])!,
-      follower: attachedDatabase.typeMapping
-          .read(i0.DriftSqlType.int, data['${effectivePrefix}follower'])!,
-    );
-  }
-
-  @override
-  Follows createAlias(String alias) {
-    return Follows(attachedDatabase, alias);
-  }
-
-  @override
-  List<String> get customConstraints =>
-      const ['PRIMARY KEY(followed, follower)'];
-  @override
-  bool get dontWriteConstraints => true;
 }
 
 class PopularUser extends i0.DataClass {

--- a/examples/web_worker_example/lib/database.g.dart
+++ b/examples/web_worker_example/lib/database.g.dart
@@ -3,6 +3,68 @@
 part of 'database.dart';
 
 // ignore_for_file: type=lint
+class Entries extends Table with TableInfo<Entries, Entrie> {
+  @override
+  final GeneratedDatabase attachedDatabase;
+  final String? _alias;
+  Entries(this.attachedDatabase, [this._alias]);
+  static const VerificationMeta _idMeta = const VerificationMeta('id');
+  late final GeneratedColumn<int> id = GeneratedColumn<int>(
+      'id', aliasedName, false,
+      type: DriftSqlType.int,
+      requiredDuringInsert: false,
+      $customConstraints: 'PRIMARY KEY');
+  static const VerificationMeta _valueMeta = const VerificationMeta('value');
+  late final GeneratedColumn<String> value = GeneratedColumn<String>(
+      'text', aliasedName, false,
+      type: DriftSqlType.string,
+      requiredDuringInsert: true,
+      $customConstraints: 'NOT NULL');
+  @override
+  List<GeneratedColumn> get $columns => [id, value];
+  @override
+  String get aliasedName => _alias ?? 'entries';
+  @override
+  String get actualTableName => 'entries';
+  @override
+  VerificationContext validateIntegrity(Insertable<Entrie> instance,
+      {bool isInserting = false}) {
+    final context = VerificationContext();
+    final data = instance.toColumns(true);
+    if (data.containsKey('id')) {
+      context.handle(_idMeta, id.isAcceptableOrUnknown(data['id']!, _idMeta));
+    }
+    if (data.containsKey('text')) {
+      context.handle(
+          _valueMeta, value.isAcceptableOrUnknown(data['text']!, _valueMeta));
+    } else if (isInserting) {
+      context.missing(_valueMeta);
+    }
+    return context;
+  }
+
+  @override
+  Set<GeneratedColumn> get $primaryKey => {id};
+  @override
+  Entrie map(Map<String, dynamic> data, {String? tablePrefix}) {
+    final effectivePrefix = tablePrefix != null ? '$tablePrefix.' : '';
+    return Entrie(
+      id: attachedDatabase.typeMapping
+          .read(DriftSqlType.int, data['${effectivePrefix}id'])!,
+      value: attachedDatabase.typeMapping
+          .read(DriftSqlType.string, data['${effectivePrefix}text'])!,
+    );
+  }
+
+  @override
+  Entries createAlias(String alias) {
+    return Entries(attachedDatabase, alias);
+  }
+
+  @override
+  bool get dontWriteConstraints => true;
+}
+
 class Entrie extends DataClass implements Insertable<Entrie> {
   final int id;
   final String value;
@@ -108,68 +170,6 @@ class EntriesCompanion extends UpdateCompanion<Entrie> {
           ..write(')'))
         .toString();
   }
-}
-
-class Entries extends Table with TableInfo<Entries, Entrie> {
-  @override
-  final GeneratedDatabase attachedDatabase;
-  final String? _alias;
-  Entries(this.attachedDatabase, [this._alias]);
-  static const VerificationMeta _idMeta = const VerificationMeta('id');
-  late final GeneratedColumn<int> id = GeneratedColumn<int>(
-      'id', aliasedName, false,
-      type: DriftSqlType.int,
-      requiredDuringInsert: false,
-      $customConstraints: 'PRIMARY KEY');
-  static const VerificationMeta _valueMeta = const VerificationMeta('value');
-  late final GeneratedColumn<String> value = GeneratedColumn<String>(
-      'text', aliasedName, false,
-      type: DriftSqlType.string,
-      requiredDuringInsert: true,
-      $customConstraints: 'NOT NULL');
-  @override
-  List<GeneratedColumn> get $columns => [id, value];
-  @override
-  String get aliasedName => _alias ?? 'entries';
-  @override
-  String get actualTableName => 'entries';
-  @override
-  VerificationContext validateIntegrity(Insertable<Entrie> instance,
-      {bool isInserting = false}) {
-    final context = VerificationContext();
-    final data = instance.toColumns(true);
-    if (data.containsKey('id')) {
-      context.handle(_idMeta, id.isAcceptableOrUnknown(data['id']!, _idMeta));
-    }
-    if (data.containsKey('text')) {
-      context.handle(
-          _valueMeta, value.isAcceptableOrUnknown(data['text']!, _valueMeta));
-    } else if (isInserting) {
-      context.missing(_valueMeta);
-    }
-    return context;
-  }
-
-  @override
-  Set<GeneratedColumn> get $primaryKey => {id};
-  @override
-  Entrie map(Map<String, dynamic> data, {String? tablePrefix}) {
-    final effectivePrefix = tablePrefix != null ? '$tablePrefix.' : '';
-    return Entrie(
-      id: attachedDatabase.typeMapping
-          .read(DriftSqlType.int, data['${effectivePrefix}id'])!,
-      value: attachedDatabase.typeMapping
-          .read(DriftSqlType.string, data['${effectivePrefix}text'])!,
-    );
-  }
-
-  @override
-  Entries createAlias(String alias) {
-    return Entries(attachedDatabase, alias);
-  }
-
-  @override
-  bool get dontWriteConstraints => true;
 }
 
 abstract class _$MyDatabase extends GeneratedDatabase {

--- a/examples/with_built_value/lib/database.drift.dart
+++ b/examples/with_built_value/lib/database.drift.dart
@@ -1,6 +1,69 @@
 // ignore_for_file: type=lint
 part of 'database.dart';
 
+class Users extends Table with TableInfo<Users, User> {
+  @override
+  final GeneratedDatabase attachedDatabase;
+  final String? _alias;
+  Users(this.attachedDatabase, [this._alias]);
+  static const VerificationMeta _idMeta = const VerificationMeta('id');
+  late final GeneratedColumn<int> id = GeneratedColumn<int>(
+      'id', aliasedName, false,
+      hasAutoIncrement: true,
+      type: DriftSqlType.int,
+      requiredDuringInsert: false,
+      $customConstraints: 'NOT NULL PRIMARY KEY AUTOINCREMENT');
+  static const VerificationMeta _nameMeta = const VerificationMeta('name');
+  late final GeneratedColumn<String> name = GeneratedColumn<String>(
+      'name', aliasedName, false,
+      type: DriftSqlType.string,
+      requiredDuringInsert: true,
+      $customConstraints: 'NOT NULL');
+  @override
+  List<GeneratedColumn> get $columns => [id, name];
+  @override
+  String get aliasedName => _alias ?? 'users';
+  @override
+  String get actualTableName => 'users';
+  @override
+  VerificationContext validateIntegrity(Insertable<User> instance,
+      {bool isInserting = false}) {
+    final context = VerificationContext();
+    final data = instance.toColumns(true);
+    if (data.containsKey('id')) {
+      context.handle(_idMeta, id.isAcceptableOrUnknown(data['id']!, _idMeta));
+    }
+    if (data.containsKey('name')) {
+      context.handle(
+          _nameMeta, name.isAcceptableOrUnknown(data['name']!, _nameMeta));
+    } else if (isInserting) {
+      context.missing(_nameMeta);
+    }
+    return context;
+  }
+
+  @override
+  Set<GeneratedColumn> get $primaryKey => {id};
+  @override
+  User map(Map<String, dynamic> data, {String? tablePrefix}) {
+    final effectivePrefix = tablePrefix != null ? '$tablePrefix.' : '';
+    return User(
+      id: attachedDatabase.typeMapping
+          .read(DriftSqlType.int, data['${effectivePrefix}id'])!,
+      name: attachedDatabase.typeMapping
+          .read(DriftSqlType.string, data['${effectivePrefix}name'])!,
+    );
+  }
+
+  @override
+  Users createAlias(String alias) {
+    return Users(attachedDatabase, alias);
+  }
+
+  @override
+  bool get dontWriteConstraints => true;
+}
+
 class User extends DataClass implements Insertable<User> {
   final int id;
   final String name;
@@ -106,69 +169,6 @@ class UsersCompanion extends UpdateCompanion<User> {
           ..write(')'))
         .toString();
   }
-}
-
-class Users extends Table with TableInfo<Users, User> {
-  @override
-  final GeneratedDatabase attachedDatabase;
-  final String? _alias;
-  Users(this.attachedDatabase, [this._alias]);
-  static const VerificationMeta _idMeta = const VerificationMeta('id');
-  late final GeneratedColumn<int> id = GeneratedColumn<int>(
-      'id', aliasedName, false,
-      hasAutoIncrement: true,
-      type: DriftSqlType.int,
-      requiredDuringInsert: false,
-      $customConstraints: 'NOT NULL PRIMARY KEY AUTOINCREMENT');
-  static const VerificationMeta _nameMeta = const VerificationMeta('name');
-  late final GeneratedColumn<String> name = GeneratedColumn<String>(
-      'name', aliasedName, false,
-      type: DriftSqlType.string,
-      requiredDuringInsert: true,
-      $customConstraints: 'NOT NULL');
-  @override
-  List<GeneratedColumn> get $columns => [id, name];
-  @override
-  String get aliasedName => _alias ?? 'users';
-  @override
-  String get actualTableName => 'users';
-  @override
-  VerificationContext validateIntegrity(Insertable<User> instance,
-      {bool isInserting = false}) {
-    final context = VerificationContext();
-    final data = instance.toColumns(true);
-    if (data.containsKey('id')) {
-      context.handle(_idMeta, id.isAcceptableOrUnknown(data['id']!, _idMeta));
-    }
-    if (data.containsKey('name')) {
-      context.handle(
-          _nameMeta, name.isAcceptableOrUnknown(data['name']!, _nameMeta));
-    } else if (isInserting) {
-      context.missing(_nameMeta);
-    }
-    return context;
-  }
-
-  @override
-  Set<GeneratedColumn> get $primaryKey => {id};
-  @override
-  User map(Map<String, dynamic> data, {String? tablePrefix}) {
-    final effectivePrefix = tablePrefix != null ? '$tablePrefix.' : '';
-    return User(
-      id: attachedDatabase.typeMapping
-          .read(DriftSqlType.int, data['${effectivePrefix}id'])!,
-      name: attachedDatabase.typeMapping
-          .read(DriftSqlType.string, data['${effectivePrefix}name'])!,
-    );
-  }
-
-  @override
-  Users createAlias(String alias) {
-    return Users(attachedDatabase, alias);
-  }
-
-  @override
-  bool get dontWriteConstraints => true;
 }
 
 abstract class _$Database extends GeneratedDatabase {

--- a/extras/benchmarks/lib/src/moor/database.g.dart
+++ b/extras/benchmarks/lib/src/moor/database.g.dart
@@ -3,6 +3,67 @@
 part of 'database.dart';
 
 // ignore_for_file: type=lint
+class $KeyValuesTable extends KeyValues
+    with TableInfo<$KeyValuesTable, KeyValue> {
+  @override
+  final GeneratedDatabase attachedDatabase;
+  final String? _alias;
+  $KeyValuesTable(this.attachedDatabase, [this._alias]);
+  static const VerificationMeta _keyMeta = const VerificationMeta('key');
+  @override
+  late final GeneratedColumn<String> key = GeneratedColumn<String>(
+      'key', aliasedName, false,
+      type: DriftSqlType.string, requiredDuringInsert: true);
+  static const VerificationMeta _valueMeta = const VerificationMeta('value');
+  @override
+  late final GeneratedColumn<String> value = GeneratedColumn<String>(
+      'value', aliasedName, false,
+      type: DriftSqlType.string, requiredDuringInsert: true);
+  @override
+  List<GeneratedColumn> get $columns => [key, value];
+  @override
+  String get aliasedName => _alias ?? 'key_values';
+  @override
+  String get actualTableName => 'key_values';
+  @override
+  VerificationContext validateIntegrity(Insertable<KeyValue> instance,
+      {bool isInserting = false}) {
+    final context = VerificationContext();
+    final data = instance.toColumns(true);
+    if (data.containsKey('key')) {
+      context.handle(
+          _keyMeta, key.isAcceptableOrUnknown(data['key']!, _keyMeta));
+    } else if (isInserting) {
+      context.missing(_keyMeta);
+    }
+    if (data.containsKey('value')) {
+      context.handle(
+          _valueMeta, value.isAcceptableOrUnknown(data['value']!, _valueMeta));
+    } else if (isInserting) {
+      context.missing(_valueMeta);
+    }
+    return context;
+  }
+
+  @override
+  Set<GeneratedColumn> get $primaryKey => {key};
+  @override
+  KeyValue map(Map<String, dynamic> data, {String? tablePrefix}) {
+    final effectivePrefix = tablePrefix != null ? '$tablePrefix.' : '';
+    return KeyValue(
+      key: attachedDatabase.typeMapping
+          .read(DriftSqlType.string, data['${effectivePrefix}key'])!,
+      value: attachedDatabase.typeMapping
+          .read(DriftSqlType.string, data['${effectivePrefix}value'])!,
+    );
+  }
+
+  @override
+  $KeyValuesTable createAlias(String alias) {
+    return $KeyValuesTable(attachedDatabase, alias);
+  }
+}
+
 class KeyValue extends DataClass implements Insertable<KeyValue> {
   final String key;
   final String value;
@@ -108,67 +169,6 @@ class KeyValuesCompanion extends UpdateCompanion<KeyValue> {
           ..write('value: $value')
           ..write(')'))
         .toString();
-  }
-}
-
-class $KeyValuesTable extends KeyValues
-    with TableInfo<$KeyValuesTable, KeyValue> {
-  @override
-  final GeneratedDatabase attachedDatabase;
-  final String? _alias;
-  $KeyValuesTable(this.attachedDatabase, [this._alias]);
-  static const VerificationMeta _keyMeta = const VerificationMeta('key');
-  @override
-  late final GeneratedColumn<String> key = GeneratedColumn<String>(
-      'key', aliasedName, false,
-      type: DriftSqlType.string, requiredDuringInsert: true);
-  static const VerificationMeta _valueMeta = const VerificationMeta('value');
-  @override
-  late final GeneratedColumn<String> value = GeneratedColumn<String>(
-      'value', aliasedName, false,
-      type: DriftSqlType.string, requiredDuringInsert: true);
-  @override
-  List<GeneratedColumn> get $columns => [key, value];
-  @override
-  String get aliasedName => _alias ?? 'key_values';
-  @override
-  String get actualTableName => 'key_values';
-  @override
-  VerificationContext validateIntegrity(Insertable<KeyValue> instance,
-      {bool isInserting = false}) {
-    final context = VerificationContext();
-    final data = instance.toColumns(true);
-    if (data.containsKey('key')) {
-      context.handle(
-          _keyMeta, key.isAcceptableOrUnknown(data['key']!, _keyMeta));
-    } else if (isInserting) {
-      context.missing(_keyMeta);
-    }
-    if (data.containsKey('value')) {
-      context.handle(
-          _valueMeta, value.isAcceptableOrUnknown(data['value']!, _valueMeta));
-    } else if (isInserting) {
-      context.missing(_valueMeta);
-    }
-    return context;
-  }
-
-  @override
-  Set<GeneratedColumn> get $primaryKey => {key};
-  @override
-  KeyValue map(Map<String, dynamic> data, {String? tablePrefix}) {
-    final effectivePrefix = tablePrefix != null ? '$tablePrefix.' : '';
-    return KeyValue(
-      key: attachedDatabase.typeMapping
-          .read(DriftSqlType.string, data['${effectivePrefix}key'])!,
-      value: attachedDatabase.typeMapping
-          .read(DriftSqlType.string, data['${effectivePrefix}value'])!,
-    );
-  }
-
-  @override
-  $KeyValuesTable createAlias(String alias) {
-    return $KeyValuesTable(attachedDatabase, alias);
   }
 }
 

--- a/extras/integration_tests/drift_testcases/lib/database/database.g.dart
+++ b/extras/integration_tests/drift_testcases/lib/database/database.g.dart
@@ -3,6 +3,110 @@
 part of 'database.dart';
 
 // ignore_for_file: type=lint
+class $UsersTable extends Users with TableInfo<$UsersTable, User> {
+  @override
+  final GeneratedDatabase attachedDatabase;
+  final String? _alias;
+  $UsersTable(this.attachedDatabase, [this._alias]);
+  static const VerificationMeta _idMeta = const VerificationMeta('id');
+  @override
+  late final GeneratedColumn<int> id = GeneratedColumn<int>(
+      'id', aliasedName, false,
+      hasAutoIncrement: true,
+      type: DriftSqlType.int,
+      requiredDuringInsert: false,
+      defaultConstraints:
+          GeneratedColumn.constraintIsAlways('PRIMARY KEY AUTOINCREMENT'));
+  static const VerificationMeta _nameMeta = const VerificationMeta('name');
+  @override
+  late final GeneratedColumn<String> name = GeneratedColumn<String>(
+      'name', aliasedName, false,
+      type: DriftSqlType.string, requiredDuringInsert: true);
+  static const VerificationMeta _birthDateMeta =
+      const VerificationMeta('birthDate');
+  @override
+  late final GeneratedColumn<DateTime> birthDate = GeneratedColumn<DateTime>(
+      'birth_date', aliasedName, false,
+      type: DriftSqlType.dateTime, requiredDuringInsert: true);
+  static const VerificationMeta _profilePictureMeta =
+      const VerificationMeta('profilePicture');
+  @override
+  late final GeneratedColumn<Uint8List> profilePicture =
+      GeneratedColumn<Uint8List>('profile_picture', aliasedName, true,
+          type: DriftSqlType.blob, requiredDuringInsert: false);
+  static const VerificationMeta _preferencesMeta =
+      const VerificationMeta('preferences');
+  @override
+  late final GeneratedColumnWithTypeConverter<Preferences?, String>
+      preferences = GeneratedColumn<String>('preferences', aliasedName, true,
+              type: DriftSqlType.string, requiredDuringInsert: false)
+          .withConverter<Preferences?>($UsersTable.$converterpreferences);
+  @override
+  List<GeneratedColumn> get $columns =>
+      [id, name, birthDate, profilePicture, preferences];
+  @override
+  String get aliasedName => _alias ?? 'users';
+  @override
+  String get actualTableName => 'users';
+  @override
+  VerificationContext validateIntegrity(Insertable<User> instance,
+      {bool isInserting = false}) {
+    final context = VerificationContext();
+    final data = instance.toColumns(true);
+    if (data.containsKey('id')) {
+      context.handle(_idMeta, id.isAcceptableOrUnknown(data['id']!, _idMeta));
+    }
+    if (data.containsKey('name')) {
+      context.handle(
+          _nameMeta, name.isAcceptableOrUnknown(data['name']!, _nameMeta));
+    } else if (isInserting) {
+      context.missing(_nameMeta);
+    }
+    if (data.containsKey('birth_date')) {
+      context.handle(_birthDateMeta,
+          birthDate.isAcceptableOrUnknown(data['birth_date']!, _birthDateMeta));
+    } else if (isInserting) {
+      context.missing(_birthDateMeta);
+    }
+    if (data.containsKey('profile_picture')) {
+      context.handle(
+          _profilePictureMeta,
+          profilePicture.isAcceptableOrUnknown(
+              data['profile_picture']!, _profilePictureMeta));
+    }
+    context.handle(_preferencesMeta, const VerificationResult.success());
+    return context;
+  }
+
+  @override
+  Set<GeneratedColumn> get $primaryKey => {id};
+  @override
+  User map(Map<String, dynamic> data, {String? tablePrefix}) {
+    final effectivePrefix = tablePrefix != null ? '$tablePrefix.' : '';
+    return User(
+      id: attachedDatabase.typeMapping
+          .read(DriftSqlType.int, data['${effectivePrefix}id'])!,
+      name: attachedDatabase.typeMapping
+          .read(DriftSqlType.string, data['${effectivePrefix}name'])!,
+      birthDate: attachedDatabase.typeMapping
+          .read(DriftSqlType.dateTime, data['${effectivePrefix}birth_date'])!,
+      profilePicture: attachedDatabase.typeMapping
+          .read(DriftSqlType.blob, data['${effectivePrefix}profile_picture']),
+      preferences: $UsersTable.$converterpreferences.fromSql(attachedDatabase
+          .typeMapping
+          .read(DriftSqlType.string, data['${effectivePrefix}preferences'])),
+    );
+  }
+
+  @override
+  $UsersTable createAlias(String alias) {
+    return $UsersTable(attachedDatabase, alias);
+  }
+
+  static TypeConverter<Preferences?, String?> $converterpreferences =
+      const PreferenceConverter();
+}
+
 class User extends DataClass implements Insertable<User> {
   /// The user id
   final int id;
@@ -205,108 +309,91 @@ class UsersCompanion extends UpdateCompanion<User> {
   }
 }
 
-class $UsersTable extends Users with TableInfo<$UsersTable, User> {
+class $FriendshipsTable extends Friendships
+    with TableInfo<$FriendshipsTable, Friendship> {
   @override
   final GeneratedDatabase attachedDatabase;
   final String? _alias;
-  $UsersTable(this.attachedDatabase, [this._alias]);
-  static const VerificationMeta _idMeta = const VerificationMeta('id');
+  $FriendshipsTable(this.attachedDatabase, [this._alias]);
+  static const VerificationMeta _firstUserMeta =
+      const VerificationMeta('firstUser');
   @override
-  late final GeneratedColumn<int> id = GeneratedColumn<int>(
-      'id', aliasedName, false,
-      hasAutoIncrement: true,
-      type: DriftSqlType.int,
-      requiredDuringInsert: false,
-      defaultConstraints:
-          GeneratedColumn.constraintIsAlways('PRIMARY KEY AUTOINCREMENT'));
-  static const VerificationMeta _nameMeta = const VerificationMeta('name');
+  late final GeneratedColumn<int> firstUser = GeneratedColumn<int>(
+      'first_user', aliasedName, false,
+      type: DriftSqlType.int, requiredDuringInsert: true);
+  static const VerificationMeta _secondUserMeta =
+      const VerificationMeta('secondUser');
   @override
-  late final GeneratedColumn<String> name = GeneratedColumn<String>(
-      'name', aliasedName, false,
-      type: DriftSqlType.string, requiredDuringInsert: true);
-  static const VerificationMeta _birthDateMeta =
-      const VerificationMeta('birthDate');
+  late final GeneratedColumn<int> secondUser = GeneratedColumn<int>(
+      'second_user', aliasedName, false,
+      type: DriftSqlType.int, requiredDuringInsert: true);
+  static const VerificationMeta _reallyGoodFriendsMeta =
+      const VerificationMeta('reallyGoodFriends');
   @override
-  late final GeneratedColumn<DateTime> birthDate = GeneratedColumn<DateTime>(
-      'birth_date', aliasedName, false,
-      type: DriftSqlType.dateTime, requiredDuringInsert: true);
-  static const VerificationMeta _profilePictureMeta =
-      const VerificationMeta('profilePicture');
-  @override
-  late final GeneratedColumn<Uint8List> profilePicture =
-      GeneratedColumn<Uint8List>('profile_picture', aliasedName, true,
-          type: DriftSqlType.blob, requiredDuringInsert: false);
-  static const VerificationMeta _preferencesMeta =
-      const VerificationMeta('preferences');
-  @override
-  late final GeneratedColumnWithTypeConverter<Preferences?, String>
-      preferences = GeneratedColumn<String>('preferences', aliasedName, true,
-              type: DriftSqlType.string, requiredDuringInsert: false)
-          .withConverter<Preferences?>($UsersTable.$converterpreferences);
+  late final GeneratedColumn<bool> reallyGoodFriends =
+      GeneratedColumn<bool>('really_good_friends', aliasedName, false,
+          type: DriftSqlType.bool,
+          requiredDuringInsert: false,
+          defaultConstraints: GeneratedColumn.constraintsDependsOnDialect({
+            SqlDialect.sqlite: 'CHECK ("really_good_friends" IN (0, 1))',
+            SqlDialect.mysql: '',
+            SqlDialect.postgres: '',
+          }),
+          defaultValue: const Constant(false));
   @override
   List<GeneratedColumn> get $columns =>
-      [id, name, birthDate, profilePicture, preferences];
+      [firstUser, secondUser, reallyGoodFriends];
   @override
-  String get aliasedName => _alias ?? 'users';
+  String get aliasedName => _alias ?? 'friendships';
   @override
-  String get actualTableName => 'users';
+  String get actualTableName => 'friendships';
   @override
-  VerificationContext validateIntegrity(Insertable<User> instance,
+  VerificationContext validateIntegrity(Insertable<Friendship> instance,
       {bool isInserting = false}) {
     final context = VerificationContext();
     final data = instance.toColumns(true);
-    if (data.containsKey('id')) {
-      context.handle(_idMeta, id.isAcceptableOrUnknown(data['id']!, _idMeta));
-    }
-    if (data.containsKey('name')) {
-      context.handle(
-          _nameMeta, name.isAcceptableOrUnknown(data['name']!, _nameMeta));
+    if (data.containsKey('first_user')) {
+      context.handle(_firstUserMeta,
+          firstUser.isAcceptableOrUnknown(data['first_user']!, _firstUserMeta));
     } else if (isInserting) {
-      context.missing(_nameMeta);
+      context.missing(_firstUserMeta);
     }
-    if (data.containsKey('birth_date')) {
-      context.handle(_birthDateMeta,
-          birthDate.isAcceptableOrUnknown(data['birth_date']!, _birthDateMeta));
-    } else if (isInserting) {
-      context.missing(_birthDateMeta);
-    }
-    if (data.containsKey('profile_picture')) {
+    if (data.containsKey('second_user')) {
       context.handle(
-          _profilePictureMeta,
-          profilePicture.isAcceptableOrUnknown(
-              data['profile_picture']!, _profilePictureMeta));
+          _secondUserMeta,
+          secondUser.isAcceptableOrUnknown(
+              data['second_user']!, _secondUserMeta));
+    } else if (isInserting) {
+      context.missing(_secondUserMeta);
     }
-    context.handle(_preferencesMeta, const VerificationResult.success());
+    if (data.containsKey('really_good_friends')) {
+      context.handle(
+          _reallyGoodFriendsMeta,
+          reallyGoodFriends.isAcceptableOrUnknown(
+              data['really_good_friends']!, _reallyGoodFriendsMeta));
+    }
     return context;
   }
 
   @override
-  Set<GeneratedColumn> get $primaryKey => {id};
+  Set<GeneratedColumn> get $primaryKey => {firstUser, secondUser};
   @override
-  User map(Map<String, dynamic> data, {String? tablePrefix}) {
+  Friendship map(Map<String, dynamic> data, {String? tablePrefix}) {
     final effectivePrefix = tablePrefix != null ? '$tablePrefix.' : '';
-    return User(
-      id: attachedDatabase.typeMapping
-          .read(DriftSqlType.int, data['${effectivePrefix}id'])!,
-      name: attachedDatabase.typeMapping
-          .read(DriftSqlType.string, data['${effectivePrefix}name'])!,
-      birthDate: attachedDatabase.typeMapping
-          .read(DriftSqlType.dateTime, data['${effectivePrefix}birth_date'])!,
-      profilePicture: attachedDatabase.typeMapping
-          .read(DriftSqlType.blob, data['${effectivePrefix}profile_picture']),
-      preferences: $UsersTable.$converterpreferences.fromSql(attachedDatabase
-          .typeMapping
-          .read(DriftSqlType.string, data['${effectivePrefix}preferences'])),
+    return Friendship(
+      firstUser: attachedDatabase.typeMapping
+          .read(DriftSqlType.int, data['${effectivePrefix}first_user'])!,
+      secondUser: attachedDatabase.typeMapping
+          .read(DriftSqlType.int, data['${effectivePrefix}second_user'])!,
+      reallyGoodFriends: attachedDatabase.typeMapping.read(
+          DriftSqlType.bool, data['${effectivePrefix}really_good_friends'])!,
     );
   }
 
   @override
-  $UsersTable createAlias(String alias) {
-    return $UsersTable(attachedDatabase, alias);
+  $FriendshipsTable createAlias(String alias) {
+    return $FriendshipsTable(attachedDatabase, alias);
   }
-
-  static TypeConverter<Preferences?, String?> $converterpreferences =
-      const PreferenceConverter();
 }
 
 class Friendship extends DataClass implements Insertable<Friendship> {
@@ -447,93 +534,6 @@ class FriendshipsCompanion extends UpdateCompanion<Friendship> {
           ..write('reallyGoodFriends: $reallyGoodFriends')
           ..write(')'))
         .toString();
-  }
-}
-
-class $FriendshipsTable extends Friendships
-    with TableInfo<$FriendshipsTable, Friendship> {
-  @override
-  final GeneratedDatabase attachedDatabase;
-  final String? _alias;
-  $FriendshipsTable(this.attachedDatabase, [this._alias]);
-  static const VerificationMeta _firstUserMeta =
-      const VerificationMeta('firstUser');
-  @override
-  late final GeneratedColumn<int> firstUser = GeneratedColumn<int>(
-      'first_user', aliasedName, false,
-      type: DriftSqlType.int, requiredDuringInsert: true);
-  static const VerificationMeta _secondUserMeta =
-      const VerificationMeta('secondUser');
-  @override
-  late final GeneratedColumn<int> secondUser = GeneratedColumn<int>(
-      'second_user', aliasedName, false,
-      type: DriftSqlType.int, requiredDuringInsert: true);
-  static const VerificationMeta _reallyGoodFriendsMeta =
-      const VerificationMeta('reallyGoodFriends');
-  @override
-  late final GeneratedColumn<bool> reallyGoodFriends =
-      GeneratedColumn<bool>('really_good_friends', aliasedName, false,
-          type: DriftSqlType.bool,
-          requiredDuringInsert: false,
-          defaultConstraints: GeneratedColumn.constraintsDependsOnDialect({
-            SqlDialect.sqlite: 'CHECK ("really_good_friends" IN (0, 1))',
-            SqlDialect.mysql: '',
-            SqlDialect.postgres: '',
-          }),
-          defaultValue: const Constant(false));
-  @override
-  List<GeneratedColumn> get $columns =>
-      [firstUser, secondUser, reallyGoodFriends];
-  @override
-  String get aliasedName => _alias ?? 'friendships';
-  @override
-  String get actualTableName => 'friendships';
-  @override
-  VerificationContext validateIntegrity(Insertable<Friendship> instance,
-      {bool isInserting = false}) {
-    final context = VerificationContext();
-    final data = instance.toColumns(true);
-    if (data.containsKey('first_user')) {
-      context.handle(_firstUserMeta,
-          firstUser.isAcceptableOrUnknown(data['first_user']!, _firstUserMeta));
-    } else if (isInserting) {
-      context.missing(_firstUserMeta);
-    }
-    if (data.containsKey('second_user')) {
-      context.handle(
-          _secondUserMeta,
-          secondUser.isAcceptableOrUnknown(
-              data['second_user']!, _secondUserMeta));
-    } else if (isInserting) {
-      context.missing(_secondUserMeta);
-    }
-    if (data.containsKey('really_good_friends')) {
-      context.handle(
-          _reallyGoodFriendsMeta,
-          reallyGoodFriends.isAcceptableOrUnknown(
-              data['really_good_friends']!, _reallyGoodFriendsMeta));
-    }
-    return context;
-  }
-
-  @override
-  Set<GeneratedColumn> get $primaryKey => {firstUser, secondUser};
-  @override
-  Friendship map(Map<String, dynamic> data, {String? tablePrefix}) {
-    final effectivePrefix = tablePrefix != null ? '$tablePrefix.' : '';
-    return Friendship(
-      firstUser: attachedDatabase.typeMapping
-          .read(DriftSqlType.int, data['${effectivePrefix}first_user'])!,
-      secondUser: attachedDatabase.typeMapping
-          .read(DriftSqlType.int, data['${effectivePrefix}second_user'])!,
-      reallyGoodFriends: attachedDatabase.typeMapping.read(
-          DriftSqlType.bool, data['${effectivePrefix}really_good_friends'])!,
-    );
-  }
-
-  @override
-  $FriendshipsTable createAlias(String alias) {
-    return $FriendshipsTable(attachedDatabase, alias);
   }
 }
 

--- a/extras/integration_tests/web/test/saves_after_migration_regression_test.g.dart
+++ b/extras/integration_tests/web/test/saves_after_migration_regression_test.g.dart
@@ -3,6 +3,54 @@
 part of 'saves_after_migration_regression_test.dart';
 
 // ignore_for_file: type=lint
+class $FoosTable extends Foos with TableInfo<$FoosTable, Foo> {
+  @override
+  final GeneratedDatabase attachedDatabase;
+  final String? _alias;
+  $FoosTable(this.attachedDatabase, [this._alias]);
+  static const VerificationMeta _idMeta = const VerificationMeta('id');
+  @override
+  late final GeneratedColumn<int> id = GeneratedColumn<int>(
+      'id', aliasedName, false,
+      hasAutoIncrement: true,
+      type: DriftSqlType.int,
+      requiredDuringInsert: false,
+      defaultConstraints:
+          GeneratedColumn.constraintIsAlways('PRIMARY KEY AUTOINCREMENT'));
+  @override
+  List<GeneratedColumn> get $columns => [id];
+  @override
+  String get aliasedName => _alias ?? 'foos';
+  @override
+  String get actualTableName => 'foos';
+  @override
+  VerificationContext validateIntegrity(Insertable<Foo> instance,
+      {bool isInserting = false}) {
+    final context = VerificationContext();
+    final data = instance.toColumns(true);
+    if (data.containsKey('id')) {
+      context.handle(_idMeta, id.isAcceptableOrUnknown(data['id']!, _idMeta));
+    }
+    return context;
+  }
+
+  @override
+  Set<GeneratedColumn> get $primaryKey => {id};
+  @override
+  Foo map(Map<String, dynamic> data, {String? tablePrefix}) {
+    final effectivePrefix = tablePrefix != null ? '$tablePrefix.' : '';
+    return Foo(
+      id: attachedDatabase.typeMapping
+          .read(DriftSqlType.int, data['${effectivePrefix}id'])!,
+    );
+  }
+
+  @override
+  $FoosTable createAlias(String alias) {
+    return $FoosTable(attachedDatabase, alias);
+  }
+}
+
 class Foo extends DataClass implements Insertable<Foo> {
   final int id;
   const Foo({required this.id});
@@ -92,11 +140,11 @@ class FoosCompanion extends UpdateCompanion<Foo> {
   }
 }
 
-class $FoosTable extends Foos with TableInfo<$FoosTable, Foo> {
+class $BarsTable extends Bars with TableInfo<$BarsTable, Bar> {
   @override
   final GeneratedDatabase attachedDatabase;
   final String? _alias;
-  $FoosTable(this.attachedDatabase, [this._alias]);
+  $BarsTable(this.attachedDatabase, [this._alias]);
   static const VerificationMeta _idMeta = const VerificationMeta('id');
   @override
   late final GeneratedColumn<int> id = GeneratedColumn<int>(
@@ -109,11 +157,11 @@ class $FoosTable extends Foos with TableInfo<$FoosTable, Foo> {
   @override
   List<GeneratedColumn> get $columns => [id];
   @override
-  String get aliasedName => _alias ?? 'foos';
+  String get aliasedName => _alias ?? 'bars';
   @override
-  String get actualTableName => 'foos';
+  String get actualTableName => 'bars';
   @override
-  VerificationContext validateIntegrity(Insertable<Foo> instance,
+  VerificationContext validateIntegrity(Insertable<Bar> instance,
       {bool isInserting = false}) {
     final context = VerificationContext();
     final data = instance.toColumns(true);
@@ -126,17 +174,17 @@ class $FoosTable extends Foos with TableInfo<$FoosTable, Foo> {
   @override
   Set<GeneratedColumn> get $primaryKey => {id};
   @override
-  Foo map(Map<String, dynamic> data, {String? tablePrefix}) {
+  Bar map(Map<String, dynamic> data, {String? tablePrefix}) {
     final effectivePrefix = tablePrefix != null ? '$tablePrefix.' : '';
-    return Foo(
+    return Bar(
       id: attachedDatabase.typeMapping
           .read(DriftSqlType.int, data['${effectivePrefix}id'])!,
     );
   }
 
   @override
-  $FoosTable createAlias(String alias) {
-    return $FoosTable(attachedDatabase, alias);
+  $BarsTable createAlias(String alias) {
+    return $BarsTable(attachedDatabase, alias);
   }
 }
 
@@ -226,54 +274,6 @@ class BarsCompanion extends UpdateCompanion<Bar> {
           ..write('id: $id')
           ..write(')'))
         .toString();
-  }
-}
-
-class $BarsTable extends Bars with TableInfo<$BarsTable, Bar> {
-  @override
-  final GeneratedDatabase attachedDatabase;
-  final String? _alias;
-  $BarsTable(this.attachedDatabase, [this._alias]);
-  static const VerificationMeta _idMeta = const VerificationMeta('id');
-  @override
-  late final GeneratedColumn<int> id = GeneratedColumn<int>(
-      'id', aliasedName, false,
-      hasAutoIncrement: true,
-      type: DriftSqlType.int,
-      requiredDuringInsert: false,
-      defaultConstraints:
-          GeneratedColumn.constraintIsAlways('PRIMARY KEY AUTOINCREMENT'));
-  @override
-  List<GeneratedColumn> get $columns => [id];
-  @override
-  String get aliasedName => _alias ?? 'bars';
-  @override
-  String get actualTableName => 'bars';
-  @override
-  VerificationContext validateIntegrity(Insertable<Bar> instance,
-      {bool isInserting = false}) {
-    final context = VerificationContext();
-    final data = instance.toColumns(true);
-    if (data.containsKey('id')) {
-      context.handle(_idMeta, id.isAcceptableOrUnknown(data['id']!, _idMeta));
-    }
-    return context;
-  }
-
-  @override
-  Set<GeneratedColumn> get $primaryKey => {id};
-  @override
-  Bar map(Map<String, dynamic> data, {String? tablePrefix}) {
-    final effectivePrefix = tablePrefix != null ? '$tablePrefix.' : '';
-    return Bar(
-      id: attachedDatabase.typeMapping
-          .read(DriftSqlType.int, data['${effectivePrefix}id'])!,
-    );
-  }
-
-  @override
-  $BarsTable createAlias(String alias) {
-    return $BarsTable(attachedDatabase, alias);
   }
 }
 


### PR DESCRIPTION
At the moment when using user generated classes, you need to write your own code `toColumns`. Because user generated columns must match the type and name the row, I feel like this is something that can be generated by drift as a mixin.

This is more a proof of concept. Any suggestions on how you'd like it implemented?