### PR TITLE
Bugfix: Only remove available implementations entries if they're available

### DIFF
--- a/docs/pages/docs/Other engines/web.md
+++ b/docs/pages/docs/Other engines/web.md
@@ -108,12 +108,21 @@ Unfortunately, there's no way (that I'm aware of) to add these headers onto `flu
 Drift will fall back to a (slightly slower) implementation in that case (see [storages](#storages)),
 but we recommend researching and enabling these headers in production if possible.
 
-Note that Safari 16 has an [unfortunate bug](https://bugs.webkit.org/show_bug.cgi?id=245346)
+{% block "blocks/alert" title="Downsides of COOP and COEP" color="danger" %}
+While these headers are required for the origin-private FileSystem Access API
+and bring a security benefit, there are some known problems:
+
+- These headers are incompatible with some other packages opening popups,
+   such as the ones used for [Google Auth](https://developers.google.com/identity/gsi/web/guides/get-google-api-clientid?hl=en#cross_origin_opener_policy).
+- Safari 16 has an [unfortunate bug](https://bugs.webkit.org/show_bug.cgi?id=245346)
 preventing dedicated workers to be loaded from cache with these headers. However, shared and service workers
 are unaffected by this.
 
-These headers are incompatible with [Google Auth
-Popups](https://developers.google.com/identity/gsi/web/guides/get-google-api-clientid#:~:text=com%2Fgsi%2F%3B-,Cross%20Origin%20Opener%20Policy,popup%20window%20or%20similar%20bugs.).
+Please carefully test your app with these headers to evaluate whether you might
+be affected by these limitations.
+If the headers break your app, you should not enable them - drift will fall back
+to another (potentially slower) implementation in that case.
+{% endblock %}
 
 ### Setup in Dart
 

--- a/docs/pages/docs/Other engines/web.md
+++ b/docs/pages/docs/Other engines/web.md
@@ -112,6 +112,9 @@ Note that Safari 16 has an [unfortunate bug](https://bugs.webkit.org/show_bug.cg
 preventing dedicated workers to be loaded from cache with these headers. However, shared and service workers
 are unaffected by this.
 
+These headers are incompatible with [Google Auth
+Popups](https://developers.google.com/identity/gsi/web/guides/get-google-api-clientid#:~:text=com%2Fgsi%2F%3B-,Cross%20Origin%20Opener%20Policy,popup%20window%20or%20similar%20bugs.).
+
 ### Setup in Dart
 
 From a perspective of the Dart code used, drift on the web is similar to drift on other platforms.

--- a/drift/lib/src/web/wasm_setup.dart
+++ b/drift/lib/src/web/wasm_setup.dart
@@ -93,11 +93,19 @@ class WasmDatabaseOpener {
     // format to avoid data loss (e.g. after a browser update that enables a
     // otherwise preferred storage implementation). In the future, we might want
     // to consider migrating between storage implementations as well.
-    if (_existsInIndexedDb) {
+    if (_existsInIndexedDb &&
+        (availableImplementations
+                .contains(WasmStorageImplementation.sharedIndexedDb) ||
+            availableImplementations
+                .contains(WasmStorageImplementation.unsafeIndexedDb))) {
       availableImplementations.removeWhere((element) =>
           element != WasmStorageImplementation.sharedIndexedDb &&
           element != WasmStorageImplementation.unsafeIndexedDb);
-    } else if (_existsInOpfs) {
+    } else if (_existsInOpfs &&
+        (availableImplementations
+                .contains(WasmStorageImplementation.opfsShared) ||
+            availableImplementations
+                .contains(WasmStorageImplementation.opfsLocks))) {
       availableImplementations.removeWhere((element) =>
           element != WasmStorageImplementation.opfsShared &&
           element != WasmStorageImplementation.opfsLocks);

--- a/extras/integration_tests/web_wasm/test/drift_wasm_test.dart
+++ b/extras/integration_tests/web_wasm/test/drift_wasm_test.dart
@@ -176,6 +176,22 @@ void main() {
             expect(await driver.amountOfRows, 1);
           },
         );
+
+        if (!browser.supports(WasmStorageImplementation.opfsShared)) {
+          test('uses indexeddb after OPFS becomes unavailable', () async {
+            // This browser only supports OPFS with the right headers. If they
+            // are ever removed, data is lost (nothing we could do about that),
+            // but drift should continue to work.
+            await driver.openDatabase(WasmStorageImplementation.opfsLocks);
+            await driver.insertIntoDatabase();
+            expect(await driver.amountOfRows, 1);
+            await Future.delayed(const Duration(seconds: 2));
+
+            await driver.driver.get('http://localhost:8080/no-coep');
+            await driver.openDatabase();
+            expect(await driver.amountOfRows, isZero);
+          });
+        }
       }
     });
   }


### PR DESCRIPTION
Hey, thanks so much for the wonderful library! It's an absolute fave of mine in the Flutter ecosystem. Incredibly well built, thank you for all of your effort.

At Superlist, we've just started using the new Web Support and I ran into one funny issue.

I added the headers to get `opfs` to work. Everything looked good while logged in. However, I then realized the headers block our Google Auth Popup from working, and so I had to remove them. Of course, that also meant we had to fall back from the `opfsShared` shared implementation to a `sharedIndexedDb` implementation.

However, after I removed the headers, the library fell back to an `inMemory` implementation instead of a `sharedIndexedDb` implementation. Why? Because the previous files "_existsInOpfs" even though that implementation was no longer available due to the change to the headers.

Therefore, the `List<WasmStorageImplementation> availableImplementations` went from:

```
[
    WasmStorageImplementation.inMemory,
   WasmStorageImplementation.sharedIndexedDb,
   WasmStorageImplementation.unsafeIndexedDb,
  ];
```

to an empty array. The fix: you should only remove entries in that array if the previous database exists *and* it's still an available implementation.

I've also added to the documentation for folks to be careful about using this with Google Auth popups and linked to the issue. Hope this helps make this awesome library a bit better, or also happy to hear about alternative ways to handle the problem if this is not a good solution.