### PR TITLE
Read references from manager queries

### DIFF
--- a/docs/lib/snippets/_shared/todo_tables.drift.dart
+++ b/docs/lib/snippets/_shared/todo_tables.drift.dart
@@ -477,8 +477,8 @@ class $$TodoItemsTableOrderingComposer
 class $$TodoItemsTableWithReferences {
   // ignore: unused_field
   final i0.GeneratedDatabase _db;
-  final i1.TodoItem todoItems;
-  $$TodoItemsTableWithReferences(this._db, this.todoItems);
+  final i1.TodoItem i1TodoItem;
+  $$TodoItemsTableWithReferences(this._db, this.i1TodoItem);
 }
 
 class $CategoriesTable extends i2.Categories
@@ -752,8 +752,8 @@ class $$CategoriesTableOrderingComposer
 class $$CategoriesTableWithReferences {
   // ignore: unused_field
   final i0.GeneratedDatabase _db;
-  final i1.Category categories;
-  $$CategoriesTableWithReferences(this._db, this.categories);
+  final i1.Category i1Category;
+  $$CategoriesTableWithReferences(this._db, this.i1Category);
 }
 
 class $UsersTable extends i2.Users with i0.TableInfo<$UsersTable, i1.User> {
@@ -1026,6 +1026,6 @@ class $$UsersTableOrderingComposer
 class $$UsersTableWithReferences {
   // ignore: unused_field
   final i0.GeneratedDatabase _db;
-  final i1.User users;
-  $$UsersTableWithReferences(this._db, this.users);
+  final i1.User i1User;
+  $$UsersTableWithReferences(this._db, this.i1User);
 }

--- a/docs/lib/snippets/_shared/todo_tables.drift.dart
+++ b/docs/lib/snippets/_shared/todo_tables.drift.dart
@@ -334,9 +334,10 @@ class $$TodoItemsTableTableManager extends i0.RootTableManager<
     i1.TodoItem,
     i1.$$TodoItemsTableFilterComposer,
     i1.$$TodoItemsTableOrderingComposer,
-    $$TodoItemsTableProcessedTableManager,
     $$TodoItemsTableInsertCompanionBuilder,
-    $$TodoItemsTableUpdateCompanionBuilder> {
+    $$TodoItemsTableUpdateCompanionBuilder,
+    $$TodoItemsTableWithReferences,
+    i1.TodoItem> {
   $$TodoItemsTableTableManager(
       i0.GeneratedDatabase db, i1.$TodoItemsTable table)
       : super(i0.TableManagerState(
@@ -346,9 +347,7 @@ class $$TodoItemsTableTableManager extends i0.RootTableManager<
               i1.$$TodoItemsTableFilterComposer(i0.ComposerState(db, table)),
           orderingComposer:
               i1.$$TodoItemsTableOrderingComposer(i0.ComposerState(db, table)),
-          getChildManagerBuilder: (p) =>
-              $$TodoItemsTableProcessedTableManager(p),
-          getUpdateCompanionBuilder: ({
+          createUpdateCompanionCallback: ({
             i0.Value<int> id = const i0.Value.absent(),
             i0.Value<String> title = const i0.Value.absent(),
             i0.Value<String> content = const i0.Value.absent(),
@@ -362,7 +361,9 @@ class $$TodoItemsTableTableManager extends i0.RootTableManager<
             category: category,
             dueDate: dueDate,
           ),
-          getInsertCompanionBuilder: ({
+          dataclassMapper: (p0) async =>
+              p0.map((e) => $$TodoItemsTableWithReferences(db, e)).toList(),
+          createInsertCompanionCallback: ({
             i0.Value<int> id = const i0.Value.absent(),
             required String title,
             required String content,
@@ -379,17 +380,16 @@ class $$TodoItemsTableTableManager extends i0.RootTableManager<
         ));
 }
 
-class $$TodoItemsTableProcessedTableManager extends i0.ProcessedTableManager<
+typedef $$TodoItemsTableProcessedTableManager = i0.ProcessedTableManager<
     i0.GeneratedDatabase,
     i1.$TodoItemsTable,
     i1.TodoItem,
     i1.$$TodoItemsTableFilterComposer,
     i1.$$TodoItemsTableOrderingComposer,
-    $$TodoItemsTableProcessedTableManager,
     $$TodoItemsTableInsertCompanionBuilder,
-    $$TodoItemsTableUpdateCompanionBuilder> {
-  $$TodoItemsTableProcessedTableManager(super.$state);
-}
+    $$TodoItemsTableUpdateCompanionBuilder,
+    $$TodoItemsTableWithReferences,
+    i1.TodoItem>;
 
 class $$TodoItemsTableFilterComposer
     extends i0.FilterComposer<i0.GeneratedDatabase, i1.$TodoItemsTable> {
@@ -472,6 +472,13 @@ class $$TodoItemsTableOrderingComposer
                     parentComposers)));
     return composer;
   }
+}
+
+class $$TodoItemsTableWithReferences {
+  // ignore: unused_field
+  final i0.GeneratedDatabase _db;
+  final i1.TodoItem todoItems;
+  $$TodoItemsTableWithReferences(this._db, this.todoItems);
 }
 
 class $CategoriesTable extends i2.Categories
@@ -669,9 +676,10 @@ class $$CategoriesTableTableManager extends i0.RootTableManager<
     i1.Category,
     i1.$$CategoriesTableFilterComposer,
     i1.$$CategoriesTableOrderingComposer,
-    $$CategoriesTableProcessedTableManager,
     $$CategoriesTableInsertCompanionBuilder,
-    $$CategoriesTableUpdateCompanionBuilder> {
+    $$CategoriesTableUpdateCompanionBuilder,
+    $$CategoriesTableWithReferences,
+    i1.Category> {
   $$CategoriesTableTableManager(
       i0.GeneratedDatabase db, i1.$CategoriesTable table)
       : super(i0.TableManagerState(
@@ -681,9 +689,7 @@ class $$CategoriesTableTableManager extends i0.RootTableManager<
               i1.$$CategoriesTableFilterComposer(i0.ComposerState(db, table)),
           orderingComposer:
               i1.$$CategoriesTableOrderingComposer(i0.ComposerState(db, table)),
-          getChildManagerBuilder: (p) =>
-              $$CategoriesTableProcessedTableManager(p),
-          getUpdateCompanionBuilder: ({
+          createUpdateCompanionCallback: ({
             i0.Value<int> id = const i0.Value.absent(),
             i0.Value<String> name = const i0.Value.absent(),
           }) =>
@@ -691,7 +697,9 @@ class $$CategoriesTableTableManager extends i0.RootTableManager<
             id: id,
             name: name,
           ),
-          getInsertCompanionBuilder: ({
+          dataclassMapper: (p0) async =>
+              p0.map((e) => $$CategoriesTableWithReferences(db, e)).toList(),
+          createInsertCompanionCallback: ({
             i0.Value<int> id = const i0.Value.absent(),
             required String name,
           }) =>
@@ -702,17 +710,16 @@ class $$CategoriesTableTableManager extends i0.RootTableManager<
         ));
 }
 
-class $$CategoriesTableProcessedTableManager extends i0.ProcessedTableManager<
+typedef $$CategoriesTableProcessedTableManager = i0.ProcessedTableManager<
     i0.GeneratedDatabase,
     i1.$CategoriesTable,
     i1.Category,
     i1.$$CategoriesTableFilterComposer,
     i1.$$CategoriesTableOrderingComposer,
-    $$CategoriesTableProcessedTableManager,
     $$CategoriesTableInsertCompanionBuilder,
-    $$CategoriesTableUpdateCompanionBuilder> {
-  $$CategoriesTableProcessedTableManager(super.$state);
-}
+    $$CategoriesTableUpdateCompanionBuilder,
+    $$CategoriesTableWithReferences,
+    i1.Category>;
 
 class $$CategoriesTableFilterComposer
     extends i0.FilterComposer<i0.GeneratedDatabase, i1.$CategoriesTable> {
@@ -740,6 +747,13 @@ class $$CategoriesTableOrderingComposer
       column: $state.table.name,
       builder: (column, joinBuilders) =>
           i0.ColumnOrderings(column, joinBuilders: joinBuilders));
+}
+
+class $$CategoriesTableWithReferences {
+  // ignore: unused_field
+  final i0.GeneratedDatabase _db;
+  final i1.Category categories;
+  $$CategoriesTableWithReferences(this._db, this.categories);
 }
 
 class $UsersTable extends i2.Users with i0.TableInfo<$UsersTable, i1.User> {
@@ -937,9 +951,10 @@ class $$UsersTableTableManager extends i0.RootTableManager<
     i1.User,
     i1.$$UsersTableFilterComposer,
     i1.$$UsersTableOrderingComposer,
-    $$UsersTableProcessedTableManager,
     $$UsersTableInsertCompanionBuilder,
-    $$UsersTableUpdateCompanionBuilder> {
+    $$UsersTableUpdateCompanionBuilder,
+    $$UsersTableWithReferences,
+    i1.User> {
   $$UsersTableTableManager(i0.GeneratedDatabase db, i1.$UsersTable table)
       : super(i0.TableManagerState(
           db: db,
@@ -948,8 +963,7 @@ class $$UsersTableTableManager extends i0.RootTableManager<
               i1.$$UsersTableFilterComposer(i0.ComposerState(db, table)),
           orderingComposer:
               i1.$$UsersTableOrderingComposer(i0.ComposerState(db, table)),
-          getChildManagerBuilder: (p) => $$UsersTableProcessedTableManager(p),
-          getUpdateCompanionBuilder: ({
+          createUpdateCompanionCallback: ({
             i0.Value<int> id = const i0.Value.absent(),
             i0.Value<DateTime> birthDate = const i0.Value.absent(),
           }) =>
@@ -957,7 +971,9 @@ class $$UsersTableTableManager extends i0.RootTableManager<
             id: id,
             birthDate: birthDate,
           ),
-          getInsertCompanionBuilder: ({
+          dataclassMapper: (p0) async =>
+              p0.map((e) => $$UsersTableWithReferences(db, e)).toList(),
+          createInsertCompanionCallback: ({
             i0.Value<int> id = const i0.Value.absent(),
             required DateTime birthDate,
           }) =>
@@ -968,17 +984,16 @@ class $$UsersTableTableManager extends i0.RootTableManager<
         ));
 }
 
-class $$UsersTableProcessedTableManager extends i0.ProcessedTableManager<
+typedef $$UsersTableProcessedTableManager = i0.ProcessedTableManager<
     i0.GeneratedDatabase,
     i1.$UsersTable,
     i1.User,
     i1.$$UsersTableFilterComposer,
     i1.$$UsersTableOrderingComposer,
-    $$UsersTableProcessedTableManager,
     $$UsersTableInsertCompanionBuilder,
-    $$UsersTableUpdateCompanionBuilder> {
-  $$UsersTableProcessedTableManager(super.$state);
-}
+    $$UsersTableUpdateCompanionBuilder,
+    $$UsersTableWithReferences,
+    i1.User>;
 
 class $$UsersTableFilterComposer
     extends i0.FilterComposer<i0.GeneratedDatabase, i1.$UsersTable> {
@@ -1006,4 +1021,11 @@ class $$UsersTableOrderingComposer
       column: $state.table.birthDate,
       builder: (column, joinBuilders) =>
           i0.ColumnOrderings(column, joinBuilders: joinBuilders));
+}
+
+class $$UsersTableWithReferences {
+  // ignore: unused_field
+  final i0.GeneratedDatabase _db;
+  final i1.User users;
+  $$UsersTableWithReferences(this._db, this.users);
 }

--- a/docs/lib/snippets/dart_api/manager.dart
+++ b/docs/lib/snippets/dart_api/manager.dart
@@ -23,8 +23,6 @@ class TodoCategory extends Table {
 class Users extends Table {
   IntColumn get id => integer().autoIncrement()();
   TextColumn get name => text()();
-  @ReferenceName("users")
-  IntColumn get group => integer().references(Groups, #id)();
 }
 
 class Groups extends Table {

--- a/docs/lib/snippets/dart_api/manager.dart
+++ b/docs/lib/snippets/dart_api/manager.dart
@@ -1,4 +1,4 @@
-// ignore_for_file: invalid_use_of_internal_member
+// ignore_for_file: invalid_use_of_internal_member, unused_local_variable
 
 import 'package:drift/drift.dart';
 
@@ -23,6 +23,8 @@ class TodoCategory extends Table {
 class Users extends Table {
   IntColumn get id => integer().autoIncrement()();
   TextColumn get name => text()();
+  @ReferenceName("users")
+  IntColumn get group => integer().references(Groups, #id)();
 }
 
 class Groups extends Table {
@@ -44,8 +46,8 @@ class AppDatabase extends _$AppDatabase {
 }
 
 extension ManagerExamples on AppDatabase {
-  // #docregion manager_create
   Future<void> createTodoItem() async {
+    // #docregion manager_create
     // Create a new item
     await managers.todoItems
         .create((o) => o(title: 'Title', content: 'Content'));
@@ -63,11 +65,11 @@ extension ManagerExamples on AppDatabase {
         o(title: 'Title 2', content: 'Content 2'),
       ],
     );
+    // #enddocregion manager_create
   }
-  // #enddocregion manager_create
 
-  // #docregion manager_update
   Future<void> updateTodoItems() async {
+    // #docregion manager_update
     // Update all items
     await managers.todoItems.update((o) => o(content: Value('New Content')));
 
@@ -75,11 +77,11 @@ extension ManagerExamples on AppDatabase {
     await managers.todoItems
         .filter((f) => f.id.isIn([1, 2, 3]))
         .update((o) => o(content: Value('New Content')));
+    // #enddocregion manager_update
   }
-  // #enddocregion manager_update
 
-  // #docregion manager_replace
   Future<void> replaceTodoItems() async {
+    // #docregion manager_replace
     // Replace a single item
     var obj = await managers.todoItems.filter((o) => o.id(1)).getSingle();
     obj = obj.copyWith(content: 'New Content');
@@ -90,21 +92,21 @@ extension ManagerExamples on AppDatabase {
         await managers.todoItems.filter((o) => o.id.isIn([1, 2, 3])).get();
     objs = objs.map((o) => o.copyWith(content: 'New Content')).toList();
     await managers.todoItems.bulkReplace(objs);
+    // #enddocregion manager_replace
   }
-  // #enddocregion manager_replace
 
-  // #docregion manager_delete
   Future<void> deleteTodoItems() async {
+    // #docregion manager_delete
     // Delete all items
     await managers.todoItems.delete();
 
     // Delete a single item
     await managers.todoItems.filter((f) => f.id(5)).delete();
+    // #enddocregion manager_delete
   }
-  // #enddocregion manager_delete
 
-  // #docregion manager_select
   Future<void> selectTodoItems() async {
+    // #docregion manager_select
     // Get all items
     managers.todoItems.get();
 
@@ -113,11 +115,11 @@ extension ManagerExamples on AppDatabase {
 
     // To get a single item, apply a filter and call `getSingle`
     await managers.todoItems.filter((f) => f.id(1)).getSingle();
+    // #enddocregion manager_select
   }
-  // #enddocregion manager_select
 
-  // #docregion manager_filter
   Future<void> filterTodoItems() async {
+    // #docregion manager_filter
     // All items with a title of "Title"
     managers.todoItems.filter((f) => f.title("Title"));
 
@@ -126,52 +128,52 @@ extension ManagerExamples on AppDatabase {
 
     // All items with a title of "Title" or content that is not null
     managers.todoItems.filter((f) => f.title("Title") | f.content.not.isNull());
+    // #enddocregion manager_filter
   }
-  // #enddocregion manager_filter
 
-  // #docregion manager_type_specific_filter
   Future filterWithType() async {
+    // #docregion manager_type_specific_filter
     // Filter all items created since 7 days ago
     managers.todoItems.filter(
         (f) => f.createdAt.isAfter(DateTime.now().subtract(Duration(days: 7))));
 
     // Filter all items with a title that starts with "Title"
     managers.todoItems.filter((f) => f.title.startsWith('Title'));
-  }
 // #enddocregion manager_type_specific_filter
+  }
 
-// #docregion manager_ordering
   Future orderWithType() async {
+// #docregion manager_ordering
     // Order all items by their creation date in ascending order
     managers.todoItems.orderBy((o) => o.createdAt.asc());
 
     // Order all items by their title in ascending order and then by their content in ascending order
     managers.todoItems.orderBy((o) => o.title.asc() & o.content.asc());
-  }
 // #enddocregion manager_ordering
+  }
 
-// #docregion manager_count
   Future count() async {
+// #docregion manager_count
     // Count all items
     await managers.todoItems.count();
 
     // Count all items with a title of "Title"
     await managers.todoItems.filter((f) => f.title("Title")).count();
-  }
 // #enddocregion manager_count
+  }
 
-// #docregion manager_exists
   Future exists() async {
+// #docregion manager_exists
     // Check if any items exist
     await managers.todoItems.exists();
 
     // Check if any items with a title of "Title" exist
     await managers.todoItems.filter((f) => f.title("Title")).exists();
-  }
 // #enddocregion manager_exists
+  }
 
-// #docregion manager_filter_forward_references
   Future relationalFilter() async {
+// #docregion manager_filter_forward_references
     // Get all items with a category description of "School"
     managers.todoItems.filter((f) => f.category.description("School"));
 
@@ -182,11 +184,11 @@ extension ManagerExamples on AppDatabase {
           (f) => f.title("Title") | f.category.description("School"),
         )
         .exists();
-  }
 // #enddocregion manager_filter_forward_references
+  }
 
-// #docregion manager_filter_back_references
   Future reverseRelationalFilter() async {
+// #docregion manager_filter_back_references
     // Get the category that has a todo item with an id of 1
     managers.todoCategory.filter((f) => f.todoItemsRefs((f) => f.id(1)));
 
@@ -195,11 +197,11 @@ extension ManagerExamples on AppDatabase {
     managers.todoCategory.filter(
       (f) => f.description("School") | f.todoItemsRefs((f) => f.id(1)),
     );
-  }
 // #enddocregion manager_filter_back_references
+  }
 
-// #docregion manager_filter_custom_back_references
   Future reverseNamedRelationalFilter() async {
+// #docregion manager_filter_custom_back_references
     // Get all users who are administrators of a group with a name containing "Business"
     // or who own a group with an id of 1, 2, 4, or 5
     managers.users.filter(
@@ -207,8 +209,41 @@ extension ManagerExamples on AppDatabase {
           f.administeredGroups((f) => f.name.contains("Business")) |
           f.ownedGroups((f) => f.id.isIn([1, 2, 4, 5])),
     );
-  }
 // #enddocregion manager_filter_custom_back_references
+  }
+
+  Future managerWithRefs() async {
+// #docregion manager_with_refs
+    final todoWithCategory = await managers.todoItems
+        .filter((f) => f.id(1))
+        .withReferences()
+        .getSingle();
+    final category = await todoWithCategory.category?.getSingle();
+
+    // You could also do nested references, even with a filter
+    // Here we will get the category of this todo item, with all the todo items in that category
+    final categoryWithTodos =
+        await todoWithCategory.category?.withReferences().getSingle();
+    // And now we can get all the todo items in that category
+    final allTodoInCategory = await categoryWithTodos?.todoItemsRefs.get();
+    // We could even filter it, so here is all the todo items in that category with a title of "Title"
+    final allTodoInCategoryWithTitle = await categoryWithTodos?.todoItemsRefs
+        .filter((f) => f.title("Title"))
+        .get();
+// #enddocregion manager_with_refs
+  }
+
+  Future managerWithRefsNPlus1() async {
+// #docregion manager_with_refs_n_plus_1
+    // Get all users with their referenced groups
+    final usersWithReferences = await managers.users.withReferences().get();
+    for (var i in usersWithReferences) {
+      final user = i.user;
+      final administeredGroups =
+          await i.administeredGroups.get(); // Will run many queries
+    }
+// #enddocregion manager_with_refs_n_plus_1
+  }
 }
 
 // #docregion manager_filter_extensions

--- a/docs/lib/snippets/modular/custom_types/drift_table.drift.dart
+++ b/docs/lib/snippets/modular/custom_types/drift_table.drift.dart
@@ -250,9 +250,10 @@ class $PeriodicRemindersTableManager extends i0.RootTableManager<
     i1.PeriodicReminder,
     i1.$PeriodicRemindersFilterComposer,
     i1.$PeriodicRemindersOrderingComposer,
-    $PeriodicRemindersProcessedTableManager,
     $PeriodicRemindersInsertCompanionBuilder,
-    $PeriodicRemindersUpdateCompanionBuilder> {
+    $PeriodicRemindersUpdateCompanionBuilder,
+    $PeriodicRemindersWithReferences,
+    i1.PeriodicReminder> {
   $PeriodicRemindersTableManager(
       i0.GeneratedDatabase db, i1.PeriodicReminders table)
       : super(i0.TableManagerState(
@@ -262,9 +263,7 @@ class $PeriodicRemindersTableManager extends i0.RootTableManager<
               i1.$PeriodicRemindersFilterComposer(i0.ComposerState(db, table)),
           orderingComposer: i1
               .$PeriodicRemindersOrderingComposer(i0.ComposerState(db, table)),
-          getChildManagerBuilder: (p) =>
-              $PeriodicRemindersProcessedTableManager(p),
-          getUpdateCompanionBuilder: ({
+          createUpdateCompanionCallback: ({
             i0.Value<int> id = const i0.Value.absent(),
             i0.Value<Duration> frequency = const i0.Value.absent(),
             i0.Value<String> reminder = const i0.Value.absent(),
@@ -274,7 +273,9 @@ class $PeriodicRemindersTableManager extends i0.RootTableManager<
             frequency: frequency,
             reminder: reminder,
           ),
-          getInsertCompanionBuilder: ({
+          dataclassMapper: (p0) async =>
+              p0.map((e) => $PeriodicRemindersWithReferences(db, e)).toList(),
+          createInsertCompanionCallback: ({
             i0.Value<int> id = const i0.Value.absent(),
             required Duration frequency,
             required String reminder,
@@ -287,17 +288,16 @@ class $PeriodicRemindersTableManager extends i0.RootTableManager<
         ));
 }
 
-class $PeriodicRemindersProcessedTableManager extends i0.ProcessedTableManager<
+typedef $PeriodicRemindersProcessedTableManager = i0.ProcessedTableManager<
     i0.GeneratedDatabase,
     i1.PeriodicReminders,
     i1.PeriodicReminder,
     i1.$PeriodicRemindersFilterComposer,
     i1.$PeriodicRemindersOrderingComposer,
-    $PeriodicRemindersProcessedTableManager,
     $PeriodicRemindersInsertCompanionBuilder,
-    $PeriodicRemindersUpdateCompanionBuilder> {
-  $PeriodicRemindersProcessedTableManager(super.$state);
-}
+    $PeriodicRemindersUpdateCompanionBuilder,
+    $PeriodicRemindersWithReferences,
+    i1.PeriodicReminder>;
 
 class $PeriodicRemindersFilterComposer
     extends i0.FilterComposer<i0.GeneratedDatabase, i1.PeriodicReminders> {
@@ -335,4 +335,11 @@ class $PeriodicRemindersOrderingComposer
       column: $state.table.reminder,
       builder: (column, joinBuilders) =>
           i0.ColumnOrderings(column, joinBuilders: joinBuilders));
+}
+
+class $PeriodicRemindersWithReferences {
+  // ignore: unused_field
+  final i0.GeneratedDatabase _db;
+  final i1.PeriodicReminder periodicReminders;
+  $PeriodicRemindersWithReferences(this._db, this.periodicReminders);
 }

--- a/docs/lib/snippets/modular/custom_types/drift_table.drift.dart
+++ b/docs/lib/snippets/modular/custom_types/drift_table.drift.dart
@@ -340,6 +340,6 @@ class $PeriodicRemindersOrderingComposer
 class $PeriodicRemindersWithReferences {
   // ignore: unused_field
   final i0.GeneratedDatabase _db;
-  final i1.PeriodicReminder periodicReminders;
-  $PeriodicRemindersWithReferences(this._db, this.periodicReminders);
+  final i1.PeriodicReminder i1PeriodicReminder;
+  $PeriodicRemindersWithReferences(this._db, this.i1PeriodicReminder);
 }

--- a/docs/lib/snippets/modular/custom_types/table.drift.dart
+++ b/docs/lib/snippets/modular/custom_types/table.drift.dart
@@ -248,9 +248,10 @@ class $$PeriodicRemindersTableTableManager extends i0.RootTableManager<
     i1.PeriodicReminder,
     i1.$$PeriodicRemindersTableFilterComposer,
     i1.$$PeriodicRemindersTableOrderingComposer,
-    $$PeriodicRemindersTableProcessedTableManager,
     $$PeriodicRemindersTableInsertCompanionBuilder,
-    $$PeriodicRemindersTableUpdateCompanionBuilder> {
+    $$PeriodicRemindersTableUpdateCompanionBuilder,
+    $$PeriodicRemindersTableWithReferences,
+    i1.PeriodicReminder> {
   $$PeriodicRemindersTableTableManager(
       i0.GeneratedDatabase db, i1.$PeriodicRemindersTable table)
       : super(i0.TableManagerState(
@@ -260,9 +261,7 @@ class $$PeriodicRemindersTableTableManager extends i0.RootTableManager<
               i0.ComposerState(db, table)),
           orderingComposer: i1.$$PeriodicRemindersTableOrderingComposer(
               i0.ComposerState(db, table)),
-          getChildManagerBuilder: (p) =>
-              $$PeriodicRemindersTableProcessedTableManager(p),
-          getUpdateCompanionBuilder: ({
+          createUpdateCompanionCallback: ({
             i0.Value<int> id = const i0.Value.absent(),
             i0.Value<Duration> frequency = const i0.Value.absent(),
             i0.Value<String> reminder = const i0.Value.absent(),
@@ -272,7 +271,10 @@ class $$PeriodicRemindersTableTableManager extends i0.RootTableManager<
             frequency: frequency,
             reminder: reminder,
           ),
-          getInsertCompanionBuilder: ({
+          dataclassMapper: (p0) async => p0
+              .map((e) => $$PeriodicRemindersTableWithReferences(db, e))
+              .toList(),
+          createInsertCompanionCallback: ({
             i0.Value<int> id = const i0.Value.absent(),
             i0.Value<Duration> frequency = const i0.Value.absent(),
             required String reminder,
@@ -285,18 +287,17 @@ class $$PeriodicRemindersTableTableManager extends i0.RootTableManager<
         ));
 }
 
-class $$PeriodicRemindersTableProcessedTableManager
-    extends i0.ProcessedTableManager<
+typedef $$PeriodicRemindersTableProcessedTableManager
+    = i0.ProcessedTableManager<
         i0.GeneratedDatabase,
         i1.$PeriodicRemindersTable,
         i1.PeriodicReminder,
         i1.$$PeriodicRemindersTableFilterComposer,
         i1.$$PeriodicRemindersTableOrderingComposer,
-        $$PeriodicRemindersTableProcessedTableManager,
         $$PeriodicRemindersTableInsertCompanionBuilder,
-        $$PeriodicRemindersTableUpdateCompanionBuilder> {
-  $$PeriodicRemindersTableProcessedTableManager(super.$state);
-}
+        $$PeriodicRemindersTableUpdateCompanionBuilder,
+        $$PeriodicRemindersTableWithReferences,
+        i1.PeriodicReminder>;
 
 class $$PeriodicRemindersTableFilterComposer extends i0
     .FilterComposer<i0.GeneratedDatabase, i1.$PeriodicRemindersTable> {
@@ -334,4 +335,11 @@ class $$PeriodicRemindersTableOrderingComposer extends i0
       column: $state.table.reminder,
       builder: (column, joinBuilders) =>
           i0.ColumnOrderings(column, joinBuilders: joinBuilders));
+}
+
+class $$PeriodicRemindersTableWithReferences {
+  // ignore: unused_field
+  final i0.GeneratedDatabase _db;
+  final i1.PeriodicReminder periodicReminders;
+  $$PeriodicRemindersTableWithReferences(this._db, this.periodicReminders);
 }

--- a/docs/lib/snippets/modular/custom_types/table.drift.dart
+++ b/docs/lib/snippets/modular/custom_types/table.drift.dart
@@ -340,6 +340,6 @@ class $$PeriodicRemindersTableOrderingComposer extends i0
 class $$PeriodicRemindersTableWithReferences {
   // ignore: unused_field
   final i0.GeneratedDatabase _db;
-  final i1.PeriodicReminder periodicReminders;
-  $$PeriodicRemindersTableWithReferences(this._db, this.periodicReminders);
+  final i1.PeriodicReminder i1PeriodicReminder;
+  $$PeriodicRemindersTableWithReferences(this._db, this.i1PeriodicReminder);
 }

--- a/docs/lib/snippets/modular/drift/example.drift.dart
+++ b/docs/lib/snippets/modular/drift/example.drift.dart
@@ -287,9 +287,10 @@ class $TodosTableManager extends i0.RootTableManager<
     i1.Todo,
     i1.$TodosFilterComposer,
     i1.$TodosOrderingComposer,
-    $TodosProcessedTableManager,
     $TodosInsertCompanionBuilder,
-    $TodosUpdateCompanionBuilder> {
+    $TodosUpdateCompanionBuilder,
+    $TodosWithReferences,
+    i1.Todo> {
   $TodosTableManager(i0.GeneratedDatabase db, i1.Todos table)
       : super(i0.TableManagerState(
           db: db,
@@ -298,8 +299,7 @@ class $TodosTableManager extends i0.RootTableManager<
               i1.$TodosFilterComposer(i0.ComposerState(db, table)),
           orderingComposer:
               i1.$TodosOrderingComposer(i0.ComposerState(db, table)),
-          getChildManagerBuilder: (p) => $TodosProcessedTableManager(p),
-          getUpdateCompanionBuilder: ({
+          createUpdateCompanionCallback: ({
             i0.Value<int> id = const i0.Value.absent(),
             i0.Value<String> title = const i0.Value.absent(),
             i0.Value<String> content = const i0.Value.absent(),
@@ -311,7 +311,9 @@ class $TodosTableManager extends i0.RootTableManager<
             content: content,
             category: category,
           ),
-          getInsertCompanionBuilder: ({
+          dataclassMapper: (p0) async =>
+              p0.map((e) => $TodosWithReferences(db, e)).toList(),
+          createInsertCompanionCallback: ({
             i0.Value<int> id = const i0.Value.absent(),
             required String title,
             required String content,
@@ -326,17 +328,16 @@ class $TodosTableManager extends i0.RootTableManager<
         ));
 }
 
-class $TodosProcessedTableManager extends i0.ProcessedTableManager<
+typedef $TodosProcessedTableManager = i0.ProcessedTableManager<
     i0.GeneratedDatabase,
     i1.Todos,
     i1.Todo,
     i1.$TodosFilterComposer,
     i1.$TodosOrderingComposer,
-    $TodosProcessedTableManager,
     $TodosInsertCompanionBuilder,
-    $TodosUpdateCompanionBuilder> {
-  $TodosProcessedTableManager(super.$state);
-}
+    $TodosUpdateCompanionBuilder,
+    $TodosWithReferences,
+    i1.Todo>;
 
 class $TodosFilterComposer
     extends i0.FilterComposer<i0.GeneratedDatabase, i1.Todos> {
@@ -408,6 +409,13 @@ class $TodosOrderingComposer
                 parentComposers)));
     return composer;
   }
+}
+
+class $TodosWithReferences {
+  // ignore: unused_field
+  final i0.GeneratedDatabase _db;
+  final i1.Todo todos;
+  $TodosWithReferences(this._db, this.todos);
 }
 
 class Categories extends i0.Table with i0.TableInfo<Categories, i1.Category> {
@@ -610,9 +618,10 @@ class $CategoriesTableManager extends i0.RootTableManager<
     i1.Category,
     i1.$CategoriesFilterComposer,
     i1.$CategoriesOrderingComposer,
-    $CategoriesProcessedTableManager,
     $CategoriesInsertCompanionBuilder,
-    $CategoriesUpdateCompanionBuilder> {
+    $CategoriesUpdateCompanionBuilder,
+    $CategoriesWithReferences,
+    i1.Category> {
   $CategoriesTableManager(i0.GeneratedDatabase db, i1.Categories table)
       : super(i0.TableManagerState(
           db: db,
@@ -621,8 +630,7 @@ class $CategoriesTableManager extends i0.RootTableManager<
               i1.$CategoriesFilterComposer(i0.ComposerState(db, table)),
           orderingComposer:
               i1.$CategoriesOrderingComposer(i0.ComposerState(db, table)),
-          getChildManagerBuilder: (p) => $CategoriesProcessedTableManager(p),
-          getUpdateCompanionBuilder: ({
+          createUpdateCompanionCallback: ({
             i0.Value<int> id = const i0.Value.absent(),
             i0.Value<String> description = const i0.Value.absent(),
           }) =>
@@ -630,7 +638,9 @@ class $CategoriesTableManager extends i0.RootTableManager<
             id: id,
             description: description,
           ),
-          getInsertCompanionBuilder: ({
+          dataclassMapper: (p0) async =>
+              p0.map((e) => $CategoriesWithReferences(db, e)).toList(),
+          createInsertCompanionCallback: ({
             i0.Value<int> id = const i0.Value.absent(),
             required String description,
           }) =>
@@ -641,17 +651,16 @@ class $CategoriesTableManager extends i0.RootTableManager<
         ));
 }
 
-class $CategoriesProcessedTableManager extends i0.ProcessedTableManager<
+typedef $CategoriesProcessedTableManager = i0.ProcessedTableManager<
     i0.GeneratedDatabase,
     i1.Categories,
     i1.Category,
     i1.$CategoriesFilterComposer,
     i1.$CategoriesOrderingComposer,
-    $CategoriesProcessedTableManager,
     $CategoriesInsertCompanionBuilder,
-    $CategoriesUpdateCompanionBuilder> {
-  $CategoriesProcessedTableManager(super.$state);
-}
+    $CategoriesUpdateCompanionBuilder,
+    $CategoriesWithReferences,
+    i1.Category>;
 
 class $CategoriesFilterComposer
     extends i0.FilterComposer<i0.GeneratedDatabase, i1.Categories> {
@@ -679,6 +688,13 @@ class $CategoriesOrderingComposer
       column: $state.table.description,
       builder: (column, joinBuilders) =>
           i0.ColumnOrderings(column, joinBuilders: joinBuilders));
+}
+
+class $CategoriesWithReferences {
+  // ignore: unused_field
+  final i0.GeneratedDatabase _db;
+  final i1.Category categories;
+  $CategoriesWithReferences(this._db, this.categories);
 }
 
 class ExampleDrift extends i2.ModularAccessor {

--- a/docs/lib/snippets/modular/drift/example.drift.dart
+++ b/docs/lib/snippets/modular/drift/example.drift.dart
@@ -414,8 +414,8 @@ class $TodosOrderingComposer
 class $TodosWithReferences {
   // ignore: unused_field
   final i0.GeneratedDatabase _db;
-  final i1.Todo todos;
-  $TodosWithReferences(this._db, this.todos);
+  final i1.Todo i1Todo;
+  $TodosWithReferences(this._db, this.i1Todo);
 }
 
 class Categories extends i0.Table with i0.TableInfo<Categories, i1.Category> {
@@ -693,8 +693,8 @@ class $CategoriesOrderingComposer
 class $CategoriesWithReferences {
   // ignore: unused_field
   final i0.GeneratedDatabase _db;
-  final i1.Category categories;
-  $CategoriesWithReferences(this._db, this.categories);
+  final i1.Category i1Category;
+  $CategoriesWithReferences(this._db, this.i1Category);
 }
 
 class ExampleDrift extends i2.ModularAccessor {

--- a/docs/lib/snippets/modular/drift/with_existing.drift.dart
+++ b/docs/lib/snippets/modular/drift/with_existing.drift.dart
@@ -209,8 +209,8 @@ class $UsersOrderingComposer
 class $UsersWithReferences {
   // ignore: unused_field
   final i0.GeneratedDatabase _db;
-  final i1.User users;
-  $UsersWithReferences(this._db, this.users);
+  final i1.User i1User;
+  $UsersWithReferences(this._db, this.i1User);
 }
 
 class Friends extends i0.Table with i0.TableInfo<Friends, i2.Friend> {
@@ -555,8 +555,8 @@ class $FriendsOrderingComposer
 class $FriendsWithReferences {
   // ignore: unused_field
   final i0.GeneratedDatabase _db;
-  final i2.Friend friends;
-  $FriendsWithReferences(this._db, this.friends);
+  final i2.Friend i2Friend;
+  $FriendsWithReferences(this._db, this.i2Friend);
 }
 
 class WithExistingDrift extends i3.ModularAccessor {

--- a/docs/lib/snippets/modular/drift/with_existing.drift.dart
+++ b/docs/lib/snippets/modular/drift/with_existing.drift.dart
@@ -134,9 +134,10 @@ class $UsersTableManager extends i0.RootTableManager<
     i1.User,
     i2.$UsersFilterComposer,
     i2.$UsersOrderingComposer,
-    $UsersProcessedTableManager,
     $UsersInsertCompanionBuilder,
-    $UsersUpdateCompanionBuilder> {
+    $UsersUpdateCompanionBuilder,
+    $UsersWithReferences,
+    i1.User> {
   $UsersTableManager(i0.GeneratedDatabase db, i2.Users table)
       : super(i0.TableManagerState(
           db: db,
@@ -145,8 +146,7 @@ class $UsersTableManager extends i0.RootTableManager<
               i2.$UsersFilterComposer(i0.ComposerState(db, table)),
           orderingComposer:
               i2.$UsersOrderingComposer(i0.ComposerState(db, table)),
-          getChildManagerBuilder: (p) => $UsersProcessedTableManager(p),
-          getUpdateCompanionBuilder: ({
+          createUpdateCompanionCallback: ({
             i0.Value<int> id = const i0.Value.absent(),
             i0.Value<String> name = const i0.Value.absent(),
           }) =>
@@ -154,7 +154,9 @@ class $UsersTableManager extends i0.RootTableManager<
             id: id,
             name: name,
           ),
-          getInsertCompanionBuilder: ({
+          dataclassMapper: (p0) async =>
+              p0.map((e) => $UsersWithReferences(db, e)).toList(),
+          createInsertCompanionCallback: ({
             i0.Value<int> id = const i0.Value.absent(),
             required String name,
           }) =>
@@ -165,17 +167,16 @@ class $UsersTableManager extends i0.RootTableManager<
         ));
 }
 
-class $UsersProcessedTableManager extends i0.ProcessedTableManager<
+typedef $UsersProcessedTableManager = i0.ProcessedTableManager<
     i0.GeneratedDatabase,
     i2.Users,
     i1.User,
     i2.$UsersFilterComposer,
     i2.$UsersOrderingComposer,
-    $UsersProcessedTableManager,
     $UsersInsertCompanionBuilder,
-    $UsersUpdateCompanionBuilder> {
-  $UsersProcessedTableManager(super.$state);
-}
+    $UsersUpdateCompanionBuilder,
+    $UsersWithReferences,
+    i1.User>;
 
 class $UsersFilterComposer
     extends i0.FilterComposer<i0.GeneratedDatabase, i2.Users> {
@@ -203,6 +204,13 @@ class $UsersOrderingComposer
       column: $state.table.name,
       builder: (column, joinBuilders) =>
           i0.ColumnOrderings(column, joinBuilders: joinBuilders));
+}
+
+class $UsersWithReferences {
+  // ignore: unused_field
+  final i0.GeneratedDatabase _db;
+  final i1.User users;
+  $UsersWithReferences(this._db, this.users);
 }
 
 class Friends extends i0.Table with i0.TableInfo<Friends, i2.Friend> {
@@ -420,9 +428,10 @@ class $FriendsTableManager extends i0.RootTableManager<
     i2.Friend,
     i2.$FriendsFilterComposer,
     i2.$FriendsOrderingComposer,
-    $FriendsProcessedTableManager,
     $FriendsInsertCompanionBuilder,
-    $FriendsUpdateCompanionBuilder> {
+    $FriendsUpdateCompanionBuilder,
+    $FriendsWithReferences,
+    i2.Friend> {
   $FriendsTableManager(i0.GeneratedDatabase db, i2.Friends table)
       : super(i0.TableManagerState(
           db: db,
@@ -431,8 +440,7 @@ class $FriendsTableManager extends i0.RootTableManager<
               i2.$FriendsFilterComposer(i0.ComposerState(db, table)),
           orderingComposer:
               i2.$FriendsOrderingComposer(i0.ComposerState(db, table)),
-          getChildManagerBuilder: (p) => $FriendsProcessedTableManager(p),
-          getUpdateCompanionBuilder: ({
+          createUpdateCompanionCallback: ({
             i0.Value<int> userA = const i0.Value.absent(),
             i0.Value<int> userB = const i0.Value.absent(),
             i0.Value<int> rowid = const i0.Value.absent(),
@@ -442,7 +450,9 @@ class $FriendsTableManager extends i0.RootTableManager<
             userB: userB,
             rowid: rowid,
           ),
-          getInsertCompanionBuilder: ({
+          dataclassMapper: (p0) async =>
+              p0.map((e) => $FriendsWithReferences(db, e)).toList(),
+          createInsertCompanionCallback: ({
             required int userA,
             required int userB,
             i0.Value<int> rowid = const i0.Value.absent(),
@@ -455,17 +465,16 @@ class $FriendsTableManager extends i0.RootTableManager<
         ));
 }
 
-class $FriendsProcessedTableManager extends i0.ProcessedTableManager<
+typedef $FriendsProcessedTableManager = i0.ProcessedTableManager<
     i0.GeneratedDatabase,
     i2.Friends,
     i2.Friend,
     i2.$FriendsFilterComposer,
     i2.$FriendsOrderingComposer,
-    $FriendsProcessedTableManager,
     $FriendsInsertCompanionBuilder,
-    $FriendsUpdateCompanionBuilder> {
-  $FriendsProcessedTableManager(super.$state);
-}
+    $FriendsUpdateCompanionBuilder,
+    $FriendsWithReferences,
+    i2.Friend>;
 
 class $FriendsFilterComposer
     extends i0.FilterComposer<i0.GeneratedDatabase, i2.Friends> {
@@ -541,6 +550,13 @@ class $FriendsOrderingComposer
                 parentComposers)));
     return composer;
   }
+}
+
+class $FriendsWithReferences {
+  // ignore: unused_field
+  final i0.GeneratedDatabase _db;
+  final i2.Friend friends;
+  $FriendsWithReferences(this._db, this.friends);
 }
 
 class WithExistingDrift extends i3.ModularAccessor {

--- a/docs/lib/snippets/modular/many_to_many/json.drift.dart
+++ b/docs/lib/snippets/modular/many_to_many/json.drift.dart
@@ -236,9 +236,10 @@ class $$ShoppingCartsTableTableManager extends i0.RootTableManager<
     i2.ShoppingCart,
     i2.$$ShoppingCartsTableFilterComposer,
     i2.$$ShoppingCartsTableOrderingComposer,
-    $$ShoppingCartsTableProcessedTableManager,
     $$ShoppingCartsTableInsertCompanionBuilder,
-    $$ShoppingCartsTableUpdateCompanionBuilder> {
+    $$ShoppingCartsTableUpdateCompanionBuilder,
+    $$ShoppingCartsTableWithReferences,
+    i2.ShoppingCart> {
   $$ShoppingCartsTableTableManager(
       i0.GeneratedDatabase db, i2.$ShoppingCartsTable table)
       : super(i0.TableManagerState(
@@ -248,9 +249,7 @@ class $$ShoppingCartsTableTableManager extends i0.RootTableManager<
               .$$ShoppingCartsTableFilterComposer(i0.ComposerState(db, table)),
           orderingComposer: i2.$$ShoppingCartsTableOrderingComposer(
               i0.ComposerState(db, table)),
-          getChildManagerBuilder: (p) =>
-              $$ShoppingCartsTableProcessedTableManager(p),
-          getUpdateCompanionBuilder: ({
+          createUpdateCompanionCallback: ({
             i0.Value<int> id = const i0.Value.absent(),
             i0.Value<i3.ShoppingCartEntries> entries = const i0.Value.absent(),
           }) =>
@@ -258,7 +257,9 @@ class $$ShoppingCartsTableTableManager extends i0.RootTableManager<
             id: id,
             entries: entries,
           ),
-          getInsertCompanionBuilder: ({
+          dataclassMapper: (p0) async =>
+              p0.map((e) => $$ShoppingCartsTableWithReferences(db, e)).toList(),
+          createInsertCompanionCallback: ({
             i0.Value<int> id = const i0.Value.absent(),
             required i3.ShoppingCartEntries entries,
           }) =>
@@ -269,18 +270,16 @@ class $$ShoppingCartsTableTableManager extends i0.RootTableManager<
         ));
 }
 
-class $$ShoppingCartsTableProcessedTableManager
-    extends i0.ProcessedTableManager<
-        i0.GeneratedDatabase,
-        i2.$ShoppingCartsTable,
-        i2.ShoppingCart,
-        i2.$$ShoppingCartsTableFilterComposer,
-        i2.$$ShoppingCartsTableOrderingComposer,
-        $$ShoppingCartsTableProcessedTableManager,
-        $$ShoppingCartsTableInsertCompanionBuilder,
-        $$ShoppingCartsTableUpdateCompanionBuilder> {
-  $$ShoppingCartsTableProcessedTableManager(super.$state);
-}
+typedef $$ShoppingCartsTableProcessedTableManager = i0.ProcessedTableManager<
+    i0.GeneratedDatabase,
+    i2.$ShoppingCartsTable,
+    i2.ShoppingCart,
+    i2.$$ShoppingCartsTableFilterComposer,
+    i2.$$ShoppingCartsTableOrderingComposer,
+    $$ShoppingCartsTableInsertCompanionBuilder,
+    $$ShoppingCartsTableUpdateCompanionBuilder,
+    $$ShoppingCartsTableWithReferences,
+    i2.ShoppingCart>;
 
 class $$ShoppingCartsTableFilterComposer
     extends i0.FilterComposer<i0.GeneratedDatabase, i2.$ShoppingCartsTable> {
@@ -311,4 +310,11 @@ class $$ShoppingCartsTableOrderingComposer
       column: $state.table.entries,
       builder: (column, joinBuilders) =>
           i0.ColumnOrderings(column, joinBuilders: joinBuilders));
+}
+
+class $$ShoppingCartsTableWithReferences {
+  // ignore: unused_field
+  final i0.GeneratedDatabase _db;
+  final i2.ShoppingCart shoppingCarts;
+  $$ShoppingCartsTableWithReferences(this._db, this.shoppingCarts);
 }

--- a/docs/lib/snippets/modular/many_to_many/json.drift.dart
+++ b/docs/lib/snippets/modular/many_to_many/json.drift.dart
@@ -315,6 +315,6 @@ class $$ShoppingCartsTableOrderingComposer
 class $$ShoppingCartsTableWithReferences {
   // ignore: unused_field
   final i0.GeneratedDatabase _db;
-  final i2.ShoppingCart shoppingCarts;
-  $$ShoppingCartsTableWithReferences(this._db, this.shoppingCarts);
+  final i2.ShoppingCart i2ShoppingCart;
+  $$ShoppingCartsTableWithReferences(this._db, this.i2ShoppingCart);
 }

--- a/docs/lib/snippets/modular/many_to_many/relational.drift.dart
+++ b/docs/lib/snippets/modular/many_to_many/relational.drift.dart
@@ -259,8 +259,8 @@ class $$ShoppingCartsTableOrderingComposer
 class $$ShoppingCartsTableWithReferences {
   // ignore: unused_field
   final i0.GeneratedDatabase _db;
-  final i2.ShoppingCart shoppingCarts;
-  $$ShoppingCartsTableWithReferences(this._db, this.shoppingCarts);
+  final i2.ShoppingCart i2ShoppingCart;
+  $$ShoppingCartsTableWithReferences(this._db, this.i2ShoppingCart);
 }
 
 class $ShoppingCartEntriesTable extends i3.ShoppingCartEntries
@@ -626,6 +626,6 @@ class $$ShoppingCartEntriesTableOrderingComposer extends i0
 class $$ShoppingCartEntriesTableWithReferences {
   // ignore: unused_field
   final i0.GeneratedDatabase _db;
-  final i2.ShoppingCartEntry shoppingCartEntries;
-  $$ShoppingCartEntriesTableWithReferences(this._db, this.shoppingCartEntries);
+  final i2.ShoppingCartEntry i2ShoppingCartEntry;
+  $$ShoppingCartEntriesTableWithReferences(this._db, this.i2ShoppingCartEntry);
 }

--- a/docs/lib/snippets/modular/many_to_many/relational.drift.dart
+++ b/docs/lib/snippets/modular/many_to_many/relational.drift.dart
@@ -197,9 +197,10 @@ class $$ShoppingCartsTableTableManager extends i0.RootTableManager<
     i2.ShoppingCart,
     i2.$$ShoppingCartsTableFilterComposer,
     i2.$$ShoppingCartsTableOrderingComposer,
-    $$ShoppingCartsTableProcessedTableManager,
     $$ShoppingCartsTableInsertCompanionBuilder,
-    $$ShoppingCartsTableUpdateCompanionBuilder> {
+    $$ShoppingCartsTableUpdateCompanionBuilder,
+    $$ShoppingCartsTableWithReferences,
+    i2.ShoppingCart> {
   $$ShoppingCartsTableTableManager(
       i0.GeneratedDatabase db, i2.$ShoppingCartsTable table)
       : super(i0.TableManagerState(
@@ -209,15 +210,15 @@ class $$ShoppingCartsTableTableManager extends i0.RootTableManager<
               .$$ShoppingCartsTableFilterComposer(i0.ComposerState(db, table)),
           orderingComposer: i2.$$ShoppingCartsTableOrderingComposer(
               i0.ComposerState(db, table)),
-          getChildManagerBuilder: (p) =>
-              $$ShoppingCartsTableProcessedTableManager(p),
-          getUpdateCompanionBuilder: ({
+          createUpdateCompanionCallback: ({
             i0.Value<int> id = const i0.Value.absent(),
           }) =>
               i2.ShoppingCartsCompanion(
             id: id,
           ),
-          getInsertCompanionBuilder: ({
+          dataclassMapper: (p0) async =>
+              p0.map((e) => $$ShoppingCartsTableWithReferences(db, e)).toList(),
+          createInsertCompanionCallback: ({
             i0.Value<int> id = const i0.Value.absent(),
           }) =>
               i2.ShoppingCartsCompanion.insert(
@@ -226,18 +227,16 @@ class $$ShoppingCartsTableTableManager extends i0.RootTableManager<
         ));
 }
 
-class $$ShoppingCartsTableProcessedTableManager
-    extends i0.ProcessedTableManager<
-        i0.GeneratedDatabase,
-        i2.$ShoppingCartsTable,
-        i2.ShoppingCart,
-        i2.$$ShoppingCartsTableFilterComposer,
-        i2.$$ShoppingCartsTableOrderingComposer,
-        $$ShoppingCartsTableProcessedTableManager,
-        $$ShoppingCartsTableInsertCompanionBuilder,
-        $$ShoppingCartsTableUpdateCompanionBuilder> {
-  $$ShoppingCartsTableProcessedTableManager(super.$state);
-}
+typedef $$ShoppingCartsTableProcessedTableManager = i0.ProcessedTableManager<
+    i0.GeneratedDatabase,
+    i2.$ShoppingCartsTable,
+    i2.ShoppingCart,
+    i2.$$ShoppingCartsTableFilterComposer,
+    i2.$$ShoppingCartsTableOrderingComposer,
+    $$ShoppingCartsTableInsertCompanionBuilder,
+    $$ShoppingCartsTableUpdateCompanionBuilder,
+    $$ShoppingCartsTableWithReferences,
+    i2.ShoppingCart>;
 
 class $$ShoppingCartsTableFilterComposer
     extends i0.FilterComposer<i0.GeneratedDatabase, i2.$ShoppingCartsTable> {
@@ -255,6 +254,13 @@ class $$ShoppingCartsTableOrderingComposer
       column: $state.table.id,
       builder: (column, joinBuilders) =>
           i0.ColumnOrderings(column, joinBuilders: joinBuilders));
+}
+
+class $$ShoppingCartsTableWithReferences {
+  // ignore: unused_field
+  final i0.GeneratedDatabase _db;
+  final i2.ShoppingCart shoppingCarts;
+  $$ShoppingCartsTableWithReferences(this._db, this.shoppingCarts);
 }
 
 class $ShoppingCartEntriesTable extends i3.ShoppingCartEntries
@@ -484,9 +490,10 @@ class $$ShoppingCartEntriesTableTableManager extends i0.RootTableManager<
     i2.ShoppingCartEntry,
     i2.$$ShoppingCartEntriesTableFilterComposer,
     i2.$$ShoppingCartEntriesTableOrderingComposer,
-    $$ShoppingCartEntriesTableProcessedTableManager,
     $$ShoppingCartEntriesTableInsertCompanionBuilder,
-    $$ShoppingCartEntriesTableUpdateCompanionBuilder> {
+    $$ShoppingCartEntriesTableUpdateCompanionBuilder,
+    $$ShoppingCartEntriesTableWithReferences,
+    i2.ShoppingCartEntry> {
   $$ShoppingCartEntriesTableTableManager(
       i0.GeneratedDatabase db, i2.$ShoppingCartEntriesTable table)
       : super(i0.TableManagerState(
@@ -496,9 +503,7 @@ class $$ShoppingCartEntriesTableTableManager extends i0.RootTableManager<
               i0.ComposerState(db, table)),
           orderingComposer: i2.$$ShoppingCartEntriesTableOrderingComposer(
               i0.ComposerState(db, table)),
-          getChildManagerBuilder: (p) =>
-              $$ShoppingCartEntriesTableProcessedTableManager(p),
-          getUpdateCompanionBuilder: ({
+          createUpdateCompanionCallback: ({
             i0.Value<int> shoppingCart = const i0.Value.absent(),
             i0.Value<int> item = const i0.Value.absent(),
             i0.Value<int> rowid = const i0.Value.absent(),
@@ -508,7 +513,10 @@ class $$ShoppingCartEntriesTableTableManager extends i0.RootTableManager<
             item: item,
             rowid: rowid,
           ),
-          getInsertCompanionBuilder: ({
+          dataclassMapper: (p0) async => p0
+              .map((e) => $$ShoppingCartEntriesTableWithReferences(db, e))
+              .toList(),
+          createInsertCompanionCallback: ({
             required int shoppingCart,
             required int item,
             i0.Value<int> rowid = const i0.Value.absent(),
@@ -521,18 +529,17 @@ class $$ShoppingCartEntriesTableTableManager extends i0.RootTableManager<
         ));
 }
 
-class $$ShoppingCartEntriesTableProcessedTableManager
-    extends i0.ProcessedTableManager<
+typedef $$ShoppingCartEntriesTableProcessedTableManager
+    = i0.ProcessedTableManager<
         i0.GeneratedDatabase,
         i2.$ShoppingCartEntriesTable,
         i2.ShoppingCartEntry,
         i2.$$ShoppingCartEntriesTableFilterComposer,
         i2.$$ShoppingCartEntriesTableOrderingComposer,
-        $$ShoppingCartEntriesTableProcessedTableManager,
         $$ShoppingCartEntriesTableInsertCompanionBuilder,
-        $$ShoppingCartEntriesTableUpdateCompanionBuilder> {
-  $$ShoppingCartEntriesTableProcessedTableManager(super.$state);
-}
+        $$ShoppingCartEntriesTableUpdateCompanionBuilder,
+        $$ShoppingCartEntriesTableWithReferences,
+        i2.ShoppingCartEntry>;
 
 class $$ShoppingCartEntriesTableFilterComposer extends i0
     .FilterComposer<i0.GeneratedDatabase, i2.$ShoppingCartEntriesTable> {
@@ -614,4 +621,11 @@ class $$ShoppingCartEntriesTableOrderingComposer extends i0
                     parentComposers)));
     return composer;
   }
+}
+
+class $$ShoppingCartEntriesTableWithReferences {
+  // ignore: unused_field
+  final i0.GeneratedDatabase _db;
+  final i2.ShoppingCartEntry shoppingCartEntries;
+  $$ShoppingCartEntriesTableWithReferences(this._db, this.shoppingCartEntries);
 }

--- a/docs/lib/snippets/modular/many_to_many/shared.drift.dart
+++ b/docs/lib/snippets/modular/many_to_many/shared.drift.dart
@@ -337,6 +337,6 @@ class $$BuyableItemsTableOrderingComposer
 class $$BuyableItemsTableWithReferences {
   // ignore: unused_field
   final i0.GeneratedDatabase _db;
-  final i1.BuyableItem buyableItems;
-  $$BuyableItemsTableWithReferences(this._db, this.buyableItems);
+  final i1.BuyableItem i1BuyableItem;
+  $$BuyableItemsTableWithReferences(this._db, this.i1BuyableItem);
 }

--- a/docs/lib/snippets/modular/many_to_many/shared.drift.dart
+++ b/docs/lib/snippets/modular/many_to_many/shared.drift.dart
@@ -247,9 +247,10 @@ class $$BuyableItemsTableTableManager extends i0.RootTableManager<
     i1.BuyableItem,
     i1.$$BuyableItemsTableFilterComposer,
     i1.$$BuyableItemsTableOrderingComposer,
-    $$BuyableItemsTableProcessedTableManager,
     $$BuyableItemsTableInsertCompanionBuilder,
-    $$BuyableItemsTableUpdateCompanionBuilder> {
+    $$BuyableItemsTableUpdateCompanionBuilder,
+    $$BuyableItemsTableWithReferences,
+    i1.BuyableItem> {
   $$BuyableItemsTableTableManager(
       i0.GeneratedDatabase db, i1.$BuyableItemsTable table)
       : super(i0.TableManagerState(
@@ -259,9 +260,7 @@ class $$BuyableItemsTableTableManager extends i0.RootTableManager<
               i1.$$BuyableItemsTableFilterComposer(i0.ComposerState(db, table)),
           orderingComposer: i1
               .$$BuyableItemsTableOrderingComposer(i0.ComposerState(db, table)),
-          getChildManagerBuilder: (p) =>
-              $$BuyableItemsTableProcessedTableManager(p),
-          getUpdateCompanionBuilder: ({
+          createUpdateCompanionCallback: ({
             i0.Value<int> id = const i0.Value.absent(),
             i0.Value<String> description = const i0.Value.absent(),
             i0.Value<int> price = const i0.Value.absent(),
@@ -271,7 +270,9 @@ class $$BuyableItemsTableTableManager extends i0.RootTableManager<
             description: description,
             price: price,
           ),
-          getInsertCompanionBuilder: ({
+          dataclassMapper: (p0) async =>
+              p0.map((e) => $$BuyableItemsTableWithReferences(db, e)).toList(),
+          createInsertCompanionCallback: ({
             i0.Value<int> id = const i0.Value.absent(),
             required String description,
             required int price,
@@ -284,17 +285,16 @@ class $$BuyableItemsTableTableManager extends i0.RootTableManager<
         ));
 }
 
-class $$BuyableItemsTableProcessedTableManager extends i0.ProcessedTableManager<
+typedef $$BuyableItemsTableProcessedTableManager = i0.ProcessedTableManager<
     i0.GeneratedDatabase,
     i1.$BuyableItemsTable,
     i1.BuyableItem,
     i1.$$BuyableItemsTableFilterComposer,
     i1.$$BuyableItemsTableOrderingComposer,
-    $$BuyableItemsTableProcessedTableManager,
     $$BuyableItemsTableInsertCompanionBuilder,
-    $$BuyableItemsTableUpdateCompanionBuilder> {
-  $$BuyableItemsTableProcessedTableManager(super.$state);
-}
+    $$BuyableItemsTableUpdateCompanionBuilder,
+    $$BuyableItemsTableWithReferences,
+    i1.BuyableItem>;
 
 class $$BuyableItemsTableFilterComposer
     extends i0.FilterComposer<i0.GeneratedDatabase, i1.$BuyableItemsTable> {
@@ -332,4 +332,11 @@ class $$BuyableItemsTableOrderingComposer
       column: $state.table.price,
       builder: (column, joinBuilders) =>
           i0.ColumnOrderings(column, joinBuilders: joinBuilders));
+}
+
+class $$BuyableItemsTableWithReferences {
+  // ignore: unused_field
+  final i0.GeneratedDatabase _db;
+  final i1.BuyableItem buyableItems;
+  $$BuyableItemsTableWithReferences(this._db, this.buyableItems);
 }

--- a/docs/lib/snippets/modular/upserts.drift.dart
+++ b/docs/lib/snippets/modular/upserts.drift.dart
@@ -290,8 +290,8 @@ class $$WordsTableOrderingComposer
 class $$WordsTableWithReferences {
   // ignore: unused_field
   final i0.GeneratedDatabase _db;
-  final i1.Word words;
-  $$WordsTableWithReferences(this._db, this.words);
+  final i1.Word i1Word;
+  $$WordsTableWithReferences(this._db, this.i1Word);
 }
 
 class $MatchResultsTable extends i2.MatchResults
@@ -686,6 +686,6 @@ class $$MatchResultsTableOrderingComposer
 class $$MatchResultsTableWithReferences {
   // ignore: unused_field
   final i0.GeneratedDatabase _db;
-  final i1.MatchResult matchResults;
-  $$MatchResultsTableWithReferences(this._db, this.matchResults);
+  final i1.MatchResult i1MatchResult;
+  $$MatchResultsTableWithReferences(this._db, this.i1MatchResult);
 }

--- a/docs/lib/snippets/modular/upserts.drift.dart
+++ b/docs/lib/snippets/modular/upserts.drift.dart
@@ -211,9 +211,10 @@ class $$WordsTableTableManager extends i0.RootTableManager<
     i1.Word,
     i1.$$WordsTableFilterComposer,
     i1.$$WordsTableOrderingComposer,
-    $$WordsTableProcessedTableManager,
     $$WordsTableInsertCompanionBuilder,
-    $$WordsTableUpdateCompanionBuilder> {
+    $$WordsTableUpdateCompanionBuilder,
+    $$WordsTableWithReferences,
+    i1.Word> {
   $$WordsTableTableManager(i0.GeneratedDatabase db, i1.$WordsTable table)
       : super(i0.TableManagerState(
           db: db,
@@ -222,8 +223,7 @@ class $$WordsTableTableManager extends i0.RootTableManager<
               i1.$$WordsTableFilterComposer(i0.ComposerState(db, table)),
           orderingComposer:
               i1.$$WordsTableOrderingComposer(i0.ComposerState(db, table)),
-          getChildManagerBuilder: (p) => $$WordsTableProcessedTableManager(p),
-          getUpdateCompanionBuilder: ({
+          createUpdateCompanionCallback: ({
             i0.Value<String> word = const i0.Value.absent(),
             i0.Value<int> usages = const i0.Value.absent(),
             i0.Value<int> rowid = const i0.Value.absent(),
@@ -233,7 +233,9 @@ class $$WordsTableTableManager extends i0.RootTableManager<
             usages: usages,
             rowid: rowid,
           ),
-          getInsertCompanionBuilder: ({
+          dataclassMapper: (p0) async =>
+              p0.map((e) => $$WordsTableWithReferences(db, e)).toList(),
+          createInsertCompanionCallback: ({
             required String word,
             i0.Value<int> usages = const i0.Value.absent(),
             i0.Value<int> rowid = const i0.Value.absent(),
@@ -246,17 +248,16 @@ class $$WordsTableTableManager extends i0.RootTableManager<
         ));
 }
 
-class $$WordsTableProcessedTableManager extends i0.ProcessedTableManager<
+typedef $$WordsTableProcessedTableManager = i0.ProcessedTableManager<
     i0.GeneratedDatabase,
     i1.$WordsTable,
     i1.Word,
     i1.$$WordsTableFilterComposer,
     i1.$$WordsTableOrderingComposer,
-    $$WordsTableProcessedTableManager,
     $$WordsTableInsertCompanionBuilder,
-    $$WordsTableUpdateCompanionBuilder> {
-  $$WordsTableProcessedTableManager(super.$state);
-}
+    $$WordsTableUpdateCompanionBuilder,
+    $$WordsTableWithReferences,
+    i1.Word>;
 
 class $$WordsTableFilterComposer
     extends i0.FilterComposer<i0.GeneratedDatabase, i1.$WordsTable> {
@@ -284,6 +285,13 @@ class $$WordsTableOrderingComposer
       column: $state.table.usages,
       builder: (column, joinBuilders) =>
           i0.ColumnOrderings(column, joinBuilders: joinBuilders));
+}
+
+class $$WordsTableWithReferences {
+  // ignore: unused_field
+  final i0.GeneratedDatabase _db;
+  final i1.Word words;
+  $$WordsTableWithReferences(this._db, this.words);
 }
 
 class $MatchResultsTable extends i2.MatchResults
@@ -574,9 +582,10 @@ class $$MatchResultsTableTableManager extends i0.RootTableManager<
     i1.MatchResult,
     i1.$$MatchResultsTableFilterComposer,
     i1.$$MatchResultsTableOrderingComposer,
-    $$MatchResultsTableProcessedTableManager,
     $$MatchResultsTableInsertCompanionBuilder,
-    $$MatchResultsTableUpdateCompanionBuilder> {
+    $$MatchResultsTableUpdateCompanionBuilder,
+    $$MatchResultsTableWithReferences,
+    i1.MatchResult> {
   $$MatchResultsTableTableManager(
       i0.GeneratedDatabase db, i1.$MatchResultsTable table)
       : super(i0.TableManagerState(
@@ -586,9 +595,7 @@ class $$MatchResultsTableTableManager extends i0.RootTableManager<
               i1.$$MatchResultsTableFilterComposer(i0.ComposerState(db, table)),
           orderingComposer: i1
               .$$MatchResultsTableOrderingComposer(i0.ComposerState(db, table)),
-          getChildManagerBuilder: (p) =>
-              $$MatchResultsTableProcessedTableManager(p),
-          getUpdateCompanionBuilder: ({
+          createUpdateCompanionCallback: ({
             i0.Value<int> id = const i0.Value.absent(),
             i0.Value<String> teamA = const i0.Value.absent(),
             i0.Value<String> teamB = const i0.Value.absent(),
@@ -600,7 +607,9 @@ class $$MatchResultsTableTableManager extends i0.RootTableManager<
             teamB: teamB,
             teamAWon: teamAWon,
           ),
-          getInsertCompanionBuilder: ({
+          dataclassMapper: (p0) async =>
+              p0.map((e) => $$MatchResultsTableWithReferences(db, e)).toList(),
+          createInsertCompanionCallback: ({
             i0.Value<int> id = const i0.Value.absent(),
             required String teamA,
             required String teamB,
@@ -615,17 +624,16 @@ class $$MatchResultsTableTableManager extends i0.RootTableManager<
         ));
 }
 
-class $$MatchResultsTableProcessedTableManager extends i0.ProcessedTableManager<
+typedef $$MatchResultsTableProcessedTableManager = i0.ProcessedTableManager<
     i0.GeneratedDatabase,
     i1.$MatchResultsTable,
     i1.MatchResult,
     i1.$$MatchResultsTableFilterComposer,
     i1.$$MatchResultsTableOrderingComposer,
-    $$MatchResultsTableProcessedTableManager,
     $$MatchResultsTableInsertCompanionBuilder,
-    $$MatchResultsTableUpdateCompanionBuilder> {
-  $$MatchResultsTableProcessedTableManager(super.$state);
-}
+    $$MatchResultsTableUpdateCompanionBuilder,
+    $$MatchResultsTableWithReferences,
+    i1.MatchResult>;
 
 class $$MatchResultsTableFilterComposer
     extends i0.FilterComposer<i0.GeneratedDatabase, i1.$MatchResultsTable> {
@@ -673,4 +681,11 @@ class $$MatchResultsTableOrderingComposer
       column: $state.table.teamAWon,
       builder: (column, joinBuilders) =>
           i0.ColumnOrderings(column, joinBuilders: joinBuilders));
+}
+
+class $$MatchResultsTableWithReferences {
+  // ignore: unused_field
+  final i0.GeneratedDatabase _db;
+  final i1.MatchResult matchResults;
+  $$MatchResultsTableWithReferences(this._db, this.matchResults);
 }

--- a/docs/pages/docs/Dart API/manager.md
+++ b/docs/pages/docs/Dart API/manager.md
@@ -38,6 +38,26 @@ Type specific filters for `int`, `double`, `Int64`, `DateTime` and `String` are 
 
 {% include "blocks/snippet" snippets = snippets name = 'manager_type_specific_filter' %}
 
+### Reading references
+It's quite common that when looking up a single row, you also want to read related rows from other tables.  
+
+The `withReferences` method can be used to read references from multiple tables.
+It return the row along with prepared managers which have the correct filters applied.
+
+Foe example, if you wanted to read a `TodoItem`, and automatically read the `Category` that it belongs to, you could do the following:
+
+{% include "blocks/snippet" snippets = snippets name = 'manager_with_refs' %}
+
+
+{% block "blocks/alert" title="N+1 Performance" color="warning" %}
+Beware of creating too many queries when using `withReferences`.
+If you were to query all `TodoItems` and then read the `Category` for each item, you could potentially create a large number of queries.  
+
+{% include "blocks/snippet" snippets = snippets name = 'manager_with_refs_n_plus_1' %}
+
+If there were 1000 `TodoItems`, you would create 1001 queries, which would grind your application to a halt. Future versions of drift will include a way to mitigate this issue.
+{% endblock %}
+
 
 ### Filtering across tables
 You can filter across references to other tables by using the generated reference filters. You can nest these as deep as you'd like and the manager will take care of adding the aliased joins behind the scenes.

--- a/drift/example/main.g.dart
+++ b/drift/example/main.g.dart
@@ -731,9 +731,10 @@ class $$TodoCategoriesTableTableManager extends RootTableManager<
     TodoCategory,
     $$TodoCategoriesTableFilterComposer,
     $$TodoCategoriesTableOrderingComposer,
-    $$TodoCategoriesTableProcessedTableManager,
     $$TodoCategoriesTableInsertCompanionBuilder,
-    $$TodoCategoriesTableUpdateCompanionBuilder> {
+    $$TodoCategoriesTableUpdateCompanionBuilder,
+    $$TodoCategoriesTableWithReferences,
+    TodoCategory> {
   $$TodoCategoriesTableTableManager(_$Database db, $TodoCategoriesTable table)
       : super(TableManagerState(
           db: db,
@@ -742,9 +743,7 @@ class $$TodoCategoriesTableTableManager extends RootTableManager<
               $$TodoCategoriesTableFilterComposer(ComposerState(db, table)),
           orderingComposer:
               $$TodoCategoriesTableOrderingComposer(ComposerState(db, table)),
-          getChildManagerBuilder: (p) =>
-              $$TodoCategoriesTableProcessedTableManager(p),
-          getUpdateCompanionBuilder: ({
+          createUpdateCompanionCallback: ({
             Value<int> id = const Value.absent(),
             Value<String> name = const Value.absent(),
           }) =>
@@ -752,7 +751,10 @@ class $$TodoCategoriesTableTableManager extends RootTableManager<
             id: id,
             name: name,
           ),
-          getInsertCompanionBuilder: ({
+          dataclassMapper: (p0) async => p0
+              .map((e) => $$TodoCategoriesTableWithReferences(db, e))
+              .toList(),
+          createInsertCompanionCallback: ({
             Value<int> id = const Value.absent(),
             required String name,
           }) =>
@@ -763,17 +765,16 @@ class $$TodoCategoriesTableTableManager extends RootTableManager<
         ));
 }
 
-class $$TodoCategoriesTableProcessedTableManager extends ProcessedTableManager<
+typedef $$TodoCategoriesTableProcessedTableManager = ProcessedTableManager<
     _$Database,
     $TodoCategoriesTable,
     TodoCategory,
     $$TodoCategoriesTableFilterComposer,
     $$TodoCategoriesTableOrderingComposer,
-    $$TodoCategoriesTableProcessedTableManager,
     $$TodoCategoriesTableInsertCompanionBuilder,
-    $$TodoCategoriesTableUpdateCompanionBuilder> {
-  $$TodoCategoriesTableProcessedTableManager(super.$state);
-}
+    $$TodoCategoriesTableUpdateCompanionBuilder,
+    $$TodoCategoriesTableWithReferences,
+    TodoCategory>;
 
 class $$TodoCategoriesTableFilterComposer
     extends FilterComposer<_$Database, $TodoCategoriesTable> {
@@ -816,6 +817,18 @@ class $$TodoCategoriesTableOrderingComposer
           ColumnOrderings(column, joinBuilders: joinBuilders));
 }
 
+class $$TodoCategoriesTableWithReferences {
+  // ignore: unused_field
+  final _$Database _db;
+  final TodoCategory todoCategories;
+  $$TodoCategoriesTableWithReferences(this._db, this.todoCategories);
+
+  $$TodoItemsTableProcessedTableManager get todoItemsRefs {
+    return $$TodoItemsTableTableManager(_db, _db.todoItems)
+        .filter((f) => f.categoryId.id(todoCategories.id));
+  }
+}
+
 typedef $$TodoItemsTableInsertCompanionBuilder = TodoItemsCompanion Function({
   Value<int> id,
   required String title,
@@ -835,9 +848,10 @@ class $$TodoItemsTableTableManager extends RootTableManager<
     TodoItem,
     $$TodoItemsTableFilterComposer,
     $$TodoItemsTableOrderingComposer,
-    $$TodoItemsTableProcessedTableManager,
     $$TodoItemsTableInsertCompanionBuilder,
-    $$TodoItemsTableUpdateCompanionBuilder> {
+    $$TodoItemsTableUpdateCompanionBuilder,
+    $$TodoItemsTableWithReferences,
+    TodoItem> {
   $$TodoItemsTableTableManager(_$Database db, $TodoItemsTable table)
       : super(TableManagerState(
           db: db,
@@ -846,9 +860,7 @@ class $$TodoItemsTableTableManager extends RootTableManager<
               $$TodoItemsTableFilterComposer(ComposerState(db, table)),
           orderingComposer:
               $$TodoItemsTableOrderingComposer(ComposerState(db, table)),
-          getChildManagerBuilder: (p) =>
-              $$TodoItemsTableProcessedTableManager(p),
-          getUpdateCompanionBuilder: ({
+          createUpdateCompanionCallback: ({
             Value<int> id = const Value.absent(),
             Value<String> title = const Value.absent(),
             Value<String?> content = const Value.absent(),
@@ -860,7 +872,9 @@ class $$TodoItemsTableTableManager extends RootTableManager<
             content: content,
             categoryId: categoryId,
           ),
-          getInsertCompanionBuilder: ({
+          dataclassMapper: (p0) async =>
+              p0.map((e) => $$TodoItemsTableWithReferences(db, e)).toList(),
+          createInsertCompanionCallback: ({
             Value<int> id = const Value.absent(),
             required String title,
             Value<String?> content = const Value.absent(),
@@ -875,17 +889,16 @@ class $$TodoItemsTableTableManager extends RootTableManager<
         ));
 }
 
-class $$TodoItemsTableProcessedTableManager extends ProcessedTableManager<
+typedef $$TodoItemsTableProcessedTableManager = ProcessedTableManager<
     _$Database,
     $TodoItemsTable,
     TodoItem,
     $$TodoItemsTableFilterComposer,
     $$TodoItemsTableOrderingComposer,
-    $$TodoItemsTableProcessedTableManager,
     $$TodoItemsTableInsertCompanionBuilder,
-    $$TodoItemsTableUpdateCompanionBuilder> {
-  $$TodoItemsTableProcessedTableManager(super.$state);
-}
+    $$TodoItemsTableUpdateCompanionBuilder,
+    $$TodoItemsTableWithReferences,
+    TodoItem>;
 
 class $$TodoItemsTableFilterComposer
     extends FilterComposer<_$Database, $TodoItemsTable> {
@@ -957,6 +970,19 @@ class $$TodoItemsTableOrderingComposer
                 $$TodoCategoriesTableOrderingComposer(ComposerState($state.db,
                     $state.db.todoCategories, joinBuilder, parentComposers)));
     return composer;
+  }
+}
+
+class $$TodoItemsTableWithReferences {
+  // ignore: unused_field
+  final _$Database _db;
+  final TodoItem todoItems;
+  $$TodoItemsTableWithReferences(this._db, this.todoItems);
+
+  $$TodoCategoriesTableProcessedTableManager? get categoryId {
+    if (todoItems.categoryId == null) return null;
+    return $$TodoCategoriesTableTableManager(_db, _db.todoCategories)
+        .filter((f) => f.id(todoItems.categoryId!));
   }
 }
 

--- a/drift/example/main.g.dart
+++ b/drift/example/main.g.dart
@@ -820,12 +820,12 @@ class $$TodoCategoriesTableOrderingComposer
 class $$TodoCategoriesTableWithReferences {
   // ignore: unused_field
   final _$Database _db;
-  final TodoCategory todoCategories;
-  $$TodoCategoriesTableWithReferences(this._db, this.todoCategories);
+  final TodoCategory todoCategory;
+  $$TodoCategoriesTableWithReferences(this._db, this.todoCategory);
 
   $$TodoItemsTableProcessedTableManager get todoItemsRefs {
     return $$TodoItemsTableTableManager(_db, _db.todoItems)
-        .filter((f) => f.categoryId.id(todoCategories.id));
+        .filter((f) => f.categoryId.id(todoCategory.id));
   }
 }
 
@@ -976,13 +976,13 @@ class $$TodoItemsTableOrderingComposer
 class $$TodoItemsTableWithReferences {
   // ignore: unused_field
   final _$Database _db;
-  final TodoItem todoItems;
-  $$TodoItemsTableWithReferences(this._db, this.todoItems);
+  final TodoItem todoItem;
+  $$TodoItemsTableWithReferences(this._db, this.todoItem);
 
   $$TodoCategoriesTableProcessedTableManager? get categoryId {
-    if (todoItems.categoryId == null) return null;
+    if (todoItem.categoryId == null) return null;
     return $$TodoCategoriesTableTableManager(_db, _db.todoCategories)
-        .filter((f) => f.id(todoItems.categoryId!));
+        .filter((f) => f.id(todoItem.categoryId!));
   }
 }
 

--- a/drift/lib/src/runtime/manager/manager.dart
+++ b/drift/lib/src/runtime/manager/manager.dart
@@ -344,7 +344,7 @@ abstract class BaseTableManager<
     $CreateCompanionCallback extends Function,
     $UpdateCompanionCallback extends Function,
     $MappedDataclass,
-    $ActiveDataclass> extends Selectable<$ActiveDataclass> {
+    $ActiveDataclass> {
   /// The state for this manager
   final TableManagerState<
       $Database,
@@ -520,8 +520,7 @@ abstract class BaseTableManager<
   /// throwing if the query completes with no rows.
   ///
   /// Uses the distinct flag by default to ensure that only distinct rows are returned
-  @override
-  Future<$ActiveDataclass> getSingle({bool distinct = true}) async =>
+  FutureOr<$ActiveDataclass> getSingle({bool distinct = true}) async =>
       (await get(distinct: distinct)).single;
 
   /// Creates an auto-updating stream of this statement, similar to
@@ -531,7 +530,6 @@ abstract class BaseTableManager<
   /// an error will be added to the stream instead.
   ///
   /// Uses the distinct flag by default to ensure that only distinct rows are returned
-  @override
   Stream<$ActiveDataclass> watchSingle({bool distinct = true}) =>
       watch(distinct: distinct).transform(singleElements());
 
@@ -540,8 +538,7 @@ abstract class BaseTableManager<
   /// Use [limit] and [offset] to limit the number of rows returned
   /// An offset will only be applied if a limit is also set
   /// Set [distinct] to true to ensure that only distinct rows are returned
-  @override
-  Future<List<$ActiveDataclass>> get(
+  FutureOr<List<$ActiveDataclass>> get(
           {bool distinct = false, int? limit, int? offset}) =>
       $state
           .copyWith(distinct: distinct, limit: limit, offset: offset)
@@ -555,7 +552,6 @@ abstract class BaseTableManager<
   /// Use [limit] and [offset] to limit the number of rows returned
   /// An offset will only be applied if a limit is also set
   /// Set [distinct] to true to ensure that only distinct rows are returned
-  @override
   Stream<List<$ActiveDataclass>> watch(
           {bool distinct = false, int? limit, int? offset}) =>
       $state
@@ -572,8 +568,7 @@ abstract class BaseTableManager<
   /// always evaluate to exactly one row.
   ///
   /// Uses the distinct flag by default to ensure that only distinct rows are returned
-  @override
-  Future<$ActiveDataclass?> getSingleOrNull({bool distinct = true}) async {
+  FutureOr<$ActiveDataclass?> getSingleOrNull({bool distinct = true}) async {
     final list = await get(distinct: distinct);
     final iterator = list.iterator;
 
@@ -596,7 +591,6 @@ abstract class BaseTableManager<
   /// to the stream instead.
   ///
   /// Uses the distinct flag by default to ensure that only distinct rows are returned
-  @override
   Stream<$ActiveDataclass?> watchSingleOrNull({bool distinct = true}) =>
       watch(distinct: distinct).transform(singleElementsOrNull());
 }

--- a/drift/test/database/data_class_test.dart
+++ b/drift/test/database/data_class_test.dart
@@ -39,7 +39,7 @@ void main() {
         id: RowId(13),
         title: 'Title',
         content: 'Content',
-        category: 3,
+        category: RowId(3),
         targetDate: DateTime.now(),
       );
       expect(

--- a/drift/test/database/statements/join_test.dart
+++ b/drift/test/database/statements/join_test.dart
@@ -85,7 +85,7 @@ void main() {
           title: 'title',
           content: 'content',
           targetDate: date,
-          category: 3,
+          category: RowId(3),
           status: TodoStatus.workInProgress,
         ));
 

--- a/drift/test/database/statements/select_test.dart
+++ b/drift/test/database/statements/select_test.dart
@@ -19,7 +19,7 @@ const _todoEntry = TodoEntry(
   id: RowId(10),
   title: 'A todo title',
   content: 'Content',
-  category: 3,
+  category: RowId(3),
 );
 
 void main() {

--- a/drift/test/database/statements/update_test.dart
+++ b/drift/test/database/statements/update_test.dart
@@ -24,7 +24,7 @@ void main() {
     test('for entire table', () async {
       await db.update(db.todosTable).write(const TodosTableCompanion(
             title: Value('Updated title'),
-            category: Value(3),
+            category: Value(RowId(3)),
           ));
 
       verify(executor.runUpdate(

--- a/drift/test/extensions/geopoly_integration_test.g.dart
+++ b/drift/test/extensions/geopoly_integration_test.g.dart
@@ -330,8 +330,8 @@ class $GeopolyTestOrderingComposer
 class $GeopolyTestWithReferences {
   // ignore: unused_field
   final _$_GeopolyTestDatabase _db;
-  final GeopolyTestData geopolyTest;
-  $GeopolyTestWithReferences(this._db, this.geopolyTest);
+  final GeopolyTestData geopolyTestData;
+  $GeopolyTestWithReferences(this._db, this.geopolyTestData);
 }
 
 class $_GeopolyTestDatabaseManager {

--- a/drift/test/extensions/geopoly_integration_test.g.dart
+++ b/drift/test/extensions/geopoly_integration_test.g.dart
@@ -251,9 +251,10 @@ class $GeopolyTestTableManager extends RootTableManager<
     GeopolyTestData,
     $GeopolyTestFilterComposer,
     $GeopolyTestOrderingComposer,
-    $GeopolyTestProcessedTableManager,
     $GeopolyTestInsertCompanionBuilder,
-    $GeopolyTestUpdateCompanionBuilder> {
+    $GeopolyTestUpdateCompanionBuilder,
+    $GeopolyTestWithReferences,
+    GeopolyTestData> {
   $GeopolyTestTableManager(_$_GeopolyTestDatabase db, GeopolyTest table)
       : super(TableManagerState(
           db: db,
@@ -262,8 +263,7 @@ class $GeopolyTestTableManager extends RootTableManager<
               $GeopolyTestFilterComposer(ComposerState(db, table)),
           orderingComposer:
               $GeopolyTestOrderingComposer(ComposerState(db, table)),
-          getChildManagerBuilder: (p) => $GeopolyTestProcessedTableManager(p),
-          getUpdateCompanionBuilder: ({
+          createUpdateCompanionCallback: ({
             Value<GeopolyPolygon?> shape = const Value.absent(),
             Value<DriftAny?> a = const Value.absent(),
             Value<int> rowid = const Value.absent(),
@@ -273,7 +273,9 @@ class $GeopolyTestTableManager extends RootTableManager<
             a: a,
             rowid: rowid,
           ),
-          getInsertCompanionBuilder: ({
+          dataclassMapper: (p0) async =>
+              p0.map((e) => $GeopolyTestWithReferences(db, e)).toList(),
+          createInsertCompanionCallback: ({
             Value<GeopolyPolygon?> shape = const Value.absent(),
             Value<DriftAny?> a = const Value.absent(),
             Value<int> rowid = const Value.absent(),
@@ -286,17 +288,16 @@ class $GeopolyTestTableManager extends RootTableManager<
         ));
 }
 
-class $GeopolyTestProcessedTableManager extends ProcessedTableManager<
+typedef $GeopolyTestProcessedTableManager = ProcessedTableManager<
     _$_GeopolyTestDatabase,
     GeopolyTest,
     GeopolyTestData,
     $GeopolyTestFilterComposer,
     $GeopolyTestOrderingComposer,
-    $GeopolyTestProcessedTableManager,
     $GeopolyTestInsertCompanionBuilder,
-    $GeopolyTestUpdateCompanionBuilder> {
-  $GeopolyTestProcessedTableManager(super.$state);
-}
+    $GeopolyTestUpdateCompanionBuilder,
+    $GeopolyTestWithReferences,
+    GeopolyTestData>;
 
 class $GeopolyTestFilterComposer
     extends FilterComposer<_$_GeopolyTestDatabase, GeopolyTest> {
@@ -324,6 +325,13 @@ class $GeopolyTestOrderingComposer
       column: $state.table.a,
       builder: (column, joinBuilders) =>
           ColumnOrderings(column, joinBuilders: joinBuilders));
+}
+
+class $GeopolyTestWithReferences {
+  // ignore: unused_field
+  final _$_GeopolyTestDatabase _db;
+  final GeopolyTestData geopolyTest;
+  $GeopolyTestWithReferences(this._db, this.geopolyTest);
 }
 
 class $_GeopolyTestDatabaseManager {

--- a/drift/test/extensions/json1_integration_test.dart
+++ b/drift/test/extensions/json1_integration_test.dart
@@ -85,12 +85,12 @@ void main() {
             TodosTableCompanion.insert(
                 title: Value('first title'),
                 content: 'entry in category',
-                category: Value(1)),
+                category: Value(RowId(1))),
             TodosTableCompanion.insert(content: 'not in category'),
             TodosTableCompanion.insert(
                 title: Value('second title'),
                 content: 'another in category',
-                category: Value(1))
+                category: Value(RowId(1)))
           ]);
       });
     });

--- a/drift/test/generated/custom_tables.g.dart
+++ b/drift/test/generated/custom_tables.g.dart
@@ -2094,8 +2094,8 @@ class $NoIdsOrderingComposer extends OrderingComposer<_$CustomTablesDb, NoIds> {
 class $NoIdsWithReferences {
   // ignore: unused_field
   final _$CustomTablesDb _db;
-  final NoIdRow noIds;
-  $NoIdsWithReferences(this._db, this.noIds);
+  final NoIdRow noIdRow;
+  $NoIdsWithReferences(this._db, this.noIdRow);
 }
 
 typedef $WithDefaultsInsertCompanionBuilder = WithDefaultsCompanion Function({
@@ -2194,8 +2194,8 @@ class $WithDefaultsOrderingComposer
 class $WithDefaultsWithReferences {
   // ignore: unused_field
   final _$CustomTablesDb _db;
-  final WithDefault withDefaults;
-  $WithDefaultsWithReferences(this._db, this.withDefaults);
+  final WithDefault withDefault;
+  $WithDefaultsWithReferences(this._db, this.withDefault);
 }
 
 typedef $WithConstraintsInsertCompanionBuilder = WithConstraintsCompanion
@@ -2312,8 +2312,8 @@ class $WithConstraintsOrderingComposer
 class $WithConstraintsWithReferences {
   // ignore: unused_field
   final _$CustomTablesDb _db;
-  final WithConstraint withConstraints;
-  $WithConstraintsWithReferences(this._db, this.withConstraints);
+  final WithConstraint withConstraint;
+  $WithConstraintsWithReferences(this._db, this.withConstraint);
 }
 
 typedef $ConfigTableInsertCompanionBuilder = ConfigCompanion Function({
@@ -2571,8 +2571,8 @@ class $MytableOrderingComposer
 class $MytableWithReferences {
   // ignore: unused_field
   final _$CustomTablesDb _db;
-  final MytableData mytable;
-  $MytableWithReferences(this._db, this.mytable);
+  final MytableData mytableData;
+  $MytableWithReferences(this._db, this.mytableData);
 }
 
 typedef $EmailInsertCompanionBuilder = EmailCompanion Function({
@@ -2683,8 +2683,8 @@ class $EmailOrderingComposer extends OrderingComposer<_$CustomTablesDb, Email> {
 class $EmailWithReferences {
   // ignore: unused_field
   final _$CustomTablesDb _db;
-  final EMail email;
-  $EmailWithReferences(this._db, this.email);
+  final EMail eMail;
+  $EmailWithReferences(this._db, this.eMail);
 }
 
 typedef $WeirdTableInsertCompanionBuilder = WeirdTableCompanion Function({
@@ -2783,8 +2783,8 @@ class $WeirdTableOrderingComposer
 class $WeirdTableWithReferences {
   // ignore: unused_field
   final _$CustomTablesDb _db;
-  final WeirdData weirdTable;
-  $WeirdTableWithReferences(this._db, this.weirdTable);
+  final WeirdData weirdData;
+  $WeirdTableWithReferences(this._db, this.weirdData);
 }
 
 class $CustomTablesDbManager {

--- a/drift/test/generated/custom_tables.g.dart
+++ b/drift/test/generated/custom_tables.g.dart
@@ -2037,23 +2037,25 @@ class $NoIdsTableManager extends RootTableManager<
     NoIdRow,
     $NoIdsFilterComposer,
     $NoIdsOrderingComposer,
-    $NoIdsProcessedTableManager,
     $NoIdsInsertCompanionBuilder,
-    $NoIdsUpdateCompanionBuilder> {
+    $NoIdsUpdateCompanionBuilder,
+    $NoIdsWithReferences,
+    NoIdRow> {
   $NoIdsTableManager(_$CustomTablesDb db, NoIds table)
       : super(TableManagerState(
           db: db,
           table: table,
           filteringComposer: $NoIdsFilterComposer(ComposerState(db, table)),
           orderingComposer: $NoIdsOrderingComposer(ComposerState(db, table)),
-          getChildManagerBuilder: (p) => $NoIdsProcessedTableManager(p),
-          getUpdateCompanionBuilder: ({
+          createUpdateCompanionCallback: ({
             Value<Uint8List> payload = const Value.absent(),
           }) =>
               NoIdsCompanion(
             payload: payload,
           ),
-          getInsertCompanionBuilder: ({
+          dataclassMapper: (p0) async =>
+              p0.map((e) => $NoIdsWithReferences(db, e)).toList(),
+          createInsertCompanionCallback: ({
             required Uint8List payload,
           }) =>
               NoIdsCompanion.insert(
@@ -2062,17 +2064,16 @@ class $NoIdsTableManager extends RootTableManager<
         ));
 }
 
-class $NoIdsProcessedTableManager extends ProcessedTableManager<
+typedef $NoIdsProcessedTableManager = ProcessedTableManager<
     _$CustomTablesDb,
     NoIds,
     NoIdRow,
     $NoIdsFilterComposer,
     $NoIdsOrderingComposer,
-    $NoIdsProcessedTableManager,
     $NoIdsInsertCompanionBuilder,
-    $NoIdsUpdateCompanionBuilder> {
-  $NoIdsProcessedTableManager(super.$state);
-}
+    $NoIdsUpdateCompanionBuilder,
+    $NoIdsWithReferences,
+    NoIdRow>;
 
 class $NoIdsFilterComposer extends FilterComposer<_$CustomTablesDb, NoIds> {
   $NoIdsFilterComposer(super.$state);
@@ -2088,6 +2089,13 @@ class $NoIdsOrderingComposer extends OrderingComposer<_$CustomTablesDb, NoIds> {
       column: $state.table.payload,
       builder: (column, joinBuilders) =>
           ColumnOrderings(column, joinBuilders: joinBuilders));
+}
+
+class $NoIdsWithReferences {
+  // ignore: unused_field
+  final _$CustomTablesDb _db;
+  final NoIdRow noIds;
+  $NoIdsWithReferences(this._db, this.noIds);
 }
 
 typedef $WithDefaultsInsertCompanionBuilder = WithDefaultsCompanion Function({
@@ -2107,9 +2115,10 @@ class $WithDefaultsTableManager extends RootTableManager<
     WithDefault,
     $WithDefaultsFilterComposer,
     $WithDefaultsOrderingComposer,
-    $WithDefaultsProcessedTableManager,
     $WithDefaultsInsertCompanionBuilder,
-    $WithDefaultsUpdateCompanionBuilder> {
+    $WithDefaultsUpdateCompanionBuilder,
+    $WithDefaultsWithReferences,
+    WithDefault> {
   $WithDefaultsTableManager(_$CustomTablesDb db, WithDefaults table)
       : super(TableManagerState(
           db: db,
@@ -2118,8 +2127,7 @@ class $WithDefaultsTableManager extends RootTableManager<
               $WithDefaultsFilterComposer(ComposerState(db, table)),
           orderingComposer:
               $WithDefaultsOrderingComposer(ComposerState(db, table)),
-          getChildManagerBuilder: (p) => $WithDefaultsProcessedTableManager(p),
-          getUpdateCompanionBuilder: ({
+          createUpdateCompanionCallback: ({
             Value<String?> a = const Value.absent(),
             Value<int?> b = const Value.absent(),
             Value<int> rowid = const Value.absent(),
@@ -2129,7 +2137,9 @@ class $WithDefaultsTableManager extends RootTableManager<
             b: b,
             rowid: rowid,
           ),
-          getInsertCompanionBuilder: ({
+          dataclassMapper: (p0) async =>
+              p0.map((e) => $WithDefaultsWithReferences(db, e)).toList(),
+          createInsertCompanionCallback: ({
             Value<String?> a = const Value.absent(),
             Value<int?> b = const Value.absent(),
             Value<int> rowid = const Value.absent(),
@@ -2142,17 +2152,16 @@ class $WithDefaultsTableManager extends RootTableManager<
         ));
 }
 
-class $WithDefaultsProcessedTableManager extends ProcessedTableManager<
+typedef $WithDefaultsProcessedTableManager = ProcessedTableManager<
     _$CustomTablesDb,
     WithDefaults,
     WithDefault,
     $WithDefaultsFilterComposer,
     $WithDefaultsOrderingComposer,
-    $WithDefaultsProcessedTableManager,
     $WithDefaultsInsertCompanionBuilder,
-    $WithDefaultsUpdateCompanionBuilder> {
-  $WithDefaultsProcessedTableManager(super.$state);
-}
+    $WithDefaultsUpdateCompanionBuilder,
+    $WithDefaultsWithReferences,
+    WithDefault>;
 
 class $WithDefaultsFilterComposer
     extends FilterComposer<_$CustomTablesDb, WithDefaults> {
@@ -2182,6 +2191,13 @@ class $WithDefaultsOrderingComposer
           ColumnOrderings(column, joinBuilders: joinBuilders));
 }
 
+class $WithDefaultsWithReferences {
+  // ignore: unused_field
+  final _$CustomTablesDb _db;
+  final WithDefault withDefaults;
+  $WithDefaultsWithReferences(this._db, this.withDefaults);
+}
+
 typedef $WithConstraintsInsertCompanionBuilder = WithConstraintsCompanion
     Function({
   Value<String?> a,
@@ -2203,9 +2219,10 @@ class $WithConstraintsTableManager extends RootTableManager<
     WithConstraint,
     $WithConstraintsFilterComposer,
     $WithConstraintsOrderingComposer,
-    $WithConstraintsProcessedTableManager,
     $WithConstraintsInsertCompanionBuilder,
-    $WithConstraintsUpdateCompanionBuilder> {
+    $WithConstraintsUpdateCompanionBuilder,
+    $WithConstraintsWithReferences,
+    WithConstraint> {
   $WithConstraintsTableManager(_$CustomTablesDb db, WithConstraints table)
       : super(TableManagerState(
           db: db,
@@ -2214,9 +2231,7 @@ class $WithConstraintsTableManager extends RootTableManager<
               $WithConstraintsFilterComposer(ComposerState(db, table)),
           orderingComposer:
               $WithConstraintsOrderingComposer(ComposerState(db, table)),
-          getChildManagerBuilder: (p) =>
-              $WithConstraintsProcessedTableManager(p),
-          getUpdateCompanionBuilder: ({
+          createUpdateCompanionCallback: ({
             Value<String?> a = const Value.absent(),
             Value<int> b = const Value.absent(),
             Value<double?> c = const Value.absent(),
@@ -2228,7 +2243,9 @@ class $WithConstraintsTableManager extends RootTableManager<
             c: c,
             rowid: rowid,
           ),
-          getInsertCompanionBuilder: ({
+          dataclassMapper: (p0) async =>
+              p0.map((e) => $WithConstraintsWithReferences(db, e)).toList(),
+          createInsertCompanionCallback: ({
             Value<String?> a = const Value.absent(),
             required int b,
             Value<double?> c = const Value.absent(),
@@ -2243,17 +2260,16 @@ class $WithConstraintsTableManager extends RootTableManager<
         ));
 }
 
-class $WithConstraintsProcessedTableManager extends ProcessedTableManager<
+typedef $WithConstraintsProcessedTableManager = ProcessedTableManager<
     _$CustomTablesDb,
     WithConstraints,
     WithConstraint,
     $WithConstraintsFilterComposer,
     $WithConstraintsOrderingComposer,
-    $WithConstraintsProcessedTableManager,
     $WithConstraintsInsertCompanionBuilder,
-    $WithConstraintsUpdateCompanionBuilder> {
-  $WithConstraintsProcessedTableManager(super.$state);
-}
+    $WithConstraintsUpdateCompanionBuilder,
+    $WithConstraintsWithReferences,
+    WithConstraint>;
 
 class $WithConstraintsFilterComposer
     extends FilterComposer<_$CustomTablesDb, WithConstraints> {
@@ -2293,6 +2309,13 @@ class $WithConstraintsOrderingComposer
           ColumnOrderings(column, joinBuilders: joinBuilders));
 }
 
+class $WithConstraintsWithReferences {
+  // ignore: unused_field
+  final _$CustomTablesDb _db;
+  final WithConstraint withConstraints;
+  $WithConstraintsWithReferences(this._db, this.withConstraints);
+}
+
 typedef $ConfigTableInsertCompanionBuilder = ConfigCompanion Function({
   required String configKey,
   Value<DriftAny?> configValue,
@@ -2314,9 +2337,10 @@ class $ConfigTableTableManager extends RootTableManager<
     Config,
     $ConfigTableFilterComposer,
     $ConfigTableOrderingComposer,
-    $ConfigTableProcessedTableManager,
     $ConfigTableInsertCompanionBuilder,
-    $ConfigTableUpdateCompanionBuilder> {
+    $ConfigTableUpdateCompanionBuilder,
+    $ConfigTableWithReferences,
+    Config> {
   $ConfigTableTableManager(_$CustomTablesDb db, ConfigTable table)
       : super(TableManagerState(
           db: db,
@@ -2325,8 +2349,7 @@ class $ConfigTableTableManager extends RootTableManager<
               $ConfigTableFilterComposer(ComposerState(db, table)),
           orderingComposer:
               $ConfigTableOrderingComposer(ComposerState(db, table)),
-          getChildManagerBuilder: (p) => $ConfigTableProcessedTableManager(p),
-          getUpdateCompanionBuilder: ({
+          createUpdateCompanionCallback: ({
             Value<String> configKey = const Value.absent(),
             Value<DriftAny?> configValue = const Value.absent(),
             Value<SyncType?> syncState = const Value.absent(),
@@ -2340,7 +2363,9 @@ class $ConfigTableTableManager extends RootTableManager<
             syncStateImplicit: syncStateImplicit,
             rowid: rowid,
           ),
-          getInsertCompanionBuilder: ({
+          dataclassMapper: (p0) async =>
+              p0.map((e) => $ConfigTableWithReferences(db, e)).toList(),
+          createInsertCompanionCallback: ({
             required String configKey,
             Value<DriftAny?> configValue = const Value.absent(),
             Value<SyncType?> syncState = const Value.absent(),
@@ -2357,17 +2382,16 @@ class $ConfigTableTableManager extends RootTableManager<
         ));
 }
 
-class $ConfigTableProcessedTableManager extends ProcessedTableManager<
+typedef $ConfigTableProcessedTableManager = ProcessedTableManager<
     _$CustomTablesDb,
     ConfigTable,
     Config,
     $ConfigTableFilterComposer,
     $ConfigTableOrderingComposer,
-    $ConfigTableProcessedTableManager,
     $ConfigTableInsertCompanionBuilder,
-    $ConfigTableUpdateCompanionBuilder> {
-  $ConfigTableProcessedTableManager(super.$state);
-}
+    $ConfigTableUpdateCompanionBuilder,
+    $ConfigTableWithReferences,
+    Config>;
 
 class $ConfigTableFilterComposer
     extends FilterComposer<_$CustomTablesDb, ConfigTable> {
@@ -2421,6 +2445,13 @@ class $ConfigTableOrderingComposer
           ColumnOrderings(column, joinBuilders: joinBuilders));
 }
 
+class $ConfigTableWithReferences {
+  // ignore: unused_field
+  final _$CustomTablesDb _db;
+  final Config config;
+  $ConfigTableWithReferences(this._db, this.config);
+}
+
 typedef $MytableInsertCompanionBuilder = MytableCompanion Function({
   Value<int> someid,
   Value<String?> sometext,
@@ -2440,17 +2471,17 @@ class $MytableTableManager extends RootTableManager<
     MytableData,
     $MytableFilterComposer,
     $MytableOrderingComposer,
-    $MytableProcessedTableManager,
     $MytableInsertCompanionBuilder,
-    $MytableUpdateCompanionBuilder> {
+    $MytableUpdateCompanionBuilder,
+    $MytableWithReferences,
+    MytableData> {
   $MytableTableManager(_$CustomTablesDb db, Mytable table)
       : super(TableManagerState(
           db: db,
           table: table,
           filteringComposer: $MytableFilterComposer(ComposerState(db, table)),
           orderingComposer: $MytableOrderingComposer(ComposerState(db, table)),
-          getChildManagerBuilder: (p) => $MytableProcessedTableManager(p),
-          getUpdateCompanionBuilder: ({
+          createUpdateCompanionCallback: ({
             Value<int> someid = const Value.absent(),
             Value<String?> sometext = const Value.absent(),
             Value<bool?> isInserting = const Value.absent(),
@@ -2462,7 +2493,9 @@ class $MytableTableManager extends RootTableManager<
             isInserting: isInserting,
             somedate: somedate,
           ),
-          getInsertCompanionBuilder: ({
+          dataclassMapper: (p0) async =>
+              p0.map((e) => $MytableWithReferences(db, e)).toList(),
+          createInsertCompanionCallback: ({
             Value<int> someid = const Value.absent(),
             Value<String?> sometext = const Value.absent(),
             Value<bool?> isInserting = const Value.absent(),
@@ -2477,17 +2510,16 @@ class $MytableTableManager extends RootTableManager<
         ));
 }
 
-class $MytableProcessedTableManager extends ProcessedTableManager<
+typedef $MytableProcessedTableManager = ProcessedTableManager<
     _$CustomTablesDb,
     Mytable,
     MytableData,
     $MytableFilterComposer,
     $MytableOrderingComposer,
-    $MytableProcessedTableManager,
     $MytableInsertCompanionBuilder,
-    $MytableUpdateCompanionBuilder> {
-  $MytableProcessedTableManager(super.$state);
-}
+    $MytableUpdateCompanionBuilder,
+    $MytableWithReferences,
+    MytableData>;
 
 class $MytableFilterComposer extends FilterComposer<_$CustomTablesDb, Mytable> {
   $MytableFilterComposer(super.$state);
@@ -2536,6 +2568,13 @@ class $MytableOrderingComposer
           ColumnOrderings(column, joinBuilders: joinBuilders));
 }
 
+class $MytableWithReferences {
+  // ignore: unused_field
+  final _$CustomTablesDb _db;
+  final MytableData mytable;
+  $MytableWithReferences(this._db, this.mytable);
+}
+
 typedef $EmailInsertCompanionBuilder = EmailCompanion Function({
   required String sender,
   required String title,
@@ -2555,17 +2594,17 @@ class $EmailTableManager extends RootTableManager<
     EMail,
     $EmailFilterComposer,
     $EmailOrderingComposer,
-    $EmailProcessedTableManager,
     $EmailInsertCompanionBuilder,
-    $EmailUpdateCompanionBuilder> {
+    $EmailUpdateCompanionBuilder,
+    $EmailWithReferences,
+    EMail> {
   $EmailTableManager(_$CustomTablesDb db, Email table)
       : super(TableManagerState(
           db: db,
           table: table,
           filteringComposer: $EmailFilterComposer(ComposerState(db, table)),
           orderingComposer: $EmailOrderingComposer(ComposerState(db, table)),
-          getChildManagerBuilder: (p) => $EmailProcessedTableManager(p),
-          getUpdateCompanionBuilder: ({
+          createUpdateCompanionCallback: ({
             Value<String> sender = const Value.absent(),
             Value<String> title = const Value.absent(),
             Value<String> body = const Value.absent(),
@@ -2577,7 +2616,9 @@ class $EmailTableManager extends RootTableManager<
             body: body,
             rowid: rowid,
           ),
-          getInsertCompanionBuilder: ({
+          dataclassMapper: (p0) async =>
+              p0.map((e) => $EmailWithReferences(db, e)).toList(),
+          createInsertCompanionCallback: ({
             required String sender,
             required String title,
             required String body,
@@ -2592,17 +2633,16 @@ class $EmailTableManager extends RootTableManager<
         ));
 }
 
-class $EmailProcessedTableManager extends ProcessedTableManager<
+typedef $EmailProcessedTableManager = ProcessedTableManager<
     _$CustomTablesDb,
     Email,
     EMail,
     $EmailFilterComposer,
     $EmailOrderingComposer,
-    $EmailProcessedTableManager,
     $EmailInsertCompanionBuilder,
-    $EmailUpdateCompanionBuilder> {
-  $EmailProcessedTableManager(super.$state);
-}
+    $EmailUpdateCompanionBuilder,
+    $EmailWithReferences,
+    EMail>;
 
 class $EmailFilterComposer extends FilterComposer<_$CustomTablesDb, Email> {
   $EmailFilterComposer(super.$state);
@@ -2640,6 +2680,13 @@ class $EmailOrderingComposer extends OrderingComposer<_$CustomTablesDb, Email> {
           ColumnOrderings(column, joinBuilders: joinBuilders));
 }
 
+class $EmailWithReferences {
+  // ignore: unused_field
+  final _$CustomTablesDb _db;
+  final EMail email;
+  $EmailWithReferences(this._db, this.email);
+}
+
 typedef $WeirdTableInsertCompanionBuilder = WeirdTableCompanion Function({
   required int sqlClass,
   required String textColumn,
@@ -2657,9 +2704,10 @@ class $WeirdTableTableManager extends RootTableManager<
     WeirdData,
     $WeirdTableFilterComposer,
     $WeirdTableOrderingComposer,
-    $WeirdTableProcessedTableManager,
     $WeirdTableInsertCompanionBuilder,
-    $WeirdTableUpdateCompanionBuilder> {
+    $WeirdTableUpdateCompanionBuilder,
+    $WeirdTableWithReferences,
+    WeirdData> {
   $WeirdTableTableManager(_$CustomTablesDb db, WeirdTable table)
       : super(TableManagerState(
           db: db,
@@ -2668,8 +2716,7 @@ class $WeirdTableTableManager extends RootTableManager<
               $WeirdTableFilterComposer(ComposerState(db, table)),
           orderingComposer:
               $WeirdTableOrderingComposer(ComposerState(db, table)),
-          getChildManagerBuilder: (p) => $WeirdTableProcessedTableManager(p),
-          getUpdateCompanionBuilder: ({
+          createUpdateCompanionCallback: ({
             Value<int> sqlClass = const Value.absent(),
             Value<String> textColumn = const Value.absent(),
             Value<int> rowid = const Value.absent(),
@@ -2679,7 +2726,9 @@ class $WeirdTableTableManager extends RootTableManager<
             textColumn: textColumn,
             rowid: rowid,
           ),
-          getInsertCompanionBuilder: ({
+          dataclassMapper: (p0) async =>
+              p0.map((e) => $WeirdTableWithReferences(db, e)).toList(),
+          createInsertCompanionCallback: ({
             required int sqlClass,
             required String textColumn,
             Value<int> rowid = const Value.absent(),
@@ -2692,17 +2741,16 @@ class $WeirdTableTableManager extends RootTableManager<
         ));
 }
 
-class $WeirdTableProcessedTableManager extends ProcessedTableManager<
+typedef $WeirdTableProcessedTableManager = ProcessedTableManager<
     _$CustomTablesDb,
     WeirdTable,
     WeirdData,
     $WeirdTableFilterComposer,
     $WeirdTableOrderingComposer,
-    $WeirdTableProcessedTableManager,
     $WeirdTableInsertCompanionBuilder,
-    $WeirdTableUpdateCompanionBuilder> {
-  $WeirdTableProcessedTableManager(super.$state);
-}
+    $WeirdTableUpdateCompanionBuilder,
+    $WeirdTableWithReferences,
+    WeirdData>;
 
 class $WeirdTableFilterComposer
     extends FilterComposer<_$CustomTablesDb, WeirdTable> {
@@ -2730,6 +2778,13 @@ class $WeirdTableOrderingComposer
       column: $state.table.textColumn,
       builder: (column, joinBuilders) =>
           ColumnOrderings(column, joinBuilders: joinBuilders));
+}
+
+class $WeirdTableWithReferences {
+  // ignore: unused_field
+  final _$CustomTablesDb _db;
+  final WeirdData weirdTable;
+  $WeirdTableWithReferences(this._db, this.weirdTable);
 }
 
 class $CustomTablesDbManager {

--- a/drift/test/generated/todos.dart
+++ b/drift/test/generated/todos.dart
@@ -30,6 +30,7 @@ class TodosTable extends Table with AutoIncrement {
   DateTimeColumn get targetDate => dateTime().nullable().unique()();
   @ReferenceName("todos")
   IntColumn get category => integer()
+      .map(TypeConverter.extensionType<RowId, int>())
       .references(Categories, #id, initiallyDeferred: true)
       .nullable()();
 

--- a/drift/test/generated/todos.g.dart
+++ b/drift/test/generated/todos.g.dart
@@ -3576,12 +3576,12 @@ class $$CategoriesTableOrderingComposer
 class $$CategoriesTableWithReferences {
   // ignore: unused_field
   final _$TodoDb _db;
-  final Category categories;
-  $$CategoriesTableWithReferences(this._db, this.categories);
+  final Category category;
+  $$CategoriesTableWithReferences(this._db, this.category);
 
   $$TodosTableTableProcessedTableManager get todos {
     return $$TodosTableTableTableManager(_db, _db.todosTable)
-        .filter((f) => f.category.id(categories.id));
+        .filter((f) => f.category.id(category.id));
   }
 }
 
@@ -3757,13 +3757,13 @@ class $$TodosTableTableOrderingComposer
 class $$TodosTableTableWithReferences {
   // ignore: unused_field
   final _$TodoDb _db;
-  final TodoEntry todosTable;
-  $$TodosTableTableWithReferences(this._db, this.todosTable);
+  final TodoEntry todoEntry;
+  $$TodosTableTableWithReferences(this._db, this.todoEntry);
 
   $$CategoriesTableProcessedTableManager? get category {
-    if (todosTable.category == null) return null;
+    if (todoEntry.category == null) return null;
     return $$CategoriesTableTableManager(_db, _db.categories)
-        .filter((f) => f.id(todosTable.category!));
+        .filter((f) => f.id(todoEntry.category!));
   }
 }
 
@@ -3906,8 +3906,8 @@ class $$UsersTableOrderingComposer
 class $$UsersTableWithReferences {
   // ignore: unused_field
   final _$TodoDb _db;
-  final User users;
-  $$UsersTableWithReferences(this._db, this.users);
+  final User user;
+  $$UsersTableWithReferences(this._db, this.user);
 }
 
 typedef $$SharedTodosTableInsertCompanionBuilder = SharedTodosCompanion
@@ -4008,8 +4008,8 @@ class $$SharedTodosTableOrderingComposer
 class $$SharedTodosTableWithReferences {
   // ignore: unused_field
   final _$TodoDb _db;
-  final SharedTodo sharedTodos;
-  $$SharedTodosTableWithReferences(this._db, this.sharedTodos);
+  final SharedTodo sharedTodo;
+  $$SharedTodosTableWithReferences(this._db, this.sharedTodo);
 }
 
 typedef $$TableWithoutPKTableInsertCompanionBuilder = TableWithoutPKCompanion
@@ -4145,8 +4145,8 @@ class $$TableWithoutPKTableOrderingComposer
 class $$TableWithoutPKTableWithReferences {
   // ignore: unused_field
   final _$TodoDb _db;
-  final CustomRowClass tableWithoutPK;
-  $$TableWithoutPKTableWithReferences(this._db, this.tableWithoutPK);
+  final CustomRowClass customRowClass;
+  $$TableWithoutPKTableWithReferences(this._db, this.customRowClass);
 }
 
 typedef $$PureDefaultsTableInsertCompanionBuilder = PureDefaultsCompanion
@@ -4233,8 +4233,8 @@ class $$PureDefaultsTableOrderingComposer
 class $$PureDefaultsTableWithReferences {
   // ignore: unused_field
   final _$TodoDb _db;
-  final PureDefault pureDefaults;
-  $$PureDefaultsTableWithReferences(this._db, this.pureDefaults);
+  final PureDefault pureDefault;
+  $$PureDefaultsTableWithReferences(this._db, this.pureDefault);
 }
 
 typedef $$WithCustomTypeTableInsertCompanionBuilder = WithCustomTypeCompanion
@@ -4320,8 +4320,8 @@ class $$WithCustomTypeTableOrderingComposer
 class $$WithCustomTypeTableWithReferences {
   // ignore: unused_field
   final _$TodoDb _db;
-  final WithCustomTypeData withCustomType;
-  $$WithCustomTypeTableWithReferences(this._db, this.withCustomType);
+  final WithCustomTypeData withCustomTypeData;
+  $$WithCustomTypeTableWithReferences(this._db, this.withCustomTypeData);
 }
 
 typedef $$TableWithEveryColumnTypeTableInsertCompanionBuilder
@@ -4553,9 +4553,9 @@ class $$TableWithEveryColumnTypeTableOrderingComposer
 class $$TableWithEveryColumnTypeTableWithReferences {
   // ignore: unused_field
   final _$TodoDb _db;
-  final TableWithEveryColumnTypeData tableWithEveryColumnType;
+  final TableWithEveryColumnTypeData tableWithEveryColumnTypeData;
   $$TableWithEveryColumnTypeTableWithReferences(
-      this._db, this.tableWithEveryColumnType);
+      this._db, this.tableWithEveryColumnTypeData);
 }
 
 typedef $$DepartmentTableInsertCompanionBuilder = DepartmentCompanion Function({
@@ -4661,12 +4661,12 @@ class $$DepartmentTableOrderingComposer
 class $$DepartmentTableWithReferences {
   // ignore: unused_field
   final _$TodoDb _db;
-  final DepartmentData department;
-  $$DepartmentTableWithReferences(this._db, this.department);
+  final DepartmentData departmentData;
+  $$DepartmentTableWithReferences(this._db, this.departmentData);
 
   $$ProductTableProcessedTableManager get productRefs {
     return $$ProductTableTableManager(_db, _db.product)
-        .filter((f) => f.department.id(department.id));
+        .filter((f) => f.department.id(departmentData.id));
   }
 }
 
@@ -4803,18 +4803,18 @@ class $$ProductTableOrderingComposer
 class $$ProductTableWithReferences {
   // ignore: unused_field
   final _$TodoDb _db;
-  final ProductData product;
-  $$ProductTableWithReferences(this._db, this.product);
+  final ProductData productData;
+  $$ProductTableWithReferences(this._db, this.productData);
 
   $$DepartmentTableProcessedTableManager? get department {
-    if (product.department == null) return null;
+    if (productData.department == null) return null;
     return $$DepartmentTableTableManager(_db, _db.department)
-        .filter((f) => f.id(product.department!));
+        .filter((f) => f.id(productData.department!));
   }
 
   $$ListingTableProcessedTableManager get listings {
     return $$ListingTableTableManager(_db, _db.listing)
-        .filter((f) => f.product.id(product.id));
+        .filter((f) => f.product.id(productData.id));
   }
 }
 
@@ -4920,12 +4920,12 @@ class $$StoreTableOrderingComposer
 class $$StoreTableWithReferences {
   // ignore: unused_field
   final _$TodoDb _db;
-  final StoreData store;
-  $$StoreTableWithReferences(this._db, this.store);
+  final StoreData storeData;
+  $$StoreTableWithReferences(this._db, this.storeData);
 
   $$ListingTableProcessedTableManager get listings {
     return $$ListingTableTableManager(_db, _db.listing)
-        .filter((f) => f.store.id(store.id));
+        .filter((f) => f.store.id(storeData.id));
   }
 }
 
@@ -5079,19 +5079,19 @@ class $$ListingTableOrderingComposer
 class $$ListingTableWithReferences {
   // ignore: unused_field
   final _$TodoDb _db;
-  final ListingData listing;
-  $$ListingTableWithReferences(this._db, this.listing);
+  final ListingData listingData;
+  $$ListingTableWithReferences(this._db, this.listingData);
 
   $$ProductTableProcessedTableManager? get product {
-    if (listing.product == null) return null;
+    if (listingData.product == null) return null;
     return $$ProductTableTableManager(_db, _db.product)
-        .filter((f) => f.id(listing.product!));
+        .filter((f) => f.id(listingData.product!));
   }
 
   $$StoreTableProcessedTableManager? get store {
-    if (listing.store == null) return null;
+    if (listingData.store == null) return null;
     return $$StoreTableTableManager(_db, _db.store)
-        .filter((f) => f.id(listing.store!));
+        .filter((f) => f.id(listingData.store!));
   }
 }
 

--- a/drift/test/generated/todos.g.dart
+++ b/drift/test/generated/todos.g.dart
@@ -308,12 +308,13 @@ class $TodosTableTable extends TodosTable
   static const VerificationMeta _categoryMeta =
       const VerificationMeta('category');
   @override
-  late final GeneratedColumn<int> category = GeneratedColumn<int>(
-      'category', aliasedName, true,
-      type: DriftSqlType.int,
-      requiredDuringInsert: false,
-      defaultConstraints: GeneratedColumn.constraintIsAlways(
-          'REFERENCES categories (id) DEFERRABLE INITIALLY DEFERRED'));
+  late final GeneratedColumnWithTypeConverter<RowId?, int> category =
+      GeneratedColumn<int>('category', aliasedName, true,
+              type: DriftSqlType.int,
+              requiredDuringInsert: false,
+              defaultConstraints: GeneratedColumn.constraintIsAlways(
+                  'REFERENCES categories (id) DEFERRABLE INITIALLY DEFERRED'))
+          .withConverter<RowId?>($TodosTableTable.$convertercategoryn);
   static const VerificationMeta _statusMeta = const VerificationMeta('status');
   @override
   late final GeneratedColumnWithTypeConverter<TodoStatus?, String> status =
@@ -350,10 +351,7 @@ class $TodosTableTable extends TodosTable
           targetDate.isAcceptableOrUnknown(
               data['target_date']!, _targetDateMeta));
     }
-    if (data.containsKey('category')) {
-      context.handle(_categoryMeta,
-          category.isAcceptableOrUnknown(data['category']!, _categoryMeta));
-    }
+    context.handle(_categoryMeta, const VerificationResult.success());
     context.handle(_statusMeta, const VerificationResult.success());
     return context;
   }
@@ -377,8 +375,9 @@ class $TodosTableTable extends TodosTable
           .read(DriftSqlType.string, data['${effectivePrefix}content'])!,
       targetDate: attachedDatabase.typeMapping
           .read(DriftSqlType.dateTime, data['${effectivePrefix}target_date']),
-      category: attachedDatabase.typeMapping
-          .read(DriftSqlType.int, data['${effectivePrefix}category']),
+      category: $TodosTableTable.$convertercategoryn.fromSql(attachedDatabase
+          .typeMapping
+          .read(DriftSqlType.int, data['${effectivePrefix}category'])),
       status: $TodosTableTable.$converterstatusn.fromSql(attachedDatabase
           .typeMapping
           .read(DriftSqlType.string, data['${effectivePrefix}status'])),
@@ -392,6 +391,10 @@ class $TodosTableTable extends TodosTable
 
   static JsonTypeConverter2<RowId, int, int> $converterid =
       TypeConverter.extensionType<RowId, int>();
+  static JsonTypeConverter2<RowId, int, int> $convertercategory =
+      TypeConverter.extensionType<RowId, int>();
+  static JsonTypeConverter2<RowId?, int?, int?> $convertercategoryn =
+      JsonTypeConverter2.asNullable($convertercategory);
   static JsonTypeConverter2<TodoStatus, String, String> $converterstatus =
       const EnumNameConverter<TodoStatus>(TodoStatus.values);
   static JsonTypeConverter2<TodoStatus?, String?, String?> $converterstatusn =
@@ -403,7 +406,7 @@ class TodoEntry extends DataClass implements Insertable<TodoEntry> {
   final String? title;
   final String content;
   final DateTime? targetDate;
-  final int? category;
+  final RowId? category;
   final TodoStatus? status;
   const TodoEntry(
       {required this.id,
@@ -426,7 +429,8 @@ class TodoEntry extends DataClass implements Insertable<TodoEntry> {
       map['target_date'] = Variable<DateTime>(targetDate);
     }
     if (!nullToAbsent || category != null) {
-      map['category'] = Variable<int>(category);
+      map['category'] =
+          Variable<int>($TodosTableTable.$convertercategoryn.toSql(category));
     }
     if (!nullToAbsent || status != null) {
       map['status'] =
@@ -461,7 +465,8 @@ class TodoEntry extends DataClass implements Insertable<TodoEntry> {
       title: serializer.fromJson<String?>(json['title']),
       content: serializer.fromJson<String>(json['content']),
       targetDate: serializer.fromJson<DateTime?>(json['target_date']),
-      category: serializer.fromJson<int?>(json['category']),
+      category: $TodosTableTable.$convertercategoryn
+          .fromJson(serializer.fromJson<int?>(json['category'])),
       status: $TodosTableTable.$converterstatusn
           .fromJson(serializer.fromJson<String?>(json['status'])),
     );
@@ -479,7 +484,8 @@ class TodoEntry extends DataClass implements Insertable<TodoEntry> {
       'title': serializer.toJson<String?>(title),
       'content': serializer.toJson<String>(content),
       'target_date': serializer.toJson<DateTime?>(targetDate),
-      'category': serializer.toJson<int?>(category),
+      'category': serializer
+          .toJson<int?>($TodosTableTable.$convertercategoryn.toJson(category)),
       'status': serializer
           .toJson<String?>($TodosTableTable.$converterstatusn.toJson(status)),
     };
@@ -490,7 +496,7 @@ class TodoEntry extends DataClass implements Insertable<TodoEntry> {
           Value<String?> title = const Value.absent(),
           String? content,
           Value<DateTime?> targetDate = const Value.absent(),
-          Value<int?> category = const Value.absent(),
+          Value<RowId?> category = const Value.absent(),
           Value<TodoStatus?> status = const Value.absent()}) =>
       TodoEntry(
         id: id ?? this.id,
@@ -545,7 +551,7 @@ class TodosTableCompanion extends UpdateCompanion<TodoEntry> {
   final Value<String?> title;
   final Value<String> content;
   final Value<DateTime?> targetDate;
-  final Value<int?> category;
+  final Value<RowId?> category;
   final Value<TodoStatus?> status;
   const TodosTableCompanion({
     this.id = const Value.absent(),
@@ -586,7 +592,7 @@ class TodosTableCompanion extends UpdateCompanion<TodoEntry> {
       Value<String?>? title,
       Value<String>? content,
       Value<DateTime?>? targetDate,
-      Value<int?>? category,
+      Value<RowId?>? category,
       Value<TodoStatus?>? status}) {
     return TodosTableCompanion(
       id: id ?? this.id,
@@ -614,7 +620,8 @@ class TodosTableCompanion extends UpdateCompanion<TodoEntry> {
       map['target_date'] = Variable<DateTime>(targetDate.value);
     }
     if (category.present) {
-      map['category'] = Variable<int>(category.value);
+      map['category'] = Variable<int>(
+          $TodosTableTable.$convertercategoryn.toSql(category.value));
     }
     if (status.present) {
       map['status'] = Variable<String>(
@@ -3355,7 +3362,9 @@ abstract class _$TodoDb extends GeneratedDatabase {
           title: row.readNullable<String>('title'),
           content: row.read<String>('content'),
           targetDate: row.readNullable<DateTime>('target_date'),
-          category: row.readNullable<int>('category'),
+          category: NullAwareTypeConverter.wrapFromSql(
+              $TodosTableTable.$convertercategory,
+              row.readNullable<int>('category')),
           status: NullAwareTypeConverter.wrapFromSql(
               $TodosTableTable.$converterstatus,
               row.readNullable<String>('status')),
@@ -3524,6 +3533,19 @@ class $$CategoriesTableFilterComposer
       column: $state.table.descriptionInUpperCase,
       builder: (column, joinBuilders) =>
           ColumnFilters(column, joinBuilders: joinBuilders));
+
+  ComposableFilter todos(
+      ComposableFilter Function($$TodosTableTableFilterComposer f) f) {
+    final $$TodosTableTableFilterComposer composer = $state.composerBuilder(
+        composer: this,
+        getCurrentColumn: (t) => t.id,
+        referencedTable: $state.db.todosTable,
+        getReferencedColumn: (t) => t.category,
+        builder: (joinBuilder, parentComposers) =>
+            $$TodosTableTableFilterComposer(ComposerState($state.db,
+                $state.db.todosTable, joinBuilder, parentComposers)));
+    return f(composer);
+  }
 }
 
 class $$CategoriesTableOrderingComposer
@@ -3556,6 +3578,11 @@ class $$CategoriesTableWithReferences {
   final _$TodoDb _db;
   final Category categories;
   $$CategoriesTableWithReferences(this._db, this.categories);
+
+  $$TodosTableTableProcessedTableManager get todos {
+    return $$TodosTableTableTableManager(_db, _db.todosTable)
+        .filter((f) => f.category.id(categories.id));
+  }
 }
 
 typedef $$TodosTableTableInsertCompanionBuilder = TodosTableCompanion Function({
@@ -3563,7 +3590,7 @@ typedef $$TodosTableTableInsertCompanionBuilder = TodosTableCompanion Function({
   Value<String?> title,
   required String content,
   Value<DateTime?> targetDate,
-  Value<int?> category,
+  Value<RowId?> category,
   Value<TodoStatus?> status,
 });
 typedef $$TodosTableTableUpdateCompanionBuilder = TodosTableCompanion Function({
@@ -3571,7 +3598,7 @@ typedef $$TodosTableTableUpdateCompanionBuilder = TodosTableCompanion Function({
   Value<String?> title,
   Value<String> content,
   Value<DateTime?> targetDate,
-  Value<int?> category,
+  Value<RowId?> category,
   Value<TodoStatus?> status,
 });
 
@@ -3598,7 +3625,7 @@ class $$TodosTableTableTableManager extends RootTableManager<
             Value<String?> title = const Value.absent(),
             Value<String> content = const Value.absent(),
             Value<DateTime?> targetDate = const Value.absent(),
-            Value<int?> category = const Value.absent(),
+            Value<RowId?> category = const Value.absent(),
             Value<TodoStatus?> status = const Value.absent(),
           }) =>
               TodosTableCompanion(
@@ -3616,7 +3643,7 @@ class $$TodosTableTableTableManager extends RootTableManager<
             Value<String?> title = const Value.absent(),
             required String content,
             Value<DateTime?> targetDate = const Value.absent(),
-            Value<int?> category = const Value.absent(),
+            Value<RowId?> category = const Value.absent(),
             Value<TodoStatus?> status = const Value.absent(),
           }) =>
               TodosTableCompanion.insert(
@@ -3672,6 +3699,18 @@ class $$TodosTableTableFilterComposer
           builder: (column, joinBuilders) => ColumnWithTypeConverterFilters(
               column,
               joinBuilders: joinBuilders));
+
+  $$CategoriesTableFilterComposer get category {
+    final $$CategoriesTableFilterComposer composer = $state.composerBuilder(
+        composer: this,
+        getCurrentColumn: (t) => t.category,
+        referencedTable: $state.db.categories,
+        getReferencedColumn: (t) => t.id,
+        builder: (joinBuilder, parentComposers) =>
+            $$CategoriesTableFilterComposer(ComposerState($state.db,
+                $state.db.categories, joinBuilder, parentComposers)));
+    return composer;
+  }
 }
 
 class $$TodosTableTableOrderingComposer
@@ -3701,6 +3740,18 @@ class $$TodosTableTableOrderingComposer
       column: $state.table.status,
       builder: (column, joinBuilders) =>
           ColumnOrderings(column, joinBuilders: joinBuilders));
+
+  $$CategoriesTableOrderingComposer get category {
+    final $$CategoriesTableOrderingComposer composer = $state.composerBuilder(
+        composer: this,
+        getCurrentColumn: (t) => t.category,
+        referencedTable: $state.db.categories,
+        getReferencedColumn: (t) => t.id,
+        builder: (joinBuilder, parentComposers) =>
+            $$CategoriesTableOrderingComposer(ComposerState($state.db,
+                $state.db.categories, joinBuilder, parentComposers)));
+    return composer;
+  }
 }
 
 class $$TodosTableTableWithReferences {
@@ -3708,6 +3759,12 @@ class $$TodosTableTableWithReferences {
   final _$TodoDb _db;
   final TodoEntry todosTable;
   $$TodosTableTableWithReferences(this._db, this.todosTable);
+
+  $$CategoriesTableProcessedTableManager? get category {
+    if (todosTable.category == null) return null;
+    return $$CategoriesTableTableManager(_db, _db.categories)
+        .filter((f) => f.id(todosTable.category!));
+  }
 }
 
 typedef $$UsersTableInsertCompanionBuilder = UsersCompanion Function({
@@ -5073,7 +5130,7 @@ class AllTodosWithCategoryResult extends CustomResultSet {
   final String? title;
   final String content;
   final DateTime? targetDate;
-  final int? category;
+  final RowId? category;
   final TodoStatus? status;
   final RowId catId;
   final String catDesc;

--- a/drift/test/generated/todos.g.dart
+++ b/drift/test/generated/todos.g.dart
@@ -3450,9 +3450,10 @@ class $$CategoriesTableTableManager extends RootTableManager<
     Category,
     $$CategoriesTableFilterComposer,
     $$CategoriesTableOrderingComposer,
-    $$CategoriesTableProcessedTableManager,
     $$CategoriesTableInsertCompanionBuilder,
-    $$CategoriesTableUpdateCompanionBuilder> {
+    $$CategoriesTableUpdateCompanionBuilder,
+    $$CategoriesTableWithReferences,
+    Category> {
   $$CategoriesTableTableManager(_$TodoDb db, $CategoriesTable table)
       : super(TableManagerState(
           db: db,
@@ -3461,9 +3462,7 @@ class $$CategoriesTableTableManager extends RootTableManager<
               $$CategoriesTableFilterComposer(ComposerState(db, table)),
           orderingComposer:
               $$CategoriesTableOrderingComposer(ComposerState(db, table)),
-          getChildManagerBuilder: (p) =>
-              $$CategoriesTableProcessedTableManager(p),
-          getUpdateCompanionBuilder: ({
+          createUpdateCompanionCallback: ({
             Value<RowId> id = const Value.absent(),
             Value<String> description = const Value.absent(),
             Value<CategoryPriority> priority = const Value.absent(),
@@ -3473,7 +3472,9 @@ class $$CategoriesTableTableManager extends RootTableManager<
             description: description,
             priority: priority,
           ),
-          getInsertCompanionBuilder: ({
+          dataclassMapper: (p0) async =>
+              p0.map((e) => $$CategoriesTableWithReferences(db, e)).toList(),
+          createInsertCompanionCallback: ({
             Value<RowId> id = const Value.absent(),
             required String description,
             Value<CategoryPriority> priority = const Value.absent(),
@@ -3486,17 +3487,16 @@ class $$CategoriesTableTableManager extends RootTableManager<
         ));
 }
 
-class $$CategoriesTableProcessedTableManager extends ProcessedTableManager<
+typedef $$CategoriesTableProcessedTableManager = ProcessedTableManager<
     _$TodoDb,
     $CategoriesTable,
     Category,
     $$CategoriesTableFilterComposer,
     $$CategoriesTableOrderingComposer,
-    $$CategoriesTableProcessedTableManager,
     $$CategoriesTableInsertCompanionBuilder,
-    $$CategoriesTableUpdateCompanionBuilder> {
-  $$CategoriesTableProcessedTableManager(super.$state);
-}
+    $$CategoriesTableUpdateCompanionBuilder,
+    $$CategoriesTableWithReferences,
+    Category>;
 
 class $$CategoriesTableFilterComposer
     extends FilterComposer<_$TodoDb, $CategoriesTable> {
@@ -3524,19 +3524,6 @@ class $$CategoriesTableFilterComposer
       column: $state.table.descriptionInUpperCase,
       builder: (column, joinBuilders) =>
           ColumnFilters(column, joinBuilders: joinBuilders));
-
-  ComposableFilter todos(
-      ComposableFilter Function($$TodosTableTableFilterComposer f) f) {
-    final $$TodosTableTableFilterComposer composer = $state.composerBuilder(
-        composer: this,
-        getCurrentColumn: (t) => t.id,
-        referencedTable: $state.db.todosTable,
-        getReferencedColumn: (t) => t.category,
-        builder: (joinBuilder, parentComposers) =>
-            $$TodosTableTableFilterComposer(ComposerState($state.db,
-                $state.db.todosTable, joinBuilder, parentComposers)));
-    return f(composer);
-  }
 }
 
 class $$CategoriesTableOrderingComposer
@@ -3564,6 +3551,13 @@ class $$CategoriesTableOrderingComposer
               ColumnOrderings(column, joinBuilders: joinBuilders));
 }
 
+class $$CategoriesTableWithReferences {
+  // ignore: unused_field
+  final _$TodoDb _db;
+  final Category categories;
+  $$CategoriesTableWithReferences(this._db, this.categories);
+}
+
 typedef $$TodosTableTableInsertCompanionBuilder = TodosTableCompanion Function({
   Value<RowId> id,
   Value<String?> title,
@@ -3587,9 +3581,10 @@ class $$TodosTableTableTableManager extends RootTableManager<
     TodoEntry,
     $$TodosTableTableFilterComposer,
     $$TodosTableTableOrderingComposer,
-    $$TodosTableTableProcessedTableManager,
     $$TodosTableTableInsertCompanionBuilder,
-    $$TodosTableTableUpdateCompanionBuilder> {
+    $$TodosTableTableUpdateCompanionBuilder,
+    $$TodosTableTableWithReferences,
+    TodoEntry> {
   $$TodosTableTableTableManager(_$TodoDb db, $TodosTableTable table)
       : super(TableManagerState(
           db: db,
@@ -3598,9 +3593,7 @@ class $$TodosTableTableTableManager extends RootTableManager<
               $$TodosTableTableFilterComposer(ComposerState(db, table)),
           orderingComposer:
               $$TodosTableTableOrderingComposer(ComposerState(db, table)),
-          getChildManagerBuilder: (p) =>
-              $$TodosTableTableProcessedTableManager(p),
-          getUpdateCompanionBuilder: ({
+          createUpdateCompanionCallback: ({
             Value<RowId> id = const Value.absent(),
             Value<String?> title = const Value.absent(),
             Value<String> content = const Value.absent(),
@@ -3616,7 +3609,9 @@ class $$TodosTableTableTableManager extends RootTableManager<
             category: category,
             status: status,
           ),
-          getInsertCompanionBuilder: ({
+          dataclassMapper: (p0) async =>
+              p0.map((e) => $$TodosTableTableWithReferences(db, e)).toList(),
+          createInsertCompanionCallback: ({
             Value<RowId> id = const Value.absent(),
             Value<String?> title = const Value.absent(),
             required String content,
@@ -3635,17 +3630,16 @@ class $$TodosTableTableTableManager extends RootTableManager<
         ));
 }
 
-class $$TodosTableTableProcessedTableManager extends ProcessedTableManager<
+typedef $$TodosTableTableProcessedTableManager = ProcessedTableManager<
     _$TodoDb,
     $TodosTableTable,
     TodoEntry,
     $$TodosTableTableFilterComposer,
     $$TodosTableTableOrderingComposer,
-    $$TodosTableTableProcessedTableManager,
     $$TodosTableTableInsertCompanionBuilder,
-    $$TodosTableTableUpdateCompanionBuilder> {
-  $$TodosTableTableProcessedTableManager(super.$state);
-}
+    $$TodosTableTableUpdateCompanionBuilder,
+    $$TodosTableTableWithReferences,
+    TodoEntry>;
 
 class $$TodosTableTableFilterComposer
     extends FilterComposer<_$TodoDb, $TodosTableTable> {
@@ -3678,18 +3672,6 @@ class $$TodosTableTableFilterComposer
           builder: (column, joinBuilders) => ColumnWithTypeConverterFilters(
               column,
               joinBuilders: joinBuilders));
-
-  $$CategoriesTableFilterComposer get category {
-    final $$CategoriesTableFilterComposer composer = $state.composerBuilder(
-        composer: this,
-        getCurrentColumn: (t) => t.category,
-        referencedTable: $state.db.categories,
-        getReferencedColumn: (t) => t.id,
-        builder: (joinBuilder, parentComposers) =>
-            $$CategoriesTableFilterComposer(ComposerState($state.db,
-                $state.db.categories, joinBuilder, parentComposers)));
-    return composer;
-  }
 }
 
 class $$TodosTableTableOrderingComposer
@@ -3719,18 +3701,13 @@ class $$TodosTableTableOrderingComposer
       column: $state.table.status,
       builder: (column, joinBuilders) =>
           ColumnOrderings(column, joinBuilders: joinBuilders));
+}
 
-  $$CategoriesTableOrderingComposer get category {
-    final $$CategoriesTableOrderingComposer composer = $state.composerBuilder(
-        composer: this,
-        getCurrentColumn: (t) => t.category,
-        referencedTable: $state.db.categories,
-        getReferencedColumn: (t) => t.id,
-        builder: (joinBuilder, parentComposers) =>
-            $$CategoriesTableOrderingComposer(ComposerState($state.db,
-                $state.db.categories, joinBuilder, parentComposers)));
-    return composer;
-  }
+class $$TodosTableTableWithReferences {
+  // ignore: unused_field
+  final _$TodoDb _db;
+  final TodoEntry todosTable;
+  $$TodosTableTableWithReferences(this._db, this.todosTable);
 }
 
 typedef $$UsersTableInsertCompanionBuilder = UsersCompanion Function({
@@ -3754,9 +3731,10 @@ class $$UsersTableTableManager extends RootTableManager<
     User,
     $$UsersTableFilterComposer,
     $$UsersTableOrderingComposer,
-    $$UsersTableProcessedTableManager,
     $$UsersTableInsertCompanionBuilder,
-    $$UsersTableUpdateCompanionBuilder> {
+    $$UsersTableUpdateCompanionBuilder,
+    $$UsersTableWithReferences,
+    User> {
   $$UsersTableTableManager(_$TodoDb db, $UsersTable table)
       : super(TableManagerState(
           db: db,
@@ -3765,8 +3743,7 @@ class $$UsersTableTableManager extends RootTableManager<
               $$UsersTableFilterComposer(ComposerState(db, table)),
           orderingComposer:
               $$UsersTableOrderingComposer(ComposerState(db, table)),
-          getChildManagerBuilder: (p) => $$UsersTableProcessedTableManager(p),
-          getUpdateCompanionBuilder: ({
+          createUpdateCompanionCallback: ({
             Value<RowId> id = const Value.absent(),
             Value<String> name = const Value.absent(),
             Value<bool> isAwesome = const Value.absent(),
@@ -3780,7 +3757,9 @@ class $$UsersTableTableManager extends RootTableManager<
             profilePicture: profilePicture,
             creationTime: creationTime,
           ),
-          getInsertCompanionBuilder: ({
+          dataclassMapper: (p0) async =>
+              p0.map((e) => $$UsersTableWithReferences(db, e)).toList(),
+          createInsertCompanionCallback: ({
             Value<RowId> id = const Value.absent(),
             required String name,
             Value<bool> isAwesome = const Value.absent(),
@@ -3797,17 +3776,16 @@ class $$UsersTableTableManager extends RootTableManager<
         ));
 }
 
-class $$UsersTableProcessedTableManager extends ProcessedTableManager<
+typedef $$UsersTableProcessedTableManager = ProcessedTableManager<
     _$TodoDb,
     $UsersTable,
     User,
     $$UsersTableFilterComposer,
     $$UsersTableOrderingComposer,
-    $$UsersTableProcessedTableManager,
     $$UsersTableInsertCompanionBuilder,
-    $$UsersTableUpdateCompanionBuilder> {
-  $$UsersTableProcessedTableManager(super.$state);
-}
+    $$UsersTableUpdateCompanionBuilder,
+    $$UsersTableWithReferences,
+    User>;
 
 class $$UsersTableFilterComposer extends FilterComposer<_$TodoDb, $UsersTable> {
   $$UsersTableFilterComposer(super.$state);
@@ -3868,6 +3846,13 @@ class $$UsersTableOrderingComposer
           ColumnOrderings(column, joinBuilders: joinBuilders));
 }
 
+class $$UsersTableWithReferences {
+  // ignore: unused_field
+  final _$TodoDb _db;
+  final User users;
+  $$UsersTableWithReferences(this._db, this.users);
+}
+
 typedef $$SharedTodosTableInsertCompanionBuilder = SharedTodosCompanion
     Function({
   required int todo,
@@ -3887,9 +3872,10 @@ class $$SharedTodosTableTableManager extends RootTableManager<
     SharedTodo,
     $$SharedTodosTableFilterComposer,
     $$SharedTodosTableOrderingComposer,
-    $$SharedTodosTableProcessedTableManager,
     $$SharedTodosTableInsertCompanionBuilder,
-    $$SharedTodosTableUpdateCompanionBuilder> {
+    $$SharedTodosTableUpdateCompanionBuilder,
+    $$SharedTodosTableWithReferences,
+    SharedTodo> {
   $$SharedTodosTableTableManager(_$TodoDb db, $SharedTodosTable table)
       : super(TableManagerState(
           db: db,
@@ -3898,9 +3884,7 @@ class $$SharedTodosTableTableManager extends RootTableManager<
               $$SharedTodosTableFilterComposer(ComposerState(db, table)),
           orderingComposer:
               $$SharedTodosTableOrderingComposer(ComposerState(db, table)),
-          getChildManagerBuilder: (p) =>
-              $$SharedTodosTableProcessedTableManager(p),
-          getUpdateCompanionBuilder: ({
+          createUpdateCompanionCallback: ({
             Value<int> todo = const Value.absent(),
             Value<int> user = const Value.absent(),
             Value<int> rowid = const Value.absent(),
@@ -3910,7 +3894,9 @@ class $$SharedTodosTableTableManager extends RootTableManager<
             user: user,
             rowid: rowid,
           ),
-          getInsertCompanionBuilder: ({
+          dataclassMapper: (p0) async =>
+              p0.map((e) => $$SharedTodosTableWithReferences(db, e)).toList(),
+          createInsertCompanionCallback: ({
             required int todo,
             required int user,
             Value<int> rowid = const Value.absent(),
@@ -3923,17 +3909,16 @@ class $$SharedTodosTableTableManager extends RootTableManager<
         ));
 }
 
-class $$SharedTodosTableProcessedTableManager extends ProcessedTableManager<
+typedef $$SharedTodosTableProcessedTableManager = ProcessedTableManager<
     _$TodoDb,
     $SharedTodosTable,
     SharedTodo,
     $$SharedTodosTableFilterComposer,
     $$SharedTodosTableOrderingComposer,
-    $$SharedTodosTableProcessedTableManager,
     $$SharedTodosTableInsertCompanionBuilder,
-    $$SharedTodosTableUpdateCompanionBuilder> {
-  $$SharedTodosTableProcessedTableManager(super.$state);
-}
+    $$SharedTodosTableUpdateCompanionBuilder,
+    $$SharedTodosTableWithReferences,
+    SharedTodo>;
 
 class $$SharedTodosTableFilterComposer
     extends FilterComposer<_$TodoDb, $SharedTodosTable> {
@@ -3963,6 +3948,13 @@ class $$SharedTodosTableOrderingComposer
           ColumnOrderings(column, joinBuilders: joinBuilders));
 }
 
+class $$SharedTodosTableWithReferences {
+  // ignore: unused_field
+  final _$TodoDb _db;
+  final SharedTodo sharedTodos;
+  $$SharedTodosTableWithReferences(this._db, this.sharedTodos);
+}
+
 typedef $$TableWithoutPKTableInsertCompanionBuilder = TableWithoutPKCompanion
     Function({
   required int notReallyAnId,
@@ -3986,9 +3978,10 @@ class $$TableWithoutPKTableTableManager extends RootTableManager<
     CustomRowClass,
     $$TableWithoutPKTableFilterComposer,
     $$TableWithoutPKTableOrderingComposer,
-    $$TableWithoutPKTableProcessedTableManager,
     $$TableWithoutPKTableInsertCompanionBuilder,
-    $$TableWithoutPKTableUpdateCompanionBuilder> {
+    $$TableWithoutPKTableUpdateCompanionBuilder,
+    $$TableWithoutPKTableWithReferences,
+    CustomRowClass> {
   $$TableWithoutPKTableTableManager(_$TodoDb db, $TableWithoutPKTable table)
       : super(TableManagerState(
           db: db,
@@ -3997,9 +3990,7 @@ class $$TableWithoutPKTableTableManager extends RootTableManager<
               $$TableWithoutPKTableFilterComposer(ComposerState(db, table)),
           orderingComposer:
               $$TableWithoutPKTableOrderingComposer(ComposerState(db, table)),
-          getChildManagerBuilder: (p) =>
-              $$TableWithoutPKTableProcessedTableManager(p),
-          getUpdateCompanionBuilder: ({
+          createUpdateCompanionCallback: ({
             Value<int> notReallyAnId = const Value.absent(),
             Value<double> someFloat = const Value.absent(),
             Value<BigInt?> webSafeInt = const Value.absent(),
@@ -4013,7 +4004,10 @@ class $$TableWithoutPKTableTableManager extends RootTableManager<
             custom: custom,
             rowid: rowid,
           ),
-          getInsertCompanionBuilder: ({
+          dataclassMapper: (p0) async => p0
+              .map((e) => $$TableWithoutPKTableWithReferences(db, e))
+              .toList(),
+          createInsertCompanionCallback: ({
             required int notReallyAnId,
             required double someFloat,
             Value<BigInt?> webSafeInt = const Value.absent(),
@@ -4030,17 +4024,16 @@ class $$TableWithoutPKTableTableManager extends RootTableManager<
         ));
 }
 
-class $$TableWithoutPKTableProcessedTableManager extends ProcessedTableManager<
+typedef $$TableWithoutPKTableProcessedTableManager = ProcessedTableManager<
     _$TodoDb,
     $TableWithoutPKTable,
     CustomRowClass,
     $$TableWithoutPKTableFilterComposer,
     $$TableWithoutPKTableOrderingComposer,
-    $$TableWithoutPKTableProcessedTableManager,
     $$TableWithoutPKTableInsertCompanionBuilder,
-    $$TableWithoutPKTableUpdateCompanionBuilder> {
-  $$TableWithoutPKTableProcessedTableManager(super.$state);
-}
+    $$TableWithoutPKTableUpdateCompanionBuilder,
+    $$TableWithoutPKTableWithReferences,
+    CustomRowClass>;
 
 class $$TableWithoutPKTableFilterComposer
     extends FilterComposer<_$TodoDb, $TableWithoutPKTable> {
@@ -4092,6 +4085,13 @@ class $$TableWithoutPKTableOrderingComposer
           ColumnOrderings(column, joinBuilders: joinBuilders));
 }
 
+class $$TableWithoutPKTableWithReferences {
+  // ignore: unused_field
+  final _$TodoDb _db;
+  final CustomRowClass tableWithoutPK;
+  $$TableWithoutPKTableWithReferences(this._db, this.tableWithoutPK);
+}
+
 typedef $$PureDefaultsTableInsertCompanionBuilder = PureDefaultsCompanion
     Function({
   Value<MyCustomObject?> txt,
@@ -4109,9 +4109,10 @@ class $$PureDefaultsTableTableManager extends RootTableManager<
     PureDefault,
     $$PureDefaultsTableFilterComposer,
     $$PureDefaultsTableOrderingComposer,
-    $$PureDefaultsTableProcessedTableManager,
     $$PureDefaultsTableInsertCompanionBuilder,
-    $$PureDefaultsTableUpdateCompanionBuilder> {
+    $$PureDefaultsTableUpdateCompanionBuilder,
+    $$PureDefaultsTableWithReferences,
+    PureDefault> {
   $$PureDefaultsTableTableManager(_$TodoDb db, $PureDefaultsTable table)
       : super(TableManagerState(
           db: db,
@@ -4120,9 +4121,7 @@ class $$PureDefaultsTableTableManager extends RootTableManager<
               $$PureDefaultsTableFilterComposer(ComposerState(db, table)),
           orderingComposer:
               $$PureDefaultsTableOrderingComposer(ComposerState(db, table)),
-          getChildManagerBuilder: (p) =>
-              $$PureDefaultsTableProcessedTableManager(p),
-          getUpdateCompanionBuilder: ({
+          createUpdateCompanionCallback: ({
             Value<MyCustomObject?> txt = const Value.absent(),
             Value<int> rowid = const Value.absent(),
           }) =>
@@ -4130,7 +4129,9 @@ class $$PureDefaultsTableTableManager extends RootTableManager<
             txt: txt,
             rowid: rowid,
           ),
-          getInsertCompanionBuilder: ({
+          dataclassMapper: (p0) async =>
+              p0.map((e) => $$PureDefaultsTableWithReferences(db, e)).toList(),
+          createInsertCompanionCallback: ({
             Value<MyCustomObject?> txt = const Value.absent(),
             Value<int> rowid = const Value.absent(),
           }) =>
@@ -4141,17 +4142,16 @@ class $$PureDefaultsTableTableManager extends RootTableManager<
         ));
 }
 
-class $$PureDefaultsTableProcessedTableManager extends ProcessedTableManager<
+typedef $$PureDefaultsTableProcessedTableManager = ProcessedTableManager<
     _$TodoDb,
     $PureDefaultsTable,
     PureDefault,
     $$PureDefaultsTableFilterComposer,
     $$PureDefaultsTableOrderingComposer,
-    $$PureDefaultsTableProcessedTableManager,
     $$PureDefaultsTableInsertCompanionBuilder,
-    $$PureDefaultsTableUpdateCompanionBuilder> {
-  $$PureDefaultsTableProcessedTableManager(super.$state);
-}
+    $$PureDefaultsTableUpdateCompanionBuilder,
+    $$PureDefaultsTableWithReferences,
+    PureDefault>;
 
 class $$PureDefaultsTableFilterComposer
     extends FilterComposer<_$TodoDb, $PureDefaultsTable> {
@@ -4173,6 +4173,13 @@ class $$PureDefaultsTableOrderingComposer
           ColumnOrderings(column, joinBuilders: joinBuilders));
 }
 
+class $$PureDefaultsTableWithReferences {
+  // ignore: unused_field
+  final _$TodoDb _db;
+  final PureDefault pureDefaults;
+  $$PureDefaultsTableWithReferences(this._db, this.pureDefaults);
+}
+
 typedef $$WithCustomTypeTableInsertCompanionBuilder = WithCustomTypeCompanion
     Function({
   required UuidValue id,
@@ -4190,9 +4197,10 @@ class $$WithCustomTypeTableTableManager extends RootTableManager<
     WithCustomTypeData,
     $$WithCustomTypeTableFilterComposer,
     $$WithCustomTypeTableOrderingComposer,
-    $$WithCustomTypeTableProcessedTableManager,
     $$WithCustomTypeTableInsertCompanionBuilder,
-    $$WithCustomTypeTableUpdateCompanionBuilder> {
+    $$WithCustomTypeTableUpdateCompanionBuilder,
+    $$WithCustomTypeTableWithReferences,
+    WithCustomTypeData> {
   $$WithCustomTypeTableTableManager(_$TodoDb db, $WithCustomTypeTable table)
       : super(TableManagerState(
           db: db,
@@ -4201,9 +4209,7 @@ class $$WithCustomTypeTableTableManager extends RootTableManager<
               $$WithCustomTypeTableFilterComposer(ComposerState(db, table)),
           orderingComposer:
               $$WithCustomTypeTableOrderingComposer(ComposerState(db, table)),
-          getChildManagerBuilder: (p) =>
-              $$WithCustomTypeTableProcessedTableManager(p),
-          getUpdateCompanionBuilder: ({
+          createUpdateCompanionCallback: ({
             Value<UuidValue> id = const Value.absent(),
             Value<int> rowid = const Value.absent(),
           }) =>
@@ -4211,7 +4217,10 @@ class $$WithCustomTypeTableTableManager extends RootTableManager<
             id: id,
             rowid: rowid,
           ),
-          getInsertCompanionBuilder: ({
+          dataclassMapper: (p0) async => p0
+              .map((e) => $$WithCustomTypeTableWithReferences(db, e))
+              .toList(),
+          createInsertCompanionCallback: ({
             required UuidValue id,
             Value<int> rowid = const Value.absent(),
           }) =>
@@ -4222,17 +4231,16 @@ class $$WithCustomTypeTableTableManager extends RootTableManager<
         ));
 }
 
-class $$WithCustomTypeTableProcessedTableManager extends ProcessedTableManager<
+typedef $$WithCustomTypeTableProcessedTableManager = ProcessedTableManager<
     _$TodoDb,
     $WithCustomTypeTable,
     WithCustomTypeData,
     $$WithCustomTypeTableFilterComposer,
     $$WithCustomTypeTableOrderingComposer,
-    $$WithCustomTypeTableProcessedTableManager,
     $$WithCustomTypeTableInsertCompanionBuilder,
-    $$WithCustomTypeTableUpdateCompanionBuilder> {
-  $$WithCustomTypeTableProcessedTableManager(super.$state);
-}
+    $$WithCustomTypeTableUpdateCompanionBuilder,
+    $$WithCustomTypeTableWithReferences,
+    WithCustomTypeData>;
 
 class $$WithCustomTypeTableFilterComposer
     extends FilterComposer<_$TodoDb, $WithCustomTypeTable> {
@@ -4250,6 +4258,13 @@ class $$WithCustomTypeTableOrderingComposer
       column: $state.table.id,
       builder: (column, joinBuilders) =>
           ColumnOrderings(column, joinBuilders: joinBuilders));
+}
+
+class $$WithCustomTypeTableWithReferences {
+  // ignore: unused_field
+  final _$TodoDb _db;
+  final WithCustomTypeData withCustomType;
+  $$WithCustomTypeTableWithReferences(this._db, this.withCustomType);
 }
 
 typedef $$TableWithEveryColumnTypeTableInsertCompanionBuilder
@@ -4285,9 +4300,10 @@ class $$TableWithEveryColumnTypeTableTableManager extends RootTableManager<
     TableWithEveryColumnTypeData,
     $$TableWithEveryColumnTypeTableFilterComposer,
     $$TableWithEveryColumnTypeTableOrderingComposer,
-    $$TableWithEveryColumnTypeTableProcessedTableManager,
     $$TableWithEveryColumnTypeTableInsertCompanionBuilder,
-    $$TableWithEveryColumnTypeTableUpdateCompanionBuilder> {
+    $$TableWithEveryColumnTypeTableUpdateCompanionBuilder,
+    $$TableWithEveryColumnTypeTableWithReferences,
+    TableWithEveryColumnTypeData> {
   $$TableWithEveryColumnTypeTableTableManager(
       _$TodoDb db, $TableWithEveryColumnTypeTable table)
       : super(TableManagerState(
@@ -4297,9 +4313,7 @@ class $$TableWithEveryColumnTypeTableTableManager extends RootTableManager<
               ComposerState(db, table)),
           orderingComposer: $$TableWithEveryColumnTypeTableOrderingComposer(
               ComposerState(db, table)),
-          getChildManagerBuilder: (p) =>
-              $$TableWithEveryColumnTypeTableProcessedTableManager(p),
-          getUpdateCompanionBuilder: ({
+          createUpdateCompanionCallback: ({
             Value<RowId> id = const Value.absent(),
             Value<bool?> aBool = const Value.absent(),
             Value<DateTime?> aDateTime = const Value.absent(),
@@ -4323,7 +4337,10 @@ class $$TableWithEveryColumnTypeTableTableManager extends RootTableManager<
             anIntEnum: anIntEnum,
             aTextWithConverter: aTextWithConverter,
           ),
-          getInsertCompanionBuilder: ({
+          dataclassMapper: (p0) async => p0
+              .map((e) => $$TableWithEveryColumnTypeTableWithReferences(db, e))
+              .toList(),
+          createInsertCompanionCallback: ({
             Value<RowId> id = const Value.absent(),
             Value<bool?> aBool = const Value.absent(),
             Value<DateTime?> aDateTime = const Value.absent(),
@@ -4350,18 +4367,17 @@ class $$TableWithEveryColumnTypeTableTableManager extends RootTableManager<
         ));
 }
 
-class $$TableWithEveryColumnTypeTableProcessedTableManager
-    extends ProcessedTableManager<
+typedef $$TableWithEveryColumnTypeTableProcessedTableManager
+    = ProcessedTableManager<
         _$TodoDb,
         $TableWithEveryColumnTypeTable,
         TableWithEveryColumnTypeData,
         $$TableWithEveryColumnTypeTableFilterComposer,
         $$TableWithEveryColumnTypeTableOrderingComposer,
-        $$TableWithEveryColumnTypeTableProcessedTableManager,
         $$TableWithEveryColumnTypeTableInsertCompanionBuilder,
-        $$TableWithEveryColumnTypeTableUpdateCompanionBuilder> {
-  $$TableWithEveryColumnTypeTableProcessedTableManager(super.$state);
-}
+        $$TableWithEveryColumnTypeTableUpdateCompanionBuilder,
+        $$TableWithEveryColumnTypeTableWithReferences,
+        TableWithEveryColumnTypeData>;
 
 class $$TableWithEveryColumnTypeTableFilterComposer
     extends FilterComposer<_$TodoDb, $TableWithEveryColumnTypeTable> {
@@ -4477,6 +4493,14 @@ class $$TableWithEveryColumnTypeTableOrderingComposer
           ColumnOrderings(column, joinBuilders: joinBuilders));
 }
 
+class $$TableWithEveryColumnTypeTableWithReferences {
+  // ignore: unused_field
+  final _$TodoDb _db;
+  final TableWithEveryColumnTypeData tableWithEveryColumnType;
+  $$TableWithEveryColumnTypeTableWithReferences(
+      this._db, this.tableWithEveryColumnType);
+}
+
 typedef $$DepartmentTableInsertCompanionBuilder = DepartmentCompanion Function({
   Value<int> id,
   Value<String?> name,
@@ -4492,9 +4516,10 @@ class $$DepartmentTableTableManager extends RootTableManager<
     DepartmentData,
     $$DepartmentTableFilterComposer,
     $$DepartmentTableOrderingComposer,
-    $$DepartmentTableProcessedTableManager,
     $$DepartmentTableInsertCompanionBuilder,
-    $$DepartmentTableUpdateCompanionBuilder> {
+    $$DepartmentTableUpdateCompanionBuilder,
+    $$DepartmentTableWithReferences,
+    DepartmentData> {
   $$DepartmentTableTableManager(_$TodoDb db, $DepartmentTable table)
       : super(TableManagerState(
           db: db,
@@ -4503,9 +4528,7 @@ class $$DepartmentTableTableManager extends RootTableManager<
               $$DepartmentTableFilterComposer(ComposerState(db, table)),
           orderingComposer:
               $$DepartmentTableOrderingComposer(ComposerState(db, table)),
-          getChildManagerBuilder: (p) =>
-              $$DepartmentTableProcessedTableManager(p),
-          getUpdateCompanionBuilder: ({
+          createUpdateCompanionCallback: ({
             Value<int> id = const Value.absent(),
             Value<String?> name = const Value.absent(),
           }) =>
@@ -4513,7 +4536,9 @@ class $$DepartmentTableTableManager extends RootTableManager<
             id: id,
             name: name,
           ),
-          getInsertCompanionBuilder: ({
+          dataclassMapper: (p0) async =>
+              p0.map((e) => $$DepartmentTableWithReferences(db, e)).toList(),
+          createInsertCompanionCallback: ({
             Value<int> id = const Value.absent(),
             Value<String?> name = const Value.absent(),
           }) =>
@@ -4524,17 +4549,16 @@ class $$DepartmentTableTableManager extends RootTableManager<
         ));
 }
 
-class $$DepartmentTableProcessedTableManager extends ProcessedTableManager<
+typedef $$DepartmentTableProcessedTableManager = ProcessedTableManager<
     _$TodoDb,
     $DepartmentTable,
     DepartmentData,
     $$DepartmentTableFilterComposer,
     $$DepartmentTableOrderingComposer,
-    $$DepartmentTableProcessedTableManager,
     $$DepartmentTableInsertCompanionBuilder,
-    $$DepartmentTableUpdateCompanionBuilder> {
-  $$DepartmentTableProcessedTableManager(super.$state);
-}
+    $$DepartmentTableUpdateCompanionBuilder,
+    $$DepartmentTableWithReferences,
+    DepartmentData>;
 
 class $$DepartmentTableFilterComposer
     extends FilterComposer<_$TodoDb, $DepartmentTable> {
@@ -4577,6 +4601,18 @@ class $$DepartmentTableOrderingComposer
           ColumnOrderings(column, joinBuilders: joinBuilders));
 }
 
+class $$DepartmentTableWithReferences {
+  // ignore: unused_field
+  final _$TodoDb _db;
+  final DepartmentData department;
+  $$DepartmentTableWithReferences(this._db, this.department);
+
+  $$ProductTableProcessedTableManager get productRefs {
+    return $$ProductTableTableManager(_db, _db.product)
+        .filter((f) => f.department.id(department.id));
+  }
+}
+
 typedef $$ProductTableInsertCompanionBuilder = ProductCompanion Function({
   Value<int> id,
   Value<String?> name,
@@ -4594,9 +4630,10 @@ class $$ProductTableTableManager extends RootTableManager<
     ProductData,
     $$ProductTableFilterComposer,
     $$ProductTableOrderingComposer,
-    $$ProductTableProcessedTableManager,
     $$ProductTableInsertCompanionBuilder,
-    $$ProductTableUpdateCompanionBuilder> {
+    $$ProductTableUpdateCompanionBuilder,
+    $$ProductTableWithReferences,
+    ProductData> {
   $$ProductTableTableManager(_$TodoDb db, $ProductTable table)
       : super(TableManagerState(
           db: db,
@@ -4605,8 +4642,7 @@ class $$ProductTableTableManager extends RootTableManager<
               $$ProductTableFilterComposer(ComposerState(db, table)),
           orderingComposer:
               $$ProductTableOrderingComposer(ComposerState(db, table)),
-          getChildManagerBuilder: (p) => $$ProductTableProcessedTableManager(p),
-          getUpdateCompanionBuilder: ({
+          createUpdateCompanionCallback: ({
             Value<int> id = const Value.absent(),
             Value<String?> name = const Value.absent(),
             Value<int?> department = const Value.absent(),
@@ -4616,7 +4652,9 @@ class $$ProductTableTableManager extends RootTableManager<
             name: name,
             department: department,
           ),
-          getInsertCompanionBuilder: ({
+          dataclassMapper: (p0) async =>
+              p0.map((e) => $$ProductTableWithReferences(db, e)).toList(),
+          createInsertCompanionCallback: ({
             Value<int> id = const Value.absent(),
             Value<String?> name = const Value.absent(),
             Value<int?> department = const Value.absent(),
@@ -4629,17 +4667,16 @@ class $$ProductTableTableManager extends RootTableManager<
         ));
 }
 
-class $$ProductTableProcessedTableManager extends ProcessedTableManager<
+typedef $$ProductTableProcessedTableManager = ProcessedTableManager<
     _$TodoDb,
     $ProductTable,
     ProductData,
     $$ProductTableFilterComposer,
     $$ProductTableOrderingComposer,
-    $$ProductTableProcessedTableManager,
     $$ProductTableInsertCompanionBuilder,
-    $$ProductTableUpdateCompanionBuilder> {
-  $$ProductTableProcessedTableManager(super.$state);
-}
+    $$ProductTableUpdateCompanionBuilder,
+    $$ProductTableWithReferences,
+    ProductData>;
 
 class $$ProductTableFilterComposer
     extends FilterComposer<_$TodoDb, $ProductTable> {
@@ -4706,6 +4743,24 @@ class $$ProductTableOrderingComposer
   }
 }
 
+class $$ProductTableWithReferences {
+  // ignore: unused_field
+  final _$TodoDb _db;
+  final ProductData product;
+  $$ProductTableWithReferences(this._db, this.product);
+
+  $$DepartmentTableProcessedTableManager? get department {
+    if (product.department == null) return null;
+    return $$DepartmentTableTableManager(_db, _db.department)
+        .filter((f) => f.id(product.department!));
+  }
+
+  $$ListingTableProcessedTableManager get listings {
+    return $$ListingTableTableManager(_db, _db.listing)
+        .filter((f) => f.product.id(product.id));
+  }
+}
+
 typedef $$StoreTableInsertCompanionBuilder = StoreCompanion Function({
   Value<int> id,
   Value<String?> name,
@@ -4721,9 +4776,10 @@ class $$StoreTableTableManager extends RootTableManager<
     StoreData,
     $$StoreTableFilterComposer,
     $$StoreTableOrderingComposer,
-    $$StoreTableProcessedTableManager,
     $$StoreTableInsertCompanionBuilder,
-    $$StoreTableUpdateCompanionBuilder> {
+    $$StoreTableUpdateCompanionBuilder,
+    $$StoreTableWithReferences,
+    StoreData> {
   $$StoreTableTableManager(_$TodoDb db, $StoreTable table)
       : super(TableManagerState(
           db: db,
@@ -4732,8 +4788,7 @@ class $$StoreTableTableManager extends RootTableManager<
               $$StoreTableFilterComposer(ComposerState(db, table)),
           orderingComposer:
               $$StoreTableOrderingComposer(ComposerState(db, table)),
-          getChildManagerBuilder: (p) => $$StoreTableProcessedTableManager(p),
-          getUpdateCompanionBuilder: ({
+          createUpdateCompanionCallback: ({
             Value<int> id = const Value.absent(),
             Value<String?> name = const Value.absent(),
           }) =>
@@ -4741,7 +4796,9 @@ class $$StoreTableTableManager extends RootTableManager<
             id: id,
             name: name,
           ),
-          getInsertCompanionBuilder: ({
+          dataclassMapper: (p0) async =>
+              p0.map((e) => $$StoreTableWithReferences(db, e)).toList(),
+          createInsertCompanionCallback: ({
             Value<int> id = const Value.absent(),
             Value<String?> name = const Value.absent(),
           }) =>
@@ -4752,17 +4809,16 @@ class $$StoreTableTableManager extends RootTableManager<
         ));
 }
 
-class $$StoreTableProcessedTableManager extends ProcessedTableManager<
+typedef $$StoreTableProcessedTableManager = ProcessedTableManager<
     _$TodoDb,
     $StoreTable,
     StoreData,
     $$StoreTableFilterComposer,
     $$StoreTableOrderingComposer,
-    $$StoreTableProcessedTableManager,
     $$StoreTableInsertCompanionBuilder,
-    $$StoreTableUpdateCompanionBuilder> {
-  $$StoreTableProcessedTableManager(super.$state);
-}
+    $$StoreTableUpdateCompanionBuilder,
+    $$StoreTableWithReferences,
+    StoreData>;
 
 class $$StoreTableFilterComposer extends FilterComposer<_$TodoDb, $StoreTable> {
   $$StoreTableFilterComposer(super.$state);
@@ -4804,6 +4860,18 @@ class $$StoreTableOrderingComposer
           ColumnOrderings(column, joinBuilders: joinBuilders));
 }
 
+class $$StoreTableWithReferences {
+  // ignore: unused_field
+  final _$TodoDb _db;
+  final StoreData store;
+  $$StoreTableWithReferences(this._db, this.store);
+
+  $$ListingTableProcessedTableManager get listings {
+    return $$ListingTableTableManager(_db, _db.listing)
+        .filter((f) => f.store.id(store.id));
+  }
+}
+
 typedef $$ListingTableInsertCompanionBuilder = ListingCompanion Function({
   Value<int> id,
   Value<int?> product,
@@ -4823,9 +4891,10 @@ class $$ListingTableTableManager extends RootTableManager<
     ListingData,
     $$ListingTableFilterComposer,
     $$ListingTableOrderingComposer,
-    $$ListingTableProcessedTableManager,
     $$ListingTableInsertCompanionBuilder,
-    $$ListingTableUpdateCompanionBuilder> {
+    $$ListingTableUpdateCompanionBuilder,
+    $$ListingTableWithReferences,
+    ListingData> {
   $$ListingTableTableManager(_$TodoDb db, $ListingTable table)
       : super(TableManagerState(
           db: db,
@@ -4834,8 +4903,7 @@ class $$ListingTableTableManager extends RootTableManager<
               $$ListingTableFilterComposer(ComposerState(db, table)),
           orderingComposer:
               $$ListingTableOrderingComposer(ComposerState(db, table)),
-          getChildManagerBuilder: (p) => $$ListingTableProcessedTableManager(p),
-          getUpdateCompanionBuilder: ({
+          createUpdateCompanionCallback: ({
             Value<int> id = const Value.absent(),
             Value<int?> product = const Value.absent(),
             Value<int?> store = const Value.absent(),
@@ -4847,7 +4915,9 @@ class $$ListingTableTableManager extends RootTableManager<
             store: store,
             price: price,
           ),
-          getInsertCompanionBuilder: ({
+          dataclassMapper: (p0) async =>
+              p0.map((e) => $$ListingTableWithReferences(db, e)).toList(),
+          createInsertCompanionCallback: ({
             Value<int> id = const Value.absent(),
             Value<int?> product = const Value.absent(),
             Value<int?> store = const Value.absent(),
@@ -4862,17 +4932,16 @@ class $$ListingTableTableManager extends RootTableManager<
         ));
 }
 
-class $$ListingTableProcessedTableManager extends ProcessedTableManager<
+typedef $$ListingTableProcessedTableManager = ProcessedTableManager<
     _$TodoDb,
     $ListingTable,
     ListingData,
     $$ListingTableFilterComposer,
     $$ListingTableOrderingComposer,
-    $$ListingTableProcessedTableManager,
     $$ListingTableInsertCompanionBuilder,
-    $$ListingTableUpdateCompanionBuilder> {
-  $$ListingTableProcessedTableManager(super.$state);
-}
+    $$ListingTableUpdateCompanionBuilder,
+    $$ListingTableWithReferences,
+    ListingData>;
 
 class $$ListingTableFilterComposer
     extends FilterComposer<_$TodoDb, $ListingTable> {
@@ -4947,6 +5016,25 @@ class $$ListingTableOrderingComposer
             ComposerState(
                 $state.db, $state.db.store, joinBuilder, parentComposers)));
     return composer;
+  }
+}
+
+class $$ListingTableWithReferences {
+  // ignore: unused_field
+  final _$TodoDb _db;
+  final ListingData listing;
+  $$ListingTableWithReferences(this._db, this.listing);
+
+  $$ProductTableProcessedTableManager? get product {
+    if (listing.product == null) return null;
+    return $$ProductTableTableManager(_db, _db.product)
+        .filter((f) => f.id(listing.product!));
+  }
+
+  $$StoreTableProcessedTableManager? get store {
+    if (listing.store == null) return null;
+    return $$StoreTableTableManager(_db, _db.store)
+        .filter((f) => f.id(listing.store!));
   }
 }
 

--- a/drift/test/integration_tests/insert_integration_test.dart
+++ b/drift/test/integration_tests/insert_integration_test.dart
@@ -262,7 +262,7 @@ void main() {
       final id = await db.categories
           .insertOne(CategoriesCompanion.insert(description: 'with entry'));
       await db.todosTable.insertOne(TodosTableCompanion.insert(
-          content: 'my content', category: Value(id)));
+          content: 'my content', category: Value(RowId(id))));
 
       final amountOfTodos =
           db.todosTable.id.count(filter: db.todosTable.id.isNotNull());

--- a/drift/test/integration_tests/regress_1894_test.dart
+++ b/drift/test/integration_tests/regress_1894_test.dart
@@ -12,7 +12,7 @@ void main() {
     final nonEmptyId = await db.categories
         .insertOne(CategoriesCompanion.insert(description: 'category'));
     await db.todosTable.insertOne(TodosTableCompanion.insert(
-        content: 'entry', category: Value(nonEmptyId)));
+        content: 'entry', category: Value(RowId(nonEmptyId))));
 
     final emptyId = await db.categories.insertOne(
         CategoriesCompanion.insert(description: 'this category empty YEET'));

--- a/drift/test/integration_tests/regress_2166_test.g.dart
+++ b/drift/test/integration_tests/regress_2166_test.g.dart
@@ -290,8 +290,8 @@ class $$_SomeTableTableOrderingComposer
 class $$_SomeTableTableWithReferences {
   // ignore: unused_field
   final _$_SomeDb _db;
-  final _SomeTableData someTable;
-  $$_SomeTableTableWithReferences(this._db, this.someTable);
+  final _SomeTableData someTableData;
+  $$_SomeTableTableWithReferences(this._db, this.someTableData);
 }
 
 class $_SomeDbManager {

--- a/drift/test/integration_tests/regress_2166_test.g.dart
+++ b/drift/test/integration_tests/regress_2166_test.g.dart
@@ -215,9 +215,10 @@ class $$_SomeTableTableTableManager extends RootTableManager<
     _SomeTableData,
     $$_SomeTableTableFilterComposer,
     $$_SomeTableTableOrderingComposer,
-    $$_SomeTableTableProcessedTableManager,
     $$_SomeTableTableInsertCompanionBuilder,
-    $$_SomeTableTableUpdateCompanionBuilder> {
+    $$_SomeTableTableUpdateCompanionBuilder,
+    $$_SomeTableTableWithReferences,
+    _SomeTableData> {
   $$_SomeTableTableTableManager(_$_SomeDb db, $_SomeTableTable table)
       : super(TableManagerState(
           db: db,
@@ -226,9 +227,7 @@ class $$_SomeTableTableTableManager extends RootTableManager<
               $$_SomeTableTableFilterComposer(ComposerState(db, table)),
           orderingComposer:
               $$_SomeTableTableOrderingComposer(ComposerState(db, table)),
-          getChildManagerBuilder: (p) =>
-              $$_SomeTableTableProcessedTableManager(p),
-          getUpdateCompanionBuilder: ({
+          createUpdateCompanionCallback: ({
             Value<int> id = const Value.absent(),
             Value<String?> name = const Value.absent(),
           }) =>
@@ -236,7 +235,9 @@ class $$_SomeTableTableTableManager extends RootTableManager<
             id: id,
             name: name,
           ),
-          getInsertCompanionBuilder: ({
+          dataclassMapper: (p0) async =>
+              p0.map((e) => $$_SomeTableTableWithReferences(db, e)).toList(),
+          createInsertCompanionCallback: ({
             Value<int> id = const Value.absent(),
             Value<String?> name = const Value.absent(),
           }) =>
@@ -247,17 +248,16 @@ class $$_SomeTableTableTableManager extends RootTableManager<
         ));
 }
 
-class $$_SomeTableTableProcessedTableManager extends ProcessedTableManager<
+typedef $$_SomeTableTableProcessedTableManager = ProcessedTableManager<
     _$_SomeDb,
     $_SomeTableTable,
     _SomeTableData,
     $$_SomeTableTableFilterComposer,
     $$_SomeTableTableOrderingComposer,
-    $$_SomeTableTableProcessedTableManager,
     $$_SomeTableTableInsertCompanionBuilder,
-    $$_SomeTableTableUpdateCompanionBuilder> {
-  $$_SomeTableTableProcessedTableManager(super.$state);
-}
+    $$_SomeTableTableUpdateCompanionBuilder,
+    $$_SomeTableTableWithReferences,
+    _SomeTableData>;
 
 class $$_SomeTableTableFilterComposer
     extends FilterComposer<_$_SomeDb, $_SomeTableTable> {
@@ -285,6 +285,13 @@ class $$_SomeTableTableOrderingComposer
       column: $state.table.name,
       builder: (column, joinBuilders) =>
           ColumnOrderings(column, joinBuilders: joinBuilders));
+}
+
+class $$_SomeTableTableWithReferences {
+  // ignore: unused_field
+  final _$_SomeDb _db;
+  final _SomeTableData someTable;
+  $$_SomeTableTableWithReferences(this._db, this.someTable);
 }
 
 class $_SomeDbManager {

--- a/drift/test/integration_tests/select_integration_test.dart
+++ b/drift/test/integration_tests/select_integration_test.dart
@@ -35,7 +35,7 @@ void main() {
     await db.todosTable.insertOne(TodosTableCompanion.insert(
         content: 'some content',
         title: const Value('title'),
-        category: Value(category.id.id)));
+        category: Value(RowId(category.id.id))));
 
     final result = await db.todoWithCategoryView.select().getSingle();
     expect(
@@ -61,9 +61,11 @@ void main() {
       batch.insertAll(
         db.todosTable,
         [
-          TodosTableCompanion.insert(content: 'aaaaa', category: Value(1)),
-          TodosTableCompanion.insert(content: 'aa', category: Value(1)),
-          TodosTableCompanion.insert(content: 'bbbbbb', category: Value(2)),
+          TodosTableCompanion.insert(
+              content: 'aaaaa', category: Value(RowId(1))),
+          TodosTableCompanion.insert(content: 'aa', category: Value(RowId(1))),
+          TodosTableCompanion.insert(
+              content: 'bbbbbb', category: Value(RowId(2))),
         ],
       );
     });

--- a/drift/test/manager/manager_order_test.dart
+++ b/drift/test/manager/manager_order_test.dart
@@ -55,14 +55,14 @@ void main() {
         id: Value(RowId(1)),
         content: "Get that english homework done",
         title: Value("English Homework"),
-        category: Value(workCategoryId),
+        category: Value(RowId(workCategoryId)),
         status: Value(TodoStatus.open),
         targetDate: Value(DateTime.now().add(Duration(days: 1, seconds: 15)))));
     await db.managers.todosTable.create((o) => o(
         id: Value(RowId(2)),
         content: "Finish that Book report",
         title: Value("Book Report"),
-        category: Value(workCategoryId),
+        category: Value(RowId(workCategoryId)),
         status: Value(TodoStatus.done),
         targetDate:
             Value(DateTime.now().subtract(Duration(days: 2, seconds: 15)))));
@@ -70,14 +70,14 @@ void main() {
         id: Value(RowId(3)),
         content: "Get that math homework done",
         title: Value("Math Homework"),
-        category: Value(schoolCategoryId),
+        category: Value(RowId(schoolCategoryId)),
         status: Value(TodoStatus.open),
         targetDate: Value(DateTime.now().add(Duration(days: 1, seconds: 10)))));
     await db.managers.todosTable.create((o) => o(
         id: Value(RowId(4)),
         content: "Finish that report",
         title: Value("Report"),
-        category: Value(schoolCategoryId),
+        category: Value(RowId(schoolCategoryId)),
         status: Value(TodoStatus.workInProgress),
         targetDate: Value(DateTime.now().add(Duration(days: 2, seconds: 10)))));
     // Order by related

--- a/drift/test/manager/manager_order_test.dart
+++ b/drift/test/manager/manager_order_test.dart
@@ -3,6 +3,7 @@ import 'package:test/test.dart';
 
 import '../generated/todos.dart';
 import '../test_utils/test_utils.dart';
+import '../utils/future_or_extension.dart';
 
 void main() {
   late TodoDb db;
@@ -35,12 +36,14 @@ void main() {
         db.managers.tableWithEveryColumnType
             .orderBy((o) => o.aDateTime.desc())
             .get()
+            .toFuture()
             .then((value) => value[0].id),
         completion(3));
     expect(
         db.managers.tableWithEveryColumnType
             .orderBy((o) => o.aDateTime.asc())
             .get()
+            .toFuture()
             .then((value) => value[0].id),
         completion(1));
   });
@@ -85,6 +88,7 @@ void main() {
         db.managers.todosTable
             .orderBy((o) => o.category.id.asc())
             .get()
+            .toFuture()
             .then((value) => value.map((e) => e.id).toList()),
         completion([3, 4, 1, 2]));
   });

--- a/drift/test/manager/manager_referenced_filter_test.dart
+++ b/drift/test/manager/manager_referenced_filter_test.dart
@@ -448,7 +448,7 @@ void main() {
       await db.managers.todosTable.create((o) => o(
           content: i.content,
           title: i.title,
-          category: i.category,
+          category: Value(RowId(i.category.value)),
           status: i.status,
           targetDate: i.targetDate));
     }

--- a/drift/test/manager/manager_referenced_filter_test.dart
+++ b/drift/test/manager/manager_referenced_filter_test.dart
@@ -1,10 +1,13 @@
 // ignore_for_file: unused_local_variable
 
+import 'dart:async';
+
 import 'package:drift/drift.dart';
 import 'package:test/test.dart';
 
 import '../generated/todos.dart';
 import '../test_utils/test_utils.dart';
+import '../utils/future_or_extension.dart';
 
 void main() {
   late TodoDb db;
@@ -482,6 +485,7 @@ void main() {
         db.managers.categories
             .filter((f) => f.todos((f) => f.title.equals("Math Homework")))
             .getSingle()
+            .toFuture()
             .then((value) => value.description),
         completion("School"));
 
@@ -494,6 +498,7 @@ void main() {
                   return q;
                 }))
             .getSingle()
+            .toFuture()
             .then((value) => value.description),
         completion("School"));
   });
@@ -509,6 +514,7 @@ void main() {
             })
             .withReferences()
             .get(distinct: true)
+            .toFuture()
             .then((value) => value.length),
         completion(3));
     expect(filter?.joinBuilders.length, 0);
@@ -522,6 +528,7 @@ void main() {
             })
             .withReferences()
             .get(distinct: true)
+            .toFuture()
             .then((value) => value.length),
         completion(3));
     expect(filter?.joinBuilders.length, 1);
@@ -537,6 +544,7 @@ void main() {
             })
             .withReferences()
             .get(distinct: true)
+            .toFuture()
             .then((value) => value.length),
         completion(5));
     expect(filter?.joinBuilders.length, 1);
@@ -548,7 +556,8 @@ void main() {
             .orderBy((f) => f.name.asc())
             .withReferences()
             .get()
-            .then((value) => value.map((e) => e.product).toList()),
+            .toFuture()
+            .then((value) => value.map((e) => e.productData).toList()),
         completion([
           products[1],
           products[2],
@@ -562,7 +571,8 @@ void main() {
             .orderBy((f) => f.department.name.asc() & f.name.desc())
             .withReferences()
             .get()
-            .then((value) => value.map((e) => e.product).toList()),
+            .toFuture()
+            .then((value) => value.map((e) => e.productData).toList()),
         completion([
           products[8],
           products[2],
@@ -578,6 +588,7 @@ void main() {
             .filter((f) => f.listings((f) => f.price.isBiggerThan(10.0)))
             .withReferences()
             .get(distinct: true)
+            .toFuture()
             .then((value) => value.length),
         completion(7));
 
@@ -590,7 +601,8 @@ void main() {
             .orderBy((f) => f.name.asc())
             .withReferences()
             .get(distinct: true)
-            .then((value) => value.map((e) => e.product).toList()),
+            .toFuture()
+            .then((value) => value.map((e) => e.productData).toList()),
         completion([
           products[1],
           products[3],
@@ -610,6 +622,7 @@ void main() {
             })
             .withReferences()
             .get(distinct: true)
+            .toFuture()
             .then((value) => value.length),
         completion(6));
     expect(filter?.joinBuilders.length, 2);
@@ -621,6 +634,7 @@ void main() {
             })
             .withReferences()
             .get(distinct: true)
+            .toFuture()
             .then((value) => value.length),
         completion(7));
     expect(filter?.joinBuilders.length, 2);
@@ -635,6 +649,7 @@ void main() {
             })
             .withReferences()
             .get(distinct: true)
+            .toFuture()
             .then((value) => value.length),
         completion(8));
     expect(
@@ -647,6 +662,7 @@ void main() {
             })
             .withReferences()
             .get(distinct: true)
+            .toFuture()
             .then((value) => value.length),
         completion(9));
 
@@ -661,6 +677,7 @@ void main() {
             })
             .withReferences()
             .get(distinct: true)
+            .toFuture()
             .then((value) => value.length),
         completion(2));
     expect(
@@ -673,6 +690,7 @@ void main() {
             })
             .withReferences()
             .get(distinct: true)
+            .toFuture()
             .then((value) => value.length),
         completion(3));
 
@@ -686,6 +704,7 @@ void main() {
             })
             .withReferences()
             .get(distinct: true)
+            .toFuture()
             .then((value) => value.length),
         completion(2));
 
@@ -699,6 +718,7 @@ void main() {
             })
             .withReferences()
             .get(distinct: true)
+            .toFuture()
             .then((value) => value.length),
         completion(9));
   });
@@ -712,6 +732,7 @@ void main() {
             .filter((f) => f.category.id(RowId(schoolCategoryId)))
             .withReferences()
             .get(distinct: true)
+            .toFuture()
             .then((value) => value.length),
         completion(4));
 
@@ -721,6 +742,7 @@ void main() {
             .filter((f) => f.category.id.not(RowId(schoolCategoryId)))
             .withReferences()
             .get(distinct: true)
+            .toFuture()
             .then((value) => value.length),
         completion(4));
 
@@ -733,6 +755,7 @@ void main() {
             .filter((f) => f.status.equals(TodoStatus.open))
             .withReferences()
             .get(distinct: true)
+            .toFuture()
             .then((value) => value.length),
         completion(2));
 
@@ -744,6 +767,7 @@ void main() {
                 f.category.descriptionInUpperCase("SCHOOL"))
             .withReferences()
             .get(distinct: true)
+            .toFuture()
             .then((value) => value.length),
         completion(8));
 
@@ -754,6 +778,7 @@ void main() {
             .filter((f) => f.category.descriptionInUpperCase("SCHOOL"))
             .withReferences()
             .get(distinct: true)
+            .toFuture()
             .then((value) => value.length),
         completion(4));
 
@@ -763,7 +788,8 @@ void main() {
             .filter((f) => f.todos((f) => f.title.equals("Math Homework")))
             .withReferences()
             .getSingle()
-            .then((value) => value.categories.description),
+            .toFuture()
+            .then((value) => value.category.description),
         completion("School"));
 
     // Nested backreference
@@ -776,7 +802,8 @@ void main() {
                 }))
             .withReferences()
             .getSingle()
-            .then((value) => value.categories.description),
+            .toFuture()
+            .then((value) => value.category.description),
         completion("School"));
   });
 
@@ -786,6 +813,7 @@ void main() {
         db.managers.product
             .withReferences()
             .get(distinct: true)
+            .toFuture()
             .then((value) =>
                 value.first.department?.getSingle() ?? Future.value(null))
             .then(
@@ -798,6 +826,7 @@ void main() {
         db.managers.department
             .withReferences()
             .get(distinct: true)
+            .toFuture()
             .then((value) => value.first.productRefs.count()),
         completion(3));
 
@@ -808,9 +837,9 @@ void main() {
       final product = await i.product?.getSingle();
       if (product != null) {
         if (!listingsWithProducts.containsKey(product)) {
-          listingsWithProducts[product] = [i.listing];
+          listingsWithProducts[product] = [i.listingData];
         } else {
-          listingsWithProducts[product]!.add(i.listing);
+          listingsWithProducts[product]!.add(i.listingData);
         }
       }
     }
@@ -828,6 +857,7 @@ void main() {
             .filter((f) => f.id.equals(2))
             .withReferences()
             .getSingle()
+            .toFuture()
             .then((value) => value.productRefs.count()),
         completion(2));
   });

--- a/drift/test/manager/manager_referenced_filter_test.dart
+++ b/drift/test/manager/manager_referenced_filter_test.dart
@@ -361,7 +361,7 @@ void main() {
         description: categoryData[1].description));
 
     final todoData = <({
-      Value<int> category,
+      int? category,
       String content,
       Value<TodoStatus> status,
       Value<DateTime> targetDate,
@@ -371,28 +371,28 @@ void main() {
       (
         content: "Get that math homework done",
         title: Value("Math Homework"),
-        category: Value(schoolCategoryId),
+        category: schoolCategoryId,
         status: Value(TodoStatus.open),
         targetDate: Value(DateTime.now().add(Duration(days: 1, seconds: 10)))
       ),
       (
         content: "Finish that report",
         title: Value("Report"),
-        category: Value(schoolCategoryId),
+        category: schoolCategoryId,
         status: Value(TodoStatus.workInProgress),
         targetDate: Value(DateTime.now().add(Duration(days: 2, seconds: 10)))
       ),
       (
         content: "Get that english homework done",
         title: Value("English Homework"),
-        category: Value(schoolCategoryId),
+        category: schoolCategoryId,
         status: Value(TodoStatus.open),
         targetDate: Value(DateTime.now().add(Duration(days: 1, seconds: 15)))
       ),
       (
         content: "Finish that Book report",
         title: Value("Book Report"),
-        category: Value(schoolCategoryId),
+        category: schoolCategoryId,
         status: Value(TodoStatus.done),
         targetDate:
             Value(DateTime.now().subtract(Duration(days: 2, seconds: 15)))
@@ -401,28 +401,28 @@ void main() {
       (
         content: "File those reports",
         title: Value("File Reports"),
-        category: Value(workCategoryId),
+        category: workCategoryId,
         status: Value(TodoStatus.open),
         targetDate: Value(DateTime.now().add(Duration(days: 1, seconds: 20)))
       ),
       (
         content: "Clean the office",
         title: Value("Clean Office"),
-        category: Value(workCategoryId),
+        category: workCategoryId,
         status: Value(TodoStatus.workInProgress),
         targetDate: Value(DateTime.now().add(Duration(days: 2, seconds: 20)))
       ),
       (
         content: "Nail that presentation",
         title: Value("Presentation"),
-        category: Value(workCategoryId),
+        category: workCategoryId,
         status: Value(TodoStatus.open),
         targetDate: Value(DateTime.now().add(Duration(days: 1, seconds: 25)))
       ),
       (
         content: "Take a break",
         title: Value("Break"),
-        category: Value(workCategoryId),
+        category: workCategoryId,
         status: Value(TodoStatus.done),
         targetDate:
             Value(DateTime.now().subtract(Duration(days: 2, seconds: 25)))
@@ -433,10 +433,10 @@ void main() {
         title: Value("Whiteboard"),
         status: Value(TodoStatus.open),
         targetDate: Value(DateTime.now().add(Duration(days: 1, seconds: 50))),
-        category: Value.absent(),
+        category: null,
       ),
       (
-        category: Value.absent(),
+        category: null,
         content: "Drink Water",
         title: Value("Water"),
         status: Value(TodoStatus.workInProgress),
@@ -448,7 +448,7 @@ void main() {
       await db.managers.todosTable.create((o) => o(
           content: i.content,
           title: i.title,
-          category: Value(RowId(i.category.value)),
+          category: Value(i.category == null ? null : RowId(i.category!)),
           status: i.status,
           targetDate: i.targetDate));
     }
@@ -514,6 +514,574 @@ void main() {
                 }))
             .getSingle()
             .then((value) => value.description),
+        completion("School"));
+  });
+
+  test('manager - filter related with regualar id with references', () async {
+    final stores = [
+      await db.managers.store.createReturning((o) => o(name: Value("Walmart"))),
+      await db.managers.store.createReturning((o) => o(name: Value("Target"))),
+      await db.managers.store.createReturning((o) => o(name: Value("Costco")))
+    ];
+
+    final departments = [
+      await db.managers.department
+          .createReturning((o) => o(name: Value("Electronics"))),
+      await db.managers.department
+          .createReturning((o) => o(name: Value("Grocery"))),
+      await db.managers.department
+          .createReturning((o) => o(name: Value("Clothing")))
+    ];
+
+    final products = [
+      // Electronics
+      await db.managers.product.createReturning(
+          (o) => o(name: Value("TV"), department: Value(departments[0].id))),
+      await db.managers.product.createReturning((o) =>
+          o(name: Value("Cell Phone"), department: Value(departments[0].id))),
+      await db.managers.product.createReturning((o) =>
+          o(name: Value("Charger"), department: Value(departments[0].id))),
+      // Grocery
+      await db.managers.product.createReturning((o) =>
+          o(name: Value("Cereal"), department: Value(departments[1].id))),
+      await db.managers.product.createReturning(
+          (o) => o(name: Value("Meat"), department: Value(departments[1].id))),
+      // Clothing
+      await db.managers.product.createReturning(
+          (o) => o(name: Value("Shirt"), department: Value(departments[2].id))),
+      await db.managers.product.createReturning(
+          (o) => o(name: Value("Pants"), department: Value(departments[2].id))),
+      await db.managers.product.createReturning(
+          (o) => o(name: Value("Socks"), department: Value(departments[2].id))),
+      await db.managers.product.createReturning(
+          (o) => o(name: Value("Cap"), department: Value(departments[2].id)))
+    ];
+
+    final listings = [
+      // Walmart - Electronics
+      await db.managers.listing.create((o) => o(
+          product: Value(products[0].id),
+          store: Value(stores[0].id),
+          price: Value(100.0))),
+      await db.managers.listing.create((o) => o(
+          product: Value(products[1].id),
+          store: Value(stores[0].id),
+          price: Value(200.0))),
+      await db.managers.listing.create((o) => o(
+          product: Value(products[2].id),
+          store: Value(stores[0].id),
+          price: Value(10.0))),
+
+      // Walmart - Grocery
+      await db.managers.listing.create((o) => o(
+          product: Value(products[3].id),
+          store: Value(stores[0].id),
+          price: Value(5.0))),
+      await db.managers.listing.create((o) => o(
+          product: Value(products[4].id),
+          store: Value(stores[0].id),
+          price: Value(15.0))),
+
+      // Walmart - Clothing
+      await db.managers.listing.create((o) => o(
+          product: Value(products[5].id),
+          store: Value(stores[0].id),
+          price: Value(20.0))),
+      await db.managers.listing.create((o) => o(
+          product: Value(products[6].id),
+          store: Value(stores[0].id),
+          price: Value(30.0))),
+      await db.managers.listing.create((o) => o(
+          product: Value(products[7].id),
+          store: Value(stores[0].id),
+          price: Value(5.0))),
+      await db.managers.listing.create((o) => o(
+          product: Value(products[8].id),
+          store: Value(stores[0].id),
+          price: Value(10.0))),
+
+      // Target - Electronics
+
+      // Target does not have any TVs
+      // But is otherwise cheaper on electronics
+      // await db.managers.listing.create((o) => o(
+      //     product: Value(products[0].id),
+      //     store: Value(stores[0].id),
+      //     price: Value(100.0))),
+      await db.managers.listing.create((o) => o(
+          product: Value(products[1].id),
+          store: Value(stores[1].id),
+          price: Value(150.0))),
+      await db.managers.listing.create((o) => o(
+          product: Value(products[2].id),
+          store: Value(stores[1].id),
+          price: Value(15.0))),
+
+      // Target - Grocery
+
+      // More expensive groceries
+      await db.managers.listing.create((o) => o(
+          product: Value(products[3].id),
+          store: Value(stores[1].id),
+          price: Value(10.0))),
+      await db.managers.listing.create((o) => o(
+          product: Value(products[4].id),
+          store: Value(stores[1].id),
+          price: Value(20.0))),
+
+      // Target - Clothing
+
+      // Does not have any shirts or pants
+      // await db.managers.listing.create((o) => o(
+      //     product: Value(products[5].id),
+      //     store: Value(stores[1].id),
+      //     price: Value(20.0))),
+      // await db.managers.listing.create((o) => o(
+      //     product: Value(products[6].id),
+      //     store: Value(stores[1].id),
+      //     price: Value(30.0))),
+      await db.managers.listing.create((o) => o(
+          product: Value(products[7].id),
+          store: Value(stores[1].id),
+          price: Value(5.0))),
+      await db.managers.listing.create((o) => o(
+          product: Value(products[8].id),
+          store: Value(stores[1].id),
+          price: Value(10.0))),
+
+      // Costco - Electronics
+      // Much cheaper electronics
+      await db.managers.listing.create((o) => o(
+          product: Value(products[0].id),
+          store: Value(stores[2].id),
+          price: Value(50.0))),
+      await db.managers.listing.create((o) => o(
+          product: Value(products[1].id),
+          store: Value(stores[2].id),
+          price: Value(100.0))),
+      await db.managers.listing.create((o) => o(
+          product: Value(products[2].id),
+          store: Value(stores[2].id),
+          price: Value(2.50))),
+
+      // Costco - Grocery
+
+      // More expensive groceries
+      await db.managers.listing.create((o) => o(
+          product: Value(products[3].id),
+          store: Value(stores[2].id),
+          price: Value(20.0))),
+      await db.managers.listing.create((o) => o(
+          product: Value(products[4].id),
+          store: Value(stores[2].id),
+          price: Value(900.0))),
+
+      // Costco - Clothing
+
+      // Does not have any clothing
+      // await db.managers.listing.create((o) => o(
+      //     product: Value(products[5].id),
+      //     store: Value(stores[0].id),
+      //     price: Value(20.0))),
+      // await db.managers.listing.create((o) => o(
+      //     product: Value(products[6].id),
+      //     store: Value(stores[0].id),
+      //     price: Value(30.0))),
+      // await db.managers.listing.create((o) => o(
+      //     product: Value(products[7].id),
+      //     store: Value(stores[0].id),
+      //     price: Value(5.0))),
+      // await db.managers.listing.create((o) => o(
+      //     product: Value(products[8].id),
+      //     store: Value(stores[0].id),
+      //     price: Value(10.0))),
+    ];
+
+    // Filter on related table's reference id - Does not require a join
+    ComposableFilter? filter;
+    expect(
+        db.managers.product
+            .filter((f) {
+              filter = f.department.id(departments[0].id);
+              return filter!;
+            })
+            .withReferences()
+            .get(distinct: true)
+            .then((value) => value.length),
+        completion(3));
+    expect(filter?.joinBuilders.length, 0);
+
+    // Filter on a unrelated column on a related table - Requires a join
+    expect(
+        db.managers.product
+            .filter((f) {
+              filter = f.department.name("Electronics");
+              return filter!;
+            })
+            .withReferences()
+            .get(distinct: true)
+            .then((value) => value.length),
+        completion(3));
+    expect(filter?.joinBuilders.length, 1);
+
+    // Filter on a unrelated column on a related table & on
+    // a related table's reference id - Requires a join
+    expect(
+        db.managers.product
+            .filter((f) {
+              filter = f.department.name("Electronics") |
+                  f.department.id(departments[1].id);
+              return filter!;
+            })
+            .withReferences()
+            .get(distinct: true)
+            .then((value) => value.length),
+        completion(5));
+    expect(filter?.joinBuilders.length, 1);
+
+    // Ordering on current table & Filtering on related table
+    expect(
+        db.managers.product
+            .filter((f) => f.department.name("Electronics"))
+            .orderBy((f) => f.name.asc())
+            .withReferences()
+            .get()
+            .then((value) => value.map((e) => e.product).toList()),
+        completion([
+          products[1],
+          products[2],
+          products[0],
+        ]));
+
+    // Ordering on related table & Filtering on current table
+    expect(
+        db.managers.product
+            .filter((f) => f.name.startsWith("c"))
+            .orderBy((f) => f.department.name.asc() & f.name.desc())
+            .withReferences()
+            .get()
+            .then((value) => value.map((e) => e.product).toList()),
+        completion([
+          products[8],
+          products[2],
+          products[1],
+          products[3],
+        ]));
+
+    // Filtering on reverse related table
+    expect(
+        // Any product that is available for more than $10
+        // Socks & Cap are excluded
+        db.managers.product
+            .filter((f) => f.listings((f) => f.price.isBiggerThan(10.0)))
+            .withReferences()
+            .get(distinct: true)
+            .then((value) => value.length),
+        completion(7));
+
+    // Filtering on reverse related table with ordering
+    expect(
+        // Any product that is available for more than $10
+        // Socks & Cap are excluded, and the rest are ordered by name
+        db.managers.product
+            .filter((f) => f.listings((f) => f.price.isBiggerThan(10.0)))
+            .orderBy((f) => f.name.asc())
+            .withReferences()
+            .get(distinct: true)
+            .then((value) => value.map((e) => e.product).toList()),
+        completion([
+          products[1],
+          products[3],
+          products[2],
+          products[4],
+          products[6],
+          products[5],
+          products[0],
+        ]));
+
+    // Filter on reverse related column and then a related column
+    expect(
+        db.managers.product
+            .filter((f) {
+              filter = f.listings((f) => f.store.name("Target"));
+              return filter!;
+            })
+            .withReferences()
+            .get(distinct: true)
+            .then((value) => value.length),
+        completion(6));
+    expect(filter?.joinBuilders.length, 2);
+    expect(
+        db.managers.product
+            .filter((f) {
+              filter = f.listings((f) => f.store.name("Target")) | f.name("TV");
+              return filter!;
+            })
+            .withReferences()
+            .get(distinct: true)
+            .then((value) => value.length),
+        completion(7));
+    expect(filter?.joinBuilders.length, 2);
+
+    // Filter on a related column and then a related column
+    expect(
+        db.managers.listing
+            .filter((f) {
+              // Listings of products in the electronics department
+              filter = f.product.department.name("Electronics");
+              return filter!;
+            })
+            .withReferences()
+            .get(distinct: true)
+            .then((value) => value.length),
+        completion(8));
+    expect(
+        db.managers.listing
+            .filter((f) {
+              // Listings of products in the electronics department
+              filter = f.product.department.name("Electronics") |
+                  f.price.isBiggerThan(150.0);
+              return filter!;
+            })
+            .withReferences()
+            .get(distinct: true)
+            .then((value) => value.length),
+        completion(9));
+
+    // Filter on a reverse related column and then a reverse related column
+    expect(
+        db.managers.department
+            .filter((f) {
+              // Departments that have products listed for more than $10
+              filter = f.productRefs(
+                  (f) => f.listings((f) => f.price.isBiggerThan(100.0)));
+              return filter!;
+            })
+            .withReferences()
+            .get(distinct: true)
+            .then((value) => value.length),
+        completion(2));
+    expect(
+        db.managers.department
+            .filter((f) {
+              // Departments that have products listed for more than $10 or is available at Walmart
+              filter = f.productRefs((f) => f.listings((f) =>
+                  f.price.isBiggerThan(100.0) | f.store.name("Walmart")));
+              return filter!;
+            })
+            .withReferences()
+            .get(distinct: true)
+            .then((value) => value.length),
+        completion(3));
+
+    // Stores that have products in the clothing department
+    expect(
+        db.managers.store
+            .filter((f) {
+              // Products that are sold in a store that sells clothing
+              filter = f.listings((f) => f.product.department.name("Clothing"));
+              return filter!;
+            })
+            .withReferences()
+            .get(distinct: true)
+            .then((value) => value.length),
+        completion(2));
+
+    // Any product that is sold in a store that sells clothing
+    expect(
+        db.managers.product
+            .filter((f) {
+              filter = f.listings((f) => f.store
+                  .listings((f) => f.product.department.name("Clothing")));
+              return filter!;
+            })
+            .withReferences()
+            .get(distinct: true)
+            .then((value) => value.length),
+        completion(9));
+  });
+
+  test(
+      'manager - filter related with custom type for primary key with references',
+      () async {
+    final categoryData = [
+      (description: "School", priority: Value(CategoryPriority.high)),
+      (description: "Work", priority: Value(CategoryPriority.low)),
+    ];
+
+    final schoolCategoryId = await db.managers.categories.create((o) => o(
+        priority: categoryData[0].priority,
+        description: categoryData[0].description));
+    final workCategoryId = await db.managers.categories.create((o) => o(
+        priority: categoryData[1].priority,
+        description: categoryData[1].description));
+
+    final todoData = <({
+      Value<RowId> category,
+      String content,
+      Value<TodoStatus> status,
+      Value<DateTime> targetDate,
+      Value<String> title
+    })>[
+      // School
+      (
+        content: "Get that math homework done",
+        title: Value("Math Homework"),
+        category: Value(RowId(schoolCategoryId)),
+        status: Value(TodoStatus.open),
+        targetDate: Value(DateTime.now().add(Duration(days: 1, seconds: 10)))
+      ),
+      (
+        content: "Finish that report",
+        title: Value("Report"),
+        category: Value(RowId(schoolCategoryId)),
+        status: Value(TodoStatus.workInProgress),
+        targetDate: Value(DateTime.now().add(Duration(days: 2, seconds: 10)))
+      ),
+      (
+        content: "Get that english homework done",
+        title: Value("English Homework"),
+        category: Value(RowId(schoolCategoryId)),
+        status: Value(TodoStatus.open),
+        targetDate: Value(DateTime.now().add(Duration(days: 1, seconds: 15)))
+      ),
+      (
+        content: "Finish that Book report",
+        title: Value("Book Report"),
+        category: Value(RowId(schoolCategoryId)),
+        status: Value(TodoStatus.done),
+        targetDate:
+            Value(DateTime.now().subtract(Duration(days: 2, seconds: 15)))
+      ),
+      // Work
+      (
+        content: "File those reports",
+        title: Value("File Reports"),
+        category: Value(RowId(workCategoryId)),
+        status: Value(TodoStatus.open),
+        targetDate: Value(DateTime.now().add(Duration(days: 1, seconds: 20)))
+      ),
+      (
+        content: "Clean the office",
+        title: Value("Clean Office"),
+        category: Value(RowId(workCategoryId)),
+        status: Value(TodoStatus.workInProgress),
+        targetDate: Value(DateTime.now().add(Duration(days: 2, seconds: 20)))
+      ),
+      (
+        content: "Nail that presentation",
+        title: Value("Presentation"),
+        category: Value(RowId(workCategoryId)),
+        status: Value(TodoStatus.open),
+        targetDate: Value(DateTime.now().add(Duration(days: 1, seconds: 25)))
+      ),
+      (
+        content: "Take a break",
+        title: Value("Break"),
+        category: Value(RowId(workCategoryId)),
+        status: Value(TodoStatus.done),
+        targetDate:
+            Value(DateTime.now().subtract(Duration(days: 2, seconds: 25)))
+      ),
+      // Items with no category
+      (
+        content: "Get Whiteboard",
+        title: Value("Whiteboard"),
+        status: Value(TodoStatus.open),
+        targetDate: Value(DateTime.now().add(Duration(days: 1, seconds: 50))),
+        category: Value.absent(),
+      ),
+      (
+        category: Value.absent(),
+        content: "Drink Water",
+        title: Value("Water"),
+        status: Value(TodoStatus.workInProgress),
+        targetDate: Value(DateTime.now().add(Duration(days: 2, seconds: 50)))
+      ),
+    ];
+
+    for (var i in todoData) {
+      await db.managers.todosTable.create((o) => o(
+          content: i.content,
+          title: i.title,
+          category: i.category,
+          status: i.status,
+          targetDate: i.targetDate));
+    }
+
+    // item without title
+
+    // Equals
+    expect(
+        db.managers.todosTable
+            .filter((f) => f.category.id(RowId(schoolCategoryId)))
+            .withReferences()
+            .get(distinct: true)
+            .then((value) => value.length),
+        completion(4));
+
+    // Not Equals
+    expect(
+        db.managers.todosTable
+            .filter((f) => f.category.id.not(RowId(schoolCategoryId)))
+            .withReferences()
+            .get(distinct: true)
+            .then((value) => value.length),
+        completion(4));
+
+    // Multiple filters
+    expect(
+        db.managers.todosTable
+            .filter((f) => f.category.id(
+                  RowId(schoolCategoryId),
+                ))
+            .filter((f) => f.status.equals(TodoStatus.open))
+            .withReferences()
+            .get(distinct: true)
+            .then((value) => value.length),
+        completion(2));
+
+    // Multiple use related filters twice
+    expect(
+        db.managers.todosTable
+            .filter((f) =>
+                f.category.priority(CategoryPriority.low) |
+                f.category.descriptionInUpperCase("SCHOOL"))
+            .withReferences()
+            .get(distinct: true)
+            .then((value) => value.length),
+        completion(8));
+
+    // Use .filter multiple times
+    expect(
+        db.managers.todosTable
+            .filter((f) => f.category.priority.equals(CategoryPriority.high))
+            .filter((f) => f.category.descriptionInUpperCase("SCHOOL"))
+            .withReferences()
+            .get(distinct: true)
+            .then((value) => value.length),
+        completion(4));
+
+    // Use backreference
+    expect(
+        db.managers.categories
+            .filter((f) => f.todos((f) => f.title.equals("Math Homework")))
+            .withReferences()
+            .getSingle()
+            .then((value) => value.categories.description),
+        completion("School"));
+
+    // Nested backreference
+    expect(
+        db.managers.categories
+            .filter((f) => f.todos((f) {
+                  final q =
+                      f.category.todos((f) => f.title.equals("Math Homework"));
+                  return q;
+                }))
+            .withReferences()
+            .getSingle()
+            .then((value) => value.categories.description),
         completion("School"));
   });
 }

--- a/drift/test/manager/manager_selectable_test.dart
+++ b/drift/test/manager/manager_selectable_test.dart
@@ -187,23 +187,29 @@ void main() {
     final getAllStoresWithFilterAndOrdering = db.managers.store
         .filter((f) => f.id.not(10))
         .orderBy((f) => f.id.asc());
+    final getAllStoresWithFilterAndOrderingWithReferences = db.managers.store
+        .filter((f) => f.id.not(10))
+        .orderBy((f) => f.id.asc())
+        .withReferences();
 
     void testManager<T, M>(
-      BaseTableManager<dynamic, dynamic, T, dynamic, dynamic, dynamic, dynamic,
-              M, T>
-          selectable,
-    ) {
+        BaseTableManager<dynamic, dynamic, T, dynamic, dynamic, dynamic,
+                dynamic, M, T>
+            selectable) {
       expect(selectable.get().then((v) => v.length), completion(3));
       expect(selectable.get(limit: 1).then((v) => v.length), completion(1));
       expect(selectable.get(offset: 1, limit: 2).then((v) => v.length),
           completion(2));
+      expect(selectable.get(offset: 1, limit: 2).then((v) => v.length),
+          completion(2));
     }
 
-    for (final selectable in [
+    for (final selectable in <BaseTableManager>[
       getAllStores,
       getAllStoresWithFilter,
       getAllStoresWithOrdering,
       getAllStoresWithFilterAndOrdering,
+      getAllStoresWithFilterAndOrderingWithReferences,
     ]) {
       testManager(selectable);
     }

--- a/drift/test/manager/manager_selectable_test.dart
+++ b/drift/test/manager/manager_selectable_test.dart
@@ -1,0 +1,211 @@
+// ignore_for_file: unused_local_variable
+
+import 'package:drift/drift.dart';
+import 'package:test/test.dart';
+
+import '../generated/todos.dart';
+import '../test_utils/test_utils.dart';
+
+/// All managers `Managers` are Selectable classes that
+/// are used by the Manager API to return results.
+/// This test will ensure that they all behave as expected, no matter what filters/ordering/limit/offsets/references are applied.
+
+void main() {
+  late TodoDb db;
+
+  setUp(() {
+    db = TodoDb(testInMemoryDatabase());
+  });
+
+  tearDown(() => db.close());
+
+  test('manager - selectable tests', () async {
+    final stores = [
+      await db.managers.store.createReturning((o) => o(name: Value("Walmart"))),
+      await db.managers.store.createReturning((o) => o(name: Value("Target"))),
+      await db.managers.store.createReturning((o) => o(name: Value("Costco")))
+    ];
+
+    final departments = [
+      await db.managers.department
+          .createReturning((o) => o(name: Value("Electronics"))),
+      await db.managers.department
+          .createReturning((o) => o(name: Value("Grocery"))),
+      await db.managers.department
+          .createReturning((o) => o(name: Value("Clothing")))
+    ];
+
+    final products = [
+      // Electronics
+      await db.managers.product.createReturning(
+          (o) => o(name: Value("TV"), department: Value(departments[0].id))),
+      await db.managers.product.createReturning((o) =>
+          o(name: Value("Cell Phone"), department: Value(departments[0].id))),
+      await db.managers.product.createReturning((o) =>
+          o(name: Value("Charger"), department: Value(departments[0].id))),
+      // Grocery
+      await db.managers.product.createReturning((o) =>
+          o(name: Value("Cereal"), department: Value(departments[1].id))),
+      await db.managers.product.createReturning(
+          (o) => o(name: Value("Meat"), department: Value(departments[1].id))),
+      // Clothing
+      await db.managers.product.createReturning(
+          (o) => o(name: Value("Shirt"), department: Value(departments[2].id))),
+      await db.managers.product.createReturning(
+          (o) => o(name: Value("Pants"), department: Value(departments[2].id))),
+      await db.managers.product.createReturning(
+          (o) => o(name: Value("Socks"), department: Value(departments[2].id))),
+      await db.managers.product.createReturning(
+          (o) => o(name: Value("Cap"), department: Value(departments[2].id)))
+    ];
+
+    final listings = [
+      // Walmart - Electronics
+      await db.managers.listing.create((o) => o(
+          product: Value(products[0].id),
+          store: Value(stores[0].id),
+          price: Value(100.0))),
+      await db.managers.listing.create((o) => o(
+          product: Value(products[1].id),
+          store: Value(stores[0].id),
+          price: Value(200.0))),
+      await db.managers.listing.create((o) => o(
+          product: Value(products[2].id),
+          store: Value(stores[0].id),
+          price: Value(10.0))),
+
+      // Walmart - Grocery
+      await db.managers.listing.create((o) => o(
+          product: Value(products[3].id),
+          store: Value(stores[0].id),
+          price: Value(5.0))),
+      await db.managers.listing.create((o) => o(
+          product: Value(products[4].id),
+          store: Value(stores[0].id),
+          price: Value(15.0))),
+
+      // Walmart - Clothing
+      await db.managers.listing.create((o) => o(
+          product: Value(products[5].id),
+          store: Value(stores[0].id),
+          price: Value(20.0))),
+      await db.managers.listing.create((o) => o(
+          product: Value(products[6].id),
+          store: Value(stores[0].id),
+          price: Value(30.0))),
+      await db.managers.listing.create((o) => o(
+          product: Value(products[7].id),
+          store: Value(stores[0].id),
+          price: Value(5.0))),
+      await db.managers.listing.create((o) => o(
+          product: Value(products[8].id),
+          store: Value(stores[0].id),
+          price: Value(10.0))),
+
+      // Target - Electronics
+
+      // Target does not have any TVs
+      // But is otherwise cheaper on electronics
+      // await db.managers.listing.create((o) => o(
+      //     product: Value(products[0].id),
+      //     store: Value(stores[0].id),
+      //     price: Value(100.0))),
+      await db.managers.listing.create((o) => o(
+          product: Value(products[1].id),
+          store: Value(stores[1].id),
+          price: Value(150.0))),
+      await db.managers.listing.create((o) => o(
+          product: Value(products[2].id),
+          store: Value(stores[1].id),
+          price: Value(15.0))),
+
+      // Target - Grocery
+
+      // More expensive groceries
+      await db.managers.listing.create((o) => o(
+          product: Value(products[3].id),
+          store: Value(stores[1].id),
+          price: Value(10.0))),
+      await db.managers.listing.create((o) => o(
+          product: Value(products[4].id),
+          store: Value(stores[1].id),
+          price: Value(20.0))),
+
+      // Target - Clothing
+
+      // Does not have any shirts or pants
+      // await db.managers.listing.create((o) => o(
+      //     product: Value(products[5].id),
+      //     store: Value(stores[1].id),
+      //     price: Value(20.0))),
+      // await db.managers.listing.create((o) => o(
+      //     product: Value(products[6].id),
+      //     store: Value(stores[1].id),
+      //     price: Value(30.0))),
+      await db.managers.listing.create((o) => o(
+          product: Value(products[7].id),
+          store: Value(stores[1].id),
+          price: Value(5.0))),
+      await db.managers.listing.create((o) => o(
+          product: Value(products[8].id),
+          store: Value(stores[1].id),
+          price: Value(10.0))),
+
+      // Costco - Electronics
+      // Much cheaper electronics
+      await db.managers.listing.create((o) => o(
+          product: Value(products[0].id),
+          store: Value(stores[2].id),
+          price: Value(50.0))),
+      await db.managers.listing.create((o) => o(
+          product: Value(products[1].id),
+          store: Value(stores[2].id),
+          price: Value(100.0))),
+      await db.managers.listing.create((o) => o(
+          product: Value(products[2].id),
+          store: Value(stores[2].id),
+          price: Value(2.50))),
+
+      // Costco - Grocery
+
+      // More expensive groceries
+      await db.managers.listing.create((o) => o(
+          product: Value(products[3].id),
+          store: Value(stores[2].id),
+          price: Value(20.0))),
+      await db.managers.listing.create((o) => o(
+          product: Value(products[4].id),
+          store: Value(stores[2].id),
+          price: Value(900.0)))
+    ];
+
+    final getAllStores = db.managers.store;
+    final getAllStoresWithFilter =
+        db.managers.store.filter((f) => f.id.not(10));
+    final getAllStoresWithOrdering =
+        db.managers.store.orderBy((f) => f.id.asc());
+    final getAllStoresWithFilterAndOrdering = db.managers.store
+        .filter((f) => f.id.not(10))
+        .orderBy((f) => f.id.asc());
+
+    void testManager<T, M>(
+      BaseTableManager<dynamic, dynamic, T, dynamic, dynamic, dynamic, dynamic,
+              M, T>
+          selectable,
+    ) {
+      expect(selectable.get().then((v) => v.length), completion(3));
+      expect(selectable.get(limit: 1).then((v) => v.length), completion(1));
+      expect(selectable.get(offset: 1, limit: 2).then((v) => v.length),
+          completion(2));
+    }
+
+    for (final selectable in [
+      getAllStores,
+      getAllStoresWithFilter,
+      getAllStoresWithOrdering,
+      getAllStoresWithFilterAndOrdering,
+    ]) {
+      testManager(selectable);
+    }
+  });
+}

--- a/drift/test/manager/manager_selectable_test.dart
+++ b/drift/test/manager/manager_selectable_test.dart
@@ -5,6 +5,7 @@ import 'package:test/test.dart';
 
 import '../generated/todos.dart';
 import '../test_utils/test_utils.dart';
+import '../utils/future_or_extension.dart';
 
 /// All managers `Managers` are Selectable classes that
 /// are used by the Manager API to return results.
@@ -196,11 +197,14 @@ void main() {
         BaseTableManager<dynamic, dynamic, T, dynamic, dynamic, dynamic,
                 dynamic, M, T>
             selectable) {
-      expect(selectable.get().then((v) => v.length), completion(3));
-      expect(selectable.get(limit: 1).then((v) => v.length), completion(1));
-      expect(selectable.get(offset: 1, limit: 2).then((v) => v.length),
+      expect(selectable.get().toFuture().then((v) => v.length), completion(3));
+      expect(selectable.get(limit: 1).toFuture().then((v) => v.length),
+          completion(1));
+      expect(
+          selectable.get(offset: 1, limit: 2).toFuture().then((v) => v.length),
           completion(2));
-      expect(selectable.get(offset: 1, limit: 2).then((v) => v.length),
+      expect(
+          selectable.get(offset: 1, limit: 2).toFuture().then((v) => v.length),
           completion(2));
     }
 

--- a/drift/test/manager/manager_test.dart
+++ b/drift/test/manager/manager_test.dart
@@ -5,6 +5,7 @@ import 'package:test/test.dart';
 
 import '../generated/todos.dart';
 import '../test_utils/test_utils.dart';
+import '../utils/future_or_extension.dart';
 
 void main() {
   driftRuntimeOptions.dontWarnAboutMultipleDatabases = true;
@@ -104,6 +105,7 @@ void main() {
         db.managers.categories
             .filter(((f) => f.id(obj1.id)))
             .getSingle()
+            .toFuture()
             .then((value) => value.description),
         completion("Hello"));
 
@@ -116,12 +118,14 @@ void main() {
         db.managers.categories
             .filter(((f) => f.id(obj1.id)))
             .getSingle()
+            .toFuture()
             .then((value) => value.description),
         completion("Hello"));
     expect(
         db.managers.categories
             .filter(((f) => f.id(obj2.id)))
             .getSingle()
+            .toFuture()
             .then((value) => value.description),
         completion("World"));
 
@@ -139,6 +143,7 @@ void main() {
         db.managers.categories
             .filter(((f) => f.id(obj2.id)))
             .getSingle()
+            .toFuture()
             .then((value) => value.description),
         completion("World"));
   });

--- a/drift/test/manager/processed_manager_test.dart
+++ b/drift/test/manager/processed_manager_test.dart
@@ -3,6 +3,7 @@ import 'package:test/test.dart';
 
 import '../generated/todos.dart';
 import '../test_utils/test_utils.dart';
+import '../utils/future_or_extension.dart';
 
 void main() {
   late TodoDb db;
@@ -34,6 +35,7 @@ void main() {
     expect(
         db.managers.tableWithEveryColumnType
             .get()
+            .toFuture()
             .then((value) => value.length),
         completion(3));
     // Test getSingle with limit
@@ -41,6 +43,7 @@ void main() {
         db.managers.tableWithEveryColumnType
             .limit(1, offset: 1)
             .getSingle()
+            .toFuture()
             .then((value) => value.id),
         completion(2));
     // Test filtered delete
@@ -60,6 +63,7 @@ void main() {
         db.managers.tableWithEveryColumnType
             .filter((f) => f.id(RowId(1)))
             .getSingle()
+            .toFuture()
             .then((value) => value.aReal),
         completion(10.0));
     // Test filtered exists

--- a/drift/test/serialization_test.dart
+++ b/drift/test/serialization_test.dart
@@ -10,7 +10,7 @@ final TodoEntry _someTodoEntry = TodoEntry(
   title: null,
   content: 'content',
   targetDate: _someDate,
-  category: 3,
+  category: RowId(3),
   status: TodoStatus.open,
 );
 

--- a/drift/test/utils/future_or_extension.dart
+++ b/drift/test/utils/future_or_extension.dart
@@ -1,0 +1,7 @@
+import 'dart:async';
+
+extension FutureOrExt<T> on FutureOr<T> {
+  Future<T> toFuture() {
+    return this is Future<T> ? this as Future<T> : Future.value(this as T);
+  }
+}

--- a/drift_dev/lib/src/services/schema/schema_files.dart
+++ b/drift_dev/lib/src/services/schema/schema_files.dart
@@ -171,7 +171,8 @@ class SchemaWriter {
       if (column.typeConverter != null)
         'type_converter': {
           'dart_expr': column.typeConverter!.expression.toString(),
-          'dart_type_name': column.typeConverter!.dartType.getDisplayString(),
+          'dart_type_name': column.typeConverter!.dartType.getDisplayString(
+              withNullability: false), // ignore: deprecated_member_use
         }
     };
   }

--- a/drift_dev/lib/src/utils/type_utils.dart
+++ b/drift_dev/lib/src/utils/type_utils.dart
@@ -31,15 +31,18 @@ extension TypeUtils on DartType {
     return $this is InterfaceType ? $this.element.name : null;
   }
 
-  String get userVisibleName => getDisplayString();
+  String get userVisibleName =>
+      getDisplayString(withNullability: false); // ignore: deprecated_member_use
 
   /// How this type should look like in generated code.
   String codeString() {
     if (nullabilitySuffix == NullabilitySuffix.star) {
       // We can't actually use the legacy star in code, so don't show it.
-      return getDisplayString();
+      return getDisplayString(
+          withNullability: false); // ignore: deprecated_member_use
     }
 
-    return getDisplayString();
+    return getDisplayString(
+        withNullability: false); // ignore: deprecated_member_use
   }
 }

--- a/drift_dev/lib/src/writer/manager/database_manager_writer.dart
+++ b/drift_dev/lib/src/writer/manager/database_manager_writer.dart
@@ -3,6 +3,7 @@ import 'package:drift_dev/src/analysis/results/results.dart';
 import 'package:drift_dev/src/writer/modules.dart';
 import 'package:drift_dev/src/writer/tables/update_companion_writer.dart';
 import 'package:drift_dev/src/writer/writer.dart';
+import 'package:recase/recase.dart';
 
 part 'manager_templates.dart';
 part 'table_manager_writer.dart';

--- a/drift_dev/lib/src/writer/manager/manager_templates.dart
+++ b/drift_dev/lib/src/writer/manager/manager_templates.dart
@@ -381,13 +381,14 @@ class _ManagerCodeTemplates {
       required List<_Relation> relations,
       required TextEmitter leaf,
       required String dbClassName}) {
+    final currentRowField = rowClassWithPrefix(currentTable, leaf).camelCase;
     return """
 
         class ${rowClassWithReferencesName(currentTable)} {
         // ignore: unused_field
         final ${databaseType(leaf, dbClassName)} _db;
-        final ${rowClassWithPrefix(currentTable, leaf)} ${currentTable.dbGetterName};
-        ${rowClassWithReferencesName(currentTable)}(this._db, this.${currentTable.dbGetterName});
+        final ${rowClassWithPrefix(currentTable, leaf)} $currentRowField;
+        ${rowClassWithReferencesName(currentTable)}(this._db, this.$currentRowField);
 
         ${relations.map((relation) {
       if (_scope.generationOptions.isModular) {
@@ -399,14 +400,14 @@ class _ManagerCodeTemplates {
         // For a reverse relation, we return a filtered table manager
         return """
         ${processedTableManagerTypeDefName(relation.referencedTable)} get ${relation.fieldName} {
-          return ${rootTableManagerWithPrefix(relation.referencedTable, leaf)}(_db,_db.${relation.referencedTable.dbGetterName}).filter((f) => f.${relation.referencedColumn.nameInDart}.${relation.currentColumn.nameInDart}(${currentTable.dbGetterName}.${relation.currentColumn.nameInDart}));
+          return ${rootTableManagerWithPrefix(relation.referencedTable, leaf)}(_db,_db.${relation.referencedTable.dbGetterName}).filter((f) => f.${relation.referencedColumn.nameInDart}.${relation.currentColumn.nameInDart}($currentRowField.${relation.currentColumn.nameInDart}));
         }
         """;
       } else {
         return """
         ${processedTableManagerTypeDefName(relation.referencedTable)}? get ${relation.fieldName} {
-          if (${currentTable.dbGetterName}.${relation.currentColumn.nameInDart} == null) return null;
-          return ${rootTableManagerWithPrefix(relation.referencedTable, leaf)}(_db, _db.${relation.referencedTable.dbGetterName}).filter((f) => f.${relation.referencedColumn.nameInDart}(${currentTable.dbGetterName}.${relation.currentColumn.nameInDart}!));
+          if ($currentRowField.${relation.currentColumn.nameInDart} == null) return null;
+          return ${rootTableManagerWithPrefix(relation.referencedTable, leaf)}(_db, _db.${relation.referencedTable.dbGetterName}).filter((f) => f.${relation.referencedColumn.nameInDart}($currentRowField.${relation.currentColumn.nameInDart}!));
         }
         """;
       }

--- a/drift_dev/test/analysis/resolver/drift/table_test.dart
+++ b/drift_dev/test/analysis/resolver/drift/table_test.dart
@@ -123,8 +123,11 @@ CREATE TABLE b (
             'expression',
             contains('EnumIndexConverter<Fruits>'),
           )
-          .having((e) => e.dartType.getDisplayString(withNullability: false),
-              'dartType', 'Fruits'), // ignore: deprecated_member_use
+          .having(
+              (e) => e.dartType.getDisplayString(
+                  withNullability: false), // ignore: deprecated_member_use
+              'dartType',
+              'Fruits'),
     );
 
     final withGenericIndexColumn = table.columns
@@ -154,8 +157,11 @@ CREATE TABLE b (
             'expression',
             contains('EnumNameConverter<Fruits>'),
           )
-          .having((e) => e.dartType.getDisplayString(withNullability: false),
-              'dartType', 'Fruits'), // ignore: deprecated_member_use
+          .having(
+              (e) => e.dartType.getDisplayString(
+                  withNullability: false), // ignore: deprecated_member_use
+              'dartType',
+              'Fruits'),
     );
 
     expect(

--- a/drift_dev/test/analysis/resolver/drift/table_test.dart
+++ b/drift_dev/test/analysis/resolver/drift/table_test.dart
@@ -123,7 +123,8 @@ CREATE TABLE b (
             'expression',
             contains('EnumIndexConverter<Fruits>'),
           )
-          .having((e) => e.dartType.getDisplayString(), 'dartType', 'Fruits'),
+          .having((e) => e.dartType.getDisplayString(withNullability: false),
+              'dartType', 'Fruits'), // ignore: deprecated_member_use
     );
 
     final withGenericIndexColumn = table.columns
@@ -153,7 +154,8 @@ CREATE TABLE b (
             'expression',
             contains('EnumNameConverter<Fruits>'),
           )
-          .having((e) => e.dartType.getDisplayString(), 'dartType', 'Fruits'),
+          .having((e) => e.dartType.getDisplayString(withNullability: false),
+              'dartType', 'Fruits'), // ignore: deprecated_member_use
     );
 
     expect(

--- a/drift_dev/test/analysis/resolver/queries/existing_row_classes_test.dart
+++ b/drift_dev/test/analysis/resolver/queries/existing_row_classes_test.dart
@@ -30,7 +30,9 @@ class MyRow {
     state.expectNoErrors();
     final query = file.analyzedElements.single as DefinedSqlQuery;
     expect(query.resultClassName, isNull);
-    expect(query.existingDartType?.type.getDisplayString(), 'MyRow');
+    expect(
+        query.existingDartType?.type.getDisplayString(withNullability: false),
+        'MyRow'); // ignore: deprecated_member_use
   });
 
   test('can use named constructors', () async {
@@ -55,7 +57,9 @@ class MyRow {
     state.expectNoErrors();
     final query = file.analyzedElements.single as DefinedSqlQuery;
     expect(query.resultClassName, isNull);
-    expect(query.existingDartType?.type.getDisplayString(), 'MyRow');
+    expect(
+        query.existingDartType?.type.getDisplayString(withNullability: false),
+        'MyRow'); // ignore: deprecated_member_use
 
     final resolvedQuery = file.fileAnalysis!.resolvedQueries.values.single;
     expect(

--- a/drift_dev/test/analysis/resolver/queries/existing_row_classes_test.dart
+++ b/drift_dev/test/analysis/resolver/queries/existing_row_classes_test.dart
@@ -31,8 +31,9 @@ class MyRow {
     final query = file.analyzedElements.single as DefinedSqlQuery;
     expect(query.resultClassName, isNull);
     expect(
-        query.existingDartType?.type.getDisplayString(withNullability: false),
-        'MyRow'); // ignore: deprecated_member_use
+        query.existingDartType?.type.getDisplayString(
+            withNullability: false), // ignore: deprecated_member_use
+        'MyRow');
   });
 
   test('can use named constructors', () async {
@@ -58,8 +59,9 @@ class MyRow {
     final query = file.analyzedElements.single as DefinedSqlQuery;
     expect(query.resultClassName, isNull);
     expect(
-        query.existingDartType?.type.getDisplayString(withNullability: false),
-        'MyRow'); // ignore: deprecated_member_use
+        query.existingDartType?.type.getDisplayString(
+            withNullability: false), // ignore: deprecated_member_use
+        'MyRow');
 
     final resolvedQuery = file.fileAnalysis!.resolvedQueries.values.single;
     expect(

--- a/examples/app/lib/database/database.g.dart
+++ b/examples/app/lib/database/database.g.dart
@@ -127,6 +127,14 @@ class Category extends DataClass implements Insertable<Category> {
         name: name ?? this.name,
         color: color ?? this.color,
       );
+  Category copyWithCompanion(CategoriesCompanion data) {
+    return Category(
+      id: data.id.present ? data.id.value : this.id,
+      name: data.name.present ? data.name.value : this.name,
+      color: data.color.present ? data.color.value : this.color,
+    );
+  }
+
   @override
   String toString() {
     return (StringBuffer('Category(')
@@ -373,6 +381,16 @@ class TodoEntry extends DataClass implements Insertable<TodoEntry> {
         category: category.present ? category.value : this.category,
         dueDate: dueDate.present ? dueDate.value : this.dueDate,
       );
+  TodoEntry copyWithCompanion(TodoEntriesCompanion data) {
+    return TodoEntry(
+      id: data.id.present ? data.id.value : this.id,
+      description:
+          data.description.present ? data.description.value : this.description,
+      category: data.category.present ? data.category.value : this.category,
+      dueDate: data.dueDate.present ? data.dueDate.value : this.dueDate,
+    );
+  }
+
   @override
   String toString() {
     return (StringBuffer('TodoEntry(')
@@ -565,6 +583,13 @@ class TextEntry extends DataClass implements Insertable<TextEntry> {
   TextEntry copyWith({String? description}) => TextEntry(
         description: description ?? this.description,
       );
+  TextEntry copyWithCompanion(TextEntriesCompanion data) {
+    return TextEntry(
+      description:
+          data.description.present ? data.description.value : this.description,
+    );
+  }
+
   @override
   String toString() {
     return (StringBuffer('TextEntry(')
@@ -736,9 +761,10 @@ class $$CategoriesTableTableManager extends RootTableManager<
     Category,
     $$CategoriesTableFilterComposer,
     $$CategoriesTableOrderingComposer,
-    $$CategoriesTableProcessedTableManager,
     $$CategoriesTableInsertCompanionBuilder,
-    $$CategoriesTableUpdateCompanionBuilder> {
+    $$CategoriesTableUpdateCompanionBuilder,
+    $$CategoriesTableWithReferences,
+    Category> {
   $$CategoriesTableTableManager(_$AppDatabase db, $CategoriesTable table)
       : super(TableManagerState(
           db: db,
@@ -747,9 +773,7 @@ class $$CategoriesTableTableManager extends RootTableManager<
               $$CategoriesTableFilterComposer(ComposerState(db, table)),
           orderingComposer:
               $$CategoriesTableOrderingComposer(ComposerState(db, table)),
-          getChildManagerBuilder: (p) =>
-              $$CategoriesTableProcessedTableManager(p),
-          getUpdateCompanionBuilder: ({
+          createUpdateCompanionCallback: ({
             Value<int> id = const Value.absent(),
             Value<String> name = const Value.absent(),
             Value<Color> color = const Value.absent(),
@@ -759,7 +783,9 @@ class $$CategoriesTableTableManager extends RootTableManager<
             name: name,
             color: color,
           ),
-          getInsertCompanionBuilder: ({
+          dataclassMapper: (p0) async =>
+              p0.map((e) => $$CategoriesTableWithReferences(db, e)).toList(),
+          createInsertCompanionCallback: ({
             Value<int> id = const Value.absent(),
             required String name,
             required Color color,
@@ -772,17 +798,16 @@ class $$CategoriesTableTableManager extends RootTableManager<
         ));
 }
 
-class $$CategoriesTableProcessedTableManager extends ProcessedTableManager<
+typedef $$CategoriesTableProcessedTableManager = ProcessedTableManager<
     _$AppDatabase,
     $CategoriesTable,
     Category,
     $$CategoriesTableFilterComposer,
     $$CategoriesTableOrderingComposer,
-    $$CategoriesTableProcessedTableManager,
     $$CategoriesTableInsertCompanionBuilder,
-    $$CategoriesTableUpdateCompanionBuilder> {
-  $$CategoriesTableProcessedTableManager(super.$state);
-}
+    $$CategoriesTableUpdateCompanionBuilder,
+    $$CategoriesTableWithReferences,
+    Category>;
 
 class $$CategoriesTableFilterComposer
     extends FilterComposer<_$AppDatabase, $CategoriesTable> {
@@ -837,6 +862,18 @@ class $$CategoriesTableOrderingComposer
           ColumnOrderings(column, joinBuilders: joinBuilders));
 }
 
+class $$CategoriesTableWithReferences {
+  // ignore: unused_field
+  final _$AppDatabase _db;
+  final Category categories;
+  $$CategoriesTableWithReferences(this._db, this.categories);
+
+  $$TodoEntriesTableProcessedTableManager get todoEntriesRefs {
+    return $$TodoEntriesTableTableManager(_db, _db.todoEntries)
+        .filter((f) => f.category.id(categories.id));
+  }
+}
+
 typedef $$TodoEntriesTableInsertCompanionBuilder = TodoEntriesCompanion
     Function({
   Value<int> id,
@@ -858,9 +895,10 @@ class $$TodoEntriesTableTableManager extends RootTableManager<
     TodoEntry,
     $$TodoEntriesTableFilterComposer,
     $$TodoEntriesTableOrderingComposer,
-    $$TodoEntriesTableProcessedTableManager,
     $$TodoEntriesTableInsertCompanionBuilder,
-    $$TodoEntriesTableUpdateCompanionBuilder> {
+    $$TodoEntriesTableUpdateCompanionBuilder,
+    $$TodoEntriesTableWithReferences,
+    TodoEntry> {
   $$TodoEntriesTableTableManager(_$AppDatabase db, $TodoEntriesTable table)
       : super(TableManagerState(
           db: db,
@@ -869,9 +907,7 @@ class $$TodoEntriesTableTableManager extends RootTableManager<
               $$TodoEntriesTableFilterComposer(ComposerState(db, table)),
           orderingComposer:
               $$TodoEntriesTableOrderingComposer(ComposerState(db, table)),
-          getChildManagerBuilder: (p) =>
-              $$TodoEntriesTableProcessedTableManager(p),
-          getUpdateCompanionBuilder: ({
+          createUpdateCompanionCallback: ({
             Value<int> id = const Value.absent(),
             Value<String> description = const Value.absent(),
             Value<int?> category = const Value.absent(),
@@ -883,7 +919,9 @@ class $$TodoEntriesTableTableManager extends RootTableManager<
             category: category,
             dueDate: dueDate,
           ),
-          getInsertCompanionBuilder: ({
+          dataclassMapper: (p0) async =>
+              p0.map((e) => $$TodoEntriesTableWithReferences(db, e)).toList(),
+          createInsertCompanionCallback: ({
             Value<int> id = const Value.absent(),
             required String description,
             Value<int?> category = const Value.absent(),
@@ -898,17 +936,16 @@ class $$TodoEntriesTableTableManager extends RootTableManager<
         ));
 }
 
-class $$TodoEntriesTableProcessedTableManager extends ProcessedTableManager<
+typedef $$TodoEntriesTableProcessedTableManager = ProcessedTableManager<
     _$AppDatabase,
     $TodoEntriesTable,
     TodoEntry,
     $$TodoEntriesTableFilterComposer,
     $$TodoEntriesTableOrderingComposer,
-    $$TodoEntriesTableProcessedTableManager,
     $$TodoEntriesTableInsertCompanionBuilder,
-    $$TodoEntriesTableUpdateCompanionBuilder> {
-  $$TodoEntriesTableProcessedTableManager(super.$state);
-}
+    $$TodoEntriesTableUpdateCompanionBuilder,
+    $$TodoEntriesTableWithReferences,
+    TodoEntry>;
 
 class $$TodoEntriesTableFilterComposer
     extends FilterComposer<_$AppDatabase, $TodoEntriesTable> {
@@ -972,6 +1009,19 @@ class $$TodoEntriesTableOrderingComposer
   }
 }
 
+class $$TodoEntriesTableWithReferences {
+  // ignore: unused_field
+  final _$AppDatabase _db;
+  final TodoEntry todoEntries;
+  $$TodoEntriesTableWithReferences(this._db, this.todoEntries);
+
+  $$CategoriesTableProcessedTableManager? get category {
+    if (todoEntries.category == null) return null;
+    return $$CategoriesTableTableManager(_db, _db.categories)
+        .filter((f) => f.id(todoEntries.category!));
+  }
+}
+
 typedef $TextEntriesInsertCompanionBuilder = TextEntriesCompanion Function({
   required String description,
   Value<int> rowid,
@@ -987,9 +1037,10 @@ class $TextEntriesTableManager extends RootTableManager<
     TextEntry,
     $TextEntriesFilterComposer,
     $TextEntriesOrderingComposer,
-    $TextEntriesProcessedTableManager,
     $TextEntriesInsertCompanionBuilder,
-    $TextEntriesUpdateCompanionBuilder> {
+    $TextEntriesUpdateCompanionBuilder,
+    $TextEntriesWithReferences,
+    TextEntry> {
   $TextEntriesTableManager(_$AppDatabase db, TextEntries table)
       : super(TableManagerState(
           db: db,
@@ -998,8 +1049,7 @@ class $TextEntriesTableManager extends RootTableManager<
               $TextEntriesFilterComposer(ComposerState(db, table)),
           orderingComposer:
               $TextEntriesOrderingComposer(ComposerState(db, table)),
-          getChildManagerBuilder: (p) => $TextEntriesProcessedTableManager(p),
-          getUpdateCompanionBuilder: ({
+          createUpdateCompanionCallback: ({
             Value<String> description = const Value.absent(),
             Value<int> rowid = const Value.absent(),
           }) =>
@@ -1007,7 +1057,9 @@ class $TextEntriesTableManager extends RootTableManager<
             description: description,
             rowid: rowid,
           ),
-          getInsertCompanionBuilder: ({
+          dataclassMapper: (p0) async =>
+              p0.map((e) => $TextEntriesWithReferences(db, e)).toList(),
+          createInsertCompanionCallback: ({
             required String description,
             Value<int> rowid = const Value.absent(),
           }) =>
@@ -1018,17 +1070,16 @@ class $TextEntriesTableManager extends RootTableManager<
         ));
 }
 
-class $TextEntriesProcessedTableManager extends ProcessedTableManager<
+typedef $TextEntriesProcessedTableManager = ProcessedTableManager<
     _$AppDatabase,
     TextEntries,
     TextEntry,
     $TextEntriesFilterComposer,
     $TextEntriesOrderingComposer,
-    $TextEntriesProcessedTableManager,
     $TextEntriesInsertCompanionBuilder,
-    $TextEntriesUpdateCompanionBuilder> {
-  $TextEntriesProcessedTableManager(super.$state);
-}
+    $TextEntriesUpdateCompanionBuilder,
+    $TextEntriesWithReferences,
+    TextEntry>;
 
 class $TextEntriesFilterComposer
     extends FilterComposer<_$AppDatabase, TextEntries> {
@@ -1046,6 +1097,13 @@ class $TextEntriesOrderingComposer
       column: $state.table.description,
       builder: (column, joinBuilders) =>
           ColumnOrderings(column, joinBuilders: joinBuilders));
+}
+
+class $TextEntriesWithReferences {
+  // ignore: unused_field
+  final _$AppDatabase _db;
+  final TextEntry textEntries;
+  $TextEntriesWithReferences(this._db, this.textEntries);
 }
 
 class $AppDatabaseManager {

--- a/examples/app/lib/database/database.g.dart
+++ b/examples/app/lib/database/database.g.dart
@@ -865,12 +865,12 @@ class $$CategoriesTableOrderingComposer
 class $$CategoriesTableWithReferences {
   // ignore: unused_field
   final _$AppDatabase _db;
-  final Category categories;
-  $$CategoriesTableWithReferences(this._db, this.categories);
+  final Category category;
+  $$CategoriesTableWithReferences(this._db, this.category);
 
   $$TodoEntriesTableProcessedTableManager get todoEntriesRefs {
     return $$TodoEntriesTableTableManager(_db, _db.todoEntries)
-        .filter((f) => f.category.id(categories.id));
+        .filter((f) => f.category.id(category.id));
   }
 }
 
@@ -1012,13 +1012,13 @@ class $$TodoEntriesTableOrderingComposer
 class $$TodoEntriesTableWithReferences {
   // ignore: unused_field
   final _$AppDatabase _db;
-  final TodoEntry todoEntries;
-  $$TodoEntriesTableWithReferences(this._db, this.todoEntries);
+  final TodoEntry todoEntry;
+  $$TodoEntriesTableWithReferences(this._db, this.todoEntry);
 
   $$CategoriesTableProcessedTableManager? get category {
-    if (todoEntries.category == null) return null;
+    if (todoEntry.category == null) return null;
     return $$CategoriesTableTableManager(_db, _db.categories)
-        .filter((f) => f.id(todoEntries.category!));
+        .filter((f) => f.id(todoEntry.category!));
   }
 }
 
@@ -1102,8 +1102,8 @@ class $TextEntriesOrderingComposer
 class $TextEntriesWithReferences {
   // ignore: unused_field
   final _$AppDatabase _db;
-  final TextEntry textEntries;
-  $TextEntriesWithReferences(this._db, this.textEntries);
+  final TextEntry textEntry;
+  $TextEntriesWithReferences(this._db, this.textEntry);
 }
 
 class $AppDatabaseManager {

--- a/examples/app/pubspec.yaml
+++ b/examples/app/pubspec.yaml
@@ -1,6 +1,6 @@
 name: app
 description: A cross-platform todo tracker built with drift.
-publish_to: 'none'
+publish_to: "none"
 
 version: 1.0.0+1
 
@@ -38,3 +38,11 @@ dev_dependencies:
 
 flutter:
   uses-material-design: true
+
+dependency_overrides:
+  drift:
+    path: ../../drift
+  drift_dev:
+    path: ../../drift_dev
+  sqlparser:
+    path: ../../sqlparser

--- a/examples/encryption/lib/database.g.dart
+++ b/examples/encryption/lib/database.g.dart
@@ -206,9 +206,10 @@ class $$NotesTableTableManager extends RootTableManager<
     Note,
     $$NotesTableFilterComposer,
     $$NotesTableOrderingComposer,
-    $$NotesTableProcessedTableManager,
     $$NotesTableInsertCompanionBuilder,
-    $$NotesTableUpdateCompanionBuilder> {
+    $$NotesTableUpdateCompanionBuilder,
+    $$NotesTableWithReferences,
+    Note> {
   $$NotesTableTableManager(_$MyEncryptedDatabase db, $NotesTable table)
       : super(TableManagerState(
           db: db,
@@ -217,8 +218,7 @@ class $$NotesTableTableManager extends RootTableManager<
               $$NotesTableFilterComposer(ComposerState(db, table)),
           orderingComposer:
               $$NotesTableOrderingComposer(ComposerState(db, table)),
-          getChildManagerBuilder: (p) => $$NotesTableProcessedTableManager(p),
-          getUpdateCompanionBuilder: ({
+          createUpdateCompanionCallback: ({
             Value<int> id = const Value.absent(),
             Value<String> content = const Value.absent(),
           }) =>
@@ -226,7 +226,9 @@ class $$NotesTableTableManager extends RootTableManager<
             id: id,
             content: content,
           ),
-          getInsertCompanionBuilder: ({
+          dataclassMapper: (p0) async =>
+              p0.map((e) => $$NotesTableWithReferences(db, e)).toList(),
+          createInsertCompanionCallback: ({
             Value<int> id = const Value.absent(),
             required String content,
           }) =>
@@ -237,17 +239,16 @@ class $$NotesTableTableManager extends RootTableManager<
         ));
 }
 
-class $$NotesTableProcessedTableManager extends ProcessedTableManager<
+typedef $$NotesTableProcessedTableManager = ProcessedTableManager<
     _$MyEncryptedDatabase,
     $NotesTable,
     Note,
     $$NotesTableFilterComposer,
     $$NotesTableOrderingComposer,
-    $$NotesTableProcessedTableManager,
     $$NotesTableInsertCompanionBuilder,
-    $$NotesTableUpdateCompanionBuilder> {
-  $$NotesTableProcessedTableManager(super.$state);
-}
+    $$NotesTableUpdateCompanionBuilder,
+    $$NotesTableWithReferences,
+    Note>;
 
 class $$NotesTableFilterComposer
     extends FilterComposer<_$MyEncryptedDatabase, $NotesTable> {
@@ -275,6 +276,13 @@ class $$NotesTableOrderingComposer
       column: $state.table.content,
       builder: (column, joinBuilders) =>
           ColumnOrderings(column, joinBuilders: joinBuilders));
+}
+
+class $$NotesTableWithReferences {
+  // ignore: unused_field
+  final _$MyEncryptedDatabase _db;
+  final Note notes;
+  $$NotesTableWithReferences(this._db, this.notes);
 }
 
 class $MyEncryptedDatabaseManager {

--- a/examples/encryption/lib/database.g.dart
+++ b/examples/encryption/lib/database.g.dart
@@ -281,8 +281,8 @@ class $$NotesTableOrderingComposer
 class $$NotesTableWithReferences {
   // ignore: unused_field
   final _$MyEncryptedDatabase _db;
-  final Note notes;
-  $$NotesTableWithReferences(this._db, this.notes);
+  final Note note;
+  $$NotesTableWithReferences(this._db, this.note);
 }
 
 class $MyEncryptedDatabaseManager {

--- a/examples/flutter_web_worker_example/lib/src/database/database.g.dart
+++ b/examples/flutter_web_worker_example/lib/src/database/database.g.dart
@@ -300,8 +300,8 @@ class $EntriesOrderingComposer extends OrderingComposer<_$MyDatabase, Entries> {
 class $EntriesWithReferences {
   // ignore: unused_field
   final _$MyDatabase _db;
-  final Entry entries;
-  $EntriesWithReferences(this._db, this.entries);
+  final Entry entry;
+  $EntriesWithReferences(this._db, this.entry);
 }
 
 class $MyDatabaseManager {

--- a/examples/flutter_web_worker_example/lib/src/database/database.g.dart
+++ b/examples/flutter_web_worker_example/lib/src/database/database.g.dart
@@ -229,17 +229,17 @@ class $EntriesTableManager extends RootTableManager<
     Entry,
     $EntriesFilterComposer,
     $EntriesOrderingComposer,
-    $EntriesProcessedTableManager,
     $EntriesInsertCompanionBuilder,
-    $EntriesUpdateCompanionBuilder> {
+    $EntriesUpdateCompanionBuilder,
+    $EntriesWithReferences,
+    Entry> {
   $EntriesTableManager(_$MyDatabase db, Entries table)
       : super(TableManagerState(
           db: db,
           table: table,
           filteringComposer: $EntriesFilterComposer(ComposerState(db, table)),
           orderingComposer: $EntriesOrderingComposer(ComposerState(db, table)),
-          getChildManagerBuilder: (p) => $EntriesProcessedTableManager(p),
-          getUpdateCompanionBuilder: ({
+          createUpdateCompanionCallback: ({
             Value<int> id = const Value.absent(),
             Value<String> value = const Value.absent(),
           }) =>
@@ -247,7 +247,9 @@ class $EntriesTableManager extends RootTableManager<
             id: id,
             value: value,
           ),
-          getInsertCompanionBuilder: ({
+          dataclassMapper: (p0) async =>
+              p0.map((e) => $EntriesWithReferences(db, e)).toList(),
+          createInsertCompanionCallback: ({
             Value<int> id = const Value.absent(),
             required String value,
           }) =>
@@ -258,17 +260,16 @@ class $EntriesTableManager extends RootTableManager<
         ));
 }
 
-class $EntriesProcessedTableManager extends ProcessedTableManager<
+typedef $EntriesProcessedTableManager = ProcessedTableManager<
     _$MyDatabase,
     Entries,
     Entry,
     $EntriesFilterComposer,
     $EntriesOrderingComposer,
-    $EntriesProcessedTableManager,
     $EntriesInsertCompanionBuilder,
-    $EntriesUpdateCompanionBuilder> {
-  $EntriesProcessedTableManager(super.$state);
-}
+    $EntriesUpdateCompanionBuilder,
+    $EntriesWithReferences,
+    Entry>;
 
 class $EntriesFilterComposer extends FilterComposer<_$MyDatabase, Entries> {
   $EntriesFilterComposer(super.$state);
@@ -294,6 +295,13 @@ class $EntriesOrderingComposer extends OrderingComposer<_$MyDatabase, Entries> {
       column: $state.table.value,
       builder: (column, joinBuilders) =>
           ColumnOrderings(column, joinBuilders: joinBuilders));
+}
+
+class $EntriesWithReferences {
+  // ignore: unused_field
+  final _$MyDatabase _db;
+  final Entry entries;
+  $EntriesWithReferences(this._db, this.entries);
 }
 
 class $MyDatabaseManager {

--- a/examples/migrations_example/lib/database.g.dart
+++ b/examples/migrations_example/lib/database.g.dart
@@ -1078,18 +1078,18 @@ class $$UsersTableOrderingComposer
 class $$UsersTableWithReferences {
   // ignore: unused_field
   final _$Database _db;
-  final User users;
-  $$UsersTableWithReferences(this._db, this.users);
+  final User user;
+  $$UsersTableWithReferences(this._db, this.user);
 
   $$UsersTableProcessedTableManager? get nextUser {
-    if (users.nextUser == null) return null;
+    if (user.nextUser == null) return null;
     return $$UsersTableTableManager(_db, _db.users)
-        .filter((f) => f.id(users.nextUser!));
+        .filter((f) => f.id(user.nextUser!));
   }
 
   $GroupsProcessedTableManager get groupsRefs {
     return $GroupsTableManager(_db, _db.groups)
-        .filter((f) => f.owner.id(users.id));
+        .filter((f) => f.owner.id(user.id));
   }
 }
 
@@ -1225,13 +1225,13 @@ class $GroupsOrderingComposer extends OrderingComposer<_$Database, Groups> {
 class $GroupsWithReferences {
   // ignore: unused_field
   final _$Database _db;
-  final Group groups;
-  $GroupsWithReferences(this._db, this.groups);
+  final Group group;
+  $GroupsWithReferences(this._db, this.group);
 
   $$UsersTableProcessedTableManager? get owner {
-    if (groups.owner == null) return null;
+    if (group.owner == null) return null;
     return $$UsersTableTableManager(_db, _db.users)
-        .filter((f) => f.id(groups.owner!));
+        .filter((f) => f.id(group.owner!));
   }
 }
 
@@ -1343,8 +1343,8 @@ class $NotesOrderingComposer extends OrderingComposer<_$Database, Notes> {
 class $NotesWithReferences {
   // ignore: unused_field
   final _$Database _db;
-  final Note notes;
-  $NotesWithReferences(this._db, this.notes);
+  final Note note;
+  $NotesWithReferences(this._db, this.note);
 }
 
 class $DatabaseManager {

--- a/examples/migrations_example/lib/database.g.dart
+++ b/examples/migrations_example/lib/database.g.dart
@@ -162,6 +162,15 @@ class User extends DataClass implements Insertable<User> {
         birthday: birthday.present ? birthday.value : this.birthday,
         nextUser: nextUser.present ? nextUser.value : this.nextUser,
       );
+  User copyWithCompanion(UsersCompanion data) {
+    return User(
+      id: data.id.present ? data.id.value : this.id,
+      name: data.name.present ? data.name.value : this.name,
+      birthday: data.birthday.present ? data.birthday.value : this.birthday,
+      nextUser: data.nextUser.present ? data.nextUser.value : this.nextUser,
+    );
+  }
+
   @override
   String toString() {
     return (StringBuffer('User(')
@@ -417,6 +426,15 @@ class Group extends DataClass implements Insertable<Group> {
         deleted: deleted.present ? deleted.value : this.deleted,
         owner: owner ?? this.owner,
       );
+  Group copyWithCompanion(GroupsCompanion data) {
+    return Group(
+      id: data.id.present ? data.id.value : this.id,
+      title: data.title.present ? data.title.value : this.title,
+      deleted: data.deleted.present ? data.deleted.value : this.deleted,
+      owner: data.owner.present ? data.owner.value : this.owner,
+    );
+  }
+
   @override
   String toString() {
     return (StringBuffer('Group(')
@@ -650,6 +668,15 @@ class Note extends DataClass implements Insertable<Note> {
         content: content ?? this.content,
         searchTerms: searchTerms ?? this.searchTerms,
       );
+  Note copyWithCompanion(NotesCompanion data) {
+    return Note(
+      title: data.title.present ? data.title.value : this.title,
+      content: data.content.present ? data.content.value : this.content,
+      searchTerms:
+          data.searchTerms.present ? data.searchTerms.value : this.searchTerms,
+    );
+  }
+
   @override
   String toString() {
     return (StringBuffer('Note(')
@@ -921,9 +948,10 @@ class $$UsersTableTableManager extends RootTableManager<
     User,
     $$UsersTableFilterComposer,
     $$UsersTableOrderingComposer,
-    $$UsersTableProcessedTableManager,
     $$UsersTableInsertCompanionBuilder,
-    $$UsersTableUpdateCompanionBuilder> {
+    $$UsersTableUpdateCompanionBuilder,
+    $$UsersTableWithReferences,
+    User> {
   $$UsersTableTableManager(_$Database db, $UsersTable table)
       : super(TableManagerState(
           db: db,
@@ -932,8 +960,7 @@ class $$UsersTableTableManager extends RootTableManager<
               $$UsersTableFilterComposer(ComposerState(db, table)),
           orderingComposer:
               $$UsersTableOrderingComposer(ComposerState(db, table)),
-          getChildManagerBuilder: (p) => $$UsersTableProcessedTableManager(p),
-          getUpdateCompanionBuilder: ({
+          createUpdateCompanionCallback: ({
             Value<int> id = const Value.absent(),
             Value<String> name = const Value.absent(),
             Value<DateTime?> birthday = const Value.absent(),
@@ -945,7 +972,9 @@ class $$UsersTableTableManager extends RootTableManager<
             birthday: birthday,
             nextUser: nextUser,
           ),
-          getInsertCompanionBuilder: ({
+          dataclassMapper: (p0) async =>
+              p0.map((e) => $$UsersTableWithReferences(db, e)).toList(),
+          createInsertCompanionCallback: ({
             Value<int> id = const Value.absent(),
             Value<String> name = const Value.absent(),
             Value<DateTime?> birthday = const Value.absent(),
@@ -960,17 +989,16 @@ class $$UsersTableTableManager extends RootTableManager<
         ));
 }
 
-class $$UsersTableProcessedTableManager extends ProcessedTableManager<
+typedef $$UsersTableProcessedTableManager = ProcessedTableManager<
     _$Database,
     $UsersTable,
     User,
     $$UsersTableFilterComposer,
     $$UsersTableOrderingComposer,
-    $$UsersTableProcessedTableManager,
     $$UsersTableInsertCompanionBuilder,
-    $$UsersTableUpdateCompanionBuilder> {
-  $$UsersTableProcessedTableManager(super.$state);
-}
+    $$UsersTableUpdateCompanionBuilder,
+    $$UsersTableWithReferences,
+    User>;
 
 class $$UsersTableFilterComposer
     extends FilterComposer<_$Database, $UsersTable> {
@@ -1047,6 +1075,24 @@ class $$UsersTableOrderingComposer
   }
 }
 
+class $$UsersTableWithReferences {
+  // ignore: unused_field
+  final _$Database _db;
+  final User users;
+  $$UsersTableWithReferences(this._db, this.users);
+
+  $$UsersTableProcessedTableManager? get nextUser {
+    if (users.nextUser == null) return null;
+    return $$UsersTableTableManager(_db, _db.users)
+        .filter((f) => f.id(users.nextUser!));
+  }
+
+  $GroupsProcessedTableManager get groupsRefs {
+    return $GroupsTableManager(_db, _db.groups)
+        .filter((f) => f.owner.id(users.id));
+  }
+}
+
 typedef $GroupsInsertCompanionBuilder = GroupsCompanion Function({
   Value<int> id,
   required String title,
@@ -1066,17 +1112,17 @@ class $GroupsTableManager extends RootTableManager<
     Group,
     $GroupsFilterComposer,
     $GroupsOrderingComposer,
-    $GroupsProcessedTableManager,
     $GroupsInsertCompanionBuilder,
-    $GroupsUpdateCompanionBuilder> {
+    $GroupsUpdateCompanionBuilder,
+    $GroupsWithReferences,
+    Group> {
   $GroupsTableManager(_$Database db, Groups table)
       : super(TableManagerState(
           db: db,
           table: table,
           filteringComposer: $GroupsFilterComposer(ComposerState(db, table)),
           orderingComposer: $GroupsOrderingComposer(ComposerState(db, table)),
-          getChildManagerBuilder: (p) => $GroupsProcessedTableManager(p),
-          getUpdateCompanionBuilder: ({
+          createUpdateCompanionCallback: ({
             Value<int> id = const Value.absent(),
             Value<String> title = const Value.absent(),
             Value<bool?> deleted = const Value.absent(),
@@ -1088,7 +1134,9 @@ class $GroupsTableManager extends RootTableManager<
             deleted: deleted,
             owner: owner,
           ),
-          getInsertCompanionBuilder: ({
+          dataclassMapper: (p0) async =>
+              p0.map((e) => $GroupsWithReferences(db, e)).toList(),
+          createInsertCompanionCallback: ({
             Value<int> id = const Value.absent(),
             required String title,
             Value<bool?> deleted = const Value.absent(),
@@ -1103,17 +1151,16 @@ class $GroupsTableManager extends RootTableManager<
         ));
 }
 
-class $GroupsProcessedTableManager extends ProcessedTableManager<
+typedef $GroupsProcessedTableManager = ProcessedTableManager<
     _$Database,
     Groups,
     Group,
     $GroupsFilterComposer,
     $GroupsOrderingComposer,
-    $GroupsProcessedTableManager,
     $GroupsInsertCompanionBuilder,
-    $GroupsUpdateCompanionBuilder> {
-  $GroupsProcessedTableManager(super.$state);
-}
+    $GroupsUpdateCompanionBuilder,
+    $GroupsWithReferences,
+    Group>;
 
 class $GroupsFilterComposer extends FilterComposer<_$Database, Groups> {
   $GroupsFilterComposer(super.$state);
@@ -1175,6 +1222,19 @@ class $GroupsOrderingComposer extends OrderingComposer<_$Database, Groups> {
   }
 }
 
+class $GroupsWithReferences {
+  // ignore: unused_field
+  final _$Database _db;
+  final Group groups;
+  $GroupsWithReferences(this._db, this.groups);
+
+  $$UsersTableProcessedTableManager? get owner {
+    if (groups.owner == null) return null;
+    return $$UsersTableTableManager(_db, _db.users)
+        .filter((f) => f.id(groups.owner!));
+  }
+}
+
 typedef $NotesInsertCompanionBuilder = NotesCompanion Function({
   required String title,
   required String content,
@@ -1194,17 +1254,17 @@ class $NotesTableManager extends RootTableManager<
     Note,
     $NotesFilterComposer,
     $NotesOrderingComposer,
-    $NotesProcessedTableManager,
     $NotesInsertCompanionBuilder,
-    $NotesUpdateCompanionBuilder> {
+    $NotesUpdateCompanionBuilder,
+    $NotesWithReferences,
+    Note> {
   $NotesTableManager(_$Database db, Notes table)
       : super(TableManagerState(
           db: db,
           table: table,
           filteringComposer: $NotesFilterComposer(ComposerState(db, table)),
           orderingComposer: $NotesOrderingComposer(ComposerState(db, table)),
-          getChildManagerBuilder: (p) => $NotesProcessedTableManager(p),
-          getUpdateCompanionBuilder: ({
+          createUpdateCompanionCallback: ({
             Value<String> title = const Value.absent(),
             Value<String> content = const Value.absent(),
             Value<String> searchTerms = const Value.absent(),
@@ -1216,7 +1276,9 @@ class $NotesTableManager extends RootTableManager<
             searchTerms: searchTerms,
             rowid: rowid,
           ),
-          getInsertCompanionBuilder: ({
+          dataclassMapper: (p0) async =>
+              p0.map((e) => $NotesWithReferences(db, e)).toList(),
+          createInsertCompanionCallback: ({
             required String title,
             required String content,
             required String searchTerms,
@@ -1231,17 +1293,16 @@ class $NotesTableManager extends RootTableManager<
         ));
 }
 
-class $NotesProcessedTableManager extends ProcessedTableManager<
+typedef $NotesProcessedTableManager = ProcessedTableManager<
     _$Database,
     Notes,
     Note,
     $NotesFilterComposer,
     $NotesOrderingComposer,
-    $NotesProcessedTableManager,
     $NotesInsertCompanionBuilder,
-    $NotesUpdateCompanionBuilder> {
-  $NotesProcessedTableManager(super.$state);
-}
+    $NotesUpdateCompanionBuilder,
+    $NotesWithReferences,
+    Note>;
 
 class $NotesFilterComposer extends FilterComposer<_$Database, Notes> {
   $NotesFilterComposer(super.$state);
@@ -1277,6 +1338,13 @@ class $NotesOrderingComposer extends OrderingComposer<_$Database, Notes> {
       column: $state.table.searchTerms,
       builder: (column, joinBuilders) =>
           ColumnOrderings(column, joinBuilders: joinBuilders));
+}
+
+class $NotesWithReferences {
+  // ignore: unused_field
+  final _$Database _db;
+  final Note notes;
+  $NotesWithReferences(this._db, this.notes);
 }
 
 class $DatabaseManager {

--- a/examples/modular/lib/src/posts.drift.dart
+++ b/examples/modular/lib/src/posts.drift.dart
@@ -355,8 +355,8 @@ class $PostsOrderingComposer
 class $PostsWithReferences {
   // ignore: unused_field
   final i0.GeneratedDatabase _db;
-  final i1.Post posts;
-  $PostsWithReferences(this._db, this.posts);
+  final i1.Post i1Post;
+  $PostsWithReferences(this._db, this.i1Post);
 }
 
 class Likes extends i0.Table with i0.TableInfo<Likes, i1.Like> {
@@ -699,6 +699,6 @@ class $LikesOrderingComposer
 class $LikesWithReferences {
   // ignore: unused_field
   final i0.GeneratedDatabase _db;
-  final i1.Like likes;
-  $LikesWithReferences(this._db, this.likes);
+  final i1.Like i1Like;
+  $LikesWithReferences(this._db, this.i1Like);
 }

--- a/examples/modular/lib/src/posts.drift.dart
+++ b/examples/modular/lib/src/posts.drift.dart
@@ -242,9 +242,10 @@ class $PostsTableManager extends i0.RootTableManager<
     i1.Post,
     i1.$PostsFilterComposer,
     i1.$PostsOrderingComposer,
-    $PostsProcessedTableManager,
     $PostsInsertCompanionBuilder,
-    $PostsUpdateCompanionBuilder> {
+    $PostsUpdateCompanionBuilder,
+    $PostsWithReferences,
+    i1.Post> {
   $PostsTableManager(i0.GeneratedDatabase db, i1.Posts table)
       : super(i0.TableManagerState(
           db: db,
@@ -253,8 +254,7 @@ class $PostsTableManager extends i0.RootTableManager<
               i1.$PostsFilterComposer(i0.ComposerState(db, table)),
           orderingComposer:
               i1.$PostsOrderingComposer(i0.ComposerState(db, table)),
-          getChildManagerBuilder: (p) => $PostsProcessedTableManager(p),
-          getUpdateCompanionBuilder: ({
+          createUpdateCompanionCallback: ({
             i0.Value<int> id = const i0.Value.absent(),
             i0.Value<int> author = const i0.Value.absent(),
             i0.Value<String?> content = const i0.Value.absent(),
@@ -264,7 +264,9 @@ class $PostsTableManager extends i0.RootTableManager<
             author: author,
             content: content,
           ),
-          getInsertCompanionBuilder: ({
+          dataclassMapper: (p0) async =>
+              p0.map((e) => $PostsWithReferences(db, e)).toList(),
+          createInsertCompanionCallback: ({
             i0.Value<int> id = const i0.Value.absent(),
             required int author,
             i0.Value<String?> content = const i0.Value.absent(),
@@ -277,17 +279,16 @@ class $PostsTableManager extends i0.RootTableManager<
         ));
 }
 
-class $PostsProcessedTableManager extends i0.ProcessedTableManager<
+typedef $PostsProcessedTableManager = i0.ProcessedTableManager<
     i0.GeneratedDatabase,
     i1.Posts,
     i1.Post,
     i1.$PostsFilterComposer,
     i1.$PostsOrderingComposer,
-    $PostsProcessedTableManager,
     $PostsInsertCompanionBuilder,
-    $PostsUpdateCompanionBuilder> {
-  $PostsProcessedTableManager(super.$state);
-}
+    $PostsUpdateCompanionBuilder,
+    $PostsWithReferences,
+    i1.Post>;
 
 class $PostsFilterComposer
     extends i0.FilterComposer<i0.GeneratedDatabase, i1.Posts> {
@@ -349,6 +350,13 @@ class $PostsOrderingComposer
                 parentComposers)));
     return composer;
   }
+}
+
+class $PostsWithReferences {
+  // ignore: unused_field
+  final i0.GeneratedDatabase _db;
+  final i1.Post posts;
+  $PostsWithReferences(this._db, this.posts);
 }
 
 class Likes extends i0.Table with i0.TableInfo<Likes, i1.Like> {
@@ -564,9 +572,10 @@ class $LikesTableManager extends i0.RootTableManager<
     i1.Like,
     i1.$LikesFilterComposer,
     i1.$LikesOrderingComposer,
-    $LikesProcessedTableManager,
     $LikesInsertCompanionBuilder,
-    $LikesUpdateCompanionBuilder> {
+    $LikesUpdateCompanionBuilder,
+    $LikesWithReferences,
+    i1.Like> {
   $LikesTableManager(i0.GeneratedDatabase db, i1.Likes table)
       : super(i0.TableManagerState(
           db: db,
@@ -575,8 +584,7 @@ class $LikesTableManager extends i0.RootTableManager<
               i1.$LikesFilterComposer(i0.ComposerState(db, table)),
           orderingComposer:
               i1.$LikesOrderingComposer(i0.ComposerState(db, table)),
-          getChildManagerBuilder: (p) => $LikesProcessedTableManager(p),
-          getUpdateCompanionBuilder: ({
+          createUpdateCompanionCallback: ({
             i0.Value<int> post = const i0.Value.absent(),
             i0.Value<int> likedBy = const i0.Value.absent(),
             i0.Value<int> rowid = const i0.Value.absent(),
@@ -586,7 +594,9 @@ class $LikesTableManager extends i0.RootTableManager<
             likedBy: likedBy,
             rowid: rowid,
           ),
-          getInsertCompanionBuilder: ({
+          dataclassMapper: (p0) async =>
+              p0.map((e) => $LikesWithReferences(db, e)).toList(),
+          createInsertCompanionCallback: ({
             required int post,
             required int likedBy,
             i0.Value<int> rowid = const i0.Value.absent(),
@@ -599,17 +609,16 @@ class $LikesTableManager extends i0.RootTableManager<
         ));
 }
 
-class $LikesProcessedTableManager extends i0.ProcessedTableManager<
+typedef $LikesProcessedTableManager = i0.ProcessedTableManager<
     i0.GeneratedDatabase,
     i1.Likes,
     i1.Like,
     i1.$LikesFilterComposer,
     i1.$LikesOrderingComposer,
-    $LikesProcessedTableManager,
     $LikesInsertCompanionBuilder,
-    $LikesUpdateCompanionBuilder> {
-  $LikesProcessedTableManager(super.$state);
-}
+    $LikesUpdateCompanionBuilder,
+    $LikesWithReferences,
+    i1.Like>;
 
 class $LikesFilterComposer
     extends i0.FilterComposer<i0.GeneratedDatabase, i1.Likes> {
@@ -685,4 +694,11 @@ class $LikesOrderingComposer
                 parentComposers)));
     return composer;
   }
+}
+
+class $LikesWithReferences {
+  // ignore: unused_field
+  final i0.GeneratedDatabase _db;
+  final i1.Like likes;
+  $LikesWithReferences(this._db, this.likes);
 }

--- a/examples/modular/lib/src/search.drift.dart
+++ b/examples/modular/lib/src/search.drift.dart
@@ -309,8 +309,8 @@ class $SearchInPostsOrderingComposer
 class $SearchInPostsWithReferences {
   // ignore: unused_field
   final i0.GeneratedDatabase _db;
-  final i1.SearchInPost searchInPosts;
-  $SearchInPostsWithReferences(this._db, this.searchInPosts);
+  final i1.SearchInPost i1SearchInPost;
+  $SearchInPostsWithReferences(this._db, this.i1SearchInPost);
 }
 
 i0.Trigger get postsInsert => i0.Trigger(

--- a/examples/modular/lib/src/search.drift.dart
+++ b/examples/modular/lib/src/search.drift.dart
@@ -230,9 +230,10 @@ class $SearchInPostsTableManager extends i0.RootTableManager<
     i1.SearchInPost,
     i1.$SearchInPostsFilterComposer,
     i1.$SearchInPostsOrderingComposer,
-    $SearchInPostsProcessedTableManager,
     $SearchInPostsInsertCompanionBuilder,
-    $SearchInPostsUpdateCompanionBuilder> {
+    $SearchInPostsUpdateCompanionBuilder,
+    $SearchInPostsWithReferences,
+    i1.SearchInPost> {
   $SearchInPostsTableManager(i0.GeneratedDatabase db, i1.SearchInPosts table)
       : super(i0.TableManagerState(
           db: db,
@@ -241,8 +242,7 @@ class $SearchInPostsTableManager extends i0.RootTableManager<
               i1.$SearchInPostsFilterComposer(i0.ComposerState(db, table)),
           orderingComposer:
               i1.$SearchInPostsOrderingComposer(i0.ComposerState(db, table)),
-          getChildManagerBuilder: (p) => $SearchInPostsProcessedTableManager(p),
-          getUpdateCompanionBuilder: ({
+          createUpdateCompanionCallback: ({
             i0.Value<String> author = const i0.Value.absent(),
             i0.Value<String> content = const i0.Value.absent(),
             i0.Value<int> rowid = const i0.Value.absent(),
@@ -252,7 +252,9 @@ class $SearchInPostsTableManager extends i0.RootTableManager<
             content: content,
             rowid: rowid,
           ),
-          getInsertCompanionBuilder: ({
+          dataclassMapper: (p0) async =>
+              p0.map((e) => $SearchInPostsWithReferences(db, e)).toList(),
+          createInsertCompanionCallback: ({
             required String author,
             required String content,
             i0.Value<int> rowid = const i0.Value.absent(),
@@ -265,17 +267,16 @@ class $SearchInPostsTableManager extends i0.RootTableManager<
         ));
 }
 
-class $SearchInPostsProcessedTableManager extends i0.ProcessedTableManager<
+typedef $SearchInPostsProcessedTableManager = i0.ProcessedTableManager<
     i0.GeneratedDatabase,
     i1.SearchInPosts,
     i1.SearchInPost,
     i1.$SearchInPostsFilterComposer,
     i1.$SearchInPostsOrderingComposer,
-    $SearchInPostsProcessedTableManager,
     $SearchInPostsInsertCompanionBuilder,
-    $SearchInPostsUpdateCompanionBuilder> {
-  $SearchInPostsProcessedTableManager(super.$state);
-}
+    $SearchInPostsUpdateCompanionBuilder,
+    $SearchInPostsWithReferences,
+    i1.SearchInPost>;
 
 class $SearchInPostsFilterComposer
     extends i0.FilterComposer<i0.GeneratedDatabase, i1.SearchInPosts> {
@@ -303,6 +304,13 @@ class $SearchInPostsOrderingComposer
       column: $state.table.content,
       builder: (column, joinBuilders) =>
           i0.ColumnOrderings(column, joinBuilders: joinBuilders));
+}
+
+class $SearchInPostsWithReferences {
+  // ignore: unused_field
+  final i0.GeneratedDatabase _db;
+  final i1.SearchInPost searchInPosts;
+  $SearchInPostsWithReferences(this._db, this.searchInPosts);
 }
 
 i0.Trigger get postsInsert => i0.Trigger(

--- a/examples/modular/lib/src/users.drift.dart
+++ b/examples/modular/lib/src/users.drift.dart
@@ -468,8 +468,8 @@ class $UsersOrderingComposer
 class $UsersWithReferences {
   // ignore: unused_field
   final i0.GeneratedDatabase _db;
-  final i1.User users;
-  $UsersWithReferences(this._db, this.users);
+  final i1.User i1User;
+  $UsersWithReferences(this._db, this.i1User);
 }
 
 i0.Index get usersName =>
@@ -820,8 +820,8 @@ class $FollowsOrderingComposer
 class $FollowsWithReferences {
   // ignore: unused_field
   final i0.GeneratedDatabase _db;
-  final i1.Follow follows;
-  $FollowsWithReferences(this._db, this.follows);
+  final i1.Follow i1Follow;
+  $FollowsWithReferences(this._db, this.i1Follow);
 }
 
 class PopularUser extends i0.DataClass {

--- a/examples/modular/lib/src/users.drift.dart
+++ b/examples/modular/lib/src/users.drift.dart
@@ -348,9 +348,10 @@ class $UsersTableManager extends i0.RootTableManager<
     i1.User,
     i1.$UsersFilterComposer,
     i1.$UsersOrderingComposer,
-    $UsersProcessedTableManager,
     $UsersInsertCompanionBuilder,
-    $UsersUpdateCompanionBuilder> {
+    $UsersUpdateCompanionBuilder,
+    $UsersWithReferences,
+    i1.User> {
   $UsersTableManager(i0.GeneratedDatabase db, i1.Users table)
       : super(i0.TableManagerState(
           db: db,
@@ -359,8 +360,7 @@ class $UsersTableManager extends i0.RootTableManager<
               i1.$UsersFilterComposer(i0.ComposerState(db, table)),
           orderingComposer:
               i1.$UsersOrderingComposer(i0.ComposerState(db, table)),
-          getChildManagerBuilder: (p) => $UsersProcessedTableManager(p),
-          getUpdateCompanionBuilder: ({
+          createUpdateCompanionCallback: ({
             i0.Value<int> id = const i0.Value.absent(),
             i0.Value<String> name = const i0.Value.absent(),
             i0.Value<String?> biography = const i0.Value.absent(),
@@ -374,7 +374,9 @@ class $UsersTableManager extends i0.RootTableManager<
             preferences: preferences,
             profilePicture: profilePicture,
           ),
-          getInsertCompanionBuilder: ({
+          dataclassMapper: (p0) async =>
+              p0.map((e) => $UsersWithReferences(db, e)).toList(),
+          createInsertCompanionCallback: ({
             i0.Value<int> id = const i0.Value.absent(),
             required String name,
             i0.Value<String?> biography = const i0.Value.absent(),
@@ -391,17 +393,16 @@ class $UsersTableManager extends i0.RootTableManager<
         ));
 }
 
-class $UsersProcessedTableManager extends i0.ProcessedTableManager<
+typedef $UsersProcessedTableManager = i0.ProcessedTableManager<
     i0.GeneratedDatabase,
     i1.Users,
     i1.User,
     i1.$UsersFilterComposer,
     i1.$UsersOrderingComposer,
-    $UsersProcessedTableManager,
     $UsersInsertCompanionBuilder,
-    $UsersUpdateCompanionBuilder> {
-  $UsersProcessedTableManager(super.$state);
-}
+    $UsersUpdateCompanionBuilder,
+    $UsersWithReferences,
+    i1.User>;
 
 class $UsersFilterComposer
     extends i0.FilterComposer<i0.GeneratedDatabase, i1.Users> {
@@ -462,6 +463,13 @@ class $UsersOrderingComposer
           column: $state.table.profilePicture,
           builder: (column, joinBuilders) =>
               i0.ColumnOrderings(column, joinBuilders: joinBuilders));
+}
+
+class $UsersWithReferences {
+  // ignore: unused_field
+  final i0.GeneratedDatabase _db;
+  final i1.User users;
+  $UsersWithReferences(this._db, this.users);
 }
 
 i0.Index get usersName =>
@@ -685,9 +693,10 @@ class $FollowsTableManager extends i0.RootTableManager<
     i1.Follow,
     i1.$FollowsFilterComposer,
     i1.$FollowsOrderingComposer,
-    $FollowsProcessedTableManager,
     $FollowsInsertCompanionBuilder,
-    $FollowsUpdateCompanionBuilder> {
+    $FollowsUpdateCompanionBuilder,
+    $FollowsWithReferences,
+    i1.Follow> {
   $FollowsTableManager(i0.GeneratedDatabase db, i1.Follows table)
       : super(i0.TableManagerState(
           db: db,
@@ -696,8 +705,7 @@ class $FollowsTableManager extends i0.RootTableManager<
               i1.$FollowsFilterComposer(i0.ComposerState(db, table)),
           orderingComposer:
               i1.$FollowsOrderingComposer(i0.ComposerState(db, table)),
-          getChildManagerBuilder: (p) => $FollowsProcessedTableManager(p),
-          getUpdateCompanionBuilder: ({
+          createUpdateCompanionCallback: ({
             i0.Value<int> followed = const i0.Value.absent(),
             i0.Value<int> follower = const i0.Value.absent(),
             i0.Value<int> rowid = const i0.Value.absent(),
@@ -707,7 +715,9 @@ class $FollowsTableManager extends i0.RootTableManager<
             follower: follower,
             rowid: rowid,
           ),
-          getInsertCompanionBuilder: ({
+          dataclassMapper: (p0) async =>
+              p0.map((e) => $FollowsWithReferences(db, e)).toList(),
+          createInsertCompanionCallback: ({
             required int followed,
             required int follower,
             i0.Value<int> rowid = const i0.Value.absent(),
@@ -720,17 +730,16 @@ class $FollowsTableManager extends i0.RootTableManager<
         ));
 }
 
-class $FollowsProcessedTableManager extends i0.ProcessedTableManager<
+typedef $FollowsProcessedTableManager = i0.ProcessedTableManager<
     i0.GeneratedDatabase,
     i1.Follows,
     i1.Follow,
     i1.$FollowsFilterComposer,
     i1.$FollowsOrderingComposer,
-    $FollowsProcessedTableManager,
     $FollowsInsertCompanionBuilder,
-    $FollowsUpdateCompanionBuilder> {
-  $FollowsProcessedTableManager(super.$state);
-}
+    $FollowsUpdateCompanionBuilder,
+    $FollowsWithReferences,
+    i1.Follow>;
 
 class $FollowsFilterComposer
     extends i0.FilterComposer<i0.GeneratedDatabase, i1.Follows> {
@@ -806,6 +815,13 @@ class $FollowsOrderingComposer
                 parentComposers)));
     return composer;
   }
+}
+
+class $FollowsWithReferences {
+  // ignore: unused_field
+  final i0.GeneratedDatabase _db;
+  final i1.Follow follows;
+  $FollowsWithReferences(this._db, this.follows);
 }
 
 class PopularUser extends i0.DataClass {

--- a/examples/multi_package/server/lib/database.drift.dart
+++ b/examples/multi_package/server/lib/database.drift.dart
@@ -149,6 +149,14 @@ class ActiveSession extends i0.DataClass
         user: user ?? this.user,
         bearerToken: bearerToken ?? this.bearerToken,
       );
+  ActiveSession copyWithCompanion(i3.ActiveSessionsCompanion data) {
+    return ActiveSession(
+      user: data.user.present ? data.user.value : this.user,
+      bearerToken:
+          data.bearerToken.present ? data.bearerToken.value : this.bearerToken,
+    );
+  }
+
   @override
   String toString() {
     return (StringBuffer('ActiveSession(')
@@ -251,9 +259,10 @@ class $$ActiveSessionsTableTableManager extends i0.RootTableManager<
     i3.ActiveSession,
     i3.$$ActiveSessionsTableFilterComposer,
     i3.$$ActiveSessionsTableOrderingComposer,
-    $$ActiveSessionsTableProcessedTableManager,
     $$ActiveSessionsTableInsertCompanionBuilder,
-    $$ActiveSessionsTableUpdateCompanionBuilder> {
+    $$ActiveSessionsTableUpdateCompanionBuilder,
+    $$ActiveSessionsTableWithReferences,
+    i3.ActiveSession> {
   $$ActiveSessionsTableTableManager(
       i0.GeneratedDatabase db, i3.$ActiveSessionsTable table)
       : super(i0.TableManagerState(
@@ -263,9 +272,7 @@ class $$ActiveSessionsTableTableManager extends i0.RootTableManager<
               .$$ActiveSessionsTableFilterComposer(i0.ComposerState(db, table)),
           orderingComposer: i3.$$ActiveSessionsTableOrderingComposer(
               i0.ComposerState(db, table)),
-          getChildManagerBuilder: (p) =>
-              $$ActiveSessionsTableProcessedTableManager(p),
-          getUpdateCompanionBuilder: ({
+          createUpdateCompanionCallback: ({
             i0.Value<int> user = const i0.Value.absent(),
             i0.Value<String> bearerToken = const i0.Value.absent(),
             i0.Value<int> rowid = const i0.Value.absent(),
@@ -275,7 +282,10 @@ class $$ActiveSessionsTableTableManager extends i0.RootTableManager<
             bearerToken: bearerToken,
             rowid: rowid,
           ),
-          getInsertCompanionBuilder: ({
+          dataclassMapper: (p0) async => p0
+              .map((e) => $$ActiveSessionsTableWithReferences(db, e))
+              .toList(),
+          createInsertCompanionCallback: ({
             required int user,
             required String bearerToken,
             i0.Value<int> rowid = const i0.Value.absent(),
@@ -288,18 +298,16 @@ class $$ActiveSessionsTableTableManager extends i0.RootTableManager<
         ));
 }
 
-class $$ActiveSessionsTableProcessedTableManager
-    extends i0.ProcessedTableManager<
-        i0.GeneratedDatabase,
-        i3.$ActiveSessionsTable,
-        i3.ActiveSession,
-        i3.$$ActiveSessionsTableFilterComposer,
-        i3.$$ActiveSessionsTableOrderingComposer,
-        $$ActiveSessionsTableProcessedTableManager,
-        $$ActiveSessionsTableInsertCompanionBuilder,
-        $$ActiveSessionsTableUpdateCompanionBuilder> {
-  $$ActiveSessionsTableProcessedTableManager(super.$state);
-}
+typedef $$ActiveSessionsTableProcessedTableManager = i0.ProcessedTableManager<
+    i0.GeneratedDatabase,
+    i3.$ActiveSessionsTable,
+    i3.ActiveSession,
+    i3.$$ActiveSessionsTableFilterComposer,
+    i3.$$ActiveSessionsTableOrderingComposer,
+    $$ActiveSessionsTableInsertCompanionBuilder,
+    $$ActiveSessionsTableUpdateCompanionBuilder,
+    $$ActiveSessionsTableWithReferences,
+    i3.ActiveSession>;
 
 class $$ActiveSessionsTableFilterComposer
     extends i0.FilterComposer<i0.GeneratedDatabase, i3.$ActiveSessionsTable> {
@@ -351,4 +359,11 @@ class $$ActiveSessionsTableOrderingComposer
                 parentComposers)));
     return composer;
   }
+}
+
+class $$ActiveSessionsTableWithReferences {
+  // ignore: unused_field
+  final i0.GeneratedDatabase _db;
+  final i3.ActiveSession activeSessions;
+  $$ActiveSessionsTableWithReferences(this._db, this.activeSessions);
 }

--- a/examples/multi_package/server/lib/database.drift.dart
+++ b/examples/multi_package/server/lib/database.drift.dart
@@ -364,6 +364,6 @@ class $$ActiveSessionsTableOrderingComposer
 class $$ActiveSessionsTableWithReferences {
   // ignore: unused_field
   final i0.GeneratedDatabase _db;
-  final i3.ActiveSession activeSessions;
-  $$ActiveSessionsTableWithReferences(this._db, this.activeSessions);
+  final i3.ActiveSession i3ActiveSession;
+  $$ActiveSessionsTableWithReferences(this._db, this.i3ActiveSession);
 }

--- a/examples/multi_package/shared/lib/src/posts.drift.dart
+++ b/examples/multi_package/shared/lib/src/posts.drift.dart
@@ -116,6 +116,13 @@ class Post extends i0.DataClass implements i0.Insertable<i1.Post> {
         author: author ?? this.author,
         content: content.present ? content.value : this.content,
       );
+  Post copyWithCompanion(i1.PostsCompanion data) {
+    return Post(
+      author: data.author.present ? data.author.value : this.author,
+      content: data.content.present ? data.content.value : this.content,
+    );
+  }
+
   @override
   String toString() {
     return (StringBuffer('Post(')
@@ -215,9 +222,10 @@ class $PostsTableManager extends i0.RootTableManager<
     i1.Post,
     i1.$PostsFilterComposer,
     i1.$PostsOrderingComposer,
-    $PostsProcessedTableManager,
     $PostsInsertCompanionBuilder,
-    $PostsUpdateCompanionBuilder> {
+    $PostsUpdateCompanionBuilder,
+    $PostsWithReferences,
+    i1.Post> {
   $PostsTableManager(i0.GeneratedDatabase db, i1.Posts table)
       : super(i0.TableManagerState(
           db: db,
@@ -226,8 +234,7 @@ class $PostsTableManager extends i0.RootTableManager<
               i1.$PostsFilterComposer(i0.ComposerState(db, table)),
           orderingComposer:
               i1.$PostsOrderingComposer(i0.ComposerState(db, table)),
-          getChildManagerBuilder: (p) => $PostsProcessedTableManager(p),
-          getUpdateCompanionBuilder: ({
+          createUpdateCompanionCallback: ({
             i0.Value<int> author = const i0.Value.absent(),
             i0.Value<String?> content = const i0.Value.absent(),
             i0.Value<int> rowid = const i0.Value.absent(),
@@ -237,7 +244,9 @@ class $PostsTableManager extends i0.RootTableManager<
             content: content,
             rowid: rowid,
           ),
-          getInsertCompanionBuilder: ({
+          dataclassMapper: (p0) async =>
+              p0.map((e) => $PostsWithReferences(db, e)).toList(),
+          createInsertCompanionCallback: ({
             required int author,
             i0.Value<String?> content = const i0.Value.absent(),
             i0.Value<int> rowid = const i0.Value.absent(),
@@ -250,17 +259,16 @@ class $PostsTableManager extends i0.RootTableManager<
         ));
 }
 
-class $PostsProcessedTableManager extends i0.ProcessedTableManager<
+typedef $PostsProcessedTableManager = i0.ProcessedTableManager<
     i0.GeneratedDatabase,
     i1.Posts,
     i1.Post,
     i1.$PostsFilterComposer,
     i1.$PostsOrderingComposer,
-    $PostsProcessedTableManager,
     $PostsInsertCompanionBuilder,
-    $PostsUpdateCompanionBuilder> {
-  $PostsProcessedTableManager(super.$state);
-}
+    $PostsUpdateCompanionBuilder,
+    $PostsWithReferences,
+    i1.Post>;
 
 class $PostsFilterComposer
     extends i0.FilterComposer<i0.GeneratedDatabase, i1.Posts> {
@@ -312,4 +320,11 @@ class $PostsOrderingComposer
                 parentComposers)));
     return composer;
   }
+}
+
+class $PostsWithReferences {
+  // ignore: unused_field
+  final i0.GeneratedDatabase _db;
+  final i1.Post posts;
+  $PostsWithReferences(this._db, this.posts);
 }

--- a/examples/multi_package/shared/lib/src/posts.drift.dart
+++ b/examples/multi_package/shared/lib/src/posts.drift.dart
@@ -325,6 +325,6 @@ class $PostsOrderingComposer
 class $PostsWithReferences {
   // ignore: unused_field
   final i0.GeneratedDatabase _db;
-  final i1.Post posts;
-  $PostsWithReferences(this._db, this.posts);
+  final i1.Post i1Post;
+  $PostsWithReferences(this._db, this.i1Post);
 }

--- a/examples/multi_package/shared/lib/src/users.drift.dart
+++ b/examples/multi_package/shared/lib/src/users.drift.dart
@@ -106,6 +106,13 @@ class User extends i0.DataClass implements i0.Insertable<i1.User> {
         id: id ?? this.id,
         name: name ?? this.name,
       );
+  User copyWithCompanion(i1.UsersCompanion data) {
+    return User(
+      id: data.id.present ? data.id.value : this.id,
+      name: data.name.present ? data.name.value : this.name,
+    );
+  }
+
   @override
   String toString() {
     return (StringBuffer('User(')
@@ -188,9 +195,10 @@ class $$UsersTableTableManager extends i0.RootTableManager<
     i1.User,
     i1.$$UsersTableFilterComposer,
     i1.$$UsersTableOrderingComposer,
-    $$UsersTableProcessedTableManager,
     $$UsersTableInsertCompanionBuilder,
-    $$UsersTableUpdateCompanionBuilder> {
+    $$UsersTableUpdateCompanionBuilder,
+    $$UsersTableWithReferences,
+    i1.User> {
   $$UsersTableTableManager(i0.GeneratedDatabase db, i1.$UsersTable table)
       : super(i0.TableManagerState(
           db: db,
@@ -199,8 +207,7 @@ class $$UsersTableTableManager extends i0.RootTableManager<
               i1.$$UsersTableFilterComposer(i0.ComposerState(db, table)),
           orderingComposer:
               i1.$$UsersTableOrderingComposer(i0.ComposerState(db, table)),
-          getChildManagerBuilder: (p) => $$UsersTableProcessedTableManager(p),
-          getUpdateCompanionBuilder: ({
+          createUpdateCompanionCallback: ({
             i0.Value<int> id = const i0.Value.absent(),
             i0.Value<String> name = const i0.Value.absent(),
           }) =>
@@ -208,7 +215,9 @@ class $$UsersTableTableManager extends i0.RootTableManager<
             id: id,
             name: name,
           ),
-          getInsertCompanionBuilder: ({
+          dataclassMapper: (p0) async =>
+              p0.map((e) => $$UsersTableWithReferences(db, e)).toList(),
+          createInsertCompanionCallback: ({
             i0.Value<int> id = const i0.Value.absent(),
             required String name,
           }) =>
@@ -219,17 +228,16 @@ class $$UsersTableTableManager extends i0.RootTableManager<
         ));
 }
 
-class $$UsersTableProcessedTableManager extends i0.ProcessedTableManager<
+typedef $$UsersTableProcessedTableManager = i0.ProcessedTableManager<
     i0.GeneratedDatabase,
     i1.$UsersTable,
     i1.User,
     i1.$$UsersTableFilterComposer,
     i1.$$UsersTableOrderingComposer,
-    $$UsersTableProcessedTableManager,
     $$UsersTableInsertCompanionBuilder,
-    $$UsersTableUpdateCompanionBuilder> {
-  $$UsersTableProcessedTableManager(super.$state);
-}
+    $$UsersTableUpdateCompanionBuilder,
+    $$UsersTableWithReferences,
+    i1.User>;
 
 class $$UsersTableFilterComposer
     extends i0.FilterComposer<i0.GeneratedDatabase, i1.$UsersTable> {
@@ -257,4 +265,11 @@ class $$UsersTableOrderingComposer
       column: $state.table.name,
       builder: (column, joinBuilders) =>
           i0.ColumnOrderings(column, joinBuilders: joinBuilders));
+}
+
+class $$UsersTableWithReferences {
+  // ignore: unused_field
+  final i0.GeneratedDatabase _db;
+  final i1.User users;
+  $$UsersTableWithReferences(this._db, this.users);
 }

--- a/examples/multi_package/shared/lib/src/users.drift.dart
+++ b/examples/multi_package/shared/lib/src/users.drift.dart
@@ -270,6 +270,6 @@ class $$UsersTableOrderingComposer
 class $$UsersTableWithReferences {
   // ignore: unused_field
   final i0.GeneratedDatabase _db;
-  final i1.User users;
-  $$UsersTableWithReferences(this._db, this.users);
+  final i1.User i1User;
+  $$UsersTableWithReferences(this._db, this.i1User);
 }

--- a/examples/web_worker_example/lib/database.g.dart
+++ b/examples/web_worker_example/lib/database.g.dart
@@ -106,6 +106,13 @@ class Entry extends DataClass implements Insertable<Entry> {
         id: id ?? this.id,
         value: value ?? this.value,
       );
+  Entry copyWithCompanion(EntriesCompanion data) {
+    return Entry(
+      id: data.id.present ? data.id.value : this.id,
+      value: data.value.present ? data.value.value : this.value,
+    );
+  }
+
   @override
   String toString() {
     return (StringBuffer('Entry(')

--- a/examples/with_built_value/lib/tables.drift.dart
+++ b/examples/with_built_value/lib/tables.drift.dart
@@ -271,6 +271,6 @@ class $UsersOrderingComposer
 class $UsersWithReferences {
   // ignore: unused_field
   final i0.GeneratedDatabase _db;
-  final i1.User users;
-  $UsersWithReferences(this._db, this.users);
+  final i1.User i1User;
+  $UsersWithReferences(this._db, this.i1User);
 }

--- a/examples/with_built_value/lib/tables.drift.dart
+++ b/examples/with_built_value/lib/tables.drift.dart
@@ -107,6 +107,13 @@ class User extends i0.DataClass implements i0.Insertable<i1.User> {
         id: id ?? this.id,
         name: name ?? this.name,
       );
+  User copyWithCompanion(i1.UsersCompanion data) {
+    return User(
+      id: data.id.present ? data.id.value : this.id,
+      name: data.name.present ? data.name.value : this.name,
+    );
+  }
+
   @override
   String toString() {
     return (StringBuffer('User(')
@@ -189,9 +196,10 @@ class $UsersTableManager extends i0.RootTableManager<
     i1.User,
     i1.$UsersFilterComposer,
     i1.$UsersOrderingComposer,
-    $UsersProcessedTableManager,
     $UsersInsertCompanionBuilder,
-    $UsersUpdateCompanionBuilder> {
+    $UsersUpdateCompanionBuilder,
+    $UsersWithReferences,
+    i1.User> {
   $UsersTableManager(i0.GeneratedDatabase db, i1.Users table)
       : super(i0.TableManagerState(
           db: db,
@@ -200,8 +208,7 @@ class $UsersTableManager extends i0.RootTableManager<
               i1.$UsersFilterComposer(i0.ComposerState(db, table)),
           orderingComposer:
               i1.$UsersOrderingComposer(i0.ComposerState(db, table)),
-          getChildManagerBuilder: (p) => $UsersProcessedTableManager(p),
-          getUpdateCompanionBuilder: ({
+          createUpdateCompanionCallback: ({
             i0.Value<int> id = const i0.Value.absent(),
             i0.Value<String> name = const i0.Value.absent(),
           }) =>
@@ -209,7 +216,9 @@ class $UsersTableManager extends i0.RootTableManager<
             id: id,
             name: name,
           ),
-          getInsertCompanionBuilder: ({
+          dataclassMapper: (p0) async =>
+              p0.map((e) => $UsersWithReferences(db, e)).toList(),
+          createInsertCompanionCallback: ({
             i0.Value<int> id = const i0.Value.absent(),
             required String name,
           }) =>
@@ -220,17 +229,16 @@ class $UsersTableManager extends i0.RootTableManager<
         ));
 }
 
-class $UsersProcessedTableManager extends i0.ProcessedTableManager<
+typedef $UsersProcessedTableManager = i0.ProcessedTableManager<
     i0.GeneratedDatabase,
     i1.Users,
     i1.User,
     i1.$UsersFilterComposer,
     i1.$UsersOrderingComposer,
-    $UsersProcessedTableManager,
     $UsersInsertCompanionBuilder,
-    $UsersUpdateCompanionBuilder> {
-  $UsersProcessedTableManager(super.$state);
-}
+    $UsersUpdateCompanionBuilder,
+    $UsersWithReferences,
+    i1.User>;
 
 class $UsersFilterComposer
     extends i0.FilterComposer<i0.GeneratedDatabase, i1.Users> {
@@ -258,4 +266,11 @@ class $UsersOrderingComposer
       column: $state.table.name,
       builder: (column, joinBuilders) =>
           i0.ColumnOrderings(column, joinBuilders: joinBuilders));
+}
+
+class $UsersWithReferences {
+  // ignore: unused_field
+  final i0.GeneratedDatabase _db;
+  final i1.User users;
+  $UsersWithReferences(this._db, this.users);
 }

--- a/extras/benchmarks/lib/src/moor/database.g.dart
+++ b/extras/benchmarks/lib/src/moor/database.g.dart
@@ -105,6 +105,13 @@ class KeyValue extends DataClass implements Insertable<KeyValue> {
         key: key ?? this.key,
         value: value ?? this.value,
       );
+  KeyValue copyWithCompanion(KeyValuesCompanion data) {
+    return KeyValue(
+      key: data.key.present ? data.key.value : this.key,
+      value: data.value.present ? data.value.value : this.value,
+    );
+  }
+
   @override
   String toString() {
     return (StringBuffer('KeyValue(')

--- a/extras/drift_postgres/example/main.g.dart
+++ b/extras/drift_postgres/example/main.g.dart
@@ -296,8 +296,8 @@ class $$UsersTableOrderingComposer
 class $$UsersTableWithReferences {
   // ignore: unused_field
   final _$DriftPostgresDatabase _db;
-  final User users;
-  $$UsersTableWithReferences(this._db, this.users);
+  final User user;
+  $$UsersTableWithReferences(this._db, this.user);
 }
 
 class $DriftPostgresDatabaseManager {

--- a/extras/drift_postgres/example/main.g.dart
+++ b/extras/drift_postgres/example/main.g.dart
@@ -103,6 +103,13 @@ class User extends DataClass implements Insertable<User> {
         id: id ?? this.id,
         name: name ?? this.name,
       );
+  User copyWithCompanion(UsersCompanion data) {
+    return User(
+      id: data.id.present ? data.id.value : this.id,
+      name: data.name.present ? data.name.value : this.name,
+    );
+  }
+
   @override
   String toString() {
     return (StringBuffer('User(')
@@ -210,9 +217,10 @@ class $$UsersTableTableManager extends RootTableManager<
     User,
     $$UsersTableFilterComposer,
     $$UsersTableOrderingComposer,
-    $$UsersTableProcessedTableManager,
     $$UsersTableInsertCompanionBuilder,
-    $$UsersTableUpdateCompanionBuilder> {
+    $$UsersTableUpdateCompanionBuilder,
+    $$UsersTableWithReferences,
+    User> {
   $$UsersTableTableManager(_$DriftPostgresDatabase db, $UsersTable table)
       : super(TableManagerState(
           db: db,
@@ -221,8 +229,7 @@ class $$UsersTableTableManager extends RootTableManager<
               $$UsersTableFilterComposer(ComposerState(db, table)),
           orderingComposer:
               $$UsersTableOrderingComposer(ComposerState(db, table)),
-          getChildManagerBuilder: (p) => $$UsersTableProcessedTableManager(p),
-          getUpdateCompanionBuilder: ({
+          createUpdateCompanionCallback: ({
             Value<UuidValue> id = const Value.absent(),
             Value<String> name = const Value.absent(),
             Value<int> rowid = const Value.absent(),
@@ -232,7 +239,9 @@ class $$UsersTableTableManager extends RootTableManager<
             name: name,
             rowid: rowid,
           ),
-          getInsertCompanionBuilder: ({
+          dataclassMapper: (p0) async =>
+              p0.map((e) => $$UsersTableWithReferences(db, e)).toList(),
+          createInsertCompanionCallback: ({
             Value<UuidValue> id = const Value.absent(),
             required String name,
             Value<int> rowid = const Value.absent(),
@@ -245,17 +254,16 @@ class $$UsersTableTableManager extends RootTableManager<
         ));
 }
 
-class $$UsersTableProcessedTableManager extends ProcessedTableManager<
+typedef $$UsersTableProcessedTableManager = ProcessedTableManager<
     _$DriftPostgresDatabase,
     $UsersTable,
     User,
     $$UsersTableFilterComposer,
     $$UsersTableOrderingComposer,
-    $$UsersTableProcessedTableManager,
     $$UsersTableInsertCompanionBuilder,
-    $$UsersTableUpdateCompanionBuilder> {
-  $$UsersTableProcessedTableManager(super.$state);
-}
+    $$UsersTableUpdateCompanionBuilder,
+    $$UsersTableWithReferences,
+    User>;
 
 class $$UsersTableFilterComposer
     extends FilterComposer<_$DriftPostgresDatabase, $UsersTable> {
@@ -283,6 +291,13 @@ class $$UsersTableOrderingComposer
       column: $state.table.name,
       builder: (column, joinBuilders) =>
           ColumnOrderings(column, joinBuilders: joinBuilders));
+}
+
+class $$UsersTableWithReferences {
+  // ignore: unused_field
+  final _$DriftPostgresDatabase _db;
+  final User users;
+  $$UsersTableWithReferences(this._db, this.users);
 }
 
 class $DriftPostgresDatabaseManager {

--- a/extras/integration_tests/drift_testcases/lib/database/database.g.dart
+++ b/extras/integration_tests/drift_testcases/lib/database/database.g.dart
@@ -858,8 +858,8 @@ class $$UsersTableOrderingComposer
 class $$UsersTableWithReferences {
   // ignore: unused_field
   final _$Database _db;
-  final User users;
-  $$UsersTableWithReferences(this._db, this.users);
+  final User user;
+  $$UsersTableWithReferences(this._db, this.user);
 }
 
 typedef $$FriendshipsTableInsertCompanionBuilder = FriendshipsCompanion
@@ -976,8 +976,8 @@ class $$FriendshipsTableOrderingComposer
 class $$FriendshipsTableWithReferences {
   // ignore: unused_field
   final _$Database _db;
-  final Friendship friendships;
-  $$FriendshipsTableWithReferences(this._db, this.friendships);
+  final Friendship friendship;
+  $$FriendshipsTableWithReferences(this._db, this.friendship);
 }
 
 class $DatabaseManager {

--- a/extras/integration_tests/drift_testcases/lib/database/database.g.dart
+++ b/extras/integration_tests/drift_testcases/lib/database/database.g.dart
@@ -199,6 +199,19 @@ class User extends DataClass implements Insertable<User> {
             profilePicture.present ? profilePicture.value : this.profilePicture,
         preferences: preferences.present ? preferences.value : this.preferences,
       );
+  User copyWithCompanion(UsersCompanion data) {
+    return User(
+      id: data.id.present ? data.id.value : this.id,
+      name: data.name.present ? data.name.value : this.name,
+      birthDate: data.birthDate.present ? data.birthDate.value : this.birthDate,
+      profilePicture: data.profilePicture.present
+          ? data.profilePicture.value
+          : this.profilePicture,
+      preferences:
+          data.preferences.present ? data.preferences.value : this.preferences,
+    );
+  }
+
   @override
   String toString() {
     return (StringBuffer('User(')
@@ -457,6 +470,17 @@ class Friendship extends DataClass implements Insertable<Friendship> {
         secondUser: secondUser ?? this.secondUser,
         reallyGoodFriends: reallyGoodFriends ?? this.reallyGoodFriends,
       );
+  Friendship copyWithCompanion(FriendshipsCompanion data) {
+    return Friendship(
+      firstUser: data.firstUser.present ? data.firstUser.value : this.firstUser,
+      secondUser:
+          data.secondUser.present ? data.secondUser.value : this.secondUser,
+      reallyGoodFriends: data.reallyGoodFriends.present
+          ? data.reallyGoodFriends.value
+          : this.reallyGoodFriends,
+    );
+  }
+
   @override
   String toString() {
     return (StringBuffer('Friendship(')
@@ -715,9 +739,10 @@ class $$UsersTableTableManager extends RootTableManager<
     User,
     $$UsersTableFilterComposer,
     $$UsersTableOrderingComposer,
-    $$UsersTableProcessedTableManager,
     $$UsersTableInsertCompanionBuilder,
-    $$UsersTableUpdateCompanionBuilder> {
+    $$UsersTableUpdateCompanionBuilder,
+    $$UsersTableWithReferences,
+    User> {
   $$UsersTableTableManager(_$Database db, $UsersTable table)
       : super(TableManagerState(
           db: db,
@@ -726,8 +751,7 @@ class $$UsersTableTableManager extends RootTableManager<
               $$UsersTableFilterComposer(ComposerState(db, table)),
           orderingComposer:
               $$UsersTableOrderingComposer(ComposerState(db, table)),
-          getChildManagerBuilder: (p) => $$UsersTableProcessedTableManager(p),
-          getUpdateCompanionBuilder: ({
+          createUpdateCompanionCallback: ({
             Value<int> id = const Value.absent(),
             Value<String> name = const Value.absent(),
             Value<DateTime> birthDate = const Value.absent(),
@@ -741,7 +765,9 @@ class $$UsersTableTableManager extends RootTableManager<
             profilePicture: profilePicture,
             preferences: preferences,
           ),
-          getInsertCompanionBuilder: ({
+          dataclassMapper: (p0) async =>
+              p0.map((e) => $$UsersTableWithReferences(db, e)).toList(),
+          createInsertCompanionCallback: ({
             Value<int> id = const Value.absent(),
             required String name,
             required DateTime birthDate,
@@ -758,17 +784,16 @@ class $$UsersTableTableManager extends RootTableManager<
         ));
 }
 
-class $$UsersTableProcessedTableManager extends ProcessedTableManager<
+typedef $$UsersTableProcessedTableManager = ProcessedTableManager<
     _$Database,
     $UsersTable,
     User,
     $$UsersTableFilterComposer,
     $$UsersTableOrderingComposer,
-    $$UsersTableProcessedTableManager,
     $$UsersTableInsertCompanionBuilder,
-    $$UsersTableUpdateCompanionBuilder> {
-  $$UsersTableProcessedTableManager(super.$state);
-}
+    $$UsersTableUpdateCompanionBuilder,
+    $$UsersTableWithReferences,
+    User>;
 
 class $$UsersTableFilterComposer
     extends FilterComposer<_$Database, $UsersTable> {
@@ -830,6 +855,13 @@ class $$UsersTableOrderingComposer
           ColumnOrderings(column, joinBuilders: joinBuilders));
 }
 
+class $$UsersTableWithReferences {
+  // ignore: unused_field
+  final _$Database _db;
+  final User users;
+  $$UsersTableWithReferences(this._db, this.users);
+}
+
 typedef $$FriendshipsTableInsertCompanionBuilder = FriendshipsCompanion
     Function({
   required int firstUser,
@@ -851,9 +883,10 @@ class $$FriendshipsTableTableManager extends RootTableManager<
     Friendship,
     $$FriendshipsTableFilterComposer,
     $$FriendshipsTableOrderingComposer,
-    $$FriendshipsTableProcessedTableManager,
     $$FriendshipsTableInsertCompanionBuilder,
-    $$FriendshipsTableUpdateCompanionBuilder> {
+    $$FriendshipsTableUpdateCompanionBuilder,
+    $$FriendshipsTableWithReferences,
+    Friendship> {
   $$FriendshipsTableTableManager(_$Database db, $FriendshipsTable table)
       : super(TableManagerState(
           db: db,
@@ -862,9 +895,7 @@ class $$FriendshipsTableTableManager extends RootTableManager<
               $$FriendshipsTableFilterComposer(ComposerState(db, table)),
           orderingComposer:
               $$FriendshipsTableOrderingComposer(ComposerState(db, table)),
-          getChildManagerBuilder: (p) =>
-              $$FriendshipsTableProcessedTableManager(p),
-          getUpdateCompanionBuilder: ({
+          createUpdateCompanionCallback: ({
             Value<int> firstUser = const Value.absent(),
             Value<int> secondUser = const Value.absent(),
             Value<bool> reallyGoodFriends = const Value.absent(),
@@ -876,7 +907,9 @@ class $$FriendshipsTableTableManager extends RootTableManager<
             reallyGoodFriends: reallyGoodFriends,
             rowid: rowid,
           ),
-          getInsertCompanionBuilder: ({
+          dataclassMapper: (p0) async =>
+              p0.map((e) => $$FriendshipsTableWithReferences(db, e)).toList(),
+          createInsertCompanionCallback: ({
             required int firstUser,
             required int secondUser,
             Value<bool> reallyGoodFriends = const Value.absent(),
@@ -891,17 +924,16 @@ class $$FriendshipsTableTableManager extends RootTableManager<
         ));
 }
 
-class $$FriendshipsTableProcessedTableManager extends ProcessedTableManager<
+typedef $$FriendshipsTableProcessedTableManager = ProcessedTableManager<
     _$Database,
     $FriendshipsTable,
     Friendship,
     $$FriendshipsTableFilterComposer,
     $$FriendshipsTableOrderingComposer,
-    $$FriendshipsTableProcessedTableManager,
     $$FriendshipsTableInsertCompanionBuilder,
-    $$FriendshipsTableUpdateCompanionBuilder> {
-  $$FriendshipsTableProcessedTableManager(super.$state);
-}
+    $$FriendshipsTableUpdateCompanionBuilder,
+    $$FriendshipsTableWithReferences,
+    Friendship>;
 
 class $$FriendshipsTableFilterComposer
     extends FilterComposer<_$Database, $FriendshipsTable> {
@@ -939,6 +971,13 @@ class $$FriendshipsTableOrderingComposer
       column: $state.table.reallyGoodFriends,
       builder: (column, joinBuilders) =>
           ColumnOrderings(column, joinBuilders: joinBuilders));
+}
+
+class $$FriendshipsTableWithReferences {
+  // ignore: unused_field
+  final _$Database _db;
+  final Friendship friendships;
+  $$FriendshipsTableWithReferences(this._db, this.friendships);
 }
 
 class $DatabaseManager {

--- a/extras/integration_tests/legacy_web/test/saves_after_migration_regression_test.g.dart
+++ b/extras/integration_tests/legacy_web/test/saves_after_migration_regression_test.g.dart
@@ -86,6 +86,12 @@ class Foo extends DataClass implements Insertable<Foo> {
   Foo copyWith({int? id}) => Foo(
         id: id ?? this.id,
       );
+  Foo copyWithCompanion(FoosCompanion data) {
+    return Foo(
+      id: data.id.present ? data.id.value : this.id,
+    );
+  }
+
   @override
   String toString() {
     return (StringBuffer('Foo(')
@@ -224,6 +230,12 @@ class Bar extends DataClass implements Insertable<Bar> {
   Bar copyWith({int? id}) => Bar(
         id: id ?? this.id,
       );
+  Bar copyWithCompanion(BarsCompanion data) {
+    return Bar(
+      id: data.id.present ? data.id.value : this.id,
+    );
+  }
+
   @override
   String toString() {
     return (StringBuffer('Bar(')

--- a/extras/integration_tests/web_wasm/lib/src/database.g.dart
+++ b/extras/integration_tests/web_wasm/lib/src/database.g.dart
@@ -107,6 +107,13 @@ class TestTableData extends DataClass implements Insertable<TestTableData> {
         id: id ?? this.id,
         content: content ?? this.content,
       );
+  TestTableData copyWithCompanion(TestTableCompanion data) {
+    return TestTableData(
+      id: data.id.present ? data.id.value : this.id,
+      content: data.content.present ? data.content.value : this.content,
+    );
+  }
+
   @override
   String toString() {
     return (StringBuffer('TestTableData(')
@@ -202,9 +209,10 @@ class $$TestTableTableTableManager extends RootTableManager<
     TestTableData,
     $$TestTableTableFilterComposer,
     $$TestTableTableOrderingComposer,
-    $$TestTableTableProcessedTableManager,
     $$TestTableTableInsertCompanionBuilder,
-    $$TestTableTableUpdateCompanionBuilder> {
+    $$TestTableTableUpdateCompanionBuilder,
+    $$TestTableTableWithReferences,
+    TestTableData> {
   $$TestTableTableTableManager(_$TestDatabase db, $TestTableTable table)
       : super(TableManagerState(
           db: db,
@@ -213,9 +221,7 @@ class $$TestTableTableTableManager extends RootTableManager<
               $$TestTableTableFilterComposer(ComposerState(db, table)),
           orderingComposer:
               $$TestTableTableOrderingComposer(ComposerState(db, table)),
-          getChildManagerBuilder: (p) =>
-              $$TestTableTableProcessedTableManager(p),
-          getUpdateCompanionBuilder: ({
+          createUpdateCompanionCallback: ({
             Value<int> id = const Value.absent(),
             Value<String> content = const Value.absent(),
           }) =>
@@ -223,7 +229,9 @@ class $$TestTableTableTableManager extends RootTableManager<
             id: id,
             content: content,
           ),
-          getInsertCompanionBuilder: ({
+          dataclassMapper: (p0) async =>
+              p0.map((e) => $$TestTableTableWithReferences(db, e)).toList(),
+          createInsertCompanionCallback: ({
             Value<int> id = const Value.absent(),
             required String content,
           }) =>
@@ -234,17 +242,16 @@ class $$TestTableTableTableManager extends RootTableManager<
         ));
 }
 
-class $$TestTableTableProcessedTableManager extends ProcessedTableManager<
+typedef $$TestTableTableProcessedTableManager = ProcessedTableManager<
     _$TestDatabase,
     $TestTableTable,
     TestTableData,
     $$TestTableTableFilterComposer,
     $$TestTableTableOrderingComposer,
-    $$TestTableTableProcessedTableManager,
     $$TestTableTableInsertCompanionBuilder,
-    $$TestTableTableUpdateCompanionBuilder> {
-  $$TestTableTableProcessedTableManager(super.$state);
-}
+    $$TestTableTableUpdateCompanionBuilder,
+    $$TestTableTableWithReferences,
+    TestTableData>;
 
 class $$TestTableTableFilterComposer
     extends FilterComposer<_$TestDatabase, $TestTableTable> {
@@ -272,6 +279,13 @@ class $$TestTableTableOrderingComposer
       column: $state.table.content,
       builder: (column, joinBuilders) =>
           ColumnOrderings(column, joinBuilders: joinBuilders));
+}
+
+class $$TestTableTableWithReferences {
+  // ignore: unused_field
+  final _$TestDatabase _db;
+  final TestTableData testTable;
+  $$TestTableTableWithReferences(this._db, this.testTable);
 }
 
 class $TestDatabaseManager {

--- a/extras/integration_tests/web_wasm/lib/src/database.g.dart
+++ b/extras/integration_tests/web_wasm/lib/src/database.g.dart
@@ -284,8 +284,8 @@ class $$TestTableTableOrderingComposer
 class $$TestTableTableWithReferences {
   // ignore: unused_field
   final _$TestDatabase _db;
-  final TestTableData testTable;
-  $$TestTableTableWithReferences(this._db, this.testTable);
+  final TestTableData testTableData;
+  $$TestTableTableWithReferences(this._db, this.testTableData);
 }
 
 class $TestDatabaseManager {


### PR DESCRIPTION
This PR does the following:

* Slightly refactor manager code to reduce code duplication. Also names the generics in a more descriptive way (`$Table` instead of `T`)
* Makes getters on Managers return a `FutureOr`, this is done in preparation for when there is a cache that will return synchronously. 
* Some methods on the manager had hard coded `distinct: true`. I've added a method to make that an optional argument
* Make managers not constant for now, this may be changed in the future once the Manager API is more mature, and we  are confident It can be const. We've added the `@immutable` decorator to make sure that we never add a field that is not `final`. 
* On older versions of analyzer `getDisplayName` has a required arg `withNullability`, it has since been depreciated, but I have added an lint to ignore it. This is to be compatible with older version of dart.
* `pubspec_overrides.yaml` is not included in version control. In order to ensure that tests on Github run the correct version, I've moved these overrides into pubspec.yaml. This was only done for the flutter example app.
* The manager doesn't generate any relation related code for foreign keys where one side has a type converter and the other doesn't
* Add an API for returning dataclasses with getters for their related rows.
* Add tests
* Add docs

---

This PR adds reference reading to the manager API.

This started originally with much larger ambitions, but the scope has shrunk once I realized how complex this is.
The current PR adds the building blocks for what will eventually be a much more powerful query builder.

```dart
// Very simple filter for getting user #5
final user = await users.filter((f)=>f.id(5)).getSingle();

// To get the group this user is apart of, you would have to write
final group = await groups.filter((f)=>f.id(user.group)).getSingle();

// This PR makes that much simpler
final userWithReferences = await  users.filter((f)=>f.id(5)).withReferences.getSingle();
final group = await userWithReferences.group.getSingle()

// This also works on back references
// Get the group #7
final groupWithReferences = await groups.filter((f)=>f.id(7)).getSingle();

// Get all the users in the group
final users = await groupWithReferences.users.get();

// The references that are returned are actually Managers with all the correct filters applied
// This allows us to get nested references or to apply more filters as we wish

// Users in this group that are 10 years old with references
final usersAgeTenWithReferences = await groupWithReferences.users.filter((f)=>f.age(10)).withReferences.get();
for (var user in usersAgeTenWithReferences){
  final user = user.user;
  final posts = await user.posts.get()
}
```

The only issue with this implementation is that it's really easy to have an n+1 issue.
The solution for this is to prefetch results and put them in a cache.
This can then be exposed with a FutureOr.

The API this uses can be extended to include such a cache, so I view this as step one of adding reference support.

- [x] Tests
- [x] Docs


