### PR TITLE
DON'T MERGE Widget test with memory database deadlock

### DIFF
--- a/extras/lock_bug/.gitignore
+++ b/extras/lock_bug/.gitignore
@@ -1,0 +1,44 @@
+# Miscellaneous
+*.class
+*.log
+*.pyc
+*.swp
+.DS_Store
+.atom/
+.buildlog/
+.history
+.svn/
+migrate_working_dir/
+
+# IntelliJ related
+*.iml
+*.ipr
+*.iws
+.idea/
+
+# The .vscode folder contains launch configuration and tasks you configure in
+# VS Code which you may wish to be included in version control, so this line
+# is commented out by default.
+#.vscode/
+
+# Flutter/Dart/Pub related
+**/doc/api/
+**/ios/Flutter/.last_build_id
+.dart_tool/
+.flutter-plugins
+.flutter-plugins-dependencies
+.packages
+.pub-cache/
+.pub/
+/build/
+
+# Symbolication related
+app.*.symbols
+
+# Obfuscation related
+app.*.map.json
+
+# Android Studio will place build artifacts here
+/android/app/debug
+/android/app/profile
+/android/app/release

--- a/extras/lock_bug/.metadata
+++ b/extras/lock_bug/.metadata
@@ -1,0 +1,45 @@
+# This file tracks properties of this Flutter project.
+# Used by Flutter tool to assess capabilities and perform upgrades etc.
+#
+# This file should be version controlled.
+
+version:
+  revision: 7048ed95a5ad3e43d697e0c397464193991fc230
+  channel: stable
+
+project_type: app
+
+# Tracks metadata for the flutter migrate command
+migration:
+  platforms:
+    - platform: root
+      create_revision: 7048ed95a5ad3e43d697e0c397464193991fc230
+      base_revision: 7048ed95a5ad3e43d697e0c397464193991fc230
+    - platform: android
+      create_revision: 7048ed95a5ad3e43d697e0c397464193991fc230
+      base_revision: 7048ed95a5ad3e43d697e0c397464193991fc230
+    - platform: ios
+      create_revision: 7048ed95a5ad3e43d697e0c397464193991fc230
+      base_revision: 7048ed95a5ad3e43d697e0c397464193991fc230
+    - platform: linux
+      create_revision: 7048ed95a5ad3e43d697e0c397464193991fc230
+      base_revision: 7048ed95a5ad3e43d697e0c397464193991fc230
+    - platform: macos
+      create_revision: 7048ed95a5ad3e43d697e0c397464193991fc230
+      base_revision: 7048ed95a5ad3e43d697e0c397464193991fc230
+    - platform: web
+      create_revision: 7048ed95a5ad3e43d697e0c397464193991fc230
+      base_revision: 7048ed95a5ad3e43d697e0c397464193991fc230
+    - platform: windows
+      create_revision: 7048ed95a5ad3e43d697e0c397464193991fc230
+      base_revision: 7048ed95a5ad3e43d697e0c397464193991fc230
+
+  # User provided section
+
+  # List of Local paths (relative to this file) that should be
+  # ignored by the migrate tool.
+  #
+  # Files that are not part of the templates will be ignored by default.
+  unmanaged_files:
+    - 'lib/main.dart'
+    - 'ios/Runner.xcodeproj/project.pbxproj'

--- a/extras/lock_bug/README.md
+++ b/extras/lock_bug/README.md
@@ -1,0 +1,7 @@
+# drift_lock_bug
+
+This project provides a widget test that seems to trigger a deadlock on `synchronized` when trying to close the Drift database.
+
+## Getting Started
+
+Run `flutter test` and the test will not finish.

