### PR TITLE
Support custom row classes for manager

### DIFF
--- a/drift/lib/src/runtime/manager/manager.dart
+++ b/drift/lib/src/runtime/manager/manager.dart
@@ -9,18 +9,16 @@ part 'filter.dart';
 part 'composable.dart';
 part 'ordering.dart';
 
-sealed class _StatementType<T extends Table, DT extends DataClass> {
+sealed class _StatementType<T extends Table, DT> {
   const _StatementType();
 }
 
-class _SimpleResult<T extends Table, DT extends DataClass>
-    extends _StatementType<T, DT> {
+class _SimpleResult<T extends Table, DT> extends _StatementType<T, DT> {
   final SimpleSelectStatement<T, DT> statement;
   const _SimpleResult(this.statement);
 }
 
-class _JoinedResult<T extends Table, DT extends DataClass>
-    extends _StatementType<T, DT> {
+class _JoinedResult<T extends Table, DT> extends _StatementType<T, DT> {
   final JoinedSelectStatement<T, DT> statement;
 
   const _JoinedResult(this.statement);
@@ -39,16 +37,16 @@ class _JoinedResult<T extends Table, DT extends DataClass>
 class TableManagerState<
     DB extends GeneratedDatabase,
     T extends Table,
-    DT extends DataClass,
+    DT,
     FS extends FilterComposer<DB, T>,
     OS extends OrderingComposer<DB, T>,
     C extends ProcessedTableManager<DB, T, DT, FS, OS, C, CI, CU>,
     CI extends Function,
     CU extends Function> {
-  /// The database that the query will be exeCCted on
+  /// The database used to run the query.
   final DB db;
 
-  /// The table that the query will be exeCCted on
+  /// The table primary table from which to select from.
   final T table;
 
   /// The expression that will be applied to the query
@@ -297,7 +295,7 @@ class TableManagerState<
 abstract class BaseTableManager<
         DB extends GeneratedDatabase,
         T extends Table,
-        DT extends DataClass,
+        DT,
         FS extends FilterComposer<DB, T>,
         OS extends OrderingComposer<DB, T>,
         C extends ProcessedTableManager<DB, T, DT, FS, OS, C, CI, CU>,
@@ -463,7 +461,7 @@ abstract class BaseTableManager<
 class ProcessedTableManager<
         DB extends GeneratedDatabase,
         T extends Table,
-        D extends DataClass,
+        D,
         FS extends FilterComposer<DB, T>,
         OS extends OrderingComposer<DB, T>,
         C extends ProcessedTableManager<DB, T, D, FS, OS, C, CI, CU>,
@@ -483,7 +481,7 @@ class ProcessedTableManager<
 abstract class RootTableManager<
     DB extends GeneratedDatabase,
     T extends Table,
-    D extends DataClass,
+    D,
     FS extends FilterComposer<DB, T>,
     OS extends OrderingComposer<DB, T>,
     C extends ProcessedTableManager<DB, T, D, FS, OS, C, CI, CU>,

--- a/drift/test/generated/custom_tables.g.dart
+++ b/drift/test/generated/custom_tables.g.dart
@@ -1971,6 +1971,72 @@ abstract class _$CustomTablesDb extends GeneratedDatabase {
       const DriftDatabaseOptions(storeDateTimeAsText: true);
 }
 
+typedef $NoIdsInsertCompanionBuilder = NoIdsCompanion Function({
+  required Uint8List payload,
+});
+typedef $NoIdsUpdateCompanionBuilder = NoIdsCompanion Function({
+  Value<Uint8List> payload,
+});
+
+class $NoIdsTableManager extends RootTableManager<
+    _$CustomTablesDb,
+    NoIds,
+    NoIdRow,
+    $NoIdsFilterComposer,
+    $NoIdsOrderingComposer,
+    $NoIdsProcessedTableManager,
+    $NoIdsInsertCompanionBuilder,
+    $NoIdsUpdateCompanionBuilder> {
+  $NoIdsTableManager(_$CustomTablesDb db, NoIds table)
+      : super(TableManagerState(
+          db: db,
+          table: table,
+          filteringComposer: $NoIdsFilterComposer(ComposerState(db, table)),
+          orderingComposer: $NoIdsOrderingComposer(ComposerState(db, table)),
+          getChildManagerBuilder: (p) => $NoIdsProcessedTableManager(p),
+          getUpdateCompanionBuilder: ({
+            Value<Uint8List> payload = const Value.absent(),
+          }) =>
+              NoIdsCompanion(
+            payload: payload,
+          ),
+          getInsertCompanionBuilder: ({
+            required Uint8List payload,
+          }) =>
+              NoIdsCompanion.insert(
+            payload: payload,
+          ),
+        ));
+}
+
+class $NoIdsProcessedTableManager extends ProcessedTableManager<
+    _$CustomTablesDb,
+    NoIds,
+    NoIdRow,
+    $NoIdsFilterComposer,
+    $NoIdsOrderingComposer,
+    $NoIdsProcessedTableManager,
+    $NoIdsInsertCompanionBuilder,
+    $NoIdsUpdateCompanionBuilder> {
+  $NoIdsProcessedTableManager(super.$state);
+}
+
+class $NoIdsFilterComposer extends FilterComposer<_$CustomTablesDb, NoIds> {
+  $NoIdsFilterComposer(super.$state);
+  ColumnFilters<Uint8List> get payload => $state.composableBuilder(
+      column: $state.table.payload,
+      builder: (column, joinBuilders) =>
+          ColumnFilters(column, joinBuilders: joinBuilders));
+}
+
+class $NoIdsOrderingComposer extends OrderingComposer<_$CustomTablesDb, NoIds> {
+  $NoIdsOrderingComposer(super.$state);
+  ColumnOrderings<Uint8List> get payload => $state.composableBuilder(
+      column: $state.table.payload,
+      builder: (column, joinBuilders) =>
+          ColumnOrderings(column, joinBuilders: joinBuilders));
+}
+
 typedef $WithDefaultsInsertCompanionBuilder = WithDefaultsCompanion Function({
   Value<String?> a,
   Value<int?> b,
@@ -2616,6 +2682,7 @@ class $WeirdTableOrderingComposer
 class _$CustomTablesDbManager {
   final _$CustomTablesDb _db;
   _$CustomTablesDbManager(this._db);
+  $NoIdsTableManager get noIds => $NoIdsTableManager(_db, _db.noIds);
   $WithDefaultsTableManager get withDefaults =>
       $WithDefaultsTableManager(_db, _db.withDefaults);
   $WithConstraintsTableManager get withConstraints =>

--- a/drift/test/generated/todos.g.dart
+++ b/drift/test/generated/todos.g.dart
@@ -3868,6 +3868,135 @@ class $$SharedTodosTableOrderingComposer
           ColumnOrderings(column, joinBuilders: joinBuilders));
 }
 
+typedef $$TableWithoutPKTableInsertCompanionBuilder = TableWithoutPKCompanion
+    Function({
+  required int notReallyAnId,
+  required double someFloat,
+  Value<BigInt?> webSafeInt,
+  Value<MyCustomObject> custom,
+  Value<int> rowid,
+});
+typedef $$TableWithoutPKTableUpdateCompanionBuilder = TableWithoutPKCompanion
+    Function({
+  Value<int> notReallyAnId,
+  Value<double> someFloat,
+  Value<BigInt?> webSafeInt,
+  Value<MyCustomObject> custom,
+  Value<int> rowid,
+});
+
+class $$TableWithoutPKTableTableManager extends RootTableManager<
+    _$TodoDb,
+    $TableWithoutPKTable,
+    CustomRowClass,
+    $$TableWithoutPKTableFilterComposer,
+    $$TableWithoutPKTableOrderingComposer,
+    $$TableWithoutPKTableProcessedTableManager,
+    $$TableWithoutPKTableInsertCompanionBuilder,
+    $$TableWithoutPKTableUpdateCompanionBuilder> {
+  $$TableWithoutPKTableTableManager(_$TodoDb db, $TableWithoutPKTable table)
+      : super(TableManagerState(
+          db: db,
+          table: table,
+          filteringComposer:
+              $$TableWithoutPKTableFilterComposer(ComposerState(db, table)),
+          orderingComposer:
+              $$TableWithoutPKTableOrderingComposer(ComposerState(db, table)),
+          getChildManagerBuilder: (p) =>
+              $$TableWithoutPKTableProcessedTableManager(p),
+          getUpdateCompanionBuilder: ({
+            Value<int> notReallyAnId = const Value.absent(),
+            Value<double> someFloat = const Value.absent(),
+            Value<BigInt?> webSafeInt = const Value.absent(),
+            Value<MyCustomObject> custom = const Value.absent(),
+            Value<int> rowid = const Value.absent(),
+          }) =>
+              TableWithoutPKCompanion(
+            notReallyAnId: notReallyAnId,
+            someFloat: someFloat,
+            webSafeInt: webSafeInt,
+            custom: custom,
+            rowid: rowid,
+          ),
+          getInsertCompanionBuilder: ({
+            required int notReallyAnId,
+            required double someFloat,
+            Value<BigInt?> webSafeInt = const Value.absent(),
+            Value<MyCustomObject> custom = const Value.absent(),
+            Value<int> rowid = const Value.absent(),
+          }) =>
+              TableWithoutPKCompanion.insert(
+            notReallyAnId: notReallyAnId,
+            someFloat: someFloat,
+            webSafeInt: webSafeInt,
+            custom: custom,
+            rowid: rowid,
+          ),
+        ));
+}
+
+class $$TableWithoutPKTableProcessedTableManager extends ProcessedTableManager<
+    _$TodoDb,
+    $TableWithoutPKTable,
+    CustomRowClass,
+    $$TableWithoutPKTableFilterComposer,
+    $$TableWithoutPKTableOrderingComposer,
+    $$TableWithoutPKTableProcessedTableManager,
+    $$TableWithoutPKTableInsertCompanionBuilder,
+    $$TableWithoutPKTableUpdateCompanionBuilder> {
+  $$TableWithoutPKTableProcessedTableManager(super.$state);
+}
+
+class $$TableWithoutPKTableFilterComposer
+    extends FilterComposer<_$TodoDb, $TableWithoutPKTable> {
+  $$TableWithoutPKTableFilterComposer(super.$state);
+  ColumnFilters<int> get notReallyAnId => $state.composableBuilder(
+      column: $state.table.notReallyAnId,
+      builder: (column, joinBuilders) =>
+          ColumnFilters(column, joinBuilders: joinBuilders));
+
+  ColumnFilters<double> get someFloat => $state.composableBuilder(
+      column: $state.table.someFloat,
+      builder: (column, joinBuilders) =>
+          ColumnFilters(column, joinBuilders: joinBuilders));
+
+  ColumnFilters<BigInt> get webSafeInt => $state.composableBuilder(
+      column: $state.table.webSafeInt,
+      builder: (column, joinBuilders) =>
+          ColumnFilters(column, joinBuilders: joinBuilders));
+
+  ColumnWithTypeConverterFilters<MyCustomObject, MyCustomObject, String>
+      get custom => $state.composableBuilder(
+          column: $state.table.custom,
+          builder: (column, joinBuilders) => ColumnWithTypeConverterFilters(
+              column,
+              joinBuilders: joinBuilders));
+}
+
+class $$TableWithoutPKTableOrderingComposer
+    extends OrderingComposer<_$TodoDb, $TableWithoutPKTable> {
+  $$TableWithoutPKTableOrderingComposer(super.$state);
+  ColumnOrderings<int> get notReallyAnId => $state.composableBuilder(
+      column: $state.table.notReallyAnId,
+      builder: (column, joinBuilders) =>
+          ColumnOrderings(column, joinBuilders: joinBuilders));
+
+  ColumnOrderings<double> get someFloat => $state.composableBuilder(
+      column: $state.table.someFloat,
+      builder: (column, joinBuilders) =>
+          ColumnOrderings(column, joinBuilders: joinBuilders));
+
+  ColumnOrderings<BigInt> get webSafeInt => $state.composableBuilder(
+      column: $state.table.webSafeInt,
+      builder: (column, joinBuilders) =>
+          ColumnOrderings(column, joinBuilders: joinBuilders));
+
+  ColumnOrderings<String> get custom => $state.composableBuilder(
+      column: $state.table.custom,
+      builder: (column, joinBuilders) =>
+          ColumnOrderings(column, joinBuilders: joinBuilders));
+}
+
 typedef $$PureDefaultsTableInsertCompanionBuilder = PureDefaultsCompanion
     Function({
   Value<MyCustomObject?> txt,
@@ -4737,6 +4866,8 @@ class _$TodoDbManager {
       $$UsersTableTableManager(_db, _db.users);
   $$SharedTodosTableTableManager get sharedTodos =>
       $$SharedTodosTableTableManager(_db, _db.sharedTodos);
+  $$TableWithoutPKTableTableManager get tableWithoutPK =>
+      $$TableWithoutPKTableTableManager(_db, _db.tableWithoutPK);
   $$PureDefaultsTableTableManager get pureDefaults =>
       $$PureDefaultsTableTableManager(_db, _db.pureDefaults);
   $$WithCustomTypeTableTableManager get withCustomType =>

--- a/drift/test/manager/manager_test.dart
+++ b/drift/test/manager/manager_test.dart
@@ -161,4 +161,20 @@ void main() {
     expect(delete2, completion(1));
     expect(db.managers.categories.count(), completion(0));
   });
+
+  test('can use custom row classes', () async {
+    final entry = await db.managers.tableWithoutPK
+        .createReturning((o) => o(notReallyAnId: 3, someFloat: 5));
+    expect(entry.notReallyAnId, 3);
+    expect(entry.someFloat, 5);
+
+    await db.managers.tableWithoutPK
+        .filter((f) => f.someFloat.isBiggerThan(3))
+        .update((o) => o(webSafeInt: Value(BigInt.from(10))));
+
+    final row = await db.managers.tableWithoutPK.getSingle();
+    expect(row.webSafeInt, BigInt.from(10));
+
+    await db.managers.tableWithoutPK.delete();
+  });
 }

--- a/drift_dev/lib/src/writer/manager/database_manager_writer.dart
+++ b/drift_dev/lib/src/writer/manager/database_manager_writer.dart
@@ -21,11 +21,7 @@ class DatabaseManagerWriter {
   ///
   /// Ignores tables that have custom row classes
   void addTable(DriftTable table) {
-    if (table.hasExistingRowClass) {
-      return;
-    } else {
-      _addedTables.add(table);
-    }
+    _addedTables.add(table);
   }
 
   /// Write a table manager for each table.

--- a/drift_dev/lib/src/writer/manager/table_manager_writer.dart
+++ b/drift_dev/lib/src/writer/manager/table_manager_writer.dart
@@ -21,9 +21,7 @@ class _TableManagerWriter {
       {required this.table,
       required this.scope,
       required this.dbClassName,
-      required this.otherTables})
-      : assert(table.existingRowClass == null,
-            "Manager Writer should ignore tables with custom row classes");
+      required this.otherTables});
 
   _ManagerCodeTemplates get _templates => _ManagerCodeTemplates(scope);
 

--- a/drift_dev/lib/src/writer/manager/table_manager_writer.dart
+++ b/drift_dev/lib/src/writer/manager/table_manager_writer.dart
@@ -199,13 +199,7 @@ _Relation? _getRelationForColumn(DriftColumn column) {
   if (referencedCol != null && referencedCol.owner is DriftTable) {
     final relation =
         _Relation(currentColumn: column, referencedColumn: referencedCol);
-    // If either table has a custom row class, we will ignore this reference and retunn null
-    if (relation.currentTable.hasExistingRowClass ||
-        relation.referencedTable.hasExistingRowClass) {
-      return null;
-    } else {
-      return relation;
-    }
+    return relation;
   } else {
     return null;
   }


### PR DESCRIPTION
This adds support for generating manager classes for tables with existing row classes. At the moment, the only thing I had to change was removing the `DataClass` generic bound in the runtime.
@dickermoshe, can you check whether you need the `extends DataClass` bound for future manager changes? If not I think this sounds like a fairly easy way to port manager code over to more tables.

Closes https://github.com/simolus3/drift/issues/2989.