### PR TITLE
Fix bitwiseAnd generated operation

### DIFF
--- a/docs/lib/snippets/expressions.dart
+++ b/docs/lib/snippets/expressions.dart
@@ -14,7 +14,7 @@ extension Expressions on MyDatabase {
 
 // #docregion bitwise
 Expression<int> bitwiseMagic(Expression<int> a, Expression<int> b) {
-  // Generates `~(a | b)` in SQL.
+  // Generates `~(a & b)` in SQL.
   return ~(a.bitwiseAnd(b));
 }
 // #enddocregion bitwise


### PR DESCRIPTION
According to https://github.com/simolus3/drift/blob/2c63c1a64e6288e7fea6bf745fff172d63bdd3cc/drift/test/database/expressions/bitwise_test.dart#L23, the result of `bitwiseAnd` should be `&`.