### PR TITLE
Start testing with minimum sqlite version

### DIFF
--- a/.github/actions/prepare/action.yml
+++ b/.github/actions/prepare/action.yml
@@ -16,13 +16,13 @@ runs:
       uses: actions/download-artifact@v4
       with:
         name: sqlite3
-        path: /tmp/sqlite/out/
+        path: drift/.dart_tool/sqlite3/
     - name: Use downloaded sqlite3
       shell: bash
       run: |
-        chmod a+x /tmp/sqlite/out/sqlite3
-        echo "/tmp/sqlite/out" >> $GITHUB_PATH
-        echo "LD_LIBRARY_PATH=/tmp/sqlite/out" >> $GITHUB_ENV
+        chmod a+x drift/.dart_tool/sqlite3/latest/sqlite3
+        echo $(realpath drift/.dart_tool/sqlite3/latest) >> $GITHUB_PATH
+        echo "LD_LIBRARY_PATH=$(realpath drift/.dart_tool/sqlite3/latest)" >> $GITHUB_ENV
     - name: Check sqlite3 version
       run: sqlite3 --version
       shell: bash

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -225,6 +225,10 @@ jobs:
       - name: Test
         working-directory: examples/migrations_example
         run: dart test
+      - name: Test with older sqlite3
+        working-directory: examples/migrations_example
+        run: |
+          LD_LIBRARY_PATH=$(realpath drift/.dart_tool/sqlite3/minimum) dart test
       - name: Check that extracting schema still works
         working-directory: examples/migrations_example
         run: dart run drift_dev schema dump lib/database.dart drift_migrations/

--- a/docs/pages/docs/Migrations/tests.md
+++ b/docs/pages/docs/Migrations/tests.md
@@ -21,6 +21,9 @@ Drift's migration tooling consists of the following steps:
 
 This page describes steps 2 and 3. It assumes that you're already following step 1 by
 [exporting your schema]({{ 'exports.md' | pageUrl }}) when it changes.
+Also consider the [general page]({{ '../testing.md' | pageUrl }}) on writing unit tests with drift.
+In particular, you may have to manually install `sqlite3` on your system as `sqlite3_flutter_libs` does
+not apply to unit tests.
 
 ## Writing tests
 

