### PR TITLE
add a dependency from the default target to the custom target

### DIFF
--- a/drift/build.yaml
+++ b/drift/build.yaml
@@ -10,6 +10,8 @@ targets:
     sources:
       exclude:
         - "test/generated/custom_tables.dart"
+    dependencies:
+      - :custom
     builders:
       drift_dev:
         options:


### PR DESCRIPTION
See https://github.com/dart-lang/build/pull/3556#issuecomment-1691965824 - this should fix the customer tests failure.

I will have to figure out how we want to roll this out longer term based on the breaking nature.