### PR TITLE
docs: add one-liner dependency addition instructions in the documentation

### DIFF
--- a/docs/pages/docs/setup.md
+++ b/docs/pages/docs/setup.md
@@ -45,6 +45,12 @@ dev_dependencies:
   build_runner: ^{{ versions.build_runner }}
 ```
 
+Alternatively, you can achieve the same result using the following command:
+
+```
+flutter pub add drift sqlite3_flutter_libs path_provider path dev:drift_dev dev:build_runner
+```
+
 If you're wondering why so many packages are necessary, here's a quick overview over what each package does:
 
 - `drift`: This is the core package defining the APIs you use to access drift databases.

--- a/docs/pages/docs/setup.md
+++ b/docs/pages/docs/setup.md
@@ -48,7 +48,7 @@ dev_dependencies:
 Alternatively, you can achieve the same result using the following command:
 
 ```
-flutter pub add drift sqlite3_flutter_libs path_provider path dev:drift_dev dev:build_runner
+dart pub add drift sqlite3_flutter_libs path_provider path dev:drift_dev dev:build_runner
 ```
 
 If you're wondering why so many packages are necessary, here's a quick overview over what each package does:


### PR DESCRIPTION
When a beginner wants to try this library, it is a bit troublesome because of the many dependencies
I think it would be helpful if you also included a one-liner on how to add it, so all you have to do is copy this and run it.