### PR TITLE
Generate copyWithCompanion on data classes

### DIFF
--- a/drift/example/main.g.dart
+++ b/drift/example/main.g.dart
@@ -85,6 +85,13 @@ class TodoCategory extends DataClass implements Insertable<TodoCategory> {
     );
   }
 
+  TodoCategory copyWithCompanion(TodoCategoriesCompanion data) {
+    return TodoCategory(
+      id: data.id.present ? data.id.value : this.id,
+      name: data.name.present ? data.name.value : this.name,
+    );
+  }
+
   factory TodoCategory.fromJson(Map<String, dynamic> json,
       {ValueSerializer? serializer}) {
     serializer ??= driftRuntimeOptions.defaultSerializer;
@@ -322,6 +329,16 @@ class TodoItem extends DataClass implements Insertable<TodoItem> {
           ? const Value.absent()
           : Value(content),
       categoryId: Value(categoryId),
+    );
+  }
+
+  TodoItem copyWithCompanion(TodoItemsCompanion data) {
+    return TodoItem(
+      id: data.id.present ? data.id.value : this.id,
+      title: data.title.present ? data.title.value : this.title,
+      content: data.content.present ? data.content.value : this.content,
+      categoryId:
+          data.categoryId.present ? data.categoryId.value : this.categoryId,
     );
   }
 

--- a/drift/example/main.g.dart
+++ b/drift/example/main.g.dart
@@ -85,13 +85,6 @@ class TodoCategory extends DataClass implements Insertable<TodoCategory> {
     );
   }
 
