### PR TITLE
Fix parameter binding when NULL is provided.

### DIFF
--- a/extras/drift_postgres/CHANGELOG.md
+++ b/extras/drift_postgres/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 1.2.2
+
+- Fix parameter binding when NULL is provided.
+
 ## 1.2.1
 
 - Fix `isOpen` so that it properly returns false after the underlying postgres

--- a/extras/drift_postgres/lib/src/pg_database.dart
+++ b/extras/drift_postgres/lib/src/pg_database.dart
@@ -168,7 +168,7 @@ class _BoundArguments {
         final value = args[i];
         return switch (value) {
           TypedValue() => value,
-          null => TypedValue(Type.text, null),
+          null => TypedValue(Type.unspecified, null),
           int() || BigInt() => TypedValue(Type.bigInteger, value),
           String() => TypedValue(Type.text, value),
           bool() => TypedValue(Type.boolean, value),

--- a/extras/drift_postgres/pubspec.yaml
+++ b/extras/drift_postgres/pubspec.yaml
@@ -1,6 +1,6 @@
 name: drift_postgres
 description: Postgres implementation and APIs for the drift database package.
-version: 1.2.1
+version: 1.2.2
 repository: https://github.com/simolus3/drift
 homepage: https://drift.simonbinder.eu/docs/platforms/postgres/
 issue_tracker: https://github.com/simolus3/drift/issues

--- a/extras/drift_postgres/test/drift_postgres_test.dart
+++ b/extras/drift_postgres/test/drift_postgres_test.dart
@@ -1,6 +1,7 @@
 import 'package:drift_postgres/drift_postgres.dart';
 import 'package:drift_testcases/tests.dart';
 import 'package:postgres/postgres.dart' as pg;
+import 'package:test/test.dart';
 
 class PgExecutor extends TestExecutor {
   @override
@@ -37,4 +38,25 @@ class PgExecutor extends TestExecutor {
 
 void main() {
   runAllTests(PgExecutor());
+
+  // Regression for https://github.com/simolus3/drift/issues/2981
+  test('bind null to nullable column', () async {
+    final executor = PgExecutor();
+    final db = Database(executor.createConnection());
+
+    await db.customStatement('''
+CREATE TABLE mytable (
+  id INTEGER PRIMARY KEY NOT NULL,
+  value INTEGER
+);
+''');
+
+    // Provide null to a nullable column
+    await db.customInsert(
+      r'INSERT INTO mytable (id, value) VALUES (1, $1);',
+      variables: [Variable(null)],
+    );
+
+    await executor.clearDatabaseAndClose(db);
+  });
 }


### PR DESCRIPTION
Fixes #2981 

It turns out we cannot use `Type.text`, because postgres will complain when the type doesn't match, even if NULL is provided.