### PR TITLE
Fix: toColumns mixin generated with wrong name

### DIFF
--- a/drift_dev/lib/src/analysis/results/result_sets.dart
+++ b/drift_dev/lib/src/analysis/results/result_sets.dart
@@ -43,6 +43,10 @@ abstract class DriftElementWithResultSet extends DriftSchemaElement {
   /// The name for the companion class associated with this table or view.
   String? get nameOfCompanionClass;
 
+  /// The name of the mixin generated when `write_to_columns_mixins` is `true` in `build.yaml`.<br/>
+  /// See documentation for [Generation options](https://drift.simonbinder.eu/docs/advanced-features/builder_options/).
+  String get toColumnsMixin => '${entityInfoName}ToColumns';
+
   /// All [columns] of this table, indexed by their name in SQL.
   late final Map<String, DriftColumn> columnBySqlName = CaseInsensitiveMap.of({
     for (final column in columns) column.nameInSql: column,

--- a/drift_dev/lib/src/writer/tables/data_class_writer.dart
+++ b/drift_dev/lib/src/writer/tables/data_class_writer.dart
@@ -53,7 +53,7 @@ class DataClassWriter {
 
     if (isInsertable) {
       if (scope.options.writeToColumnsMixins) {
-        _buffer.writeln('with ${table.entityInfoName}ToColumns {');
+        _buffer.writeln('with ${table.toColumnsMixin} {');
       } else {
         // The data class is only an insertable if we can actually insert rows
         // into the target entity.

--- a/drift_dev/lib/src/writer/tables/table_writer.dart
+++ b/drift_dev/lib/src/writer/tables/table_writer.dart
@@ -434,7 +434,7 @@ class TableWriter extends TableOrViewWriter {
   }
 
   void writeToColumnsMixin() {
-    buffer.write('mixin ${table.entityInfoName}ToColumns ');
+    buffer.write('mixin ${table.toColumnsMixin} ');
 
     final type = emitter.dartCode(emitter.writer.rowType(table));
     buffer.writeln('implements ${emitter.drift('Insertable')}<$type> {');

--- a/drift_dev/lib/src/writer/tables/table_writer.dart
+++ b/drift_dev/lib/src/writer/tables/table_writer.dart
@@ -434,7 +434,7 @@ class TableWriter extends TableOrViewWriter {
   }
 
   void writeToColumnsMixin() {
-    buffer.write('mixin ${table.baseDartName}ToColumns ');
+    buffer.write('mixin ${table.entityInfoName}ToColumns ');
 
     final type = emitter.dartCode(emitter.writer.rowType(table));
     buffer.writeln('implements ${emitter.drift('Insertable')}<$type> {');


### PR DESCRIPTION
In `data_class_writer.dart` we expect a mixin named `${table.entityInfoName}ToColumns`, but then we create one named `${table.baseDartName}ToColumns` in `table_writer.dart`.