### PR TITLE
Fix `schema generate` instruction for migration tests

### DIFF
--- a/docs/pages/docs/Advanced Features/migrations.md
+++ b/docs/pages/docs/Advanced Features/migrations.md
@@ -396,7 +396,11 @@ This can be used to insert data before a migration. After the migration ran, you
 Note that you can't use the regular database class from you app for this, since its data classes always expect the latest
 schema. However, you can instruct drift to generate older snapshots of your data classes and companions for this purpose.
 To enable this feature, pass the `--data-classes` and `--companions` command-line arguments to the `drift_dev schema generate`
-command.
+command:
+
+```
+$ dart run drift_dev schema generate --data-classes --companions drift_schemas/ test/generated_migrations/
+```
 
 Then, you can import the generated classes with an alias:
 


### PR DESCRIPTION
Without these flags, following the example code below leads to an error:

    Unsupported operation: TableInfo.map in schema verification code

because the generated code has a stub implementation of `map`.

The README in `examples/migrations_example`, which has very similar test code, says to use these flags.  So use them here.