### PR TITLE
remove leading slashes from URI paths

### DIFF
--- a/docs/lib/sample/database.dart
+++ b/docs/lib/sample/database.dart
@@ -86,8 +86,8 @@ class Database extends _$Database {
 Future<WasmDatabaseResult> connect() async {
   final result = await WasmDatabase.open(
     databaseName: 'todo_example',
-    sqlite3Uri: Uri.parse('/sqlite3.wasm'),
-    driftWorkerUri: Uri.parse('/drift_worker.dart.js'),
+    sqlite3Uri: Uri.parse('sqlite3.wasm'),
+    driftWorkerUri: Uri.parse('drift_worker.dart.js'),
   );
 
   if (!result.chosenImplementation.fullySupported) {

--- a/docs/lib/snippets/engines/web.dart
+++ b/docs/lib/snippets/engines/web.dart
@@ -10,8 +10,8 @@ DatabaseConnection connectOnWeb() {
   return DatabaseConnection.delayed(Future(() async {
     final result = await WasmDatabase.open(
       databaseName: 'my_app_db', // prefer to only use valid identifiers here
-      sqlite3Uri: Uri.parse('/sqlite3.wasm'),
-      driftWorkerUri: Uri.parse('/drift_worker.dart.js'),
+      sqlite3Uri: Uri.parse('sqlite3.wasm'),
+      driftWorkerUri: Uri.parse('drift_worker.dart.js'),
     );
 
     if (result.missingFeatures.isNotEmpty) {
@@ -64,8 +64,8 @@ DatabaseConnection migrateAndConnect() {
     // Then you can migrate like this
     final result = await WasmDatabase.open(
       databaseName: 'my_app',
-      sqlite3Uri: Uri.parse('/sqlite3.wasm'),
-      driftWorkerUri: Uri.parse('/drift_worker.dart.js'),
+      sqlite3Uri: Uri.parse('sqlite3.wasm'),
+      driftWorkerUri: Uri.parse('drift_worker.dart.js'),
       initializeDatabase: () async {
         // Manually open the file system previously used
         final fs = await IndexedDbFileSystem.open(dbName: 'my_app');
@@ -101,8 +101,8 @@ DatabaseConnection migrateFromLegacy() {
     // #docregion migrate-legacy
     final result = await WasmDatabase.open(
       databaseName: 'my_app',
-      sqlite3Uri: Uri.parse('/sqlite3.wasm'),
-      driftWorkerUri: Uri.parse('/drift_worker.dart.js'),
+      sqlite3Uri: Uri.parse('sqlite3.wasm'),
+      driftWorkerUri: Uri.parse('drift_worker.dart.js'),
       initializeDatabase: () async {
         final storage = await DriftWebStorage.indexedDbIfSupported('old_db');
         await storage.open();

--- a/docs/web/web/compatibility.dart
+++ b/docs/web/web/compatibility.dart
@@ -18,8 +18,8 @@ void main() async {
     try {
       final db = await WasmDatabase.open(
         databaseName: 'test_db',
-        sqlite3Uri: Uri.parse('/sqlite3.wasm'),
-        driftWorkerUri: Uri.parse('/drift_worker.dart.js'),
+        sqlite3Uri: Uri.parse('sqlite3.wasm'),
+        driftWorkerUri: Uri.parse('drift_worker.dart.js'),
       );
 
       results.innerText += '''

--- a/examples/app/lib/database/connection/web.dart
+++ b/examples/app/lib/database/connection/web.dart
@@ -9,8 +9,8 @@ DatabaseConnection connect() {
   return DatabaseConnection.delayed(Future(() async {
     final db = await WasmDatabase.open(
       databaseName: 'todo-app',
-      sqlite3Uri: Uri.parse('/sqlite3.wasm'),
-      driftWorkerUri: Uri.parse('/drift_worker.js'),
+      sqlite3Uri: Uri.parse('sqlite3.wasm'),
+      driftWorkerUri: Uri.parse('drift_worker.js'),
     );
 
     if (db.missingFeatures.isNotEmpty) {

--- a/extras/integration_tests/web_wasm/README.md
+++ b/extras/integration_tests/web_wasm/README.md
@@ -3,5 +3,5 @@ Integration tests for `package:drift/native.dart`.
 To run the tests automatically (with us managing a browser driver), just run `dart test`.
 
 To manually debug issues, it might make sense to trigger some functionality manually.
-You can run `dart run tool/server_manually.dart` to start a web server hosting the test
-content on http://localhost:8080.
+You can run `dart run tool/serve_manually.dart` to start a web server hosting the test
+content on <http://localhost:8080>.

--- a/extras/integration_tests/web_wasm/web/main.dart
+++ b/extras/integration_tests/web_wasm/web/main.dart
@@ -11,8 +11,8 @@ import 'package:web_wasm/src/database.dart';
 import 'package:sqlite3/wasm.dart';
 
 const dbName = 'drift_test';
-final sqlite3WasmUri = Uri.parse('/sqlite3.wasm');
-final driftWorkerUri = Uri.parse('/worker.dart.js');
+final sqlite3WasmUri = Uri.parse('sqlite3.wasm');
+final driftWorkerUri = Uri.parse('worker.dart.js');
 
 TestDatabase? openedDatabase;
 StreamQueue<void>? tableUpdates;
@@ -82,18 +82,18 @@ Future<Uint8List?> _initializeDatabase() async {
 
       // Let's first open a custom WasmDatabase, the way it would have been
       // done before WasmDatabase.open.
-      final sqlite3 = await WasmSqlite3.loadFromUrl(Uri.parse('/sqlite3.wasm'));
+      final sqlite3 = await WasmSqlite3.loadFromUrl(Uri.parse('sqlite3.wasm'));
       final fs = await IndexedDbFileSystem.open(dbName: dbName);
       sqlite3.registerVirtualFileSystem(fs, makeDefault: true);
 
-      final wasmDb = WasmDatabase(sqlite3: sqlite3, path: '/app.db');
+      final wasmDb = WasmDatabase(sqlite3: sqlite3, path: 'app.db');
       final db = TestDatabase(wasmDb);
       await db
           .into(db.testTable)
           .insert(TestTableCompanion.insert(content: 'from old database'));
       await db.close();
 
-      final (file: file, outFlags: _) = fs.xOpen(Sqlite3Filename('/app.db'), 0);
+      final (file: file, outFlags: _) = fs.xOpen(Sqlite3Filename('app.db'), 0);
       final blob = Uint8List(file.xFileSize());
       file.xRead(blob, 0);
       file.xClose();


### PR DESCRIPTION
In order to allow for drift web setups where the app is served from a subdirectory, the leading slashes have been removed from the Uri.parse() calls.