### PR TITLE
[bugfix/max_and_min_string]

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,3 +20,4 @@ docs/**/*.g.dart
 */build/
 drift/extension/devtools/build
 **/pubspec_overrides.yaml
+**.history/

--- a/drift/lib/src/runtime/query_builder/expressions/aggregate.dart
+++ b/drift/lib/src/runtime/query_builder/expressions/aggregate.dart
@@ -30,6 +30,20 @@ extension BaseAggregate<DT extends Object> on Expression<DT> {
         filter: filter, distinct: distinct);
   }
 
+  /// Return the maximum of all non-null values in this group.
+  ///
+  /// If there are no non-null values in the group, returns null.
+  /// {@macro drift_aggregate_filter}
+  Expression<DT> max({Expression<bool>? filter}) =>
+      _AggregateExpression('MAX', [this], filter: filter);
+
+  /// Return the minimum of all non-null values in this group.
+  ///
+  /// If there are no non-null values in the group, returns null.
+  /// {@macro drift_aggregate_filter}
+  Expression<DT> min({Expression<bool>? filter}) =>
+      _AggregateExpression('MIN', [this], filter: filter);
+
   /// Returns the concatenation of all non-null values in the current group,
   /// joined by the [separator].
   ///

--- a/drift/test/database/expressions/aggregate_test.dart
+++ b/drift/test/database/expressions/aggregate_test.dart
@@ -5,6 +5,7 @@ import '../../test_utils/test_utils.dart';
 
 void main() {
   const foo = CustomExpression<int>('foo', precedence: Precedence.primary);
+  const s1 = CustomExpression<String>('s1', precedence: Precedence.primary);
 
   group('count', () {
     test('all', () {
@@ -49,10 +50,12 @@ void main() {
 
   test('max', () {
     expect(foo.max(), generates('MAX(foo)'));
+    expect(s1.max(), generates('MAX(s1)'));
   });
 
   test('min', () {
     expect(foo.min(), generates('MIN(foo)'));
+    expect(s1.min(), generates('MIN(s1)'));
   });
 
   test('sum', () {


### PR DESCRIPTION
# Bugfix feature - String columns to support MAX and MIN

### We have the following table:

```dart
class example extends Table {
  IntColumn get id => integer().autoIncrement()();
  TextColumn get name => text()();
  TextColumn get string_type => text().withDefault(const Constant('N'))(); //N,Y
  RealColumn get quantity => real()();
}
```

#### Example Table:

| id  | name   | string_type | quantity |
| --- | ------ | ----------- | -------- |
| 1   | TREE01 | N           | 700.0    |
| 2   | TREE01 | N           | 800.0    |
| 3   | TREE01 | N           | 600.0    |
| 4   | TREE01 | Y           | 200.0    |

### We need to execute the following SQL:

```sql
SELECT
	"example"."name" AS "example.name",
	MAX("example"."string_type") AS "c1",
	SUM("example"."quantity") AS "c2"
FROM
	"example"
GROUP BY
	"example"."name"
```

#### Result:

| example.name | c1  | c2     |
| ------------ | --- | ------ |
| TREE01       | Y   | 2300.0 |

### The following is how to use it.

```dart
    final maxStringType = example.string_type.max(); //<-- Fix this LINE
    final sumQuantity = example.quantity.sum();
    final queryExample = selectOnly(
      example,
    )
      ..addColumns([
        example.name,
        maxStringType,
        sumQuantity,
      ])
      ..groupBy([
        example.name,
      ])
     ;
```
