### PR TITLE
Remove hackyvariables from Postgres tests

### DIFF
--- a/drift/lib/src/runtime/query_builder/expressions/variables.dart
+++ b/drift/lib/src/runtime/query_builder/expressions/variables.dart
@@ -74,15 +74,23 @@ class Variable<T extends Object> extends Expression<T> {
     var explicitStart = context.explicitVariableIndex;
 
     var mark = '?';
+    var suffix = '';
     if (context.dialect == SqlDialect.postgres) {
       explicitStart = 1;
       mark = '@';
+
+      if (value is List<int>) {
+        // We need to explicitly bind the variable as byte array. Otherwise
+        // a Uint8List like [1,2,3] would bind to "{1,2,3}" as bytes
+        suffix += ":bytea";
+      }
     }
 
     if (explicitStart != null) {
       context.buffer
         ..write(mark)
-        ..write(explicitStart + context.amountOfVariables);
+        ..write(explicitStart + context.amountOfVariables)
+        ..write(suffix);
       context.introduceVariable(
         this,
         mapToSimpleValue(context),

--- a/extras/drift_postgres/lib/src/pg_database.dart
+++ b/extras/drift_postgres/lib/src/pg_database.dart
@@ -58,9 +58,7 @@ class _PgDelegate extends DatabaseDelegate {
       final stmt = statements.statements[row.statementIndex];
       final args = row.arguments;
 
-      await _ec.execute(stmt,
-          substitutionValues: args.asMap().map((key, value) =>
-              MapEntry((key + 1).toString(), _convertValue(value))));
+      await _ec.execute(stmt, substitutionValues: _convertArgs(args));
     }
 
     return Future.value();
@@ -72,9 +70,7 @@ class _PgDelegate extends DatabaseDelegate {
     if (args.isEmpty) {
       return _ec.execute(statement);
     } else {
-      return _ec.execute(statement,
-          substitutionValues: args.asMap().map((key, value) =>
-              MapEntry((key + 1).toString(), _convertValue(value))));
+      return _ec.execute(statement, substitutionValues: _convertArgs(args));
     }
   }
 
@@ -90,9 +86,10 @@ class _PgDelegate extends DatabaseDelegate {
     if (args.isEmpty) {
       result = await _ec.query(statement);
     } else {
-      result = await _ec.query(statement,
-          substitutionValues: args.asMap().map((key, value) =>
-              MapEntry((key + 1).toString(), _convertValue(value))));
+      result = await _ec.query(
+        statement,
+        substitutionValues: _convertArgs(args),
+      );
     }
     return result.firstOrNull?[0] as int? ?? 0;
   }
@@ -105,9 +102,10 @@ class _PgDelegate extends DatabaseDelegate {
   @override
   Future<QueryResult> runSelect(String statement, List<Object?> args) async {
     await _ensureOpen();
-    final result = await _ec.query(statement,
-        substitutionValues: args.asMap().map((key, value) =>
-            MapEntry((key + 1).toString(), _convertValue(value))));
+    final result = await _ec.query(
+      statement,
+      substitutionValues: _convertArgs(args),
+    );
 
     return Future.value(QueryResult.fromRows(
         result.map((e) => e.toColumnMap()).toList(growable: false)));
@@ -125,6 +123,15 @@ class _PgDelegate extends DatabaseDelegate {
       return value.toInt();
     }
     return value;
+  }
+
+  Map<String, dynamic> _convertArgs(List<Object?> args) {
+    return args.asMap().map(
+          (key, value) => MapEntry(
+            (key + 1).toString(),
+            _convertValue(value),
+          ),
+        );
   }
 }
 

--- a/extras/drift_postgres/lib/src/pg_database.dart
+++ b/extras/drift_postgres/lib/src/pg_database.dart
@@ -25,7 +25,7 @@ class _PgDelegate extends DatabaseDelegate {
   final bool closeUnderlyingWhenClosed;
 
   @override
-  TransactionDelegate get transactionDelegate => _PgTransactionDelegate(_db);
+  TransactionDelegate get transactionDelegate => const NoTransactionDelegate();
 
   @override
   late DbVersionDelegate versionDelegate;
@@ -159,19 +159,5 @@ class _PgVersionDelegate extends DynamicVersionDelegate {
   Future<void> setSchemaVersion(int version) async {
     await database.query('UPDATE __schema SET version = @1',
         substitutionValues: {'1': version});
-  }
-}
-
-class _PgTransactionDelegate extends SupportedTransactionDelegate {
-  final PostgreSQLConnection _db;
-
-  const _PgTransactionDelegate(this._db);
-
-  @override
-  bool get managesLockInternally => false;
-
-  @override
-  Future startTransaction(Future Function(QueryDelegate) run) async {
-    await _db.transaction((connection) => run(_PgDelegate(_db, connection)));
   }
 }

--- a/extras/drift_postgres/test/drift_postgres_test.dart
+++ b/extras/drift_postgres/test/drift_postgres_test.dart
@@ -7,9 +7,6 @@ class PgExecutor extends TestExecutor {
   bool get supportsReturning => true;
 
   @override
-  bool get hackyVariables => true;
-
-  @override
   DatabaseConnection createConnection() {
     final pgConnection = PostgreSQLConnection('localhost', 5432, 'postgres',
         username: 'postgres', password: 'postgres');

--- a/extras/drift_postgres/test/drift_postgres_test.dart
+++ b/extras/drift_postgres/test/drift_postgres_test.dart
@@ -7,6 +7,9 @@ class PgExecutor extends TestExecutor {
   bool get supportsReturning => true;
 
   @override
+  bool get supportsNestedTransactions => true;
+
+  @override
   DatabaseConnection createConnection() {
     final pgConnection = PostgreSQLConnection('localhost', 5432, 'postgres',
         username: 'postgres', password: 'postgres');

--- a/extras/integration_tests/drift_testcases/lib/database/database.dart
+++ b/extras/integration_tests/drift_testcases/lib/database/database.dart
@@ -69,7 +69,7 @@ class PreferenceConverter extends NullAwareTypeConverter<Preferences, String> {
         'ORDER BY (SELECT COUNT(*) FROM friendships '
         'WHERE first_user = u.id OR second_user = u.id) DESC LIMIT :amount',
     'amountOfGoodFriends': 'SELECT COUNT(*) FROM friendships f WHERE '
-        'f.really_good_friends = 1 AND '
+        'f.really_good_friends = TRUE AND '
         '(f.first_user = :user OR f.second_user = :user)',
     'friendshipsOf': ''' SELECT
           f.really_good_friends, "user".**

--- a/extras/integration_tests/drift_testcases/lib/database/database.g.dart
+++ b/extras/integration_tests/drift_testcases/lib/database/database.g.dart
@@ -555,7 +555,7 @@ abstract class _$Database extends GeneratedDatabase {
 
   Selectable<int> amountOfGoodFriends(int user) {
     return customSelect(
-        'SELECT COUNT(*) AS _c0 FROM friendships AS f WHERE f.really_good_friends = 1 AND(f.first_user = @1 OR f.second_user = @1)',
+        'SELECT COUNT(*) AS _c0 FROM friendships AS f WHERE f.really_good_friends = TRUE AND(f.first_user = @1 OR f.second_user = @1)',
         variables: [
           Variable<int>(user)
         ],


### PR DESCRIPTION
I took a stab at improving the support for the Postgres dialect in the integration tests.

I fixed the variable binding test which were being skipped, but other issues remain which I will briefly mention.

One is the query `amountOfGoodFriends` which uses `WHERE f.really_good_friends = 1`.
That expression is invalid in postgres, as a bool is being compared with an int. Do you have any idea in mind with how to solve this?

The other is nested transaction support. Is there any reason why the Postgres implementation is not using the same logic as the SAVEPOINTs in the nested transactions for regular drift + sqlite? 

I've encountered with https://github.com/isoos/postgresql-dart/issues/85 so I was looking for a way to handle nested transactions at the library level.

As for the PR, casting the SELECT expression in the test was the main fix, but for UInt8List it's not enough, as the output is `"{1,2,3,..}"` (with curly braces) instead of the bytes 1,2,3...