### PR TITLE
fix code generation for `enum` with generics

### DIFF
--- a/drift_dev/lib/src/analysis/resolver/shared/dart_types.dart
+++ b/drift_dev/lib/src/analysis/resolver/shared/dart_types.dart
@@ -357,9 +357,9 @@ AppliedTypeConverter readEnumConverter(
     }
     builder
       ..addText('<')
-      ..addDartType(dartEnumType)
+      ..addTopLevelElement(dartEnumType.element!)
       ..addText('>(')
-      ..addDartType(dartEnumType)
+      ..addTopLevelElement(dartEnumType.element!)
       ..addText('.values)');
   });
 

--- a/drift_dev/test/analysis/resolver/dart/enum_columns_test.dart
+++ b/drift_dev/test/analysis/resolver/dart/enum_columns_test.dart
@@ -17,10 +17,15 @@ void main() {
           apple, orange, banana
         }
 
+        enum FruitsWithGeneric<T> {
+          apple, orange, banana
+        }
+
         class NotAnEnum {}
 
         class ValidUsage extends Table {
           IntColumn get intFruit => intEnum<Fruits>()();
+          IntColumn get intFruitsWithGeneric => intEnum<FruitsWithGeneric>()();
           TextColumn get textFruit => textEnum<Fruits>()();
         }
 

--- a/drift_dev/test/analysis/resolver/drift/table_test.dart
+++ b/drift_dev/test/analysis/resolver/drift/table_test.dart
@@ -135,8 +135,8 @@ CREATE TABLE b (
             'expression',
             contains('EnumIndexConverter<FruitsWithGeneric>'),
           )
-          .having((e) => e.dartType.getDisplayString(withNullability: true),
-              'dartType', 'FruitsWithGeneric'),
+          .having(
+              (e) => e.dartType.element!.name, 'dartType', 'FruitsWithGeneric'),
     );
 
     final nameColumn =

--- a/drift_dev/test/analysis/resolver/drift/table_test.dart
+++ b/drift_dev/test/analysis/resolver/drift/table_test.dart
@@ -89,6 +89,7 @@ CREATE TABLE b (
 
          CREATE TABLE foo (
            fruitIndex ENUM(Fruits) NOT NULL,
+           fruitWithGenericIndex ENUM(FruitsWithGeneric) NOT NULL,
            fruitName ENUMNAME(Fruits) NOT NULL,
            anotherIndex ENUM(DoesNotExist) NOT NULL,
            anotherName ENUMNAME(DoesNotExist) NOT NULL
@@ -96,6 +97,10 @@ CREATE TABLE b (
       ''',
       'a|lib/enum.dart': '''
         enum Fruits {
+          apple, orange, banana
+        }
+
+        enum FruitsWithGeneric<T> {
           apple, orange, banana
         }
       ''',
@@ -118,6 +123,22 @@ CREATE TABLE b (
           .having((e) => e.dartType.getDisplayString(withNullability: true),
               'dartType', 'Fruits'),
     );
+
+    final withGenericIndexColumn = table.columns
+        .singleWhere((c) => c.nameInSql == 'fruitWithGenericIndex');
+    expect(withGenericIndexColumn.sqlType, DriftSqlType.int);
+    expect(
+      withGenericIndexColumn.typeConverter,
+      isA<AppliedTypeConverter>()
+          .having(
+            (e) => e.expression.toString(),
+            'expression',
+            contains('EnumIndexConverter<FruitsWithGeneric>'),
+          )
+          .having((e) => e.dartType.getDisplayString(withNullability: true),
+              'dartType', 'FruitsWithGeneric'),
+    );
+
     final nameColumn =
         table.columns.singleWhere((c) => c.nameInSql == 'fruitName');
 


### PR DESCRIPTION
Sometimes you need to use `enum` with generics:
```dart
enum MyEnum<T> {
  ...
}
```

But in this case, the code generator generates the wrong code:
```dart
  static JsonTypeConverter2<MyEnum<Object?>, int, int> $convertername =
      const EnumIndexConverter<MyEnum<Object?>>(MyEnum<Object?>.values);
```

Since this part is not considered valid in Dart:
```dart
MyEnum<Object?>.values
```

Correct use:
```dart
MyEnum.values
```

This PR fixes this behavior