### PR TITLE
In variable helper, check for UserDefinedSqlType, not CustomSqlType

### DIFF
--- a/drift/lib/src/runtime/query_builder/expressions/custom.dart
+++ b/drift/lib/src/runtime/query_builder/expressions/custom.dart
@@ -24,14 +24,14 @@ class CustomExpression<D extends Object> extends Expression<D> {
   @override
   final Precedence precedence;
 
-  final CustomSqlType<D>? _customSqlType;
+  final UserDefinedSqlType<D>? _customSqlType;
 
   /// Constructs a custom expression by providing the raw sql [content].
   const CustomExpression(
     this.content, {
     this.watchedTables = const [],
     this.precedence = Precedence.unknown,
-    CustomSqlType<D>? customType,
+    UserDefinedSqlType<D>? customType,
   })  : _dialectSpecificContent = null,
         _customSqlType = customType;
 
@@ -41,7 +41,7 @@ class CustomExpression<D extends Object> extends Expression<D> {
     Map<SqlDialect, String> content, {
     this.watchedTables = const [],
     this.precedence = Precedence.unknown,
-    CustomSqlType<D>? customType,
+    UserDefinedSqlType<D>? customType,
   })  : _dialectSpecificContent = content,
         content = '',
         _customSqlType = customType;

--- a/drift/lib/src/runtime/query_builder/helpers.dart
+++ b/drift/lib/src/runtime/query_builder/helpers.dart
@@ -54,7 +54,7 @@ extension WithTypes<T extends Object> on Expression<T> {
   /// Creates a variable with a matching [driftSqlType].
   Variable<T> variable(T? value) {
     return switch (driftSqlType) {
-      CustomSqlType<T> custom => Variable(value, custom),
+      UserDefinedSqlType<T> custom => Variable(value, custom),
       _ => Variable(value),
     };
   }

--- a/drift/test/database/expressions/custom_types_test.dart
+++ b/drift/test/database/expressions/custom_types_test.dart
@@ -44,6 +44,23 @@ void main() {
     expect(exp, generates('?', [10]));
     expect(exp.driftSqlType, isA<_NegatedIntType>());
   });
+
+  test('also supports dialect-aware types', () {
+    const b = CustomExpression(
+      'b',
+      customType: DialectAwareSqlType<int>.via(
+        fallback: _NegatedIntType(),
+        overrides: {SqlDialect.postgres: DriftSqlType.int},
+      ),
+      precedence: Precedence.primary,
+    );
+
+    expect(b.equals(3), generates('b = ?', [-3]));
+    expect(
+        b.equals(3),
+        generatesWithOptions('b = \$1',
+            variables: [3], dialect: SqlDialect.postgres));
+  });
 }
 
 class _NegatedIntType implements CustomSqlType<int> {


### PR DESCRIPTION
I am using ElectricSQL and the Electric Dart package. Their custom types for Postgres all implement `UserDefinedSqlType` and not `CustomSqlType`.

Please see: https://github.com/SkillDevs/electric_dart/blob/master/packages/electricsql/lib/src/client/conversions/custom_types.dart

This helper is therefore not being caught by this type check and the custom type is not being passed through to the variable, which means that the custom type is not being correctly mapped into the resulting SQL. This affects all queries as the query builders all use the `variable` helper

As the `Variable` constructor is expecting `UserDefinedSqlType`, it seems more correct that this is the type that it is checking against.