--- a/extras/lock_bug/lib/database.dart
+++ b/extras/lock_bug/lib/database.dart
@@ -1,0 +1,49 @@
+import 'package:drift/drift.dart';
+
+part 'database.g.dart';
+
+class Users extends Table {
+  /// The user id
+  IntColumn get id => integer().autoIncrement()();
+
+  // The user name
+  TextColumn get name => text()();
+
+  /// The users birth date
+  ///
+  /// Mapped from json `born_on`
+  DateTimeColumn get birthDate => dateTime()();
+
+  BlobColumn get profilePicture => blob().nullable()();
+}
+
+@DriftDatabase(
+  tables: [Users],
+)
+class Database extends _$Database {
+  /// We make the schema version configurable to test migrations
+  @override
+  final int schemaVersion;
+
+  Database(super.connection, {this.schemaVersion = 2}) : super.connect();
+
+  Database.executor(QueryExecutor db) : this(DatabaseConnection(db));
+
+  /// It will be set in the onUpgrade callback. Null if no migration occurred
+  int? schemaVersionChangedFrom;
+
+  /// It will be set in the onUpgrade callback. Null if no migration occurred
+  int? schemaVersionChangedTo;
+
+  MigrationStrategy? overrideMigration;
+
+  @override
+  MigrationStrategy get migration {
+    return overrideMigration ??
+        MigrationStrategy(
+          onCreate: (m) async {
+            await m.createTable(users);
+          },
+        );
+  }
+}

