### PR TITLE
example app - updated gradle wrapper to 7.5 to match filepicker plugin

### DIFF
--- a/examples/app/android/build.gradle
+++ b/examples/app/android/build.gradle
@@ -1,3 +1,4 @@
+
 buildscript {
     ext.kotlin_version = '1.6.10'
     repositories {
@@ -6,7 +7,7 @@ buildscript {
     }
 
     dependencies {
-        classpath 'com.android.tools.build:gradle:4.1.0'
+        classpath 'com.android.tools.build:gradle:7.4.2'
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
     }
 }
@@ -26,6 +27,6 @@ subprojects {
     project.evaluationDependsOn(':app')
 }
 
-task clean(type: Delete) {
+tasks.register("clean", Delete) {
     delete rootProject.buildDir
 }

--- a/examples/app/android/gradle/wrapper/gradle-wrapper.properties
+++ b/examples/app/android/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-6.7-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.5-all.zip


### PR DESCRIPTION
Wasn't building on android due to a version conflict between existing 7.4.2 and the filepicker plugin 7.5 version

https://github.com/miguelpruivo/flutter_file_picker/blob/master/android/gradle/wrapper/gradle-wrapper.properties

builds tested: android,linux,chrome