### PR TITLE
Fix Assertion failure during setting up router in example app

### DIFF
--- a/examples/app/lib/main.dart
+++ b/examples/app/lib/main.dart
@@ -36,8 +36,7 @@ class MyApp extends StatelessWidget {
           primarySwatch: Colors.amber,
           typography: Typography.material2018(),
         ),
-        routeInformationParser: _router.routeInformationParser,
-        routerDelegate: _router.routerDelegate,
+        routerConfig: _router,
       ),
     );
   }


### PR DESCRIPTION
Fixes the following assertion failure:

```
The following assertion was thrown building DefaultSelectionStyle:
Assertion failed:
file://.pub-cache/hosted/pub.dev/go_router-9.0.0/lib/src/parser.dart:63:12
parser.dart:63
routeInformation.state != null
is not true
The relevant error-causing widget was:
  MaterialApp
MaterialApp:file://drift/examples/app/lib/main.dart:33:26
main.dart:33
```