### PR TITLE
#2743: Ignore empty custom constraints + revert if statement for readability

### DIFF
--- a/drift/lib/src/runtime/query_builder/schema/column_impl.dart
+++ b/drift/lib/src/runtime/query_builder/schema/column_impl.dart
@@ -126,7 +126,11 @@ class GeneratedColumn<T extends Object> extends Column<T> {
       into.buffer.write('$escapedName ${type.sqlTypeName(into)}');
     }
 
-    if ($customConstraints == null) {
+    if ($customConstraints != null && $customConstraints!.isNotEmpty) {
+      into.buffer
+        ..write(' ')
+        ..write($customConstraints);
+    } else {
       if (!isSerial) {
         into.buffer.write($nullable ? ' NULL' : ' NOT NULL');
       }
@@ -164,10 +168,6 @@ class GeneratedColumn<T extends Object> extends Column<T> {
       if (!isSerial && _defaultConstraints != null) {
         _defaultConstraints!(into);
       }
-    } else if ($customConstraints?.isNotEmpty == true) {
-      into.buffer
-        ..write(' ')
-        ..write($customConstraints);
     }
   }
 


### PR DESCRIPTION
What if we check custom constraints for null and empty first, and fill in defaults otherwise?
Looks like it can fix #2743 without breaking backwards compatibility, but i'm not sure. 😁