### PR TITLE
fix: use async syntax to fix timeout when closing database in unit tests

### DIFF
--- a/drift/lib/src/sqlite3/database.dart
+++ b/drift/lib/src/sqlite3/database.dart
@@ -104,8 +104,8 @@ abstract class Sqlite3Delegate<DB extends CommonDatabase>
 
   @override
   @mustCallSuper
-  Future<void> close() {
-    return Future(_preparedStmtsCache.disposeAll);
+  Future<void> close() async {
+    _preparedStmtsCache.disposeAll();
   }
 
   /// Synchronously prepares and runs [statements] collected from a batch.


### PR DESCRIPTION
Closes #2458