### PR TITLE
Add column-name-list syntax spec

### DIFF
--- a/sqlparser/lib/src/analysis/steps/linting_visitor.dart
+++ b/sqlparser/lib/src/analysis/steps/linting_visitor.dart
@@ -529,6 +529,8 @@ class LintingVisitor extends RecursiveVisitor<void, void> {
       // In expressions are tricky. The rhs can always be a row value, but the
       // lhs can only be a row value if the rhs is a subquery
       isAllowed = e == parent.inside || parent.inside is SubQuery;
+    } else if (parent is SetComponent) {
+      isAllowed = true;
     }
 
     if (!isAllowed) {

--- a/sqlparser/lib/src/analysis/steps/reference_resolver.dart
+++ b/sqlparser/lib/src/analysis/steps/reference_resolver.dart
@@ -113,7 +113,9 @@ class ReferenceResolver
     if (table != null) {
       // Resolve the set components against the primary table
       for (final set in e.set) {
-        _resolveReferenceInTable(set.column, table);
+        for (final column in set.columns) {
+          _resolveReferenceInTable(column, table);
+        }
       }
     }
 

--- a/sqlparser/lib/src/analysis/types/resolving_visitor.dart
+++ b/sqlparser/lib/src/analysis/types/resolving_visitor.dart
@@ -131,10 +131,26 @@ class TypeResolver extends RecursiveVisitor<TypeExpectation, void> {
   }
 
   @override
-  void visitSetComponent(SetComponent e, TypeExpectation arg) {
+  void visitSingleColumnSetComponent(
+      SingleColumnSetComponent e, TypeExpectation arg) {
     visit(e.column, const NoTypeExpectation());
     _lazyCopy(e.expression, e.column);
     visit(e.expression, const NoTypeExpectation());
+  }
+
+  @override
+  void visitMultiColumnSetComponent(
+      MultiColumnSetComponent e, TypeExpectation arg) {
+    visitList(e.columns, const NoTypeExpectation());
+    if (e.rowValue is Tuple) {
+      final expressions = (e.rowValue as Tuple).expressions;
+      for (final (idx, expression) in expressions.indexed) {
+        _lazyCopy(expression, e.columns.elementAtOrNull(idx));
+      }
+    } else if (e.rowValue is SubQuery) {
+      // TODO: handle subquery case
+    }
+    visit(e.rowValue, const NoTypeExpectation());
   }
 
   @override

--- a/sqlparser/lib/src/ast/statements/update.dart
+++ b/sqlparser/lib/src/ast/statements/update.dart
@@ -112,6 +112,11 @@ class MultiColumnSetComponent extends SetComponent {
   // Will be either Tuple or SubQuery
   Expression rowValue;
 
+  List<Column?>? get resolvedTargetColumns {
+    if (columns.isEmpty) return null;
+    return columns.map((c) => c.resolvedColumn).toList();
+  }
+
   MultiColumnSetComponent({required this.columns, required this.rowValue});
 
   @override

--- a/sqlparser/lib/src/ast/visitor.dart
+++ b/sqlparser/lib/src/ast/visitor.dart
@@ -43,7 +43,8 @@ abstract class AstVisitor<A, R> {
   R visitDoNothing(DoNothing e, A arg);
   R visitDoUpdate(DoUpdate e, A arg);
 
-  R visitSetComponent(SetComponent e, A arg);
+  R visitSingleColumnSetComponent(SingleColumnSetComponent e, A arg);
+  R visitMultiColumnSetComponent(MultiColumnSetComponent e, A arg);
 
   R visitValuesSource(ValuesSource e, A arg);
   R visitSelectInsertSource(SelectInsertSource e, A arg);
@@ -315,7 +316,16 @@ class RecursiveVisitor<A, R> implements AstVisitor<A, R?> {
   }
 
   @override
-  R? visitSetComponent(SetComponent e, A arg) {
+  R? visitSingleColumnSetComponent(SingleColumnSetComponent e, A arg) {
+    return defaultSetComponent(e, arg);
+  }
+
+  @override
+  R? visitMultiColumnSetComponent(MultiColumnSetComponent e, A arg) {
+    return defaultSetComponent(e, arg);
+  }
+
+  R? defaultSetComponent(SetComponent e, A arg) {
     return defaultNode(e, arg);
   }
 

--- a/sqlparser/lib/src/reader/parser.dart
+++ b/sqlparser/lib/src/reader/parser.dart
@@ -1690,9 +1690,7 @@ class Parser {
   }
 
   SingleColumnSetComponent _singleColumnSetComponent() {
-    final columnName =
-        _consume(TokenType.identifier, 'Expected a column name to set')
-            as IdentifierToken;
+    final columnName = _consumeIdentifier('Expected a column name to set');
     final reference = Reference(columnName: columnName.identifier)
       ..setSpan(columnName, columnName);
     _consume(TokenType.equal, 'Expected = after the column name');

--- a/sqlparser/lib/src/reader/parser.dart
+++ b/sqlparser/lib/src/reader/parser.dart
@@ -1030,10 +1030,10 @@ class Parser {
   }
 
   /// Parses a [Tuple]. If [orSubQuery] is set (defaults to false), a [SubQuery]
-  /// (in brackets) will be accepted as well. If parsing a [Tuple], [useAsRowValue] is
+  /// (in brackets) will be accepted as well. If parsing a [Tuple], [usedAsRowValue] is
   /// passed into the [Tuple] constructor.
   Expression _consumeTuple(
-      {bool orSubQuery = false, bool useAsRowValue = false}) {
+      {bool orSubQuery = false, bool usedAsRowValue = false}) {
     final firstToken =
         _consume(TokenType.leftParen, 'Expected opening parenthesis for tuple');
     final expressions = <Expression>[];
@@ -1051,7 +1051,7 @@ class Parser {
 
       _consume(
           TokenType.rightParen, 'Expected right parenthesis to close tuple');
-      return Tuple(expressions: expressions, usedAsRowValue: useAsRowValue)
+      return Tuple(expressions: expressions, usedAsRowValue: usedAsRowValue)
         ..setSpan(firstToken, _previous);
     } else {
       _consume(TokenType.rightParen,
@@ -1717,7 +1717,7 @@ class Parser {
         TokenType.rightParen, 'Expected closing parenthesis after column list');
     _consume(TokenType.equal, 'Expected = after the column name list');
     final tupleOrSubQuery =
-        _consumeTuple(orSubQuery: true, useAsRowValue: true);
+        _consumeTuple(orSubQuery: true, usedAsRowValue: true);
 
     return MultiColumnSetComponent(
         columns: targetColumns, rowValue: tupleOrSubQuery)

--- a/sqlparser/lib/src/utils/ast_equality.dart
+++ b/sqlparser/lib/src/utils/ast_equality.dart
@@ -608,8 +608,14 @@ class EqualityEnforcingVisitor implements AstVisitor<void, void> {
   }
 
   @override
-  void visitSetComponent(SetComponent e, void arg) {
-    _currentAs<SetComponent>(e);
+  void visitSingleColumnSetComponent(SingleColumnSetComponent e, void arg) {
+    _currentAs<SingleColumnSetComponent>(e);
+    _checkChildren(e);
+  }
+
+  @override
+  void visitMultiColumnSetComponent(MultiColumnSetComponent e, void arg) {
+    _currentAs<MultiColumnSetComponent>(e);
     _checkChildren(e);
   }
 

--- a/sqlparser/lib/utils/node_to_text.dart
+++ b/sqlparser/lib/utils/node_to_text.dart
@@ -1062,10 +1062,19 @@ class NodeSqlBuilder extends AstVisitor<void, void> {
   }
 
   @override
-  void visitSetComponent(SetComponent e, void arg) {
+  void visitSingleColumnSetComponent(SingleColumnSetComponent e, void arg) {
     visit(e.column, arg);
     symbol('=', spaceBefore: true, spaceAfter: true);
     visit(e.expression, arg);
+  }
+
+  @override
+  void visitMultiColumnSetComponent(MultiColumnSetComponent e, void arg) {
+    symbol('(', spaceBefore: true);
+    _join(e.columns, ',');
+    symbol(')');
+    symbol('=', spaceBefore: true, spaceAfter: true);
+    visit(e.rowValue, arg);
   }
 
   @override

--- a/sqlparser/test/analysis/common_table_expressions_test.dart
+++ b/sqlparser/test/analysis/common_table_expressions_test.dart
@@ -89,9 +89,22 @@ void main() {
       expect(result.errors, isEmpty);
     });
 
+    test('update statements with column-name-list', () {
+      final result = engine.analyze(
+          'WITH x AS (SELECT * FROM demo) UPDATE demo '
+          'SET (id, content) = (x.id, x.content) FROM x WHERE demo.id = x.id;');
+      expect(result.errors, isEmpty);
+    });
+
     test('insert statements', () {
       final result = engine.analyze(
           'WITH x AS (SELECT * FROM demo) INSERT INTO demo SELECT * FROM x;');
+      expect(result.errors, isEmpty);
+    });
+
+    test('insert statements with upsert using column-name-list', () {
+      final result = engine.analyze(
+          'WITH x AS (SELECT * FROM demo) INSERT INTO demo SELECT * FROM x ON CONFLICT(content) DO UPDATE SET (id, content) = (0, \'hello\');');
       expect(result.errors, isEmpty);
     });
 

--- a/sqlparser/test/analysis/errors/update_column_name_list_count_mismatch_test.dart
+++ b/sqlparser/test/analysis/errors/update_column_name_list_count_mismatch_test.dart
@@ -1,0 +1,72 @@
+import 'package:sqlparser/sqlparser.dart';
+import 'package:test/test.dart';
+
+import '../data.dart';
+import 'utils.dart';
+
+void main() {
+  late SqlEngine engine;
+
+  setUp(() {
+    engine = SqlEngine();
+    engine.registerTableFromSql('''
+      CREATE TABLE foo (
+        a INTEGER NOT NULL,
+        b INTEGER NOT NULL
+      );
+    ''');
+  });
+
+  group("using column-name-list and tuple in update", () {
+    test('reports error if they have different sizes', () {
+      engine
+          .analyze("UPDATE foo SET (a, b) = (1);")
+          .expectError('(1)', type: AnalysisErrorType.cteColumnCountMismatch);
+      engine
+          .analyze("UPDATE foo SET (a) = (1,2);")
+          .expectError('(1,2)', type: AnalysisErrorType.cteColumnCountMismatch);
+    });
+    test('reports no error if they have same sizes', () {
+      engine.analyze("UPDATE foo SET (a, b) = (1,2);").expectNoError();
+    });
+  });
+
+  group("using column-name-list and values in update", () {
+    test('reports error if they have different sizes', () {
+      engine.analyze("UPDATE foo SET (a, b) = (VALUES(1));").expectError(
+          "(VALUES(1))",
+          type: AnalysisErrorType.cteColumnCountMismatch);
+      engine.analyze("UPDATE foo SET (a) = (VALUES(1,2));").expectError(
+          "(VALUES(1,2))",
+          type: AnalysisErrorType.cteColumnCountMismatch);
+    });
+
+    test('reports no error if they have same sizes', () {
+      engine.analyze("UPDATE foo SET (a, b) = (VALUES(1,2));").expectNoError();
+    });
+  });
+
+  group("using column-name-list and subquery in update", () {
+    test('reports error if they have different sizes', () {
+      engine.analyze("UPDATE foo SET (a, b) = (SELECT 1);").expectError(
+          '(SELECT 1)',
+          type: AnalysisErrorType.cteColumnCountMismatch);
+      engine.analyze("UPDATE foo SET (a) = (SELECT 1,2);").expectError(
+          '(SELECT 1,2)',
+          type: AnalysisErrorType.cteColumnCountMismatch);
+      engine
+          .analyze(
+              "UPDATE foo SET (a, b) = (SELECT b FROM foo as f WHERE f.a=a);")
+          .expectError('(SELECT b FROM foo as f WHERE f.a=a)',
+              type: AnalysisErrorType.cteColumnCountMismatch);
+    });
+
+    test('reports no error if they have same sizes', () {
+      engine.analyze("UPDATE foo SET (a, b) = (SELECT 1,2);").expectNoError();
+      engine
+          .analyze(
+              "UPDATE foo SET (a, b) = (SELECT b, a FROM foo as f WHERE f.a=a);")
+          .expectNoError();
+    });
+  });
+}

--- a/sqlparser/test/analysis/errors/write_to_generated_column.dart
+++ b/sqlparser/test/analysis/errors/write_to_generated_column.dart
@@ -23,6 +23,13 @@ void main() {
         .expectError('g', type: AnalysisErrorType.writeToGeneratedColumn);
   });
 
+  test('reports error when updating generated column with column-name-list',
+      () {
+    engine
+        .analyze("UPDATE a SET (ok, g) = ('new', 'old');")
+        .expectError('g', type: AnalysisErrorType.writeToGeneratedColumn);
+  });
+
   test('reports error when inserting generated column', () {
     engine
         .analyze('INSERT INTO a (ok, g) VALUES (?, ?)')

--- a/sqlparser/test/parser/create_trigger_test.dart
+++ b/sqlparser/test/parser/create_trigger_test.dart
@@ -5,7 +5,7 @@ import 'utils.dart';
 
 final _block = Block([
   UpdateStatement(table: TableReference('tbl'), set: [
-    SetComponent(
+    SingleColumnSetComponent(
       column: Reference(columnName: 'foo'),
       expression: Reference(columnName: 'bar'),
     ),

--- a/sqlparser/test/parser/drift_file_test.dart
+++ b/sqlparser/test/parser/drift_file_test.dart
@@ -151,7 +151,7 @@ END;
               UpdateStatement(
                 table: TableReference('foo'),
                 set: [
-                  SetComponent(
+                  SingleColumnSetComponent(
                     column: Reference(columnName: 'bar'),
                     expression: Reference(columnName: 'baz'),
                   ),

--- a/sqlparser/test/parser/insert_test.dart
+++ b/sqlparser/test/parser/insert_test.dart
@@ -133,7 +133,7 @@ void main() {
               UpsertClauseEntry(
                 action: DoUpdate(
                   [
-                    SetComponent(
+                    SingleColumnSetComponent(
                       column: Reference(columnName: 'foo'),
                       expression: NumericLiteral(2),
                     ),
@@ -158,7 +158,7 @@ void main() {
               UpsertClauseEntry(
                 action: DoUpdate(
                   [
-                    SetComponent(
+                    SingleColumnSetComponent(
                       column: Reference(columnName: 'foo'),
                       expression: NumericLiteral(2),
                     ),
@@ -189,7 +189,7 @@ void main() {
                 onColumns: [IndexedColumn(Reference(columnName: 'bar'))],
                 action: DoUpdate(
                   [
-                    SetComponent(
+                    SingleColumnSetComponent(
                       column: Reference(columnName: 'x'),
                       expression: NumericLiteral(2),
                     ),

--- a/sqlparser/test/parser/multiple_statements_test.dart
+++ b/sqlparser/test/parser/multiple_statements_test.dart
@@ -18,7 +18,7 @@ void main() {
           UpdateStatement(
             table: TableReference('tbl'),
             set: [
-              SetComponent(
+              SingleColumnSetComponent(
                 column: Reference(columnName: 'a'),
                 expression: Reference(columnName: 'b'),
               ),

--- a/sqlparser/test/parser/update_test.dart
+++ b/sqlparser/test/parser/update_test.dart
@@ -8,11 +8,11 @@ final Map<String, AstNode> testCases = {
     or: FailureMode.rollback,
     table: TableReference('tbl'),
     set: [
-      SetComponent(
+      SingleColumnSetComponent(
         column: Reference(columnName: 'a'),
         expression: NullLiteral(),
       ),
-      SetComponent(
+      SingleColumnSetComponent(
         column: Reference(columnName: 'b'),
         expression: Reference(columnName: 'c'),
       )
@@ -38,7 +38,7 @@ void main() {
       UpdateStatement(
         table: TableReference('inventory'),
         set: [
-          SetComponent(
+          SingleColumnSetComponent(
             column: Reference(columnName: 'quantity'),
             expression: BinaryExpression(
               Reference(columnName: 'quantity'),
@@ -85,7 +85,7 @@ void main() {
       UpdateStatement(
         table: TableReference('tbl'),
         set: [
-          SetComponent(
+          SingleColumnSetComponent(
             column: Reference(columnName: 'foo'),
             expression: Reference(columnName: 'bar'),
           ),

--- a/sqlparser/test/parser/update_test.dart
+++ b/sqlparser/test/parser/update_test.dart
@@ -28,47 +28,53 @@ void main() {
 
   test('parses updates with column-name-list and subquery', () {
     testStatement(
-        '''
+      '''
       UPDATE foo
       SET (a, b) = (SELECT b, a FROM bar AS b WHERE b.id=foo.id);
       ''',
-        UpdateStatement(table: TableReference('foo'), set: [
-          MultiColumnSetComponent(
-              columns: [Reference(columnName: 'a'), Reference(columnName: 'b')],
-              rowValue: SubQuery(
-                  select: SelectStatement(
-                      columns: [
-                    ExpressionResultColumn(
-                      expression: Reference(columnName: 'b'),
-                    ),
-                    ExpressionResultColumn(
-                      expression: Reference(columnName: 'a'),
-                    ),
-                  ],
-                      from: TableReference('bar', as: 'b'),
-                      where: BinaryExpression(
-                        Reference(entityName: 'b', columnName: 'id'),
-                        token(TokenType.equal),
-                        Reference(entityName: 'foo', columnName: 'id'),
-                      ))))
-        ]));
+      UpdateStatement(table: TableReference('foo'), set: [
+        MultiColumnSetComponent(
+          columns: [Reference(columnName: 'a'), Reference(columnName: 'b')],
+          rowValue: SubQuery(
+            select: SelectStatement(
+              columns: [
+                ExpressionResultColumn(
+                  expression: Reference(columnName: 'b'),
+                ),
+                ExpressionResultColumn(
+                  expression: Reference(columnName: 'a'),
+                ),
+              ],
+              from: TableReference('bar', as: 'b'),
+              where: BinaryExpression(
+                Reference(entityName: 'b', columnName: 'id'),
+                token(TokenType.equal),
+                Reference(entityName: 'foo', columnName: 'id'),
+              ),
+            ),
+          ),
+        )
+      ]),
+    );
   });
 
   test('parses updates with column-name-list and scalar rowValues', () {
     testStatement(
-        '''
+      '''
       UPDATE foo
       SET (a, b) = (b, 3+4);
       ''',
-        UpdateStatement(table: TableReference('foo'), set: [
-          MultiColumnSetComponent(
-              columns: [Reference(columnName: 'a'), Reference(columnName: 'b')],
-              rowValue: Tuple(expressions: [
-                Reference(columnName: "b"),
-                BinaryExpression(NumericLiteral(3), token(TokenType.plus),
-                    NumericLiteral(4)),
-              ], usedAsRowValue: true))
-        ]));
+      UpdateStatement(table: TableReference('foo'), set: [
+        MultiColumnSetComponent(
+          columns: [Reference(columnName: 'a'), Reference(columnName: 'b')],
+          rowValue: Tuple(expressions: [
+            Reference(columnName: "b"),
+            BinaryExpression(
+                NumericLiteral(3), token(TokenType.plus), NumericLiteral(4)),
+          ], usedAsRowValue: true),
+        )
+      ]),
+    );
   });
 
   test('parses updates with FROM clause', () {

--- a/sqlparser/test/parser/update_test.dart
+++ b/sqlparser/test/parser/update_test.dart
@@ -26,6 +26,51 @@ void main() {
     testAll(testCases);
   });
 
+  test('parses updates with column-name-list and subquery', () {
+    testStatement(
+        '''
+      UPDATE foo
+      SET (a, b) = (SELECT b, a FROM bar AS b WHERE b.id=foo.id);
+      ''',
+        UpdateStatement(table: TableReference('foo'), set: [
+          MultiColumnSetComponent(
+              columns: [Reference(columnName: 'a'), Reference(columnName: 'b')],
+              rowValue: SubQuery(
+                  select: SelectStatement(
+                      columns: [
+                    ExpressionResultColumn(
+                      expression: Reference(columnName: 'b'),
+                    ),
+                    ExpressionResultColumn(
+                      expression: Reference(columnName: 'a'),
+                    ),
+                  ],
+                      from: TableReference('bar', as: 'b'),
+                      where: BinaryExpression(
+                        Reference(entityName: 'b', columnName: 'id'),
+                        token(TokenType.equal),
+                        Reference(entityName: 'foo', columnName: 'id'),
+                      ))))
+        ]));
+  });
+
+  test('parses updates with column-name-list and scalar rowValues', () {
+    testStatement(
+        '''
+      UPDATE foo
+      SET (a, b) = (b, 3+4);
+      ''',
+        UpdateStatement(table: TableReference('foo'), set: [
+          MultiColumnSetComponent(
+              columns: [Reference(columnName: 'a'), Reference(columnName: 'b')],
+              rowValue: Tuple(expressions: [
+                Reference(columnName: "b"),
+                BinaryExpression(NumericLiteral(3), token(TokenType.plus),
+                    NumericLiteral(4)),
+              ], usedAsRowValue: true))
+        ]));
+  });
+
   test('parses updates with FROM clause', () {
     testStatement(
       '''

--- a/sqlparser/test/utils/node_to_text_test.dart
+++ b/sqlparser/test/utils/node_to_text_test.dart
@@ -407,6 +407,11 @@ CREATE UNIQUE INDEX my_idx ON t1 (c1, c2, c3) WHERE c1 < c3;
             'ON CONFLICT DO UPDATE SET a = b, c = d WHERE d < a;');
       });
 
+      test('upsert - update with column-name-list', () {
+        testFormat('INSERT INTO foo VALUES (1, 2, 3) '
+            'ON CONFLICT DO UPDATE SET (a, c) = (b, d) WHERE d < a;');
+      });
+
       test('upsert - multiple clauses', () {
         testFormat('INSERT INTO foo VALUES (1, 2, 3) '
             'ON CONFLICT DO NOTHING '
@@ -417,6 +422,14 @@ CREATE UNIQUE INDEX my_idx ON t1 (c1, c2, c3) WHERE c1 < c3;
     group('update', () {
       test('simple', () {
         testFormat('UPDATE foo SET bar = baz WHERE 1;');
+      });
+
+      test('with column-name-list', () {
+        testFormat('UPDATE foo SET (bar, baz) = (baz, bar) WHERE 1;');
+      });
+
+      test('with column-name-list and subquery', () {
+        testFormat('UPDATE foo SET (bar, baz) = (SELECT 1,2) WHERE 1;');
       });
 
       test('with returning', () {


### PR DESCRIPTION
This PR aims to solve issue #2731 .

Please read the commit messages / code changes for more details on the actual implementation.

A few notes:
This PR only targets the sqlparser.
All tests pass except the ones for type-resolving variables when using subqueries. Please feel free to suggest any ideas on how to implement this (see the TODO in `TypeResolver.visitMultiColumnSetComponent`). I am not as familiar with the code base as you, and there are still some things i don't quite understand, so there definitely may be better ways to implement some things. I tried to be as similar as possible to other code in the code base based on what i've read in the past few hours. 
Anyway, i would love to get some feedback and details on how to procceed with this :)