--- a/extras/lock_bug/lib/database.g.dart
+++ b/extras/lock_bug/lib/database.g.dart
@@ -1,0 +1,276 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+// ignore_for_file: implicit_dynamic_parameter
+
+part of 'database.dart';
+
+// ignore_for_file: type=lint
+class $UsersTable extends Users with TableInfo<$UsersTable, User> {
+  @override
+  final GeneratedDatabase attachedDatabase;
+  final String? _alias;
+  $UsersTable(this.attachedDatabase, [this._alias]);
+  static const VerificationMeta _idMeta = const VerificationMeta('id');
+  @override
+  late final GeneratedColumn<int> id = GeneratedColumn<int>(
+      'id', aliasedName, false,
+      hasAutoIncrement: true,
+      type: DriftSqlType.int,
+      requiredDuringInsert: false,
+      defaultConstraints:
+          GeneratedColumn.constraintIsAlways('PRIMARY KEY AUTOINCREMENT'));
+  static const VerificationMeta _nameMeta = const VerificationMeta('name');
+  @override
+  late final GeneratedColumn<String> name = GeneratedColumn<String>(
+      'name', aliasedName, false,
+      type: DriftSqlType.string, requiredDuringInsert: true);
+  static const VerificationMeta _birthDateMeta =
+      const VerificationMeta('birthDate');
+  @override
+  late final GeneratedColumn<DateTime> birthDate = GeneratedColumn<DateTime>(
+      'birth_date', aliasedName, false,
+      type: DriftSqlType.dateTime, requiredDuringInsert: true);
+  static const VerificationMeta _profilePictureMeta =
+      const VerificationMeta('profilePicture');
+  @override
+  late final GeneratedColumn<Uint8List> profilePicture =
+      GeneratedColumn<Uint8List>('profile_picture', aliasedName, true,
+          type: DriftSqlType.blob, requiredDuringInsert: false);
+  @override
+  List<GeneratedColumn> get $columns => [id, name, birthDate, profilePicture];
+  @override
+  String get aliasedName => _alias ?? 'users';
+  @override
+  String get actualTableName => 'users';
+  @override
+  VerificationContext validateIntegrity(Insertable<User> instance,
+      {bool isInserting = false}) {
+    final context = VerificationContext();
+    final data = instance.toColumns(true);
+    if (data.containsKey('id')) {
+      context.handle(_idMeta, id.isAcceptableOrUnknown(data['id']!, _idMeta));
+    }
+    if (data.containsKey('name')) {
+      context.handle(
+          _nameMeta, name.isAcceptableOrUnknown(data['name']!, _nameMeta));
+    } else if (isInserting) {
+      context.missing(_nameMeta);
+    }
+    if (data.containsKey('birth_date')) {
+      context.handle(_birthDateMeta,
+          birthDate.isAcceptableOrUnknown(data['birth_date']!, _birthDateMeta));
+    } else if (isInserting) {
+      context.missing(_birthDateMeta);
+    }
+    if (data.containsKey('profile_picture')) {
+      context.handle(
+          _profilePictureMeta,
+          profilePicture.isAcceptableOrUnknown(
+              data['profile_picture']!, _profilePictureMeta));
+    }
+    return context;
+  }
+
+  @override
+  Set<GeneratedColumn> get $primaryKey => {id};
+  @override
+  User map(Map<String, dynamic> data, {String? tablePrefix}) {
+    final effectivePrefix = tablePrefix != null ? '$tablePrefix.' : '';
+    return User(
+      id: attachedDatabase.typeMapping
+          .read(DriftSqlType.int, data['${effectivePrefix}id'])!,
+      name: attachedDatabase.typeMapping
+          .read(DriftSqlType.string, data['${effectivePrefix}name'])!,
+      birthDate: attachedDatabase.typeMapping
+          .read(DriftSqlType.dateTime, data['${effectivePrefix}birth_date'])!,
+      profilePicture: attachedDatabase.typeMapping
+          .read(DriftSqlType.blob, data['${effectivePrefix}profile_picture']),
+    );
+  }
+
+  @override
+  $UsersTable createAlias(String alias) {
+    return $UsersTable(attachedDatabase, alias);
+  }
+}
+
+class User extends DataClass implements Insertable<User> {
+  /// The user id
+  final int id;
+  final String name;
+
+  /// The users birth date
+  ///
+  /// Mapped from json `born_on`
+  final DateTime birthDate;
+  final Uint8List? profilePicture;
+  const User(
+      {required this.id,
+      required this.name,
+      required this.birthDate,
+      this.profilePicture});
+  @override
+  Map<String, Expression> toColumns(bool nullToAbsent) {
+    final map = <String, Expression>{};
+    map['id'] = Variable<int>(id);
+    map['name'] = Variable<String>(name);
+    map['birth_date'] = Variable<DateTime>(birthDate);
+    if (!nullToAbsent || profilePicture != null) {
+      map['profile_picture'] = Variable<Uint8List>(profilePicture);
+    }
+    return map;
+  }
+
+  UsersCompanion toCompanion(bool nullToAbsent) {
+    return UsersCompanion(
+      id: Value(id),
+      name: Value(name),
+      birthDate: Value(birthDate),
+      profilePicture: profilePicture == null && nullToAbsent
+          ? const Value.absent()
+          : Value(profilePicture),
+    );
+  }
+
+  factory User.fromJson(Map<String, dynamic> json,
+      {ValueSerializer? serializer}) {
+    serializer ??= driftRuntimeOptions.defaultSerializer;
+    return User(
+      id: serializer.fromJson<int>(json['id']),
+      name: serializer.fromJson<String>(json['name']),
+      birthDate: serializer.fromJson<DateTime>(json['birthDate']),
+      profilePicture: serializer.fromJson<Uint8List?>(json['profilePicture']),
+    );
+  }
+  @override
+  Map<String, dynamic> toJson({ValueSerializer? serializer}) {
+    serializer ??= driftRuntimeOptions.defaultSerializer;
+    return <String, dynamic>{
+      'id': serializer.toJson<int>(id),
+      'name': serializer.toJson<String>(name),
+      'birthDate': serializer.toJson<DateTime>(birthDate),
+      'profilePicture': serializer.toJson<Uint8List?>(profilePicture),
+    };
+  }
+
+  User copyWith(
+          {int? id,
+          String? name,
+          DateTime? birthDate,
+          Value<Uint8List?> profilePicture = const Value.absent()}) =>
+      User(
+        id: id ?? this.id,
+        name: name ?? this.name,
+        birthDate: birthDate ?? this.birthDate,
+        profilePicture:
+            profilePicture.present ? profilePicture.value : this.profilePicture,
+      );
+  @override
+  String toString() {
+    return (StringBuffer('User(')
+          ..write('id: $id, ')
+          ..write('name: $name, ')
+          ..write('birthDate: $birthDate, ')
+          ..write('profilePicture: $profilePicture')
+          ..write(')'))
+        .toString();
+  }
+
+  @override
+  int get hashCode =>
+      Object.hash(id, name, birthDate, $driftBlobEquality.hash(profilePicture));
+  @override
+  bool operator ==(Object other) =>
+      identical(this, other) ||
+      (other is User &&
+          other.id == this.id &&
+          other.name == this.name &&
+          other.birthDate == this.birthDate &&
+          $driftBlobEquality.equals(other.profilePicture, this.profilePicture));
+}
+
+class UsersCompanion extends UpdateCompanion<User> {
+  final Value<int> id;
+  final Value<String> name;
+  final Value<DateTime> birthDate;
+  final Value<Uint8List?> profilePicture;
+  const UsersCompanion({
+    this.id = const Value.absent(),
+    this.name = const Value.absent(),
+    this.birthDate = const Value.absent(),
+    this.profilePicture = const Value.absent(),
+  });
+  UsersCompanion.insert({
+    this.id = const Value.absent(),
+    required String name,
+    required DateTime birthDate,
+    this.profilePicture = const Value.absent(),
+  })  : name = Value(name),
+        birthDate = Value(birthDate);
+  static Insertable<User> custom({
+    Expression<int>? id,
+    Expression<String>? name,
+    Expression<DateTime>? birthDate,
+    Expression<Uint8List>? profilePicture,
+  }) {
+    return RawValuesInsertable({
+      if (id != null) 'id': id,
+      if (name != null) 'name': name,
+      if (birthDate != null) 'birth_date': birthDate,
+      if (profilePicture != null) 'profile_picture': profilePicture,
+    });
+  }
+
+  UsersCompanion copyWith(
+      {Value<int>? id,
+      Value<String>? name,
+      Value<DateTime>? birthDate,
+      Value<Uint8List?>? profilePicture}) {
+    return UsersCompanion(
+      id: id ?? this.id,
+      name: name ?? this.name,
+      birthDate: birthDate ?? this.birthDate,
+      profilePicture: profilePicture ?? this.profilePicture,
+    );
+  }
+
+  @override
+  Map<String, Expression> toColumns(bool nullToAbsent) {
+    final map = <String, Expression>{};
+    if (id.present) {
+      map['id'] = Variable<int>(id.value);
+    }
+    if (name.present) {
+      map['name'] = Variable<String>(name.value);
+    }
+    if (birthDate.present) {
+      map['birth_date'] = Variable<DateTime>(birthDate.value);
+    }
+    if (profilePicture.present) {
+      map['profile_picture'] = Variable<Uint8List>(profilePicture.value);
+    }
+    return map;
+  }
+
+  @override
+  String toString() {
+    return (StringBuffer('UsersCompanion(')
+          ..write('id: $id, ')
+          ..write('name: $name, ')
+          ..write('birthDate: $birthDate, ')
+          ..write('profilePicture: $profilePicture')
+          ..write(')'))
+        .toString();
+  }
+}
+
+abstract class _$Database extends GeneratedDatabase {
+  _$Database(QueryExecutor e) : super(e);
+  _$Database.connect(DatabaseConnection c) : super.connect(c);
+  late final $UsersTable users = $UsersTable(this);
+  @override
+  Iterable<TableInfo<Table, Object?>> get allTables =>
+      allSchemaEntities.whereType<TableInfo<Table, Object?>>();
+  @override
+  List<DatabaseSchemaEntity> get allSchemaEntities => [users];
+}

