### PR TITLE
pass missing initializeDatabase property to WasmProbeResult.open

### DIFF
--- a/drift/lib/wasm.dart
+++ b/drift/lib/wasm.dart
@@ -150,7 +150,7 @@ class WasmDatabase extends DelegatedDatabase {
     final bestImplementation = availableImplementations.firstOrNull ??
         WasmStorageImplementation.inMemory;
     final connection = await probed.open(bestImplementation, databaseName,
-        localSetup: localSetup);
+        localSetup: localSetup, initializeDatabase: initializeDatabase);
 
     return WasmDatabaseResult(
         connection, bestImplementation, probed.missingFeatures);

--- a/extras/integration_tests/web_wasm/test/drift_wasm_test.dart
+++ b/extras/integration_tests/web_wasm/test/drift_wasm_test.dart
@@ -85,10 +85,27 @@ void main() {
         expect(result.storages, expectedImplementations);
       });
 
+      test('via regular open', () async {
+        await driver.openDatabase();
+        expect(await driver.amountOfRows, 0);
+
+        await driver.insertIntoDatabase();
+        await driver.waitForTableUpdate();
+        expect(await driver.amountOfRows, 1);
+      });
+
+      test('regular open with initializaton', () async {
+        await driver.enableInitialization(InitializationMode.loadAsset);
+        await driver.openDatabase();
+
+        expect(await driver.amountOfRows, 1);
+      });
+
       for (final entry in browser.availableImplementations) {
         group(entry.name, () {
           test('basic', () async {
             await driver.openDatabase(entry);
+            expect(await driver.amountOfRows, 0);
 
             await driver.insertIntoDatabase();
             await driver.waitForTableUpdate();


### PR DESCRIPTION
`WasmDatabase.open` takes an `initializeDatabase` argument, but this is never passed to `WasmProbeResult.open` so it's never actually called.