### PR TITLE
Improve Postgres `isOpen` check

### DIFF
--- a/extras/drift_postgres/lib/src/pg_database.dart
+++ b/extras/drift_postgres/lib/src/pg_database.dart
@@ -54,7 +54,8 @@ class _PgDelegate extends DatabaseDelegate {
   late DbVersionDelegate versionDelegate;
 
   @override
-  Future<bool> get isOpen => Future.value(_openedSession != null);
+  Future<bool> get isOpen =>
+      Future.value(_openedSession != null && _openedSession!.isOpen);
 
   @override
   Future<void> open(QueryExecutorUser user) async {


### PR DESCRIPTION
After a certain period, the Postgres session could be closed when the app is in the background, this improves the `isOpen` to ensure the session is still open.