### PR TITLE
[bugfix/sum-and-total-aggregate]

### DIFF
--- a/drift/lib/src/runtime/query_builder/expressions/aggregate.dart
+++ b/drift/lib/src/runtime/query_builder/expressions/aggregate.dart
@@ -44,6 +44,26 @@ extension BaseAggregate<DT extends Object> on Expression<DT> {
   Expression<DT> min({Expression<bool>? filter}) =>
       _AggregateExpression('MIN', [this], filter: filter);
 
+  /// Calculate the sum of all non-null values in the group.
+  ///
+  /// If all values are null, evaluates to null as well. If an overflow occurs
+  /// during calculation, sqlite will terminate the query with an "integer
+  /// overflow" exception.
+  ///
+  /// See also [total], which behaves similarly but returns a floating point
+  /// value and doesn't throw an overflow exception.
+  /// {@macro drift_aggregate_filter}
+  Expression<int> sum({Expression<bool>? filter}) =>
+      _AggregateExpression('SUM', [this], filter: filter);
+
+  /// Calculate the sum of all non-null values in the group.
+  ///
+  /// If all values in the group are null, [total] returns `0.0`. This function
+  /// uses floating-point values internally.
+  /// {@macro drift_aggregate_filter}
+  Expression<double> total({Expression<bool>? filter}) =>
+      _AggregateExpression('TOTAL', [this], filter: filter);
+
   /// Returns the concatenation of all non-null values in the current group,
   /// joined by the [separator].
   ///

--- a/drift/test/database/expressions/aggregate_test.dart
+++ b/drift/test/database/expressions/aggregate_test.dart
@@ -115,11 +115,15 @@ void main() {
   test('sum', () {
     expect(foo.sum(), generates('SUM(foo)'));
     expect(b1.sum(), generates('SUM(b1)'));
+    expect(s1.sum(), generates('SUM(s1)'));
+    expect(p1.sum(), generates('SUM(p1)'));
   });
 
   test('total', () {
     expect(foo.total(), generates('TOTAL(foo)'));
     expect(b1.total(), generates('TOTAL(b1)'));
+    expect(s1.total(), generates('TOTAL(s1)'));
+    expect(p1.total(), generates('TOTAL(p1)'));
   });
 
   group('group_concat', () {


### PR DESCRIPTION
# Bugfix feature - String columns to support MAX and MIN

### We have the following table:

```dart
class example extends Table {
  IntColumn get id => integer().autoIncrement()();
  TextColumn get name => text()();
  TextColumn get string_type => text().withDefault(const Constant('N'))(); //N,Y
  RealColumn get quantity => real()();
}
```

#### Example Table:

| id  | name   | string_type | quantity |
| --- | ------ | ----------- | -------- |
| 1   | TREE01 | N           | 700.0    |
| 2   | TREE01 | N           | 800.0    |
| 3   | TREE01 | N           | 600.0    |
| 4   | TREE01 | Y           | 200.0    |

### We need to execute the following SQL:

```sql
SELECT
	"example"."name" AS "example.name",
	SUM("example"."string_type" IS 'N') AS "c1",
	SUM("example"."quantity") AS "c2"
FROM
	"example"
GROUP BY
	"example"."name"
```

#### Result:

| example.name | c1  | c2     |
| ------------ | --- | ------ |
| TREE01       | 3   | 2300.0 |

### The following is how to use it.

```dart
    final sumStringTypeEqN = example.string_type.equals('N').sum(); //<-- Fix this LINE
    final sumQuantity = example.quantity.sum();
    final queryExample = selectOnly(
      example,
    )
      ..addColumns([
        example.name,
        sumStringTypeEqN,
        sumQuantity,
      ])
      ..groupBy([
        example.name,
      ])
     ;
```
