### PR TITLE
Upsert constraint support DO NOTHING

### DIFF
--- a/drift/CHANGELOG.md
+++ b/drift/CHANGELOG.md
@@ -9,6 +9,7 @@
   in the database class, the schema version in the database will now be downgraded.
 - When using a drift isolate in the same engine group, errors on the remote end are
   reported as-is instead of wrapping them in a `DriftRemoteException`.
+- Added support for `DO NOTHING` during upsert operations with constraint violations
 
 ## 2.5.0
 

--- a/drift/test/database/statements/insert_test.dart
+++ b/drift/test/database/statements/insert_test.dart
@@ -340,6 +340,34 @@ void main() {
     ));
   });
 
+  test('can use do nothing on upsert', () async {
+    await db.into(db.todosTable).insert(
+          TodosTableCompanion.insert(content: 'my content'),
+          onConflict: DoNothing(),
+        );
+
+    verify(executor.runInsert(
+      'INSERT INTO "todos" ("content") VALUES (?) '
+      'ON CONFLICT("id") DO NOTHING',
+      argThat(equals(['my content'])),
+    ));
+  });
+
+  test('can use a custom conflict clause with do nothing', () async {
+    await db.into(db.todosTable).insert(
+          TodosTableCompanion.insert(content: 'my content'),
+          onConflict: DoNothing(
+            target: [db.todosTable.content],
+          ),
+        );
+
+    verify(executor.runInsert(
+      'INSERT INTO "todos" ("content") VALUES (?) '
+      'ON CONFLICT("content") DO NOTHING',
+      argThat(equals(['my content'])),
+    ));
+  });
+
   test('insertOnConflictUpdate', () async {
     when(executor.runInsert(any, any)).thenAnswer((_) => Future.value(3));
 


### PR DESCRIPTION
This PR adds `ON CONFLICT (...) DO NOTHING` support for upserts.

Yes, there is `INSERT OR IGNORE INTO` but this will swallow other errors too:
`... No error is returned for uniqueness, NOT NULL, and UNIQUE constraint errors when the IGNORE conflict resolution algorithm is used` (https://www.sqlite.org/lang_conflict.html)

With `DO NOTHING` we explicitly target constraint errors.