### PR TITLE
Fixes for schema generate

### DIFF
--- a/drift_dev/lib/src/cli/commands/schema/generate_utils.dart
+++ b/drift_dev/lib/src/cli/commands/schema/generate_utils.dart
@@ -75,7 +75,8 @@ class GenerateUtilsCommand extends Command {
       );
     }
 
-    await _writeLibraryFile(outputDir, schema.keys);
+    final versions = schema.keys.toList()..sort();
+    await _writeLibraryFile(outputDir, versions);
     print(
         'Wrote ${schema.length + 1} files into ${p.relative(outputDir.path)}');
   }

--- a/drift_dev/lib/src/writer/tables/data_class_writer.dart
+++ b/drift_dev/lib/src/writer/tables/data_class_writer.dart
@@ -66,6 +66,9 @@ class DataClassWriter {
       if (column.documentationComment != null) {
         _buffer.write('${column.documentationComment}\n');
       }
+      if (scope.options.writeToColumnsMixins) {
+        _buffer.writeln('@override');
+      }
       final modifier = scope.options.fieldModifier;
       _buffer.writeln('$modifier ${_columnType(column)} ${column.nameInDart};');
     }

--- a/drift_dev/lib/src/writer/tables/data_class_writer.dart
+++ b/drift_dev/lib/src/writer/tables/data_class_writer.dart
@@ -100,7 +100,8 @@ class DataClassWriter {
       if (!scope.options.writeToColumnsMixins) {
         _emitter.writeToColumnsOverride(columns);
       }
-      if (scope.options.dataClassToCompanions) {
+      if (scope.options.dataClassToCompanions &&
+          scope.generationOptions.writeCompanions) {
         _writeToCompanion();
       }
     }

--- a/drift_dev/lib/src/writer/tables/table_writer.dart
+++ b/drift_dev/lib/src/writer/tables/table_writer.dart
@@ -272,11 +272,11 @@ class TableWriter extends TableOrViewWriter {
   }
 
   void writeDataClass() {
-    if (scope.options.writeToColumnsMixins) {
-      writeToColumnsMixin();
-    }
-
     if (scope.generationOptions.writeDataClasses) {
+      if (scope.options.writeToColumnsMixins) {
+        writeToColumnsMixin();
+      }
+
       final existing = table.existingRowClass;
       if (existing != null) {
         // We don't have to write a row class if we're using one provided by the

--- a/drift_dev/lib/src/writer/tables/update_companion_writer.dart
+++ b/drift_dev/lib/src/writer/tables/update_companion_writer.dart
@@ -25,12 +25,14 @@ class UpdateCompanionWriter {
   String get _companionClass => _emitter.companionType(table).toString();
   String get _companionType => _emitter.dartCode(_emitter.companionType(table));
 
-  void write() {
-    final rowClass = _emitter.dartCode(_emitter.rowType(table));
+  String get _rowType => scope.generationOptions.writeDataClasses
+      ? _emitter.dartCode(_emitter.rowType(table))
+      : 'dynamic';
 
+  void write() {
     _buffer.write('class $_companionClass '
         'extends '
-        '${_emitter.drift('UpdateCompanion')}<$rowClass> {\n');
+        '${_emitter.drift('UpdateCompanion')}<$_rowType> {\n');
     _writeFields();
 
     _writeConstructor();
@@ -124,10 +126,9 @@ class UpdateCompanionWriter {
             ? 'createCustom'
             : 'custom';
 
-    final rowType = _emitter.dartCode(_emitter.rowType(table));
     _buffer
       ..write(
-          'static ${_emitter.drift('Insertable')}<$rowType> $constructorName')
+          'static ${_emitter.drift('Insertable')}<$_rowType> $constructorName')
       ..write('({');
 
     final expression = _emitter.drift('Expression');

--- a/drift_dev/test/writer/queries/query_writer_test.dart
+++ b/drift_dev/test/writer/queries/query_writer_test.dart
@@ -206,20 +206,20 @@ class MyRow {
     checkOutputs(
       {
         'a|lib/a.drift.dart': decodedMatches(contains('''
-  i1.Selectable<i0.MyRow> foo() {
+  i0.Selectable<i1.MyRow> foo() {
     return customSelect(
         'SELECT name,"otherUser"."id" AS "nested_0.id", "otherUser"."name" AS "nested_0.name" FROM users INNER JOIN users AS otherUser ON otherUser.id = users.id + 1',
         variables: [],
         readsFrom: {
           users,
-        }).asyncMap((i1.QueryRow row) async => i0.MyRow(
+        }).asyncMap((i0.QueryRow row) async => i1.MyRow(
           row.read<String>('name'),
           otherUser: await users.mapFromRow(row, tablePrefix: 'nested_0'),
           nested: await customSelect('SELECT id FROM users',
               variables: [],
               readsFrom: {
                 users,
-              }).map((i1.QueryRow row) => row.read<int>('id')).get(),
+              }).map((i0.QueryRow row) => row.read<int>('id')).get(),
         ));
   }
 '''))


### PR DESCRIPTION
- Fixes writing `toColumns` mixin when `writeDataClasses` is disabled.
- Fixes writing `toCompanions` method when `writeCompanions` is disabled.
- Fixes not writing `@override` when using `toColumns` mixin.
- Fixes writing companion with row type that doesn't exist when `writeCompanions` is enabled and `writeDataClasses` is disabled. `dymamic` is used instead.
- Sorts schema versions