### PR TITLE
Fix melos package filters

### DIFF
--- a/melos.yaml
+++ b/melos.yaml
@@ -26,12 +26,12 @@ scripts:
   build:
     run: flutter pub run build_runner build --delete-conflicting-outputs
     exec: {concurrency: 1}
-    select-package:
-      depends-on: build_runner
+    packageFilters:
+      dependsOn: build_runner
 
   test:
     run: dart test
     exec: {concurrency: 1}
-    select-package:
-      depends-on: test
+    packageFilters:
+      dependsOn: test
       ignore: drift_postgres # this is an integration test


### PR DESCRIPTION
As part of Melos 3.0.0 we changed all configuration options to camel case to be more consistent and renamed some options to be more self documenting.