### PR TITLE
[drift_postgres] Let values go through as is, so that Postgres uses native conversions

### DIFF
--- a/extras/drift_postgres/lib/src/pg_database.dart
+++ b/extras/drift_postgres/lib/src/pg_database.dart
@@ -168,11 +168,13 @@ class _BoundArguments {
         final value = args[i];
         return switch (value) {
           TypedValue() => value,
-          null => TypedValue(Type.unspecified, null),
-          int() || BigInt() => TypedValue(Type.bigInteger, value),
-          String() => TypedValue(Type.text, value),
-          bool() => TypedValue(Type.boolean, value),
-          double() => TypedValue(Type.double, value),
+          null ||
+          int() ||
+          String() ||
+          bool() ||
+          double() =>
+            TypedValue(Type.unspecified, value),
+          BigInt() => TypedValue(Type.bigInteger, value.toInt()),
           List<int>() => TypedValue(Type.byteArray, value),
           _ => throw ArgumentError.value(value, 'value', 'Unsupported type'),
         };

--- a/extras/drift_postgres/lib/src/pg_database.dart
+++ b/extras/drift_postgres/lib/src/pg_database.dart
@@ -174,7 +174,7 @@ class _BoundArguments {
           bool() ||
           double() =>
             TypedValue(Type.unspecified, value),
-          BigInt() => TypedValue(Type.bigInteger, value.toInt()),
+          BigInt() => TypedValue(Type.bigInteger, value.checkRange.toInt()),
           List<int>() => TypedValue(Type.byteArray, value),
           _ => throw ArgumentError.value(value, 'value', 'Unsupported type'),
         };
@@ -215,5 +215,17 @@ class _PgVersionDelegate extends DynamicVersionDelegate {
         TypedValue(Type.integer, version),
       ],
     );
+  }
+}
+
+extension _BigIntRangeCheck on BigInt {
+  static final _bigIntMinValue64 = BigInt.parse('-9223372036854775808');
+  static final _bigIntMaxValue64 = BigInt.parse('9223372036854775807');
+
+  BigInt get checkRange {
+    if (this < _bigIntMinValue64 || this > _bigIntMaxValue64) {
+      throw Exception('BigInt value exceeds the range of 64 bits');
+    }
+    return this;
   }
 }

--- a/extras/drift_postgres/test/drift_postgres_test.dart
+++ b/extras/drift_postgres/test/drift_postgres_test.dart
@@ -61,7 +61,11 @@ void main() {
       await testBindingError(
         columnType: 'INT8',
         input: BigInt.parse('9223372036854775808'),
-        matcher: isA<Exception>(),
+        matcher: isA<Exception>().having(
+          (e) => e.toString(),
+          'message',
+          'Exception: BigInt value exceeds the range of 64 bits',
+        ),
       );
     });
 


### PR DESCRIPTION
Fixes #2986