### PR TITLE
fix: Update BigInt extension to handle JavaScript bit length difference

### DIFF
--- a/extras/drift_postgres/lib/src/pg_database.dart
+++ b/extras/drift_postgres/lib/src/pg_database.dart
@@ -220,8 +220,10 @@ class _PgVersionDelegate extends DynamicVersionDelegate {
 }
 
 extension on BigInt {
-  static final _bigIntMinValue64 = BigInt.from(-9223372036854775808);
-  static final _bigIntMaxValue64 = BigInt.from(9223372036854775807);
+  static const _isJs = identical(1.0, 1);
+  static const _allowedBitLength = _isJs ? 53 : 63;
+  static final _bigIntMinValue64 = BigInt.from(1 << _allowedBitLength);
+  static final _bigIntMaxValue64 = BigInt.from((1 << _allowedBitLength) - 1);
 
   int rangeCheckedToInt() {
     if (this < _bigIntMinValue64 || this > _bigIntMaxValue64) {


### PR DESCRIPTION
This PR fixes the `BigInt` bound check testing that previous used hardcoded min/max values for 64-bit signed ints, but JS only supports up to 53-bit ints in Dart.

This prevented the package from being built on Wb when the extension was used.

https://api.flutter.dev/flutter/dart-core/int-class.html