### PR TITLE
docs: indicate minimum drift version for manager functionality

### DIFF
--- a/docs/pages/docs/Dart API/manager.md
+++ b/docs/pages/docs/Dart API/manager.md
@@ -10,6 +10,8 @@ path: /docs/manager/
 
 {% assign snippets = 'package:drift_docs/snippets/dart_api/manager.dart.excerpt.json' | readString | json_decode %}
 
+Minimum Drift version: 2.18.0
+
 With generated code, drift allows writing SQL queries in type-safe Dart.
 While this is provides lots of flexibility, it requires familiarity with SQL.
 As a simpler alternative, drift 2.17 introduced a new set of APIs designed to


### PR DESCRIPTION
I believe something like this could be helpful.

Also:
> drift 2.17 introduced a new set of APIs designed to make common queries much easier to write

It could be good to link/clarify the docs regarding that, though I suspect it is basically referencing the remainder of the docs site? Still, it potentially leaves a new consumer unsure if they are referencing the correct info.
