### PR TITLE
Expose rowid in results when using FTS5 with content table

### DIFF
--- a/sqlparser/lib/src/analysis/schema/column.dart
+++ b/sqlparser/lib/src/analysis/schema/column.dart
@@ -183,10 +183,11 @@ class ViewColumn extends Column with DelegatedColumn implements ColumnWithType {
 class RowId extends TableColumn {
   // note that such alias is always called "rowid" in the result set -
   // "SELECT oid FROM table" yields a sinle column called "rowid"
-  RowId() : super('rowid', const ResolvedType(type: BasicType.int));
+  RowId({this.includedInResults = false})
+      : super('rowid', const ResolvedType(type: BasicType.int));
 
   @override
-  bool get includedInResults => false;
+  final bool includedInResults;
 }
 
 /// A column that is created by an expression. For instance, in the select

--- a/sqlparser/lib/src/engine/module/fts5.dart
+++ b/sqlparser/lib/src/engine/module/fts5.dart
@@ -122,7 +122,8 @@ class Fts5Table extends Table {
   }) : super(
           name: name,
           resolvedColumns: [
-            if (contentTable != null && contentRowId != null) RowId(),
+            if (contentTable != null && contentRowId != null)
+              RowId(includedInResults: true),
             ...columns,
             _Fts5RankColumn(),
             _Fts5TableColumn(name),

--- a/sqlparser/test/engine/module/fts5_test.dart
+++ b/sqlparser/test/engine/module/fts5_test.dart
@@ -34,9 +34,10 @@ void main() {
           .read(result.root as TableInducingStatement);
 
       expect(table.name, 'foo');
-      expect(table.resultColumns,
-          [isA<Column>().having((c) => c.name, 'name', 'bar')]);
-      expect(table.findColumn('oid'), isA<RowId>());
+      expect(table.resultColumns, [
+        isA<RowId>().having((c) => c.name, 'name', 'rowid'),
+        isA<Column>().having((c) => c.name, 'name', 'bar')
+      ]);
 
       expect(
         table,


### PR DESCRIPTION
It is required to provide the rowid when inserting elements into FTS5 (referring the entry in the referenced table). So it is required to expose rowid.