--- a/extras/lock_bug/lib/main.dart
+++ b/extras/lock_bug/lib/main.dart
@@ -1,0 +1,5 @@
+import 'package:flutter/material.dart';
+
+void main() {
+  runApp(const SizedBox());
+}

--- a/extras/lock_bug/pubspec.yaml
+++ b/extras/lock_bug/pubspec.yaml
@@ -1,0 +1,27 @@
+name: drift_lock_bug
+description: A new Flutter project.
+publish_to: "none" # Remove this line if you wish to publish to pub.dev
+
+version: 1.0.0+1
+
+environment:
+  sdk: ">=2.19.1 <3.0.0"
+
+dependencies:
+  flutter:
+    sdk: flutter
+
+  cupertino_icons: ^1.0.2
+  drift: ^2.5.0
+  flutter_riverpod: ^2.1.3
+
+dev_dependencies:
+  flutter_test:
+    sdk: flutter
+
+dependency_overrides:
+  drift:
+    path: ../../drift
+
+flutter:
+  uses-material-design: true

--- a/extras/lock_bug/pubspec.yaml
+++ b/extras/lock_bug/pubspec.yaml
@@ -13,7 +13,6 @@ dependencies:
 
   cupertino_icons: ^1.0.2
   drift: ^2.5.0