--- a/docs/pages/docs/testing.md
+++ b/docs/pages/docs/testing.md
@@ -66,6 +66,12 @@ On Windows, you can [download 'Precompiled Binaries for Windows'](https://www.sq
 and extract `sqlite3.dll` into a folder that's in your `PATH`
 environment variable. Then restart your device to ensure that
 all apps will run with this `PATH` change.
+
+As `sqlite3_flutter_libs` bundles the latest sqlite3 version with your app,
+using a recent sqlite3 version is recommended to avoid differences in how tests
+behave from your app.
+The minimum sqlite version tested with drift is 3.29.0, but many drift features
+like `returning` or generated columns will require more recent versions.
 {% endblock %}
 
 ## Writing tests

--- a/drift/test/test_utils/database_vm.dart
+++ b/drift/test/test_utils/database_vm.dart
@@ -10,12 +10,14 @@ import 'package:path/path.dart' as p;
 bool _checkedForLocalSqlite3 = false;
 
 String? get expectedLocalSqlite3Path {
+  final folder = p.join('.dart_tool', 'sqlite3', 'latest');
+
   if (Platform.isWindows) {
-    return p.join('.dart_tool', 'sqlite3', 'sqlite3.dll');
+    return p.join(folder, 'sqlite3.dll');
   } else if (Platform.isMacOS) {
-    return p.join('.dart_tool', 'sqlite3', 'libsqlite3.dylib');
+    return p.join(folder, 'libsqlite3.dylib');
   } else if (Platform.isLinux) {
-    return p.join('.dart_tool', 'sqlite3', 'libsqlite3.so');
+    return p.join(folder, 'libsqlite3.so');
   } else {
     return null;
   }

--- a/drift/tool/download_sqlite3.dart
+++ b/drift/tool/download_sqlite3.dart
@@ -4,31 +4,49 @@ import 'package:archive/archive_io.dart';
 import 'package:http/http.dart';
 import 'package:path/path.dart' as p;
 
-const _version = '3450000';
-const _year = '2024';
-const _url = 'https://www.sqlite.org/$_year/sqlite-autoconf-$_version.tar.gz';
+typedef SqliteVersion = ({String version, String year});
+
+const SqliteVersion latest = (version: '3460000', year: '2024');
+const SqliteVersion minimum = (version: '3290000', year: '2019');
 
 Future<void> main(List<String> args) async {
   if (args.contains('version')) {
-    print(_version);
+    print(latest.version);
     exit(0);
   }
 
+  await _downloadAndCompile('latest', latest, force: args.contains('--force'));
+  await _downloadAndCompile('minimum', minimum,
+      force: args.contains('--force'));
+}
+
+extension on SqliteVersion {
+  String get autoconfUrl =>
+      'https://www.sqlite.org/$year/sqlite-autoconf-$version.tar.gz';
+
+  String get windowsUrl =>
+      'https://www.sqlite.org/$year/sqlite-dll-win-x64-$version.zip';
+}
+
+Future<void> _downloadAndCompile(String name, SqliteVersion version,
+    {bool force = false}) async {
   final driftDirectory = p.dirname(p.dirname(Platform.script.toFilePath()));
-  final target = p.join(driftDirectory, '.dart_tool', 'sqlite3');
+  final target = p.join(driftDirectory, '.dart_tool', 'sqlite3', name);
   final versionFile = File(p.join(target, 'version'));
 
-  final needsDownload = args.contains('--force') ||
+  final needsDownload = force ||
       !versionFile.existsSync() ||
-      versionFile.readAsStringSync() != _version;
+      versionFile.readAsStringSync() != version.version;
 
   if (!needsDownload) {
-    print('Not doing anything as sqlite3 has already been downloaded. Use '
-        '--force to re-compile it.');
+    print(
+      'Not downloading sqlite3 $name as it has already been downloaded. Use '
+      '--force to re-compile it.',
+    );
     exit(0);
   }
 
-  print('Downloading and compiling sqlite3 for drift test');
+  print('Downloading and compiling sqlite3 $name (${version.version})');
 
   final temporaryDir =
       await Directory.systemTemp.createTemp('drift-compile-sqlite3');
@@ -38,8 +56,7 @@ Future<void> main(List<String> args) async {
   // installed and all those tools activated in the current shell.
   // Much easier to just download precompiled builds.
   if (Platform.isWindows) {
-    const windowsUri =
-        'https://www.sqlite.org/$_year/sqlite-dll-win-x64-$_version.zip';
+    final windowsUri = version.windowsUrl;
     final sqlite3Zip = p.join(temporaryDirPath, 'sqlite3.zip');
     final client = Client();
     final response = await client.send(Request('GET', Uri.parse(windowsUri)));
@@ -62,15 +79,16 @@ Future<void> main(List<String> args) async {
       }
     }
 
-    await File(p.join(target, 'version')).writeAsString(_version);
+    await File(p.join(target, 'version')).writeAsString(version.version);
     exit(0);
   }
 
-  await _run('curl $_url --output sqlite.tar.gz',
+  await _run('curl ${version.autoconfUrl} --output sqlite.tar.gz',
       workingDirectory: temporaryDirPath);
   await _run('tar zxvf sqlite.tar.gz', workingDirectory: temporaryDirPath);
 
-  final sqlitePath = p.join(temporaryDirPath, 'sqlite-autoconf-$_version');
+  final sqlitePath =
+      p.join(temporaryDirPath, 'sqlite-autoconf-${version.version}');
   await _run('./configure', workingDirectory: sqlitePath);
   await _run('make -j', workingDirectory: sqlitePath);
 
@@ -91,7 +109,7 @@ Future<void> main(List<String> args) async {
         .copy(p.join(target, 'libsqlite3.dylib'));
   }
 
-  await File(p.join(target, 'version')).writeAsString(_version);
+  await File(p.join(target, 'version')).writeAsString(version.version);
 }
 
 Future<void> _run(String command, {String? workingDirectory}) async {

--- a/drift/tool/download_sqlite3.dart
+++ b/drift/tool/download_sqlite3.dart
@@ -47,6 +47,11 @@ Future<void> _downloadAndCompile(String name, SqliteVersion version,
   }
 
   print('Downloading and compiling sqlite3 $name (${version.version})');
+  final targetDirectory = Directory(target);
+
+  if (!targetDirectory.existsSync()) {
+    targetDirectory.createSync(recursive: true);
+  }
 
   final temporaryDir =
       await Directory.systemTemp.createTemp('drift-compile-sqlite3');
@@ -91,13 +96,6 @@ Future<void> _downloadAndCompile(String name, SqliteVersion version,
       p.join(temporaryDirPath, 'sqlite-autoconf-${version.version}');
   await _run('./configure', workingDirectory: sqlitePath);
   await _run('make -j', workingDirectory: sqlitePath);
-
-  final targetDirectory = Directory(target);
-
-  if (!targetDirectory.existsSync()) {
-    // Not using recursive since .dart_tool should really exist already.
-    targetDirectory.createSync();
-  }
 
   await File(p.join(sqlitePath, 'sqlite3')).copy(p.join(target, 'sqlite3'));
 

--- a/drift_dev/lib/src/services/schema/verifier_impl.dart
+++ b/drift_dev/lib/src/services/schema/verifier_impl.dart
@@ -60,7 +60,16 @@ class VerifierImplementation implements SchemaVerifier {
 
   Database _setupDatabase(String uri) {
     final database = sqlite3.open(uri, uri: true);
-    database.config.doubleQuotedStringLiterals = false;
+    try {
+      database.config.doubleQuotedStringLiterals = false;
+    } on SqliteException {
+      print(
+        'Could not disable double-quoted string literals, migration tests '
+        'may behave differently than sqlite3 in your app. Please consider '
+        'updating sqlite3 on your system.',
+      );
+    }
+
     setup?.call(database);
     return database;
   }


### PR DESCRIPTION
- Build a recent sqlite3 version (for most tests), but also a fixed older version (so that we know we're at least compatible with that).
- We can't run drift's unit tests against the older version without a lot of skips since the test databases use generated columns or `STRICT` tables which are unavailable in the old version.
- Still, we run the migration tests with the old sqlite version (as that's what the issue was about).

Closes #3021.