### PR TITLE
Add individual stmt dispose when not caching statements

### DIFF
--- a/drift/lib/src/sqlite3/database.dart
+++ b/drift/lib/src/sqlite3/database.dart
@@ -149,7 +149,6 @@ abstract class Sqlite3Delegate<DB extends CommonDatabase>
   @override
   Future<QueryResult> runSelect(String statement, List<Object?> args) async {
     final stmt = _getPreparedStatement(statement);
-
     try {
       final result = stmt.select(args);
       return QueryResult.fromRows(result.toList());


### PR DESCRIPTION
I've included the try/finally when not using the prepared statements cache.

@simolus3 Do you want to use this PR to change the default flag of `cachePreparedStatements` to false? 

I'm not sure what could cause the SQLITE_BUSY error from #2464 in this context.