### PR TITLE
Preventing getter name conflicts in step-by-step migrations

### DIFF
--- a/drift_dev/lib/src/writer/schema_version_writer.dart
+++ b/drift_dev/lib/src/writer/schema_version_writer.dart
@@ -325,6 +325,9 @@ class SchemaVersionWriter {
       final versionClass = '_S$versionNo';
       final versionScope = libraryScope.child();
 
+      // Reserve all the names already in use in [VersionedSchema] and its
+      // superclasses. Without this certain table names would cause us to
+      // generate invalid code.
       versionScope.reserveNames([
         'database',
         'entities',

--- a/drift_dev/lib/src/writer/schema_version_writer.dart
+++ b/drift_dev/lib/src/writer/schema_version_writer.dart
@@ -71,6 +71,21 @@ class SchemaVersionWriter {
   final Map<String, String> _columnCodeToFactory = {};
   final Map<_TableShape, String> _shapes = {};
 
+  // A list of member names already in use in the generated class. This is used
+  // to prevent table getters from conflicting with other class members.
+  final Set<String> _usedNames = {};
+
+  void _resetUsedNames() {
+    _usedNames.clear();
+    _usedNames.addAll([
+      'database',
+      'entities',
+      'version',
+      'stepByStepHelper',
+      'runMigrationSteps',
+    ]);
+  }
+
   SchemaVersionWriter(this.versions, this.libraryScope) {
     assert(versions.isSortedBy<num>((element) => element.version));
   }
@@ -158,9 +173,26 @@ class SchemaVersionWriter {
     });
   }
 
+  String _getNonCollidingGetterName(DriftSchemaElement element) {
+    var name = element.dbGetterName!;
+    while (_usedNames.contains(name)) {
+      name = '$name${_suffixForElement(element)}';
+    }
+    _usedNames.add(name);
+    return name;
+  }
+
+  String _suffixForElement(DriftSchemaElement element) => switch (element) {
+        DriftTable() => 'Table',
+        DriftView() => 'View',
+        DriftIndex() => 'Index',
+        DriftTrigger() => 'Trigger',
+        _ => throw ArgumentError('Unhandled element type $element'),
+      };
+
   String _writeWithResultSet(
       DriftElementWithResultSet entity, TextEmitter writer) {
-    final getterName = entity.dbGetterName;
+    final getterName = _getNonCollidingGetterName(entity);
     final shape = _shapeClass(entity);
     writer
       ..write('late final $shape $getterName = ')
@@ -259,7 +291,7 @@ class SchemaVersionWriter {
     writer.write('attachedDatabase: database,');
     writer.write('), alias: null)');
 
-    return getterName!;
+    return getterName;
   }
 
   String _writeEntity({
@@ -271,14 +303,14 @@ class SchemaVersionWriter {
     if (element is DriftElementWithResultSet) {
       name = _writeWithResultSet(element, definition);
     } else if (element is DriftIndex) {
-      name = element.dbGetterName;
+      name = _getNonCollidingGetterName(element);
       final index = definition.drift('Index');
 
       definition
         ..write('final $index $name = ')
         ..writeln(DatabaseWriter.createIndex(definition.parent!, element));
     } else if (element is DriftTrigger) {
-      name = element.dbGetterName;
+      name = _getNonCollidingGetterName(element);
       final trigger = definition.drift('Trigger');
 
       definition
@@ -313,6 +345,7 @@ class SchemaVersionWriter {
       final versionNo = version.version;
       final versionClass = '_S$versionNo';
       final versionScope = libraryScope.child();
+      _resetUsedNames();
 
       // Write an _S<x> class for each schema version x.
       versionScope.leaf()

--- a/drift_dev/lib/src/writer/writer.dart
+++ b/drift_dev/lib/src/writer/writer.dart
@@ -298,7 +298,7 @@ class Scope extends _Node {
   /// This can be used to generated methods which must have a unique name-
   int counter = 0;
 
-  /// The set of names already used in this scope. Used by methos like
+  /// The set of names already used in this scope. Used by methods like
   /// [getNonConflictingName] to prevent name collisions.
   final Set<String> _usedNames = {};
 

--- a/drift_dev/lib/src/writer/writer.dart
+++ b/drift_dev/lib/src/writer/writer.dart
@@ -1,10 +1,10 @@
 import 'package:drift/drift.dart';
+import 'package:path/path.dart' show url;
 import 'package:recase/recase.dart';
 import 'package:sqlparser/sqlparser.dart' as sql;
-import 'package:path/path.dart' show url;
 
-import '../analysis/results/results.dart';
 import '../analysis/options.dart';
+import '../analysis/results/results.dart';
 import 'import_manager.dart';
 import 'queries/sql_writer.dart';
 
@@ -298,6 +298,10 @@ class Scope extends _Node {
   /// This can be used to generated methods which must have a unique name-
   int counter = 0;
 
+  /// The set of names already used in this scope. Used by methos like
+  /// [getNonConflictingName] to prevent name collisions.
+  final Set<String> _usedNames = {};
+
   Scope({required Scope? parent, Writer? writer})
       : writer = writer ?? parent!.writer,
         super(parent);
@@ -324,6 +328,28 @@ class Scope extends _Node {
     final child = TextEmitter(this);
     _children.add(child);
     return child;
+  }
+
+  /// Reserve a collection of names in this scope. See [getNonConflictingName]
+  /// for more information.
+  void reserveNames(Iterable<String> names) {
+    _usedNames.addAll(names);
+  }
+
+  /// Returns a variation of [name] that does not conflict with any names
+  /// already in use in this [Scope].
+  ///
+  /// If [name] does not conflict with any existing names then it is returned
+  /// unmodified. If a conflict is detected then [name] is repeatedly passed to
+  /// [modify] until the result no longer conflicts. Each result returned from
+  /// this method is recorded in an internal set, so subsequent calls with the
+  /// same name will produce a different, non-conflicting result.
+  String getNonConflictingName(String name, String Function(String) modify) {
+    while (_usedNames.contains(name)) {
+      name = modify(name);
+    }
+    _usedNames.add(name);
+    return name;
   }
 }
 

--- a/drift_dev/test/writer/schema_version_writer_test.dart
+++ b/drift_dev/test/writer/schema_version_writer_test.dart
@@ -77,8 +77,6 @@ void main() {
 
     final output = writer.writeGenerated();
 
-    print(output);
-
     // Tables without conflicting names shouldn't be modified.
     expect(output, matches(containsTableRegex(normalTable.baseDartName)));
 

--- a/drift_dev/test/writer/schema_version_writer_test.dart
+++ b/drift_dev/test/writer/schema_version_writer_test.dart
@@ -1,0 +1,104 @@
+import 'package:drift/drift.dart';
+import 'package:drift_dev/src/analysis/options.dart';
+import 'package:drift_dev/src/analysis/results/results.dart';
+import 'package:drift_dev/src/writer/import_manager.dart';
+import 'package:drift_dev/src/writer/schema_version_writer.dart';
+import 'package:drift_dev/src/writer/writer.dart';
+import 'package:test/test.dart';
+
+void main() {
+  final fakeUri = Uri.parse('drift:hidden');
+
+  DriftTable buildTable(String name) {
+    return DriftTable(
+      DriftElementId(fakeUri, name),
+      DriftDeclaration(fakeUri, -1, ''),
+      columns: [
+        DriftColumn(
+          sqlType: DriftSqlType.int,
+          nullable: false,
+          nameInSql: 'foo',
+          nameInDart: 'foo',
+          declaration: DriftDeclaration(
+            fakeUri,
+            -1,
+            '',
+          ),
+        ),
+      ],
+      baseDartName: name,
+      nameOfRowClass: name.substring(0, 1).toUpperCase() + name.substring(1),
+    );
+  }
+
+  String containsTableRegex(String name, {bool withSuffix = false}) =>
+      'late final Shape\\d+ $name${withSuffix ? r'\w+' : ''} =';
+
+  test('avoids conflict with getters in schema class', () async {
+    final imports = LibraryImportManager();
+    final writer = Writer(
+      const DriftOptions.defaults(),
+      generationOptions: GenerationOptions(imports: imports),
+    );
+    imports.linkToWriter(writer);
+
+    final normalTable = buildTable('myFirstTable');
+
+    final problemTables = [
+      'database',
+      'entities',
+      'version',
+      'stepByStepHelper',
+      'runMigrationSteps',
+    ].map(buildTable).toList();
+    final secondaryProblemTables = problemTables
+        .map((t) => '${t.baseDartName}Table')
+        .map(buildTable)
+        .toList();
+    SchemaVersionWriter(
+      [
+        SchemaVersion(
+          1,
+          [normalTable],
+          const {},
+        ),
+        SchemaVersion(
+          2,
+          [
+            normalTable,
+            ...problemTables,
+            ...secondaryProblemTables,
+          ],
+          const {},
+        ),
+      ],
+      writer.child(),
+    ).write();
+
+    final output = writer.writeGenerated();
+
+    print(output);
+
+    // Tables without conflicting names shouldn't be modified.
+    expect(output, matches(containsTableRegex(normalTable.baseDartName)));
+
+    // Tables that directly conflict with member names from VersionedSchema and
+    // its superclasses should have their names modified and not appear with
+    // their original name at all.
+    for (final tableName in problemTables.map((t) => t.baseDartName)) {
+      expect(
+        output,
+        isNot(matches(containsTableRegex(tableName))),
+      );
+      expect(output, matches(containsTableRegex(tableName, withSuffix: true)));
+    }
+
+    // Tables that conflict with modified table names should themselves be
+    // modified to prevent the conflict. We can't check for nonexistence here
+    // because the the entire point is the name conficts with an in-use table
+    // name, so we only check for the existence of the doubly modified name.
+    for (final tableName in secondaryProblemTables.map((t) => t.baseDartName)) {
+      expect(output, matches(containsTableRegex(tableName, withSuffix: true)));
+    }
+  });
+}


### PR DESCRIPTION
Closes #2610.

I added a couple methods to `Scope` to keep track of which names have been used and allow the caller to specify how non-conflicting names should be calculated. As is this fixes the issue in my codebase with a table named `entities`.

In #2610 you mentioned:

> This is not only a problem with table names, but also with the getter names for columns potentially colliding with columns inherited from VersionedTable (and its superclasses).

I began looking into addressing that as well but as far as I can tell any name collisions there will fail while generating Drift code for runtime. Both `VersionedTable` and table the table classes generated for runtime extend `Table` and mixin `TableInfo`.

Are there tests for the code generation I should be updating or adding to? I see there are tests for various parts of the `drift_dev` package but couldn't find any that covered `SchemaVersionWriter`.