### PR TITLE
Support listing and deleting wasm databases

### DIFF
--- a/drift/lib/src/web/wasm_setup.dart
+++ b/drift/lib/src/web/wasm_setup.dart
@@ -13,7 +13,6 @@ import 'dart:async';
 import 'dart:html';
 
 import 'package:async/async.dart';
-import 'package:collection/collection.dart';
 import 'package:drift/drift.dart';
 import 'package:drift/remote.dart';
 import 'package:drift/wasm.dart';
@@ -25,7 +24,6 @@ import 'package:sqlite3/wasm.dart';
 import 'broadcast_stream_queries.dart';
 import 'channel.dart';
 import 'wasm_setup/protocol.dart';
-import 'wasm_setup/shared.dart';
 
 /// Whether the `crossOriginIsolated` JavaScript property is true in the current
 /// context.
@@ -38,7 +36,7 @@ bool get supportsSharedWorkers => hasProperty(globalThis, 'SharedWorker');
 /// Whether dedicated workers can be constructed in the current context.
 bool get supportsWorkers => hasProperty(globalThis, 'Worker');
 
-class WasmDatabaseOpener2 {
+class WasmDatabaseOpener {
   final Uri sqlite3WasmUri;
   final Uri driftWorkerUri;
 
@@ -53,7 +51,7 @@ class WasmDatabaseOpener2 {
   MessagePort? _sharedWorker;
   Worker? _dedicatedWorker;
 
-  WasmDatabaseOpener2(
+  WasmDatabaseOpener(
     this.sqlite3WasmUri,
     this.driftWorkerUri,
     this.databaseName,
@@ -89,7 +87,21 @@ class WasmDatabaseOpener2 {
   }
 
   Future<WasmProbeResult> probe() async {
-    await _probeDedicated();
+    try {
+      await _probeShared();
+    } on Object {
+      _sharedWorker?.close();
+      _sharedWorker = null;
+    }
+    try {
+      await _probeDedicated();
+    } on Object {
+      _dedicatedWorker?.terminate();
+      _dedicatedWorker = null;
+    }
+
+    return _ProbeResult(availableImplementations, existingDatabases.toList(),
+        missingFeatures, this);
   }
 
   Future<void> _probeDedicated() async {
@@ -119,9 +131,40 @@ class WasmDatabaseOpener2 {
       missingFeatures.add(MissingBrowserFeature.dedicatedWorkers);
     }
   }
+
+  Future<void> _probeShared() async {
+    if (supportsSharedWorkers) {
+      final sharedWorker =
+          SharedWorker(driftWorkerUri.toString(), 'drift worker');
+      final port = _sharedWorker = sharedWorker.port!;
+
+      final sharedMessages =
+          StreamQueue(_readMessages(port.onMessage, sharedWorker.onError));
+
+      // First, the shared worker will tell us which features it supports.
+      _createCompatibilityCheck().sendToPort(port);
+      final sharedFeatures =
+          await sharedMessages.nextNoError as SharedWorkerCompatibilityResult;
+      await sharedMessages.cancel();
+
+      _handleCompatibilityResult(sharedFeatures);
+
+      // Prefer to use the shared worker to host the database if it supports the
+      // necessary APIs.
+      if (sharedFeatures.canSpawnDedicatedWorkers &&
+          sharedFeatures.dedicatedWorkersCanUseOpfs) {
+        availableImplementations.add(WasmStorageImplementation.opfsShared);
+      }
+      if (sharedFeatures.canUseIndexedDb) {
+        availableImplementations.add(WasmStorageImplementation.sharedIndexedDb);
+      }
+    } else {
+      missingFeatures.add(MissingBrowserFeature.sharedWorkers);
+    }
+  }
 }
 
-final class _ProbeResult extends WasmProbeResult {
+final class _ProbeResult implements WasmProbeResult {
   @override
   final List<WasmStorageImplementation> availableStorages;
 
@@ -131,7 +174,7 @@ final class _ProbeResult extends WasmProbeResult {
   @override
   final Set<MissingBrowserFeature> missingFeatures;
 
-  final WasmDatabaseOpener2 opener;
+  final WasmDatabaseOpener opener;
 
   _ProbeResult(
     this.availableStorages,
@@ -142,124 +185,27 @@ final class _ProbeResult extends WasmProbeResult {
 
   @override
   Future<DatabaseConnection> open(
-      WasmStorageImplementation implementation, String name,
-      {FutureOr<Uint8List?> Function()? initializeDatabase}) async {
-    // TODO: implement open
-    throw UnimplementedError();
-  }
-
-  @override
-  Future<void> deleteDatabase(
-      DatabaseLocation implementation, String name) async {
-    // TODO: implement deleteDatabase
-    throw UnimplementedError();
-  }
-}
-
-class WasmDatabaseOpener {
-  final Uri sqlite3WasmUri;
-  final Uri driftWorkerUri;
-  final String databaseName;
-  FutureOr<Uint8List?> Function()? initializeDatabase;
-
-  final Set<MissingBrowserFeature> missingFeatures = {};
-  final List<WasmStorageImplementation> availableImplementations = [
-    WasmStorageImplementation.inMemory,
-  ];
-
-  bool _existsInIndexedDb = false;
-  bool _existsInOpfs = false;
-
-  MessagePort? _sharedWorker;
-  Worker? _dedicatedWorker;
-
-  WasmDatabaseOpener({
-    required this.sqlite3WasmUri,
-    required this.driftWorkerUri,
-    required this.databaseName,
-    this.initializeDatabase,
-  });
-
-  Future<void> probe() async {
-    try {
-      await _probeShared();
-    } on Object {
-      _sharedWorker?.close();
-      _sharedWorker = null;
-    }
-    try {
-      await _probeDedicated();
-    } on Object {
-      _dedicatedWorker?.terminate();
-      _dedicatedWorker = null;
-    }
-
-    if (_dedicatedWorker == null) {
-      // Something is wrong with web workers, let's see if we can get things
-      // running without a worker.
-      if (await checkIndexedDbSupport()) {
-        availableImplementations.add(WasmStorageImplementation.unsafeIndexedDb);
-        _existsInIndexedDb = await checkIndexedDbExists(databaseName);
-      }
-    }
-  }
-
-  Future<WasmDatabaseResult> open() async {
-    await probe();
-
-    // If we have an existing database in storage, we want to keep using that
-    // format to avoid data loss (e.g. after a browser update that enables a
-    // otherwise preferred storage implementation). In the future, we might want
-    // to consider migrating between storage implementations as well.
-    if (_existsInIndexedDb &&
-        (availableImplementations
-                .contains(WasmStorageImplementation.sharedIndexedDb) ||
-            availableImplementations
-                .contains(WasmStorageImplementation.unsafeIndexedDb))) {
-      availableImplementations.removeWhere((element) =>
-          element != WasmStorageImplementation.sharedIndexedDb &&
-          element != WasmStorageImplementation.unsafeIndexedDb);
-    } else if (_existsInOpfs &&
-        (availableImplementations
-                .contains(WasmStorageImplementation.opfsShared) ||
-            availableImplementatioobjectns
-                .contains(WasmStorageImplementation.opfsLocks))) {
-      availableImplementations.removeWhere((element) =>
-          element != WasmStorageImplementation.opfsShared &&
-          element != WasmStorageImplementation.opfsLocks);
-    }
-
-    // Enum values are ordered by preferrability, so just pick the best option
-    // left.
-    availableImplementations.sortBy<num>((element) => element.index);
-    return await _connect(availableImplementations.firstOrNull ??
-        WasmStorageImplementation.inMemory);
-  }
-
-  /// Opens a database with the given [storage] implementation, bypassing the
-  /// feature detection. Must be called after [probe].
-  Future<WasmDatabaseResult> openWith(WasmStorageImplementation storage) async {
-    return await _connect(storage);
-  }
-
-  Future<WasmDatabaseResult> _connect(WasmStorageImplementation storage) async {
+    WasmStorageImplementation implementation,
+    String name, {
+    FutureOr<Uint8List?> Function()? initializeDatabase,
+  }) async {
     final channel = MessageChannel();
     final initializer = initializeDatabase;
     final initChannel = initializer != null ? MessageChannel() : null;
     final local = channel.port1.channel();
 
     final message = ServeDriftDatabase(
-      sqlite3WasmUri: sqlite3WasmUri,
+      sqlite3WasmUri: opener.sqlite3WasmUri,
       port: channel.port2,
-      storage: storage,
-      databaseName: databaseName,
+      storage: implementation,
+      databaseName: name,
       initializationPort: initChannel?.port2,
     );
 
-    final sharedWorker = _sharedWorker;
-    final dedicatedWorker = _dedicatedWorker;
+    final sharedWorker = opener._sharedWorker;
+    final dedicatedWorker = opener._dedicatedWorker;
 
-    switch (storage) {
+    switch (implementation) {
       case WasmStorageImplementation.opfsShared:
       case WasmStorageImplementation.sharedIndexedDb:
         // These are handled by the shared worker, so we can close the dedicated
@@ -275,14 +221,14 @@ class WasmDatabaseOpener {
         } else {
           // Workers seem to be broken, but we don't need them with this storage
           // mode.
-          return _hostDatabaseLocally(
-              storage, await IndexedDbFileSystem.open(dbName: databaseName));
+          return _hostDatabaseLocally(implementation,
+              await IndexedDbFileSystem.open(dbName: name), initializeDatabase);
         }
-
       case WasmStorageImplementation.inMemory:
         // Nothing works on this browser, so we'll fall back to an in-memory
         // database.
-        return _hostDatabaseLocally(storage, InMemoryFileSystem());
+        return _hostDatabaseLocally(
+            implementation, InMemoryFileSystem(), initializeDatabase);
     }
 
     initChannel?.port1.onMessage.listen((event) async {
@@ -299,7 +245,7 @@ class WasmDatabaseOpener {
     });
 
     var connection = await connectToRemoteAndInitialize(local);
-    if (storage == WasmStorageImplementation.opfsLocks) {
+    if (implementation == WasmStorageImplementation.opfsLocks) {
       // We want stream queries to update for writes in other tabs. For the
       // implementations backed by a shared worker, the worker takes care of
       // that.
@@ -311,20 +257,21 @@ class WasmDatabaseOpener {
         connection = DatabaseConnection(
           connection.executor,
           connectionData: connection.connectionData,
-          streamQueries: BroadcastStreamQueryStore(databaseName),
+          streamQueries: BroadcastStreamQueryStore(name),
         );
       }
     }
 
-    return WasmDatabaseResult(connection, storage, missingFeatures);
+    return connection;
   }
 
   /// Returns a database connection that doesn't use web workers.
-  Future<WasmDatabaseResult> _hostDatabaseLocally(
-      WasmStorageImplementation storage, VirtualFileSystem vfs) async {
-    final initializer = initializeDatabase;
-
-    final sqlite3 = await WasmSqlite3.loadFromUrl(sqlite3WasmUri);
+  Future<DatabaseConnection> _hostDatabaseLocally(
+    WasmStorageImplementation storage,
+    VirtualFileSystem vfs,
+    FutureOr<Uint8List?> Function()? initializer,
+  ) async {
+    final sqlite3 = await WasmSqlite3.loadFromUrl(opener.sqlite3WasmUri);
     sqlite3.registerVirtualFileSystem(vfs);
 
     if (initializer != null) {
@@ -338,76 +285,16 @@ class WasmDatabaseOpener {
       }
     }
 
-    return WasmDatabaseResult(
-      DatabaseConnection(
-        WasmDatabase(sqlite3: sqlite3, path: '/database'),
-      ),
-      storage,
-      missingFeatures,
+    return DatabaseConnection(
+      WasmDatabase(sqlite3: sqlite3, path: '/database'),
     );
   }
 
-  Future<void> _probeShared() async {
-    if (supportsSharedWorkers) {
-      final sharedWorker =
-          SharedWorker(driftWorkerUri.toString(), 'drift worker');
-      final port = _sharedWorker = sharedWorker.port!;
-
-      final sharedMessages =
-          StreamQueue(_readMessages(port.onMessage, sharedWorker.onError));
-
-      // First, the shared worker will tell us which features it supports.
-      RequestCompatibilityCheck(databaseName).sendToPort(port);
-      final sharedFeatures =
-          await sharedMessages.nextNoError as SharedWorkerCompatibilityResult;
-      await sharedMessages.cancel();
-      missingFeatures.addAll(sharedFeatures.missingFeatures);
-
-      _existsInOpfs |= sharedFeatures.opfsExists;
-      _existsInIndexedDb |= sharedFeatures.indexedDbExists;
-
-      // Prefer to use the shared worker to host the database if it supports the
-      // necessary APIs.
-      if (sharedFeatures.canSpawnDedicatedWorkers &&
-          sharedFeatures.dedicatedWorkersCanUseOpfs) {
-        availableImplementations.add(WasmStorageImplementation.opfsShared);
-      }
-      if (sharedFeatures.canUseIndexedDb) {
-        availableImplementations.add(WasmStorageImplementation.sharedIndexedDb);
-      }
-    } else {
-      missingFeatures.add(MissingBrowserFeature.sharedWorkers);
-    }
-  }
-
-  Future<void> _probeDedicated() async {
-    if (supportsWorkers) {
-      final dedicatedWorker =
-          _dedicatedWorker = Worker(driftWorkerUri.toString());
-      RequestCompatibilityCheck(databaseName).sendToWorker(dedicatedWorker);
-
-      final workerMessages = StreamQueue(
-          _readMessages(dedicatedWorker.onMessage, dedicatedWorker.onError));
-
-      final status = await workerMessages.nextNoError
-          as DedicatedWorkerCompatibilityResult;
-      missingFeatures.addAll(status.missingFeatures);
-
-      _existsInOpfs |= status.opfsExists;
-      _existsInIndexedDb |= status.indexedDbExists;
-
-      if (status.supportsNestedWorkers &&
-          status.canAccessOpfs &&
-          status.supportsSharedArrayBuffers) {
-        availableImplementations.add(WasmStorageImplementation.opfsLocks);
-      }
-
-      if (status.supportsIndexedDb) {
-        availableImplementations.add(WasmStorageImplementation.unsafeIndexedDb);
-      }
-    } else {
-      missingFeatures.add(MissingBrowserFeature.dedicatedWorkers);
-    }
+  @override
+  Future<void> deleteDatabase(
+      DatabaseLocation implementation, String name) async {
+    // TODO: implement deleteDatabase
+    throw UnimplementedError();
   }
 }
 

--- a/drift/lib/src/web/wasm_setup/dedicated_worker.dart
+++ b/drift/lib/src/web/wasm_setup/dedicated_worker.dart
@@ -3,11 +3,9 @@
 import 'dart:async';
 import 'dart:html';
 
+import 'package:drift/wasm.dart';
 import 'package:js/js_util.dart';
 import 'package:sqlite3/wasm.dart';
-// ignore: implementation_imports
-import 'package:sqlite3/src/wasm/js_interop/file_system_access.dart';
-import 'package:path/path.dart' as p;
 
 import '../../utils/synchronized.dart';
 import 'protocol.dart';
@@ -48,32 +46,25 @@ class DedicatedDriftWorker {
         });
 
         final existingServer = _servers.servers[dbName];
+
         var indexedDbExists = false, opfsExists = false;
+        final existingDatabases = <(DatabaseLocation, String)>[];
+
+        if (supportsOpfs) {
+          for (final database in await opfsDatabases()) {
+            existingDatabases.add((DatabaseLocation.opfs, database));
+
+            if (database == dbName) {
+              opfsExists = true;
+            }
+          }
+        }
 
         if (existingServer != null) {
           indexedDbExists = existingServer.storage.isIndexedDbBased;
           opfsExists = existingServer.storage.isOpfsBased;
-        } else {
-          if (supportsIndexedDb) {
-            indexedDbExists = await checkIndexedDbExists(dbName);
-          }
-
-          if (supportsOpfs) {
-            final storage = storageManager!;
-            final pathSegments = p.url.split(pathForOpfs(dbName));
-
-            var directory = await storage.directory;
-            opfsExists = true;
-
-            for (final segment in pathSegments) {
-              try {
-                directory = await directory.getDirectory(segment);
-              } on Object {
-                opfsExists = false;
-                break;
-              }
-            }
-          }
+        } else if (supportsIndexedDb) {
+          indexedDbExists = await checkIndexedDbExists(dbName);
         }
 
         DedicatedWorkerCompatibilityResult(
@@ -84,6 +75,7 @@ class DedicatedDriftWorker {
               hasProperty(globalThis, 'SharedArrayBuffer'),
           opfsExists: opfsExists,
           indexedDbExists: indexedDbExists,
+          existingDatabases: existingDatabases,
         ).sendToClient(self);
       case ServeDriftDatabase():
         _servers.serve(message);

--- a/drift/lib/src/web/wasm_setup/protocol.dart
+++ b/drift/lib/src/web/wasm_setup/protocol.dart
@@ -103,7 +103,8 @@ final class SharedWorkerCompatibilityResult extends CompatibilityResult {
 
     final List<(DatabaseLocation, String)> existingDatabases;
     if (asList.length > 5) {
-      existingDatabases = EncodeLocations.readFromJs(asList[5] as JsArray);
+      existingDatabases =
+          EncodeLocations.readFromJs(asList[5] as List<dynamic>);
     } else {
       existingDatabases = const [];
     }
@@ -300,7 +301,7 @@ final class DedicatedWorkerCompatibilityResult extends CompatibilityResult {
 }
 
 extension EncodeLocations on List<(DatabaseLocation, String)> {
-  static List<(DatabaseLocation, String)> readFromJs(JsArray object) {
+  static List<(DatabaseLocation, String)> readFromJs(List<Object?> object) {
     final existing = <(DatabaseLocation, String)>[];
 
     for (final entry in object) {

--- a/drift/lib/src/web/wasm_setup/shared.dart
+++ b/drift/lib/src/web/wasm_setup/shared.dart
@@ -87,7 +87,7 @@ Future<bool> checkIndexedDbExists(String databaseName) async {
   try {
     final idb = getProperty<IdbFactory>(globalThis, 'indexedDB');
 
-    await idb.open(
+    final database = await idb.open(
       databaseName,
       // Current schema version used by the [IndexedDbFileSystem]
       version: 1,
@@ -100,11 +100,20 @@ Future<bool> checkIndexedDbExists(String databaseName) async {
     );
 
     indexedDbExists ??= true;
+    database.close();
   } catch (_) {
     // May throw due to us aborting in the upgrade callback.
   }
 
   return indexedDbExists ?? false;
+}
+
+/// Deletes a database from IndexedDb if supported.
+Future<void> deleteDatabaseInIndexedDb(String databaseName) async {
+  final idb = window.indexedDB;
+  if (idb != null) {
+    await idb.deleteDatabase(databaseName);
+  }
 }
 
 /// Constructs the path used by drift to store a database in the origin-private
@@ -132,6 +141,22 @@ Future<List<String>> opfsDatabases() async {
   ];
 }
 
+/// Deletes the OPFS folder storing a database with the given [databaseName] if
+/// such folder exists.
+Future<void> deleteDatabaseInOpfs(String databaseName) async {
+  final storage = storageManager;
+  if (storage == null) return;
+
+  var directory = await storage.directory;
+  try {
+    directory = await directory.getDirectory('drift_db');
+    await directory.removeEntry(databaseName, recursive: true);
+  } on Object {
+    // fine, an error probably means that the database didn't exist in the first
+    // place.
+  }
+}
+
 /// Manages drift servers.
 ///
 /// When using a shared worker, multiple clients may want to use different drift
@@ -151,7 +176,8 @@ class DriftServerController {
 
         final vfs = await switch (message.storage) {
           WasmStorageImplementation.opfsShared =>
-            SimpleOpfsFileSystem.loadFromStorage(message.databaseName),
+            SimpleOpfsFileSystem.loadFromStorage(
+                pathForOpfs(message.databaseName)),
           WasmStorageImplementation.opfsLocks =>
             _loadLockedWasmVfs(message.databaseName),
           WasmStorageImplementation.unsafeIndexedDb ||
@@ -190,7 +216,7 @@ class DriftServerController {
   Future<WasmVfs> _loadLockedWasmVfs(String databaseName) async {
     // Create SharedArrayBuffers to synchronize requests
     final options = WasmVfs.createOptions(
-      root: 'drift_db/$databaseName/',
+      root: pathForOpfs(databaseName),
     );
     final worker = Worker(Uri.base.toString());
 

--- a/drift/lib/src/web/wasm_setup/shared.dart
+++ b/drift/lib/src/web/wasm_setup/shared.dart
@@ -113,6 +113,25 @@ String pathForOpfs(String databaseName) {
   return 'drift_db/$databaseName';
 }
 
+/// Collects all drift OPFS databases.
+Future<List<String>> opfsDatabases() async {
+  final storage = storageManager;
+  if (storage == null) return const [];
+
+  var directory = await storage.directory;
+  try {
+    directory = await directory.getDirectory('drift_db');
+  } on Object {
+    // The drift_db folder doesn't exist, so there aren't any databases.
+    return const [];
+  }
+
+  return [
+    await for (final entry in directory.list())
+      if (entry.isDirectory) entry.name,
+  ];
+}
+
 /// Manages drift servers.
 ///
 /// When using a shared worker, multiple clients may want to use different drift

--- a/drift/lib/src/web/wasm_setup/types.dart
+++ b/drift/lib/src/web/wasm_setup/types.dart
@@ -182,6 +182,10 @@ abstract interface class WasmProbeResult {
   ///
   /// This method should not be called while a connection to the database is
   /// opened.
+  ///
+  /// This method is only supported when using the drift worker shipped with the
+  /// drift 2.11 release or later. This method will not work when using an older
+  /// worker.
   Future<void> deleteDatabase(ExistingDatabase database);
 }
 

--- a/drift/lib/wasm.dart
+++ b/drift/lib/wasm.dart
@@ -161,6 +161,10 @@ class WasmDatabase extends DelegatedDatabase {
   /// with that name exists in IndexedDb and whether it is a drift database.
   /// Drift is always able to list databases stored in OPFS, regardless of
   /// whether [databaseName] is passed or not.
+  ///
+  /// Note that this method is only fully supported when using the drift worker
+  /// shipped with the drift 2.11 release. Older workers are only supported when
+  /// [databaseName] is non-null.
   static Future<WasmProbeResult> probe({
     required Uri sqlite3Uri,
     required Uri driftWorkerUri,

--- a/drift/lib/wasm.dart
+++ b/drift/lib/wasm.dart
@@ -108,11 +108,11 @@ class WasmDatabase extends DelegatedDatabase {
     for (final (location, name) in probed.existingDatabases) {
       if (name == databaseName) {
         final implementationsForStorage = switch (location) {
-          DatabaseLocation.indexedDb => const [
+          WebStorageApi.indexedDb => const [
               WasmStorageImplementation.sharedIndexedDb,
               WasmStorageImplementation.unsafeIndexedDb
             ],
-          DatabaseLocation.opfs => const [
+          WebStorageApi.opfs => const [
               WasmStorageImplementation.opfsShared,
               WasmStorageImplementation.opfsLocks,
             ],

--- a/extras/integration_tests/web_wasm/README.md
+++ b/extras/integration_tests/web_wasm/README.md
@@ -1,18 +1,7 @@
 Integration tests for `package:drift/native.dart`.
 
-To test persistence, we need to instrument a browsers in a way not covered by the normal
-`test` package. For instance, we need to reload pages to ensure data is still there.
+To run the tests automatically (with us managing a browser driver), just run `dart test`.
 
-## Running tests with Firefox
-
-```
-geckodriver &
-dart run tool/drift_wasm_test.dart firefox http://localhost:4444
-```
-
-## Running tests with Chrome
-
-```
-chromedriver --port=4444 --url-base=wd/hub &
-dart run tool/drift_wasm_test.dart chrome http://localhost:4444/wd/hub/
-```
+To manually debug issues, it might make sense to trigger some functionality manually.
+You can run `dart run tool/server_manually.dart` to start a web server hosting the test
+content on http://localhost:8080.

--- a/extras/integration_tests/web_wasm/lib/driver.dart
+++ b/extras/integration_tests/web_wasm/lib/driver.dart
@@ -105,6 +105,7 @@ class DriftWebDriver {
       ({
         Set<WasmStorageImplementation> storages,
         Set<MissingBrowserFeature> missingFeatures,
+        List<ExistingDatabase> existing,
       })> probeImplementations() async {
     final rawResult = await driver
         .executeAsync('detectImplementations("", arguments[0])', []);
@@ -119,6 +120,13 @@ class DriftWebDriver {
         for (final entry in result['missing'])
           MissingBrowserFeature.values.byName(entry)
       },
+      existing: <ExistingDatabase>[
+        for (final entry in result['existing'])
+          (
+            WebStorageApi.byName[entry[0] as String]!,
+            entry[1] as String,
+          ),
+      ],
     );
   }
 
@@ -148,5 +156,11 @@ class DriftWebDriver {
     if (result != true) {
       throw 'Could not set initialization mode';
     }
+  }
+
+  Future<void> deleteDatabase(WebStorageApi storageApi, String name) async {
+    await driver.executeAsync('delete_database(arguments[0], arguments[1])', [
+      json.encode([storageApi.name, name]),
+    ]);
   }
 }

--- a/extras/integration_tests/web_wasm/test/drift_wasm_test.dart
+++ b/extras/integration_tests/web_wasm/test/drift_wasm_test.dart
@@ -118,6 +118,29 @@ void main() {
             }
           });
 
+          if (entry != WasmStorageImplementation.inMemory) {
+            test('delete', () async {
+              final impl = await driver.probeImplementations();
+              expect(impl.existing, isEmpty);
+
+              await driver.openDatabase(entry);
+              await driver.insertIntoDatabase();
+              await driver.waitForTableUpdate();
+
+              await driver.driver.refresh(); // Reset JS state
+
+              final newImpls = await driver.probeImplementations();
+              expect(newImpls.existing, hasLength(1));
+              final existing = newImpls.existing[0];
+              await driver.deleteDatabase(existing.$1, existing.$2);
+
+              await driver.driver.refresh();
+
+              final finalImpls = await driver.probeImplementations();
+              expect(finalImpls.existing, isEmpty);
+            });
+          }
+
           group(
             'initialization from ',
             () {

--- a/extras/integration_tests/web_wasm/web/main.dart
+++ b/extras/integration_tests/web_wasm/web/main.dart
@@ -5,14 +5,15 @@ import 'dart:js_util';
 import 'package:async/async.dart';
 import 'package:drift/drift.dart';
 import 'package:drift/wasm.dart';
-// ignore: invalid_use_of_internal_member
-import 'package:drift/src/web/wasm_setup.dart';
 import 'package:http/http.dart' as http;
 import 'package:web_wasm/initialization_mode.dart';
 import 'package:web_wasm/src/database.dart';
 import 'package:sqlite3/wasm.dart';
 
 const dbName = 'drift_test';
+final sqlite3WasmUri = Uri.parse('/sqlite3.wasm');
+final driftWorkerUri = Uri.parse('/worker.dart.js');
+
 TestDatabase? openedDatabase;
 StreamQueue<void>? tableUpdates;
 
@@ -31,7 +32,12 @@ void main() {
 
   document.getElementById('selfcheck')?.onClick.listen((event) async {
     print('starting');
-    final database = await _opener.open();
+    final database = await WasmDatabase.open(
+      databaseName: dbName,
+      sqlite3Uri: sqlite3WasmUri,
+      driftWorkerUri: driftWorkerUri,
+      initializeDatabase: _initializeDatabase,
+    );
 
     print('selected storage: ${database.chosenImplementation}');
     print('missing features: ${database.missingFeatures}');
@@ -54,77 +60,80 @@ void _addCallbackForWebDriver(String name, Future Function(String?) impl) {
   }));
 }
 
-WasmDatabaseOpener get _opener {
-  Future<Uint8List> Function()? initializeDatabase;
-
+Future<Uint8List?> _initializeDatabase() async {
   switch (initializationMode) {
     case InitializationMode.loadAsset:
-      initializeDatabase = () async {
-        final response = await http.get(Uri.parse('/initial.db'));
-        return response.bodyBytes;
-      };
+      final response = await http.get(Uri.parse('/initial.db'));
+      return response.bodyBytes;
+
     case InitializationMode.migrateCustomWasmDatabase:
-      initializeDatabase = () async {
-        // Let's first open a custom WasmDatabase, the way it would have been
-        // done before WasmDatabase.open.
-        final sqlite3 =
-            await WasmSqlite3.loadFromUrl(Uri.parse('/sqlite3.wasm'));
-        final fs = await IndexedDbFileSystem.open(dbName: dbName);
-        sqlite3.registerVirtualFileSystem(fs, makeDefault: true);
 
-        final wasmDb = WasmDatabase(sqlite3: sqlite3, path: '/app.db');
-        final db = TestDatabase(wasmDb);
-        await db
-            .into(db.testTable)
-            .insert(TestTableCompanion.insert(content: 'from old database'));
-        await db.close();
+      // Let's first open a custom WasmDatabase, the way it would have been
+      // done before WasmDatabase.open.
+      final sqlite3 = await WasmSqlite3.loadFromUrl(Uri.parse('/sqlite3.wasm'));
+      final fs = await IndexedDbFileSystem.open(dbName: dbName);
+      sqlite3.registerVirtualFileSystem(fs, makeDefault: true);
 
-        final (file: file, outFlags: _) =
-            fs.xOpen(Sqlite3Filename('/app.db'), 0);
-        final blob = Uint8List(file.xFileSize());
-        file.xRead(blob, 0);
-        file.xClose();
-        fs.xDelete('/app.db', 0);
-        await fs.close();
+      final wasmDb = WasmDatabase(sqlite3: sqlite3, path: '/app.db');
+      final db = TestDatabase(wasmDb);
+      await db
+          .into(db.testTable)
+          .insert(TestTableCompanion.insert(content: 'from old database'));
+      await db.close();
 
-        return blob;
-      };
-      break;
+      final (file: file, outFlags: _) = fs.xOpen(Sqlite3Filename('/app.db'), 0);
+      final blob = Uint8List(file.xFileSize());
+      file.xRead(blob, 0);
+      file.xClose();
+      fs.xDelete('/app.db', 0);
+      await fs.close();
+
+      return blob;
     case InitializationMode.none:
-      break;
+      return null;
   }
-
-  return WasmDatabaseOpener(
-    databaseName: dbName,
-    sqlite3WasmUri: Uri.parse('/sqlite3.wasm'),
-    driftWorkerUri: Uri.parse('/worker.dart.js'),
-    initializeDatabase: initializeDatabase,
-  );
 }
 
 Future<String> _detectImplementations(String? _) async {
-  final opener = _opener;
-  await opener.probe();
+  final result = await WasmDatabase.probe(
+    sqlite3Uri: sqlite3WasmUri,
+    driftWorkerUri: driftWorkerUri,
+    databaseName: dbName,
+  );
 
   return json.encode({
-    'impls': opener.availableImplementations.map((r) => r.name).toList(),
-    'missing': opener.missingFeatures.map((r) => r.name).toList(),
+    'impls': result.availableStorages.map((r) => r.name).toList(),
+    'missing': result.missingFeatures.map((r) => r.name).toList(),
   });
 }
 
 Future<void> _open(String? implementationName) async {
-  final opener = _opener;
-  WasmDatabaseResult result;
+  DatabaseConnection connection;
 
   if (implementationName != null) {
-    await opener.probe();
-    result = await opener
-        .openWith(WasmStorageImplementation.values.byName(implementationName));
+    final probeResult = await WasmDatabase.probe(
+      sqlite3Uri: sqlite3WasmUri,
+      driftWorkerUri: driftWorkerUri,
+      databaseName: dbName,
+    );
+
+    connection = await probeResult.open(
+      WasmStorageImplementation.values.byName(implementationName),
+      dbName,
+      initializeDatabase: _initializeDatabase,
+    );
   } else {
-    result = await opener.open();
+    final result = await WasmDatabase.open(
+      databaseName: dbName,
+      sqlite3Uri: sqlite3WasmUri,
+      driftWorkerUri: driftWorkerUri,
+      initializeDatabase: _initializeDatabase,
+    );
+
+    connection = result.resolvedExecutor;
   }
 
-  final db = openedDatabase = TestDatabase(result.resolvedExecutor);
+  final db = openedDatabase = TestDatabase(connection);
 
   // Make sure it works!
   await db.customSelect('SELECT 1').get();

--- a/extras/integration_tests/web_wasm/web/main.dart
+++ b/extras/integration_tests/web_wasm/web/main.dart
@@ -29,6 +29,18 @@ void main() {
     initializationMode = InitializationMode.values.byName(arg!);
     return true;
   });
+  _addCallbackForWebDriver('delete_database', (arg) async {
+    final result = await WasmDatabase.probe(
+      sqlite3Uri: sqlite3WasmUri,
+      driftWorkerUri: driftWorkerUri,
+    );
+
+    final decoded = json.decode(arg!);
+
+    await result.deleteDatabase(
+      (WebStorageApi.byName[decoded[0] as String]!, decoded[1] as String),
+    );
+  });
 
   document.getElementById('selfcheck')?.onClick.listen((event) async {
     print('starting');
@@ -104,6 +116,7 @@ Future<String> _detectImplementations(String? _) async {
   return json.encode({
     'impls': result.availableStorages.map((r) => r.name).toList(),
     'missing': result.missingFeatures.map((r) => r.name).toList(),
+    'existing': result.existingDatabases.map((r) => [r.$1.name, r.$2]).toList(),
   });
 }
 


### PR DESCRIPTION
This adds the `WasmDatabase.probe` API, which can be used to list existing databases and delete them. It can also be used to open a database with a specific storage implementation which can be useful for apps needing a higher degree of customization.

@FaFre Feel free to take a look [at the API](https://github.com/simolus3/drift/pull/2554/files#diff-be9f1be52a4a84dba71787a14fea605e8bbf79a62b87f0905a6c06d1dc759d3e) to see if would satisfy your requirements. Unfortunately we can't efficiently iterate through IndexedDb databases, so we can only give you a complete list of OPFS databases.