### PR TITLE
Support bytea sql literal in postgres

### DIFF
--- a/drift/lib/src/runtime/types/mapping.dart
+++ b/drift/lib/src/runtime/types/mapping.dart
@@ -115,9 +115,17 @@ final class SqlTypes {
         return (dart.millisecondsSinceEpoch ~/ 1000).toString();
       }
     } else if (dart is Uint8List) {
-      // BLOB literals are string literals containing hexadecimal data and
-      // preceded by a single "x" or "X" character. Example: X'53514C697465'
-      return "x'${hex.encode(dart)}'";
+      final String hexString = hex.encode(dart);
+
+      if (dialect == SqlDialect.postgres) {
+        // Postgres BYTEA hex format
+        // https://www.postgresql.org/docs/current/datatype-binary.html#DATATYPE-BINARY-BYTEA-HEX-FORMAT
+        return "'\\x$hexString'::bytea";
+      } else {
+        // BLOB literals are string literals containing hexadecimal data and
+        // preceded by a single "x" or "X" character. Example: X'53514C697465'
+        return "x'${hex.encode(dart)}'";
+      }
     } else if (dart is DriftAny) {
       return mapToSqlLiteral(dart.rawSqlValue);
     }

--- a/extras/drift_postgres/test/types_test.dart
+++ b/extras/drift_postgres/test/types_test.dart
@@ -26,19 +26,19 @@ void main() {
     return row.read(expression)!;
   }
 
+  void testWith<T extends Object>(CustomSqlType<T>? type, T value) {
+    test('with variable', () async {
+      final variable = Variable(value, type);
+      expect(await eval(variable), value);
+    });
+
+    test('with constant', () async {
+      final constant = Constant(value, type);
+      expect(await eval(constant), value);
+    });
+  }
+
   group('custom types pass through', () {
-    void testWith<T extends Object>(CustomSqlType<T> type, T value) {
-      test('with variable', () async {
-        final variable = Variable(value, type);
-        expect(await eval(variable), value);
-      });
-
-      test('with constant', () async {
-        final constant = Constant(value, type);
-        expect(await eval(constant), value);
-      });
-    }
-
     group('uuid', () => testWith(PgTypes.uuid, Uuid().v4obj()));
     group(
       'interval',
@@ -59,6 +59,8 @@ void main() {
           PgDateTime(DateTime.utc(1996, 7, 8, 10, 0, 0))),
     );
   });
+
+  group('bytea', () => testWith(null, Uint8List.fromList([1, 2, 3, 4, 5])));
 
   test('compare datetimes', () async {
     final time = DateTime.now();


### PR DESCRIPTION
Currently, when using a bytea literal, the generated Postgres SQL is invalid.

In Postgres we can use a similar syntax to pass the value as HEX.