-  TodoCategory copyWithCompanion(TodoCategoriesCompanion data) {
-    return TodoCategory(
-      id: data.id.present ? data.id.value : this.id,
-      name: data.name.present ? data.name.value : this.name,
-    );
-  }
-
   factory TodoCategory.fromJson(Map<String, dynamic> json,
       {ValueSerializer? serializer}) {
     serializer ??= driftRuntimeOptions.defaultSerializer;
@@ -118,6 +111,13 @@ class TodoCategory extends DataClass implements Insertable<TodoCategory> {
         id: id ?? this.id,
         name: name ?? this.name,
       );
+  TodoCategory copyWithCompanion(TodoCategoriesCompanion data) {
+    return TodoCategory(
+      id: data.id.present ? data.id.value : this.id,
+      name: data.name.present ? data.name.value : this.name,
+    );
+  }
+
   @override
   String toString() {
     return (StringBuffer('TodoCategory(')
@@ -329,16 +329,6 @@ class TodoItem extends DataClass implements Insertable<TodoItem> {
           ? const Value.absent()
           : Value(content),
       categoryId: Value(categoryId),
-    );
-  }
-
-  TodoItem copyWithCompanion(TodoItemsCompanion data) {
-    return TodoItem(
-      id: data.id.present ? data.id.value : this.id,
-      title: data.title.present ? data.title.value : this.title,
-      content: data.content.present ? data.content.value : this.content,
-      categoryId:
-          data.categoryId.present ? data.categoryId.value : this.categoryId,
     );
   }
 

--- a/drift/test/database/data_class_test.dart
+++ b/drift/test/database/data_class_test.dart
@@ -105,6 +105,24 @@ void main() {
     expect(entry.toCompanion(true), const PureDefaultsCompanion());
   });
 
+  test('data classes can be copied with changes given by companion', () {
+    const nameless = DepartmentData(id: 1);
+    expect(nameless.copyWithCompanion(DepartmentCompanion()),
+        const DepartmentData(id: 1));
+    expect(nameless.copyWithCompanion(DepartmentCompanion(id: Value(2))),
+        const DepartmentData(id: 2));
+    expect(nameless.copyWithCompanion(DepartmentCompanion(name: Value("a"))),
+        const DepartmentData(id: 1, name: "a"));
+
+    const named = DepartmentData(id: 2, name: "b");
+    expect(named.copyWithCompanion(DepartmentCompanion()),
+        const DepartmentData(id: 2, name: "b"));
+    expect(named.copyWithCompanion(DepartmentCompanion(name: Value("c"))),
+        const DepartmentData(id: 2, name: "c"));
+    expect(named.copyWithCompanion(DepartmentCompanion(name: Value(null))),
+        const DepartmentData(id: 2));
+  });
+
   test('utilities to wrap nullable values', () {
     expect(
         // ignore: prefer_const_constructors, deprecated_member_use_from_same_package

--- a/drift/test/extensions/geopoly_integration_test.g.dart
+++ b/drift/test/extensions/geopoly_integration_test.g.dart
@@ -94,13 +94,6 @@ class GeopolyTestData extends DataClass implements Insertable<GeopolyTestData> {
     );
   }
 
-  GeopolyTestData copyWithCompanion(GeopolyTestCompanion data) {
-    return GeopolyTestData(
-      shape: data.shape.present ? data.shape.value : this.shape,
-      a: data.a.present ? data.a.value : this.a,
-    );
-  }
-
   factory GeopolyTestData.fromJson(Map<String, dynamic> json,
       {ValueSerializer? serializer}) {
     serializer ??= driftRuntimeOptions.defaultSerializer;
@@ -130,6 +123,13 @@ class GeopolyTestData extends DataClass implements Insertable<GeopolyTestData> {
         shape: shape.present ? shape.value : this.shape,
         a: a.present ? a.value : this.a,
       );
+  GeopolyTestData copyWithCompanion(GeopolyTestCompanion data) {
+    return GeopolyTestData(
+      shape: data.shape.present ? data.shape.value : this.shape,
+      a: data.a.present ? data.a.value : this.a,
+    );
+  }
+
   @override
   String toString() {
     return (StringBuffer('GeopolyTestData(')

--- a/drift/test/extensions/geopoly_integration_test.g.dart
+++ b/drift/test/extensions/geopoly_integration_test.g.dart
@@ -94,6 +94,13 @@ class GeopolyTestData extends DataClass implements Insertable<GeopolyTestData> {
     );
   }
 
+  GeopolyTestData copyWithCompanion(GeopolyTestCompanion data) {
+    return GeopolyTestData(
+      shape: data.shape.present ? data.shape.value : this.shape,
+      a: data.a.present ? data.a.value : this.a,
+    );
+  }
+
   factory GeopolyTestData.fromJson(Map<String, dynamic> json,
       {ValueSerializer? serializer}) {
     serializer ??= driftRuntimeOptions.defaultSerializer;

--- a/drift/test/generated/custom_tables.g.dart
+++ b/drift/test/generated/custom_tables.g.dart
@@ -182,13 +182,6 @@ class WithDefault extends DataClass implements Insertable<WithDefault> {
     );
   }
 
-  WithDefault copyWithCompanion(WithDefaultsCompanion data) {
-    return WithDefault(
-      a: data.a.present ? data.a.value : this.a,
-      b: data.b.present ? data.b.value : this.b,
-    );
-  }
-
   factory WithDefault.fromJson(Map<String, dynamic> json,
       {ValueSerializer? serializer}) {
     serializer ??= driftRuntimeOptions.defaultSerializer;
@@ -218,6 +211,13 @@ class WithDefault extends DataClass implements Insertable<WithDefault> {
         a: a.present ? a.value : this.a,
         b: b.present ? b.value : this.b,
       );
+  WithDefault copyWithCompanion(WithDefaultsCompanion data) {
+    return WithDefault(
+      a: data.a.present ? data.a.value : this.a,
+      b: data.b.present ? data.b.value : this.b,
+    );
+  }
+
   @override
   String toString() {
     return (StringBuffer('WithDefault(')
@@ -399,14 +399,6 @@ class WithConstraint extends DataClass implements Insertable<WithConstraint> {
     );
   }
 
-  WithConstraint copyWithCompanion(WithConstraintsCompanion data) {
-    return WithConstraint(
-      a: data.a.present ? data.a.value : this.a,
-      b: data.b.present ? data.b.value : this.b,
-      c: data.c.present ? data.c.value : this.c,
-    );
-  }
-
   factory WithConstraint.fromJson(Map<String, dynamic> json,
       {ValueSerializer? serializer}) {
     serializer ??= driftRuntimeOptions.defaultSerializer;
@@ -440,6 +432,14 @@ class WithConstraint extends DataClass implements Insertable<WithConstraint> {
         b: b ?? this.b,
         c: c.present ? c.value : this.c,
       );
+  WithConstraint copyWithCompanion(WithConstraintsCompanion data) {
+    return WithConstraint(
+      a: data.a.present ? data.a.value : this.a,
+      b: data.b.present ? data.b.value : this.b,
+      c: data.c.present ? data.c.value : this.c,
+    );
+  }
+
   @override
   String toString() {
     return (StringBuffer('WithConstraint(')
@@ -685,18 +685,6 @@ class Config extends DataClass implements Insertable<Config> {
     );
   }
 
-  Config copyWithCompanion(ConfigCompanion data) {
-    return Config(
-      configKey: data.configKey.present ? data.configKey.value : this.configKey,
-      configValue:
-          data.configValue.present ? data.configValue.value : this.configValue,
-      syncState: data.syncState.present ? data.syncState.value : this.syncState,
-      syncStateImplicit: data.syncStateImplicit.present
-          ? data.syncStateImplicit.value
-          : this.syncStateImplicit,
-    );
-  }
-
   factory Config.fromJson(Map<String, dynamic> json,
       {ValueSerializer? serializer}) {
     serializer ??= driftRuntimeOptions.defaultSerializer;
@@ -737,6 +725,18 @@ class Config extends DataClass implements Insertable<Config> {
             ? syncStateImplicit.value
             : this.syncStateImplicit,
       );
+  Config copyWithCompanion(ConfigCompanion data) {
+    return Config(
+      configKey: data.configKey.present ? data.configKey.value : this.configKey,
+      configValue:
+          data.configValue.present ? data.configValue.value : this.configValue,
+      syncState: data.syncState.present ? data.syncState.value : this.syncState,
+      syncStateImplicit: data.syncStateImplicit.present
+          ? data.syncStateImplicit.value
+          : this.syncStateImplicit,
+    );
+  }
+
   @override
   String toString() {
     return (StringBuffer('Config(')
@@ -987,16 +987,6 @@ class MytableData extends DataClass implements Insertable<MytableData> {
     );
   }
 
-  MytableData copyWithCompanion(MytableCompanion data) {
-    return MytableData(
-      someid: data.someid.present ? data.someid.value : this.someid,
-      sometext: data.sometext.present ? data.sometext.value : this.sometext,
-      isInserting:
-          data.isInserting.present ? data.isInserting.value : this.isInserting,
-      somedate: data.somedate.present ? data.somedate.value : this.somedate,
-    );
-  }
-
   factory MytableData.fromJson(Map<String, dynamic> json,
       {ValueSerializer? serializer}) {
     serializer ??= driftRuntimeOptions.defaultSerializer;
@@ -1034,6 +1024,16 @@ class MytableData extends DataClass implements Insertable<MytableData> {
         isInserting: isInserting.present ? isInserting.value : this.isInserting,
         somedate: somedate.present ? somedate.value : this.somedate,
       );
+  MytableData copyWithCompanion(MytableCompanion data) {
+    return MytableData(
+      someid: data.someid.present ? data.someid.value : this.someid,
+      sometext: data.sometext.present ? data.sometext.value : this.sometext,
+      isInserting:
+          data.isInserting.present ? data.isInserting.value : this.isInserting,
+      somedate: data.somedate.present ? data.somedate.value : this.somedate,
+    );
+  }
+
   @override
   String toString() {
     return (StringBuffer('MytableData(')
@@ -1236,14 +1236,6 @@ class EMail extends DataClass implements Insertable<EMail> {
     );
   }
 
-  EMail copyWithCompanion(EmailCompanion data) {
-    return EMail(
-      sender: data.sender.present ? data.sender.value : this.sender,
-      title: data.title.present ? data.title.value : this.title,
-      body: data.body.present ? data.body.value : this.body,
-    );
-  }
-
   factory EMail.fromJson(Map<String, dynamic> json,
       {ValueSerializer? serializer}) {
     serializer ??= driftRuntimeOptions.defaultSerializer;
@@ -1272,6 +1264,14 @@ class EMail extends DataClass implements Insertable<EMail> {
         title: title ?? this.title,
         body: body ?? this.body,
       );
+  EMail copyWithCompanion(EmailCompanion data) {
+    return EMail(
+      sender: data.sender.present ? data.sender.value : this.sender,
+      title: data.title.present ? data.title.value : this.title,
+      body: data.body.present ? data.body.value : this.body,
+    );
+  }
+
   @override
   String toString() {
     return (StringBuffer('EMail(')
@@ -1456,14 +1456,6 @@ class WeirdData extends DataClass implements Insertable<WeirdData> {
     );
   }
 
-  WeirdData copyWithCompanion(WeirdTableCompanion data) {
-    return WeirdData(
-      sqlClass: data.sqlClass.present ? data.sqlClass.value : this.sqlClass,
-      textColumn:
-          data.textColumn.present ? data.textColumn.value : this.textColumn,
-    );
-  }
-
   factory WeirdData.fromJson(Map<String, dynamic> json,
       {ValueSerializer? serializer}) {
     serializer ??= driftRuntimeOptions.defaultSerializer;
@@ -1490,6 +1482,14 @@ class WeirdData extends DataClass implements Insertable<WeirdData> {
         sqlClass: sqlClass ?? this.sqlClass,
         textColumn: textColumn ?? this.textColumn,
       );
+  WeirdData copyWithCompanion(WeirdTableCompanion data) {
+    return WeirdData(
+      sqlClass: data.sqlClass.present ? data.sqlClass.value : this.sqlClass,
+      textColumn:
+          data.textColumn.present ? data.textColumn.value : this.textColumn,
+    );
+  }
+
   @override
   String toString() {
     return (StringBuffer('WeirdData(')

--- a/drift/test/generated/custom_tables.g.dart
+++ b/drift/test/generated/custom_tables.g.dart
@@ -182,6 +182,13 @@ class WithDefault extends DataClass implements Insertable<WithDefault> {
     );
   }
 
+  WithDefault copyWithCompanion(WithDefaultsCompanion data) {
+    return WithDefault(
+      a: data.a.present ? data.a.value : this.a,
+      b: data.b.present ? data.b.value : this.b,
+    );
+  }
+
   factory WithDefault.fromJson(Map<String, dynamic> json,
       {ValueSerializer? serializer}) {
     serializer ??= driftRuntimeOptions.defaultSerializer;
@@ -389,6 +396,14 @@ class WithConstraint extends DataClass implements Insertable<WithConstraint> {
       a: a == null && nullToAbsent ? const Value.absent() : Value(a),
       b: Value(b),
       c: c == null && nullToAbsent ? const Value.absent() : Value(c),
+    );
+  }
+
+  WithConstraint copyWithCompanion(WithConstraintsCompanion data) {
+    return WithConstraint(
+      a: data.a.present ? data.a.value : this.a,
+      b: data.b.present ? data.b.value : this.b,
+      c: data.c.present ? data.c.value : this.c,
     );
   }
 
@@ -667,6 +682,18 @@ class Config extends DataClass implements Insertable<Config> {
       syncStateImplicit: syncStateImplicit == null && nullToAbsent
           ? const Value.absent()
           : Value(syncStateImplicit),
+    );
+  }
+
+  Config copyWithCompanion(ConfigCompanion data) {
+    return Config(
+      configKey: data.configKey.present ? data.configKey.value : this.configKey,
+      configValue:
+          data.configValue.present ? data.configValue.value : this.configValue,
+      syncState: data.syncState.present ? data.syncState.value : this.syncState,
+      syncStateImplicit: data.syncStateImplicit.present
+          ? data.syncStateImplicit.value
+          : this.syncStateImplicit,
     );
   }
 
@@ -960,6 +987,16 @@ class MytableData extends DataClass implements Insertable<MytableData> {
     );
   }
 
+  MytableData copyWithCompanion(MytableCompanion data) {
+    return MytableData(
+      someid: data.someid.present ? data.someid.value : this.someid,
+      sometext: data.sometext.present ? data.sometext.value : this.sometext,
+      isInserting:
+          data.isInserting.present ? data.isInserting.value : this.isInserting,
+      somedate: data.somedate.present ? data.somedate.value : this.somedate,
+    );
+  }
+
   factory MytableData.fromJson(Map<String, dynamic> json,
       {ValueSerializer? serializer}) {
     serializer ??= driftRuntimeOptions.defaultSerializer;
@@ -1199,6 +1236,14 @@ class EMail extends DataClass implements Insertable<EMail> {
     );
   }
 
+  EMail copyWithCompanion(EmailCompanion data) {
+    return EMail(
+      sender: data.sender.present ? data.sender.value : this.sender,
+      title: data.title.present ? data.title.value : this.title,
+      body: data.body.present ? data.body.value : this.body,
+    );
+  }
+
   factory EMail.fromJson(Map<String, dynamic> json,
       {ValueSerializer? serializer}) {
     serializer ??= driftRuntimeOptions.defaultSerializer;
@@ -1408,6 +1453,14 @@ class WeirdData extends DataClass implements Insertable<WeirdData> {
     return WeirdTableCompanion(
       sqlClass: Value(sqlClass),
       textColumn: Value(textColumn),
+    );
+  }
+
+  WeirdData copyWithCompanion(WeirdTableCompanion data) {
+    return WeirdData(
+      sqlClass: data.sqlClass.present ? data.sqlClass.value : this.sqlClass,
+      textColumn:
+          data.textColumn.present ? data.textColumn.value : this.textColumn,
     );
   }
 

--- a/drift/test/generated/todos.g.dart
+++ b/drift/test/generated/todos.g.dart
@@ -136,6 +136,15 @@ class Category extends DataClass implements Insertable<Category> {
     );
   }
 
+  Category copyWithCompanion(CategoriesCompanion data) {
+    return Category(
+      id: data.id.present ? data.id.value : this.id,
+      description:
+          data.description.present ? data.description.value : this.description,
+      priority: data.priority.present ? data.priority.value : this.priority,
+    );
+  }
+
   factory Category.fromJson(Map<String, dynamic> json,
       {ValueSerializer? serializer}) {
     serializer ??= driftRuntimeOptions.defaultSerializer;
@@ -449,6 +458,18 @@ class TodoEntry extends DataClass implements Insertable<TodoEntry> {
           : Value(category),
       status:
           status == null && nullToAbsent ? const Value.absent() : Value(status),
+    );
+  }
+
+  TodoEntry copyWithCompanion(TodosTableCompanion data) {
+    return TodoEntry(
+      id: data.id.present ? data.id.value : this.id,
+      title: data.title.present ? data.title.value : this.title,
+      content: data.content.present ? data.content.value : this.content,
+      targetDate:
+          data.targetDate.present ? data.targetDate.value : this.targetDate,
+      category: data.category.present ? data.category.value : this.category,
+      status: data.status.present ? data.status.value : this.status,
     );
   }
 
@@ -778,6 +799,20 @@ class User extends DataClass implements Insertable<User> {
     );
   }
 
+  User copyWithCompanion(UsersCompanion data) {
+    return User(
+      id: data.id.present ? data.id.value : this.id,
+      name: data.name.present ? data.name.value : this.name,
+      isAwesome: data.isAwesome.present ? data.isAwesome.value : this.isAwesome,
+      profilePicture: data.profilePicture.present
+          ? data.profilePicture.value
+          : this.profilePicture,
+      creationTime: data.creationTime.present
+          ? data.creationTime.value
+          : this.creationTime,
+    );
+  }
+
   factory User.fromJson(Map<String, dynamic> json,
       {ValueSerializer? serializer}) {
     serializer ??= driftRuntimeOptions.defaultSerializer;
@@ -1010,6 +1045,13 @@ class SharedTodo extends DataClass implements Insertable<SharedTodo> {
     return SharedTodosCompanion(
       todo: Value(todo),
       user: Value(user),
+    );
+  }
+
+  SharedTodo copyWithCompanion(SharedTodosCompanion data) {
+    return SharedTodo(
+      todo: data.todo.present ? data.todo.value : this.todo,
+      user: data.user.present ? data.user.value : this.user,
     );
   }
 
@@ -1393,6 +1435,12 @@ class PureDefault extends DataClass implements Insertable<PureDefault> {
     );
   }
 
+  PureDefault copyWithCompanion(PureDefaultsCompanion data) {
+    return PureDefault(
+      txt: data.txt.present ? data.txt.value : this.txt,
+    );
+  }
+
   factory PureDefault.fromJson(Map<String, dynamic> json,
       {ValueSerializer? serializer}) {
     serializer ??= driftRuntimeOptions.defaultSerializer;
@@ -1548,6 +1596,12 @@ class WithCustomTypeData extends DataClass
   WithCustomTypeCompanion toCompanion(bool nullToAbsent) {
     return WithCustomTypeCompanion(
       id: Value(id),
+    );
+  }
+
+  WithCustomTypeData copyWithCompanion(WithCustomTypeCompanion data) {
+    return WithCustomTypeData(
+      id: data.id.present ? data.id.value : this.id,
     );
   }
 
@@ -1917,6 +1971,24 @@ class TableWithEveryColumnTypeData extends DataClass
     );
   }
 
+  TableWithEveryColumnTypeData copyWithCompanion(
+      TableWithEveryColumnTypeCompanion data) {
+    return TableWithEveryColumnTypeData(
+      id: data.id.present ? data.id.value : this.id,
+      aBool: data.aBool.present ? data.aBool.value : this.aBool,
+      aDateTime: data.aDateTime.present ? data.aDateTime.value : this.aDateTime,
+      aText: data.aText.present ? data.aText.value : this.aText,
+      anInt: data.anInt.present ? data.anInt.value : this.anInt,
+      anInt64: data.anInt64.present ? data.anInt64.value : this.anInt64,
+      aReal: data.aReal.present ? data.aReal.value : this.aReal,
+      aBlob: data.aBlob.present ? data.aBlob.value : this.aBlob,
+      anIntEnum: data.anIntEnum.present ? data.anIntEnum.value : this.anIntEnum,
+      aTextWithConverter: data.aTextWithConverter.present
+          ? data.aTextWithConverter.value
+          : this.aTextWithConverter,
+    );
+  }
+
   factory TableWithEveryColumnTypeData.fromJson(Map<String, dynamic> json,
       {ValueSerializer? serializer}) {
     serializer ??= driftRuntimeOptions.defaultSerializer;
@@ -2254,6 +2326,13 @@ class DepartmentData extends DataClass implements Insertable<DepartmentData> {
     );
   }
 
+  DepartmentData copyWithCompanion(DepartmentCompanion data) {
+    return DepartmentData(
+      id: data.id.present ? data.id.value : this.id,
+      name: data.name.present ? data.name.value : this.name,
+    );
+  }
+
   factory DepartmentData.fromJson(Map<String, dynamic> json,
       {ValueSerializer? serializer}) {
     serializer ??= driftRuntimeOptions.defaultSerializer;
@@ -2456,6 +2535,15 @@ class ProductData extends DataClass implements Insertable<ProductData> {
     );
   }
 
+  ProductData copyWithCompanion(ProductCompanion data) {
+    return ProductData(
+      id: data.id.present ? data.id.value : this.id,
+      name: data.name.present ? data.name.value : this.name,
+      department:
+          data.department.present ? data.department.value : this.department,
+    );
+  }
+
   factory ProductData.fromJson(Map<String, dynamic> json,
       {ValueSerializer? serializer}) {
     serializer ??= driftRuntimeOptions.defaultSerializer;
@@ -2649,6 +2737,13 @@ class StoreData extends DataClass implements Insertable<StoreData> {
     return StoreCompanion(
       id: Value(id),
       name: name == null && nullToAbsent ? const Value.absent() : Value(name),
+    );
+  }
+
+  StoreData copyWithCompanion(StoreCompanion data) {
+    return StoreData(
+      id: data.id.present ? data.id.value : this.id,
+      name: data.name.present ? data.name.value : this.name,
     );
   }
 
@@ -2867,6 +2962,15 @@ class ListingData extends DataClass implements Insertable<ListingData> {
           store == null && nullToAbsent ? const Value.absent() : Value(store),
       price:
           price == null && nullToAbsent ? const Value.absent() : Value(price),
+    );
+  }
+
+  ListingData copyWithCompanion(ListingCompanion data) {
+    return ListingData(
+      id: data.id.present ? data.id.value : this.id,
+      product: data.product.present ? data.product.value : this.product,
+      store: data.store.present ? data.store.value : this.store,
+      price: data.price.present ? data.price.value : this.price,
     );
   }
 

--- a/drift/test/generated/todos.g.dart
+++ b/drift/test/generated/todos.g.dart
@@ -136,15 +136,6 @@ class Category extends DataClass implements Insertable<Category> {
     );
   }
 
-  Category copyWithCompanion(CategoriesCompanion data) {
-    return Category(
-      id: data.id.present ? data.id.value : this.id,
-      description:
-          data.description.present ? data.description.value : this.description,
-      priority: data.priority.present ? data.priority.value : this.priority,
-    );
-  }
-
   factory Category.fromJson(Map<String, dynamic> json,
       {ValueSerializer? serializer}) {
     serializer ??= driftRuntimeOptions.defaultSerializer;
@@ -461,18 +452,6 @@ class TodoEntry extends DataClass implements Insertable<TodoEntry> {
     );
   }
 
-  TodoEntry copyWithCompanion(TodosTableCompanion data) {
-    return TodoEntry(
-      id: data.id.present ? data.id.value : this.id,
-      title: data.title.present ? data.title.value : this.title,
-      content: data.content.present ? data.content.value : this.content,
-      targetDate:
-          data.targetDate.present ? data.targetDate.value : this.targetDate,
-      category: data.category.present ? data.category.value : this.category,
-      status: data.status.present ? data.status.value : this.status,
-    );
-  }
-
   factory TodoEntry.fromJson(Map<String, dynamic> json,
       {ValueSerializer? serializer}) {
     serializer ??= driftRuntimeOptions.defaultSerializer;
@@ -521,6 +500,18 @@ class TodoEntry extends DataClass implements Insertable<TodoEntry> {
         category: category.present ? category.value : this.category,
         status: status.present ? status.value : this.status,
       );
+  TodoEntry copyWithCompanion(TodosTableCompanion data) {
+    return TodoEntry(
+      id: data.id.present ? data.id.value : this.id,
+      title: data.title.present ? data.title.value : this.title,
+      content: data.content.present ? data.content.value : this.content,
+      targetDate:
+          data.targetDate.present ? data.targetDate.value : this.targetDate,
+      category: data.category.present ? data.category.value : this.category,
+      status: data.status.present ? data.status.value : this.status,
+    );
+  }
+
   @override
   String toString() {
     return (StringBuffer('TodoEntry(')
@@ -799,20 +790,6 @@ class User extends DataClass implements Insertable<User> {
     );
   }
 
-  User copyWithCompanion(UsersCompanion data) {
-    return User(
-      id: data.id.present ? data.id.value : this.id,
-      name: data.name.present ? data.name.value : this.name,
-      isAwesome: data.isAwesome.present ? data.isAwesome.value : this.isAwesome,
-      profilePicture: data.profilePicture.present
-          ? data.profilePicture.value
-          : this.profilePicture,
-      creationTime: data.creationTime.present
-          ? data.creationTime.value
-          : this.creationTime,
-    );
-  }
-
   factory User.fromJson(Map<String, dynamic> json,
       {ValueSerializer? serializer}) {
     serializer ??= driftRuntimeOptions.defaultSerializer;
@@ -854,6 +831,20 @@ class User extends DataClass implements Insertable<User> {
         profilePicture: profilePicture ?? this.profilePicture,
         creationTime: creationTime ?? this.creationTime,
       );
+  User copyWithCompanion(UsersCompanion data) {
+    return User(
+      id: data.id.present ? data.id.value : this.id,
+      name: data.name.present ? data.name.value : this.name,
+      isAwesome: data.isAwesome.present ? data.isAwesome.value : this.isAwesome,
+      profilePicture: data.profilePicture.present
+          ? data.profilePicture.value
+          : this.profilePicture,
+      creationTime: data.creationTime.present
+          ? data.creationTime.value
+          : this.creationTime,
+    );
+  }
+
   @override
   String toString() {
     return (StringBuffer('User(')
@@ -1048,13 +1039,6 @@ class SharedTodo extends DataClass implements Insertable<SharedTodo> {
     );
   }
 
-  SharedTodo copyWithCompanion(SharedTodosCompanion data) {
-    return SharedTodo(
-      todo: data.todo.present ? data.todo.value : this.todo,
-      user: data.user.present ? data.user.value : this.user,
-    );
-  }
-
   factory SharedTodo.fromJson(Map<String, dynamic> json,
       {ValueSerializer? serializer}) {
     serializer ??= driftRuntimeOptions.defaultSerializer;
@@ -1081,6 +1065,13 @@ class SharedTodo extends DataClass implements Insertable<SharedTodo> {
         todo: todo ?? this.todo,
         user: user ?? this.user,
       );
+  SharedTodo copyWithCompanion(SharedTodosCompanion data) {
+    return SharedTodo(
+      todo: data.todo.present ? data.todo.value : this.todo,
+      user: data.user.present ? data.user.value : this.user,
+    );
+  }
+
   @override
   String toString() {
     return (StringBuffer('SharedTodo(')
@@ -1435,12 +1426,6 @@ class PureDefault extends DataClass implements Insertable<PureDefault> {
     );
   }
 
-  PureDefault copyWithCompanion(PureDefaultsCompanion data) {
-    return PureDefault(
-      txt: data.txt.present ? data.txt.value : this.txt,
-    );
-  }
-
   factory PureDefault.fromJson(Map<String, dynamic> json,
       {ValueSerializer? serializer}) {
     serializer ??= driftRuntimeOptions.defaultSerializer;
@@ -1467,6 +1452,12 @@ class PureDefault extends DataClass implements Insertable<PureDefault> {
       PureDefault(
         txt: txt.present ? txt.value : this.txt,
       );
+  PureDefault copyWithCompanion(PureDefaultsCompanion data) {
+    return PureDefault(
+      txt: data.txt.present ? data.txt.value : this.txt,
+    );
+  }
+
   @override
   String toString() {
     return (StringBuffer('PureDefault(')
@@ -1599,12 +1590,6 @@ class WithCustomTypeData extends DataClass
     );
   }
 
-  WithCustomTypeData copyWithCompanion(WithCustomTypeCompanion data) {
-    return WithCustomTypeData(
-      id: data.id.present ? data.id.value : this.id,
-    );
-  }
-
   factory WithCustomTypeData.fromJson(Map<String, dynamic> json,
       {ValueSerializer? serializer}) {
     serializer ??= driftRuntimeOptions.defaultSerializer;
@@ -1628,6 +1613,12 @@ class WithCustomTypeData extends DataClass
   WithCustomTypeData copyWith({UuidValue? id}) => WithCustomTypeData(
         id: id ?? this.id,
       );
+  WithCustomTypeData copyWithCompanion(WithCustomTypeCompanion data) {
+    return WithCustomTypeData(
+      id: data.id.present ? data.id.value : this.id,
+    );
+  }
+
   @override
   String toString() {
     return (StringBuffer('WithCustomTypeData(')
@@ -1971,24 +1962,6 @@ class TableWithEveryColumnTypeData extends DataClass
     );
   }
 
-  TableWithEveryColumnTypeData copyWithCompanion(
-      TableWithEveryColumnTypeCompanion data) {
-    return TableWithEveryColumnTypeData(
-      id: data.id.present ? data.id.value : this.id,
-      aBool: data.aBool.present ? data.aBool.value : this.aBool,
-      aDateTime: data.aDateTime.present ? data.aDateTime.value : this.aDateTime,
-      aText: data.aText.present ? data.aText.value : this.aText,
-      anInt: data.anInt.present ? data.anInt.value : this.anInt,
-      anInt64: data.anInt64.present ? data.anInt64.value : this.anInt64,
-      aReal: data.aReal.present ? data.aReal.value : this.aReal,
-      aBlob: data.aBlob.present ? data.aBlob.value : this.aBlob,
-      anIntEnum: data.anIntEnum.present ? data.anIntEnum.value : this.anIntEnum,
-      aTextWithConverter: data.aTextWithConverter.present
-          ? data.aTextWithConverter.value
-          : this.aTextWithConverter,
-    );
-  }
-
   factory TableWithEveryColumnTypeData.fromJson(Map<String, dynamic> json,
       {ValueSerializer? serializer}) {
     serializer ??= driftRuntimeOptions.defaultSerializer;
@@ -2062,6 +2035,24 @@ class TableWithEveryColumnTypeData extends DataClass
             ? aTextWithConverter.value
             : this.aTextWithConverter,
       );
+  TableWithEveryColumnTypeData copyWithCompanion(
+      TableWithEveryColumnTypeCompanion data) {
+    return TableWithEveryColumnTypeData(
+      id: data.id.present ? data.id.value : this.id,
+      aBool: data.aBool.present ? data.aBool.value : this.aBool,
+      aDateTime: data.aDateTime.present ? data.aDateTime.value : this.aDateTime,
+      aText: data.aText.present ? data.aText.value : this.aText,
+      anInt: data.anInt.present ? data.anInt.value : this.anInt,
+      anInt64: data.anInt64.present ? data.anInt64.value : this.anInt64,
+      aReal: data.aReal.present ? data.aReal.value : this.aReal,
+      aBlob: data.aBlob.present ? data.aBlob.value : this.aBlob,
+      anIntEnum: data.anIntEnum.present ? data.anIntEnum.value : this.anIntEnum,
+      aTextWithConverter: data.aTextWithConverter.present
+          ? data.aTextWithConverter.value
+          : this.aTextWithConverter,
+    );
+  }
+
   @override
   String toString() {
     return (StringBuffer('TableWithEveryColumnTypeData(')
@@ -2326,13 +2317,6 @@ class DepartmentData extends DataClass implements Insertable<DepartmentData> {
     );
   }
 
-  DepartmentData copyWithCompanion(DepartmentCompanion data) {
-    return DepartmentData(
-      id: data.id.present ? data.id.value : this.id,
-      name: data.name.present ? data.name.value : this.name,
-    );
-  }
-
   factory DepartmentData.fromJson(Map<String, dynamic> json,
       {ValueSerializer? serializer}) {
     serializer ??= driftRuntimeOptions.defaultSerializer;
@@ -2361,6 +2345,13 @@ class DepartmentData extends DataClass implements Insertable<DepartmentData> {
         id: id ?? this.id,
         name: name.present ? name.value : this.name,
       );
+  DepartmentData copyWithCompanion(DepartmentCompanion data) {
+    return DepartmentData(
+      id: data.id.present ? data.id.value : this.id,
+      name: data.name.present ? data.name.value : this.name,
+    );
+  }
+
   @override
   String toString() {
     return (StringBuffer('DepartmentData(')
@@ -2535,15 +2526,6 @@ class ProductData extends DataClass implements Insertable<ProductData> {
     );
   }
 
-  ProductData copyWithCompanion(ProductCompanion data) {
-    return ProductData(
-      id: data.id.present ? data.id.value : this.id,
-      name: data.name.present ? data.name.value : this.name,
-      department:
-          data.department.present ? data.department.value : this.department,
-    );
-  }
-
   factory ProductData.fromJson(Map<String, dynamic> json,
       {ValueSerializer? serializer}) {
     serializer ??= driftRuntimeOptions.defaultSerializer;
@@ -2577,6 +2559,15 @@ class ProductData extends DataClass implements Insertable<ProductData> {
         name: name.present ? name.value : this.name,
         department: department.present ? department.value : this.department,
       );
+  ProductData copyWithCompanion(ProductCompanion data) {
+    return ProductData(
+      id: data.id.present ? data.id.value : this.id,
+      name: data.name.present ? data.name.value : this.name,
+      department:
+          data.department.present ? data.department.value : this.department,
+    );
+  }
+
   @override
   String toString() {
     return (StringBuffer('ProductData(')
@@ -2740,13 +2731,6 @@ class StoreData extends DataClass implements Insertable<StoreData> {
     );
   }
 
-  StoreData copyWithCompanion(StoreCompanion data) {
-    return StoreData(
-      id: data.id.present ? data.id.value : this.id,
-      name: data.name.present ? data.name.value : this.name,
-    );
-  }
-
   factory StoreData.fromJson(Map<String, dynamic> json,
       {ValueSerializer? serializer}) {
     serializer ??= driftRuntimeOptions.defaultSerializer;
@@ -2774,6 +2758,13 @@ class StoreData extends DataClass implements Insertable<StoreData> {
         id: id ?? this.id,
         name: name.present ? name.value : this.name,
       );
+  StoreData copyWithCompanion(StoreCompanion data) {
+    return StoreData(
+      id: data.id.present ? data.id.value : this.id,
+      name: data.name.present ? data.name.value : this.name,
+    );
+  }
+
   @override
   String toString() {
     return (StringBuffer('StoreData(')
@@ -2965,15 +2956,6 @@ class ListingData extends DataClass implements Insertable<ListingData> {
     );
   }
 
-  ListingData copyWithCompanion(ListingCompanion data) {
-    return ListingData(
-      id: data.id.present ? data.id.value : this.id,
-      product: data.product.present ? data.product.value : this.product,
-      store: data.store.present ? data.store.value : this.store,
-      price: data.price.present ? data.price.value : this.price,
-    );
-  }
-
   factory ListingData.fromJson(Map<String, dynamic> json,
       {ValueSerializer? serializer}) {
     serializer ??= driftRuntimeOptions.defaultSerializer;
@@ -3011,6 +2993,15 @@ class ListingData extends DataClass implements Insertable<ListingData> {
         store: store.present ? store.value : this.store,
         price: price.present ? price.value : this.price,
       );
+  ListingData copyWithCompanion(ListingCompanion data) {
+    return ListingData(
+      id: data.id.present ? data.id.value : this.id,
+      product: data.product.present ? data.product.value : this.product,
+      store: data.store.present ? data.store.value : this.store,
+      price: data.price.present ? data.price.value : this.price,
+    );
+  }
+
   @override
   String toString() {
     return (StringBuffer('ListingData(')

--- a/drift/test/integration_tests/regress_2166_test.g.dart
+++ b/drift/test/integration_tests/regress_2166_test.g.dart
@@ -85,13 +85,6 @@ class _SomeTableData extends DataClass implements Insertable<_SomeTableData> {
     );
   }
 
-  _SomeTableData copyWithCompanion(_SomeTableCompanion data) {
-    return _SomeTableData(
-      id: data.id.present ? data.id.value : this.id,
-      name: data.name.present ? data.name.value : this.name,
-    );
-  }
-
   factory _SomeTableData.fromJson(Map<String, dynamic> json,
       {ValueSerializer? serializer}) {
     serializer ??= driftRuntimeOptions.defaultSerializer;
@@ -120,6 +113,13 @@ class _SomeTableData extends DataClass implements Insertable<_SomeTableData> {
         id: id ?? this.id,
         name: name.present ? name.value : this.name,
       );
+  _SomeTableData copyWithCompanion(_SomeTableCompanion data) {
+    return _SomeTableData(
+      id: data.id.present ? data.id.value : this.id,
+      name: data.name.present ? data.name.value : this.name,
+    );
+  }
+
   @override
   String toString() {
     return (StringBuffer('_SomeTableData(')

--- a/drift/test/integration_tests/regress_2166_test.g.dart
+++ b/drift/test/integration_tests/regress_2166_test.g.dart
@@ -85,6 +85,13 @@ class _SomeTableData extends DataClass implements Insertable<_SomeTableData> {
     );
   }
 
+  _SomeTableData copyWithCompanion(_SomeTableCompanion data) {
+    return _SomeTableData(
+      id: data.id.present ? data.id.value : this.id,
+      name: data.name.present ? data.name.value : this.name,
+    );
+  }
+
   factory _SomeTableData.fromJson(Map<String, dynamic> json,
       {ValueSerializer? serializer}) {
     serializer ??= driftRuntimeOptions.defaultSerializer;

--- a/drift_dev/lib/src/writer/tables/data_class_writer.dart
+++ b/drift_dev/lib/src/writer/tables/data_class_writer.dart
@@ -107,6 +107,7 @@ class DataClassWriter {
       if (scope.options.dataClassToCompanions &&
           scope.generationOptions.writeCompanions) {
         _writeToCompanion();
+        _writeCopyWithCompanion();
       }
     }
 
@@ -254,6 +255,29 @@ class DataClassWriter {
     }
 
     _buffer.write(');');
+  }
+
+  void _writeCopyWithCompanion() {
+    final asTable = table as DriftTable;
+    final companionType = _emitter.writer.companionType(asTable);
+
+    _emitter
+      ..write('${table.nameOfRowClass} copyWithCompanion(')
+      ..writeDart(companionType)
+      ..writeln(' data) {')
+      ..writeln('return ${table.nameOfRowClass}(');
+
+    for (final column in columns) {
+      // Generated columns are not fields of companions.
+      if (column.isGenerated) continue;
+      final name = column.nameInDart;
+      _buffer
+          .write('$name: data.$name.present ? data.$name.value : this.$name,');
+    }
+
+    _buffer
+      ..writeln(');')
+      ..writeln('}');
   }
 
   void _writeToCompanion() {

--- a/drift_dev/lib/src/writer/tables/data_class_writer.dart
+++ b/drift_dev/lib/src/writer/tables/data_class_writer.dart
@@ -117,7 +117,6 @@ class DataClassWriter {
     // And convenience methods to copy data from this class.
     _writeCopyWith();
     if (isInsertable &&
-        scope.options.dataClassToCompanions &&
         scope.generationOptions.writeCompanions &&
         !columns.any((column) => column.isGenerated)) {
       _writeCopyWithCompanion();

--- a/drift_dev/lib/src/writer/tables/data_class_writer.dart
+++ b/drift_dev/lib/src/writer/tables/data_class_writer.dart
@@ -107,7 +107,6 @@ class DataClassWriter {
       if (scope.options.dataClassToCompanions &&
           scope.generationOptions.writeCompanions) {
         _writeToCompanion();
-        _writeCopyWithCompanion();
       }
     }
 
@@ -115,8 +114,14 @@ class DataClassWriter {
     _writeFromJson();
     _writeToJson();
 
-    // And a convenience method to copy data from this class.
+    // And convenience methods to copy data from this class.
     _writeCopyWith();
+    if (isInsertable &&
+        scope.options.dataClassToCompanions &&
+        scope.generationOptions.writeCompanions &&
+        !columns.any((column) => column.isGenerated)) {
+      _writeCopyWithCompanion();
+    }
 
     _writeToString();
     _writeHashCode();
@@ -268,8 +273,8 @@ class DataClassWriter {
       ..writeln('return ${table.nameOfRowClass}(');
 
     for (final column in columns) {
-      // Generated columns are not fields of companions.
-      if (column.isGenerated) continue;
+      // Generated columns do not appear in companions.
+      assert(!column.isGenerated);
       final name = column.nameInDart;
       _buffer
           .write('$name: data.$name.present ? data.$name.value : this.$name,');

--- a/drift_dev/test/writer/data_class_writer_test.dart
+++ b/drift_dev/test/writer/data_class_writer_test.dart
@@ -175,6 +175,28 @@ mixin PostsToColumns implements i1.Insertable<i2.Post> {
     }, writer.dartOutputs, writer.writer);
   });
 
+  test('generates copyWithCompanion', () async {
+    final result = await emulateDriftBuild(modularBuild: true, inputs: {
+      'a|lib/a.dart': '''
+import 'package:drift/drift.dart';
+
+class Items extends Table {
+  TextColumn get name => text()();
+}
+''',
+    });
+
+    checkOutputs({
+      'a|lib/a.drift.dart': decodedMatches(contains(r'''
+  Item copyWithCompanion(i1.ItemsCompanion data) {
+    return Item(
+      name: data.name.present ? data.name.value : this.name,
+    );
+  }
+''')),
+    }, result.dartOutputs, result.writer);
+  });
+
   test('generates correct fromJson for nullable converters', () async {
     // Regression test for https://github.com/simolus3/drift/issues/2281
     final result = await emulateDriftBuild(


### PR DESCRIPTION
The companion class makes an extremely useful way to bundle up a set of changes to make to a record.  This copyWithCompanion method makes it possible to apply those changes directly to a record as represented in Dart, as an instance of the data class.

For example, it can be used by a wrapper that keeps a write-through cache in Dart for a given database table.  Here's slightly simplified from a real example we have in Zulip:

    /// Update an account in the store, returning the new version.
    ///
    /// The account with the given account ID will be updated.
    /// It must already exist in the store.
    Future<Account> updateAccount(int accountId, AccountsCompanion data) async {
      assert(!data.id.present);
      await (_db.update(_db.accounts)
        ..where((a) => a.id.equals(accountId))
      ).write(data);
      final result = _accounts.update(accountId,
        (value) => value.copyWithCompanion(data));
      notifyListeners();
      return result;
    }

It's possible to write such a method by hand, of course (in an extension), or to call copyWith directly.  But it needs a line for each column of the table, which makes either of those error-prone: in particular, because copyWith naturally has its parameters all optional, it would be very easy for someone adding a new column to overlook the need to add a line to this method, and then updates to the new column would just silently get dropped.  So this is a case where there's a large benefit to generating the code.