### PR TITLE
CustomExpression.dialectSpecific when used would add in empty arguments when generating queries

### DIFF
--- a/drift/lib/src/runtime/query_builder/expressions/custom.dart
+++ b/drift/lib/src/runtime/query_builder/expressions/custom.dart
@@ -41,6 +41,8 @@ class CustomExpression<D extends Object> extends Expression<D> {
     final dialectSpecific = _dialectSpecificContent;
 
     if (dialectSpecific != null) {
+      final dialect = context.dialect;
+      context.buffer.write(dialectSpecific[dialect]);
     } else {
       context.buffer.write(content);
     }

--- a/drift/test/database/expressions/expression_test.dart
+++ b/drift/test/database/expressions/expression_test.dart
@@ -175,4 +175,16 @@ void main() {
       generates('(a OR b) AND c AND d'),
     );
   });
+
+  test('dialect-specific custom expression', () {
+    final expr = CustomExpression.dialectSpecific({
+      SqlDialect.mariadb: 'mariadb',
+      SqlDialect.postgres: 'pg',
+      SqlDialect.sqlite: 'default',
+    });
+
+    expect(expr, generatesWithOptions('mariadb', dialect: SqlDialect.mariadb));
+    expect(expr, generatesWithOptions('pg', dialect: SqlDialect.postgres));
+    expect(expr, generatesWithOptions('default', dialect: SqlDialect.sqlite));
+  });
 }

--- a/drift/test/test_utils/matchers.dart
+++ b/drift/test/test_utils/matchers.dart
@@ -17,14 +17,25 @@ void expectNotEquals(dynamic a, dynamic expected) {
 /// matching [sql] and, optionally, the matching [variables].
 Matcher generates(dynamic sql, [dynamic variables = isEmpty]) {
   return _GeneratesSqlMatcher(
-      wrapMatcher(sql), wrapMatcher(variables), const DriftDatabaseOptions());
+    wrapMatcher(sql),
+    wrapMatcher(variables),
+    const DriftDatabaseOptions(),
+    SqlDialect.sqlite,
+  );
 }
 
-Matcher generatesWithOptions(dynamic sql,
-    {dynamic variables = isEmpty,
-    DriftDatabaseOptions options = const DriftDatabaseOptions()}) {
+Matcher generatesWithOptions(
+  dynamic sql, {
+  dynamic variables = isEmpty,
+  DriftDatabaseOptions options = const DriftDatabaseOptions(),
+  SqlDialect dialect = SqlDialect.sqlite,
+}) {
   return _GeneratesSqlMatcher(
-      wrapMatcher(sql), wrapMatcher(variables), options);
+    wrapMatcher(sql),
+    wrapMatcher(variables),
+    options,
+    dialect,
+  );
 }
 
 class _GeneratesSqlMatcher extends Matcher {
@@ -32,8 +43,14 @@ class _GeneratesSqlMatcher extends Matcher {
   final Matcher? _matchVariables;
 
   final DriftDatabaseOptions options;
+  final SqlDialect dialect;
 
-  _GeneratesSqlMatcher(this._matchSql, this._matchVariables, this.options);
+  _GeneratesSqlMatcher(
+    this._matchSql,
+    this._matchVariables,
+    this.options,
+    this.dialect,
+  );
 
   @override
   Description describe(Description description) {
@@ -78,7 +95,7 @@ class _GeneratesSqlMatcher extends Matcher {
       return false;
     }
 
-    final ctx = stubContext(options: options);
+    final ctx = stubContext(options: options, dialect: dialect);
     item.writeInto(ctx);
 
     var matches = true;

--- a/examples/encryption/linux/flutter/generated_plugin_registrant.cc
+++ b/examples/encryption/linux/flutter/generated_plugin_registrant.cc
@@ -6,6 +6,10 @@
 
 #include "generated_plugin_registrant.h"
 
+#include <sqlcipher_flutter_libs/sqlite3_flutter_libs_plugin.h>
 
 void fl_register_plugins(FlPluginRegistry* registry) {
+  g_autoptr(FlPluginRegistrar) sqlcipher_flutter_libs_registrar =
+      fl_plugin_registry_get_registrar_for_plugin(registry, "Sqlite3FlutterLibsPlugin");
+  sqlite3_flutter_libs_plugin_register_with_registrar(sqlcipher_flutter_libs_registrar);
 }

--- a/examples/encryption/linux/flutter/generated_plugins.cmake
+++ b/examples/encryption/linux/flutter/generated_plugins.cmake
@@ -3,6 +3,7 @@
 #
 
 list(APPEND FLUTTER_PLUGIN_LIST
+  sqlcipher_flutter_libs
 )
 
 list(APPEND FLUTTER_FFI_PLUGIN_LIST

--- a/examples/encryption/macos/Flutter/GeneratedPluginRegistrant.swift
+++ b/examples/encryption/macos/Flutter/GeneratedPluginRegistrant.swift
@@ -5,7 +5,7 @@
 import FlutterMacOS
 import Foundation
 
-import path_provider_macos
+import path_provider_foundation
 import sqlcipher_flutter_libs
 
 func RegisterGeneratedPlugins(registry: FlutterPluginRegistry) {

--- a/examples/encryption/windows/flutter/generated_plugin_registrant.cc
+++ b/examples/encryption/windows/flutter/generated_plugin_registrant.cc
@@ -6,6 +6,9 @@
 
 #include "generated_plugin_registrant.h"
 
+#include <sqlcipher_flutter_libs/sqlite3_flutter_libs_plugin.h>
 
 void RegisterPlugins(flutter::PluginRegistry* registry) {
+  Sqlite3FlutterLibsPluginRegisterWithRegistrar(
+      registry->GetRegistrarForPlugin("Sqlite3FlutterLibsPlugin"));
 }

--- a/examples/encryption/windows/flutter/generated_plugins.cmake
+++ b/examples/encryption/windows/flutter/generated_plugins.cmake
@@ -3,6 +3,7 @@
 #
 
 list(APPEND FLUTTER_PLUGIN_LIST
+  sqlcipher_flutter_libs
 )
 
 list(APPEND FLUTTER_FFI_PLUGIN_LIST


### PR DESCRIPTION
This is a fix when using the CustomExpression.dialectSpecific. If there is more than one dialect it would add no parameters when generating the queries. I just added to writeInto function where it will add the dialect specific content to the buffer.