### PR TITLE
fix parsing of nested cte's

### DIFF
--- a/sqlparser/lib/src/reader/parser.dart
+++ b/sqlparser/lib/src/reader/parser.dart
@@ -1350,7 +1350,7 @@ class Parser {
       return tableRef;
     } else if (_matchOne(TokenType.leftParen)) {
       final first = _previous;
-      final innerStmt = select()!;
+      final innerStmt = _fullSelect()!;
       _consume(TokenType.rightParen,
           'Expected a right bracket to terminate the inner select');
 


### PR DESCRIPTION
Nested CTE's are currently throwing an generator error.

```
nestedCte:
  SELECT
    *
    FROM
      (
	      WITH cte AS (
	          SELECT 1 AS val
	      )
	      SELECT * from cte
      )
```

Resulting error: `Null check operator used on a null value`