### PR TITLE
feat: add coverage ignore for generated files

### DIFF
--- a/drift_dev/lib/src/backends/build/drift_builder.dart
+++ b/drift_dev/lib/src/backends/build/drift_builder.dart
@@ -422,6 +422,7 @@ class _DriftBuildRun {
     }
 
     output.writeln('// ignore_for_file: type=lint');
+    output.writeln('// coverage:ignore-file');
 
     if (mode == DriftGenerationMode.monolithicPart) {
       final originalFile = buildStep.inputId.pathSegments.last;

--- a/drift_dev/test/backends/build/drift_builder_test.dart
+++ b/drift_dev/test/backends/build/drift_builder_test.dart
@@ -50,4 +50,25 @@ class Database {}
       writer.writer,
     );
   });
+
+  test("includes coverage ignore", () async {
+    final writer = await emulateDriftBuild(inputs: {
+      'a|lib/a.dart': '''
+// @dart = 2.13
+
+import 'package:drift/drift.dart';
+
+@DriftDatabase(tables: [])
+class Database {}
+        ''',
+    });
+    checkOutputs(
+      {
+        'a|lib/a.drift.dart':
+            decodedMatches(contains('// coverage:ignore-file')),
+      },
+      writer.dartOutputs,
+      writer.writer,
+    );
+  });
 }


### PR DESCRIPTION
With these changes, generated files will always be ignored when running tests with coverage.