-  flutter_riverpod: ^2.1.3
 
 dev_dependencies:
   flutter_test:

--- a/extras/lock_bug/test/widget_test.dart
+++ b/extras/lock_bug/test/widget_test.dart
@@ -1,20 +1,6 @@
 import 'package:drift/native.dart';
 import 'package:drift_lock_bug/database.dart';
-import 'package:flutter/material.dart';
-import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
-
-final databaseProvider = Provider<Database>((ref) {
-  throw UnimplementedError();
-});
-
-final myFutureProvider = FutureProvider<int>((ref) async {
-  final db = ref.watch(databaseProvider);
-
-  await db.customSelect("SELECT 1").get();
-
-  return 1;
-});
 
 void main() {
   testWidgets("deadlock test", (tester) async {
@@ -22,32 +8,12 @@ void main() {
       NativeDatabase.memory(logStatements: true),
     );
 
-    final container = ProviderContainer(
-      overrides: [
-        databaseProvider.overrideWithValue(db),
-      ],
-    );
-
     addTearDown(() async {
       print("closing db");
       await db.close();
       print("db closed");
-      container.dispose();
-      print("finish teardown");
     });
 
-    final widget = UncontrolledProviderScope(
-      container: container,
-      child: Consumer(
-        builder: (BuildContext context, WidgetRef ref, Widget? child) {
-          final dbRes = ref.watch(myFutureProvider);
-          print("db result $dbRes");
-
-          return const SizedBox();
-        },
-      ),
-    );
-
-    await tester.pumpWidget(widget);
+    await db.customSelect("SELECT 1").get();
   });
 }

--- a/extras/lock_bug/test/widget_test.dart
+++ b/extras/lock_bug/test/widget_test.dart
@@ -1,0 +1,53 @@
+import 'package:drift/native.dart';
+import 'package:drift_lock_bug/database.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+final databaseProvider = Provider<Database>((ref) {
+  throw UnimplementedError();
+});
+
+final myFutureProvider = FutureProvider<int>((ref) async {
+  final db = ref.watch(databaseProvider);
+
+  await db.customSelect("SELECT 1").get();
+
+  return 1;
+});
+
+void main() {
+  testWidgets("deadlock test", (tester) async {
+    final db = Database.executor(
+      NativeDatabase.memory(logStatements: true),
+    );
+
+    final container = ProviderContainer(
+      overrides: [
+        databaseProvider.overrideWithValue(db),
+      ],
+    );
+
+    addTearDown(() async {
+      print("closing db");
+      await db.close();
+      print("db closed");
+      container.dispose();
+      print("finish teardown");
+    });
+
+    final widget = UncontrolledProviderScope(
+      container: container,
+      child: Consumer(
+        builder: (BuildContext context, WidgetRef ref, Widget? child) {
+          final dbRes = ref.watch(myFutureProvider);
+          print("db result $dbRes");
+
+          return const SizedBox();
+        },
+      ),
+    );
+
+    await tester.pumpWidget(widget);
+  });
+}


### PR DESCRIPTION
Hello!
I've recently encountered with an issue with drift when doing a widget test.
With a `NativeDatabase.memory` I get a deadlock when trying to cleanup the test. `db.close()` gets called and it hangs forever.
After some debugging it looks like the `Lock` from `synchronized` in the method `close()` is never entered.

In this "PR" I've included a failing simple test and a few logs to help debugging. 
I tried to debug the problem, but I'm not sure why it doesn't obtain the lock.

Here are the logs from running the test:

```
❯ flutter test
00:01 +0: deadlock test                                                                                               
Opening - 3703 - lock requested
Opening - 3703 - lock obtained
Drift: Sent CREATE TABLE IF NOT EXISTS "users" ("id" INTEGER NOT NULL PRIMARY KEY AUTOINCREMENT, "name" TEXT NOT NULL, "birth_date" INTEGER NOT NULL, "profile_picture" BLOB NULL); with args []
Opening - 3703 - will release lock
Drift: Sent SELECT 1 with args []
closing db
Closing - 9536 - lock requested

(HERE IT HANGS)
```

Flutter version 3.7.1