### PR TITLE
Add `exclusively` API

### DIFF
--- a/drift/CHANGELOG.md
+++ b/drift/CHANGELOG.md
@@ -1,5 +1,8 @@
 ## 2.19.0-dev
 
+- Add `exclusively` method to database classes, allowing a block to temporarily
+  take exclusive control over a database connection without starting a
+  transaction.
 - Add the `enableMigrations` parameter to `WasmDatabase` to control whether drift
   migrations are enabled on that database.
 - Add `initiallyDeferred` option to `references()` column builder for foreign

--- a/drift/lib/src/runtime/api/connection.dart
+++ b/drift/lib/src/runtime/api/connection.dart
@@ -75,6 +75,9 @@ class DatabaseConnection implements QueryExecutor {
   }
 
   @override
+  QueryExecutor beginExclusive() => executor.beginExclusive();
+
+  @override
   TransactionExecutor beginTransaction() => executor.beginTransaction();
 
   @override

--- a/drift/lib/src/runtime/api/connection_user.dart
+++ b/drift/lib/src/runtime/api/connection_user.dart
@@ -514,6 +514,13 @@ abstract class DatabaseConnectionUser {
   /// If the [exclusively] block had been omitted from the previous snippet,
   /// it would have been possible for other concurrent database calls to occur
   /// between the transaction and the `pragma` statements.
+  ///
+  /// Outside of blocks requiring exclusive access to set pragmas not supported
+  /// in transactions, consider using [transaction] instead of [exclusively].
+  /// Transactions also take exclusive control over the database, but they also
+  /// are atomic (either all statements in a transaction complete or none at
+  /// all), whereas an error in an [exclusively] block does not roll back
+  /// earlier statements.
   Future<T> exclusively<T>(Future<T> Function() action) async {
     return await resolvedEngine.doWhenOpened((executor) {
       final exclusive = executor.beginExclusive();

--- a/drift/lib/src/runtime/api/connection_user.dart
+++ b/drift/lib/src/runtime/api/connection_user.dart
@@ -486,6 +486,51 @@ abstract class DatabaseConnectionUser {
     });
   }
 
+  /// Obtains an exclusive lock on the current database context, runs [action]
+  /// in it and then releases the lock.
+  ///
+  /// This obtains a local lock on the underlying [executor] without starting a
+  /// transaction or coordinating with other processes on the same database.
+  /// It is possible to start a [transaction] within an [exclusively] block.
+  /// When [exclusively] is called on a database connected to a remote isolate
+  /// or a shared web worker, other isolates and tabs will be blocked on the
+  /// database until the returned future completes.
+  ///
+  /// With sqlite3, [exclusively] is useful to set certain pragmas like
+  /// `foreign_keys` which can't be done in a transaction for a limited scope.
+  /// For instance, some migrations may look like this:
+  ///
+  /// ```dart
+  /// await exclusively(() async {
+  ///   await customStatement('pragma foreign_keys = OFF;');
+  ///   await transaction(() async {
+  ///     // complex updates or migrations temporarily breaking foreign
+  ///     // references...
+  ///   });
+  ///   await customStatement('pragma foreign_keys = OFF;');
+  /// });
+  /// ```
+  ///
+  /// If the [exclusively] block had been omitted from the previous snippet,
+  /// it would have been possible for other concurrent database calls to occur
+  /// between the transaction and the `pragma` statements.
+  Future<T> exclusively<T>(Future<T> Function() action) async {
+    return await resolvedEngine.doWhenOpened((executor) {
+      final exclusive = executor.beginExclusive();
+
+      return _runConnectionZoned(
+        _ExclusiveExecutor(this, executor: exclusive),
+        () async {
+          try {
+            return await action();
+          } finally {
+            exclusive.close();
+          }
+        },
+      );
+    });
+  }
+
   /// Runs statements inside a batch.
   ///
   /// A batch can only run a subset of statements, and those statements must be
@@ -620,4 +665,13 @@ extension RunWithEngine on DatabaseConnectionUser {
     final engine = resolvedEngine;
     return engine.doWhenOpened(run);
   }
+}
+
+class _ExclusiveExecutor extends DatabaseConnectionUser {
+  @override
+  final GeneratedDatabase attachedDatabase;
+
+  _ExclusiveExecutor(super.other, {super.executor})
+      : attachedDatabase = other.attachedDatabase,
+        super.delegate();
 }

--- a/drift/lib/src/runtime/devtools/service_extension.dart
+++ b/drift/lib/src/runtime/devtools/service_extension.dart
@@ -113,6 +113,11 @@ class _CollectCreateStatements extends QueryExecutor {
   final List<String> statements = [];
 
   @override
+  QueryExecutor beginExclusive() {
+    return this;
+  }
+
+  @override
   TransactionExecutor beginTransaction() {
     throw UnimplementedError();
   }

--- a/drift/lib/src/runtime/executor/connection_pool.dart
+++ b/drift/lib/src/runtime/executor/connection_pool.dart
@@ -112,6 +112,15 @@ class _MultiExecutorImpl extends MultiExecutor {
   }
 
   @override
+  QueryExecutor beginExclusive() {
+    // This is technically not correct - readers can still read while the
+    // exclusive write is active, but the same thing is true for transactions
+    // and since we're using separate connections for reads and writes this
+    // should be fine.
+    return _write.beginExclusive();
+  }
+
+  @override
   TransactionExecutor beginTransaction() => _write.beginTransaction();
 
   @override

--- a/drift/lib/src/runtime/executor/executor.dart
+++ b/drift/lib/src/runtime/executor/executor.dart
@@ -51,6 +51,16 @@ abstract class QueryExecutor {
   /// Starts a [TransactionExecutor].
   TransactionExecutor beginTransaction();
 
+  /// Returns a new [QueryExecutor] that, when first opened, takes an exclusive
+  /// lock over `this` executor and prevents queries from running until it is
+  /// closed.
+  ///
+  /// The difference between this and [beginTransaction] is that this does not
+  /// start a database transaction. The [QueryExecutor] returned by
+  /// [beginExclusive] can be used to start a transaction with
+  /// [beginTransaction].
+  QueryExecutor beginExclusive();
+
   /// Closes this database connection and releases all resources associated with
   /// it. Implementations should also handle [close] calls in a state where the
   /// database isn't open.

--- a/drift/lib/src/runtime/executor/helpers/delegates.dart
+++ b/drift/lib/src/runtime/executor/helpers/delegates.dart
@@ -116,9 +116,7 @@ abstract class QueryDelegate {
 }
 
 /// An interface to start and manage transactions.
-///
-/// Clients may not extend, implement or mix-in this class directly.
-abstract class TransactionDelegate {
+sealed class TransactionDelegate {
   /// Const constructor on superclass
   const TransactionDelegate();
 }
@@ -127,7 +125,7 @@ abstract class TransactionDelegate {
 /// creating transactions. Drift will send a `BEGIN TRANSACTION` statement at
 /// the beginning, then block the database, and finally send a `COMMIT`
 /// statement at the end.
-class NoTransactionDelegate extends TransactionDelegate {
+final class NoTransactionDelegate extends TransactionDelegate {
   /// The statement that starts a transaction on this database engine.
   final String start;
 
@@ -212,22 +210,20 @@ abstract class WrappedTransactionDelegate extends SupportedTransactionDelegate {
 }
 
 /// An interface that supports setting the database version.
-///
-/// Clients may not extend, implement or mix-in this class directly.
-abstract class DbVersionDelegate {
+sealed class DbVersionDelegate {
   /// Constant constructor on superclass
   const DbVersionDelegate();
 }
 
 /// A database that doesn't support setting schema versions.
-class NoVersionDelegate extends DbVersionDelegate {
+final class NoVersionDelegate extends DbVersionDelegate {
   /// Delegate indicating that the underlying database does not support schema
   /// versions.
   const NoVersionDelegate();
 }
 
 /// A database that only support setting the schema version while being opened.
-class OnOpenVersionDelegate extends DbVersionDelegate {
+final class OnOpenVersionDelegate extends DbVersionDelegate {
   /// Function that returns with the current schema version.
   final Future<int> Function() loadSchemaVersion;
 

--- a/drift/lib/src/runtime/executor/interceptor.dart
+++ b/drift/lib/src/runtime/executor/interceptor.dart
@@ -44,6 +44,9 @@ abstract class QueryInterceptor {
   TransactionExecutor beginTransaction(QueryExecutor parent) =>
       parent.beginTransaction();
 
+  /// Intercept [QueryExecutor.beginExclusive] calls.
+  QueryExecutor beginExclusive(QueryExecutor parent) => parent.beginExclusive();
+
   /// Intercept [TransactionExecutor.supportsNestedTransactions] calls.
   bool transactionCanBeNested(TransactionExecutor inner) {
     return inner.supportsNestedTransactions;
@@ -112,6 +115,12 @@ class _InterceptedExecutor extends QueryExecutor {
   @override
   TransactionExecutor beginTransaction() => _InterceptedTransactionExecutor(
       _interceptor.beginTransaction(_inner), _interceptor);
+
+  @override
+  QueryExecutor beginExclusive() {
+    return _InterceptedExecutor(
+        _interceptor.beginExclusive(_inner), _interceptor);
+  }
 
   @override
   SqlDialect get dialect => _interceptor.dialect(_inner);

--- a/drift/lib/src/utils/lazy_database.dart
+++ b/drift/lib/src/utils/lazy_database.dart
@@ -54,6 +54,9 @@ class LazyDatabase extends QueryExecutor {
   }
 
   @override
+  QueryExecutor beginExclusive() => _delegate.beginExclusive();
+
+  @override
   TransactionExecutor beginTransaction() => _delegate.beginTransaction();
 
   @override

--- a/drift/test/generated/todos.mocks.dart
+++ b/drift/test/generated/todos.mocks.dart
@@ -1391,6 +1391,49 @@ class MockTodoDb extends _i1.Mock implements _i3.TodoDb {
       ) as _i5.Future<T>);
 
   @override
+  _i5.Future<T> exclusively<T>(_i5.Future<T> Function()? action) =>
+      (super.noSuchMethod(
+        Invocation.method(
+          #exclusively,
+          [action],
+        ),
+        returnValue: _i6.ifNotNull(
+              _i6.dummyValueOrNull<T>(
+                this,
+                Invocation.method(
+                  #exclusively,
+                  [action],
+                ),
+              ),
+              (T v) => _i5.Future<T>.value(v),
+            ) ??
+            _FakeFuture_26<T>(
+              this,
+              Invocation.method(
+                #exclusively,
+                [action],
+              ),
+            ),
+        returnValueForMissingStub: _i6.ifNotNull(
+              _i6.dummyValueOrNull<T>(
+                this,
+                Invocation.method(
+                  #exclusively,
+                  [action],
+                ),
+              ),
+              (T v) => _i5.Future<T>.value(v),
+            ) ??
+            _FakeFuture_26<T>(
+              this,
+              Invocation.method(
+                #exclusively,
+                [action],
+              ),
+            ),
+      ) as _i5.Future<T>);
+
+  @override
   _i5.Future<void> batch(_i5.FutureOr<void> Function(_i2.Batch)? runInBatch) =>
       (super.noSuchMethod(
         Invocation.method(

--- a/drift/test/remote_test.dart
+++ b/drift/test/remote_test.dart
@@ -5,6 +5,7 @@ import 'package:async/async.dart';
 import 'package:drift/drift.dart';
 import 'package:drift/remote.dart';
 import 'package:drift/src/remote/protocol.dart';
+import 'package:drift/src/utils/synchronized.dart';
 import 'package:mockito/mockito.dart';
 import 'package:stream_channel/stream_channel.dart';
 import 'package:test/test.dart';
@@ -233,6 +234,88 @@ void main() {
     verify(outerTransaction.send());
   });
 
+  test('handles exclusive executors', () async {
+    final controller = StreamChannelController<Object?>();
+    final executor = MockExecutor();
+    final multi = MultiChannel<Object?>(controller.local);
+
+    final testEvents = StreamController<String>();
+    final testEventQueue = StreamQueue(testEvents.stream);
+    final lock = Lock();
+
+    final server = DriftServer(DatabaseConnection(executor));
+    controller.foreign.serveMulti(server);
+    addTearDown(server.shutdown);
+
+    final a = TodoDb(await multi.newRemoteConnection());
+    final b = TodoDb(await multi.newRemoteConnection());
+
+    final exclusiveA = MockExecutor();
+    final exclusiveB = MockExecutor();
+
+    var exclusiveCount = 0;
+    when(executor.beginExclusive()).thenAnswer(expectAsync1((_) {
+      if (exclusiveCount == 0) {
+        exclusiveCount++;
+        testEvents.add('try-a');
+        return exclusiveA;
+      } else {
+        testEvents.add('try-b');
+        return exclusiveB;
+      }
+    }, count: 2, id: 'beginExclusive'));
+
+    for (final (name, executor) in [('a', exclusiveA), ('b', exclusiveB)]) {
+      final closeCompleter = Completer<void>();
+
+      when(executor.ensureOpen(any)).thenAnswer((i) {
+        if (!executor.opened) {
+          return expectAsync0(() async {
+            await Future<void>.delayed(Duration.zero);
+
+            final ready = Completer<bool>();
+            lock.synchronized(() {
+              testEvents.add('grant-$name');
+              ready.complete(true);
+              executor.opened = true;
+              return closeCompleter.future;
+            });
+
+            return ready.future;
+          }, id: 'ensureOpen-$name')();
+        } else {
+          return Future.value(true);
+        }
+      });
+
+      when(executor.close()).thenAnswer(expectAsync1((_) async {
+        testEvents.add('close-$name');
+        closeCompleter.complete();
+      }, id: 'close-$name'));
+    }
+
+    final wait = Completer<void>();
+    a.exclusively(() async {
+      await a.customSelect('SELECT 1').get();
+      await wait.future;
+    });
+
+    b.exclusively(() async {
+      await b.customSelect('SELECT 1').get();
+    });
+
+    await expectLater(
+      testEventQueue,
+      emitsInOrder(['try-a', 'grant-a']),
+    );
+
+    wait.complete();
+    await expectLater(
+      testEventQueue,
+      emitsInOrder(['close-a', 'try-b', 'grant-b', 'close-b']),
+    );
+  });
+
   test('reports correct dialect of remote', () async {
     final executor = MockExecutor();
     when(executor.dialect).thenReturn(SqlDialect.postgres);
@@ -276,5 +359,21 @@ extension<T> on StreamChannel<T> {
     return transformStream(StreamTransformer.fromHandlers(
       handleDone: expectAsync1((out) => out.close()),
     ));
+  }
+
+  void serveMulti(DriftServer server) {
+    final multi = MultiChannel<T>(this);
+    multi.stream.listen((message) {
+      server.serve(multi.virtualChannel(message as int));
+    });
+  }
+}
+
+extension on MultiChannel<Object?> {
+  Future<DatabaseConnection> newRemoteConnection() async {
+    final channel = virtualChannel();
+    sink.add(channel.id);
+
+    return await connectToRemoteAndInitialize(channel);
   }
 }

--- a/drift/test/test_utils/test_utils.mocks.dart
+++ b/drift/test/test_utils/test_utils.mocks.dart
@@ -3,13 +3,14 @@
 // Do not manually edit this file.
 
 // ignore_for_file: no_leading_underscores_for_library_prefixes
-import 'dart:async' as _i4;
+import 'dart:async' as _i5;
 
-import 'package:drift/drift.dart' as _i5;
-import 'package:drift/src/runtime/executor/helpers/delegates.dart' as _i2;
-import 'package:drift/src/runtime/executor/helpers/results.dart' as _i3;
-import 'package:drift/src/runtime/executor/stream_queries.dart' as _i6;
+import 'package:drift/drift.dart' as _i6;
+import 'package:drift/src/runtime/executor/helpers/delegates.dart' as _i3;
+import 'package:drift/src/runtime/executor/helpers/results.dart' as _i2;
+import 'package:drift/src/runtime/executor/stream_queries.dart' as _i7;
 import 'package:mockito/mockito.dart' as _i1;
+import 'package:mockito/src/dummies.dart' as _i4;
 
 // ignore_for_file: type=lint
 // ignore_for_file: avoid_redundant_argument_values
@@ -24,30 +25,8 @@ import 'package:mockito/mockito.dart' as _i1;
 // ignore_for_file: camel_case_types
 // ignore_for_file: subtype_of_sealed_class
 
-class _FakeDbVersionDelegate_0 extends _i1.SmartFake
-    implements _i2.DbVersionDelegate {
-  _FakeDbVersionDelegate_0(
-    Object parent,
-    Invocation parentInvocation,
-  ) : super(
-          parent,
-          parentInvocation,
-        );
-}
-
-class _FakeTransactionDelegate_1 extends _i1.SmartFake
-    implements _i2.TransactionDelegate {
-  _FakeTransactionDelegate_1(
-    Object parent,
-    Invocation parentInvocation,
-  ) : super(
-          parent,
-          parentInvocation,
-        );
-}
-
-class _FakeQueryResult_2 extends _i1.SmartFake implements _i3.QueryResult {
-  _FakeQueryResult_2(
+class _FakeQueryResult_0 extends _i1.SmartFake implements _i2.QueryResult {
+  _FakeQueryResult_0(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -59,7 +38,7 @@ class _FakeQueryResult_2 extends _i1.SmartFake implements _i3.QueryResult {
 /// A class which mocks [DatabaseDelegate].
 ///
 /// See the documentation for Mockito's code generation for more information.
-class MockDatabaseDelegate extends _i1.Mock implements _i2.DatabaseDelegate {
+class MockDatabaseDelegate extends _i1.Mock implements _i3.DatabaseDelegate {
   @override
   bool get isInTransaction => (super.noSuchMethod(
         Invocation.getter(#isInTransaction),
@@ -77,60 +56,60 @@ class MockDatabaseDelegate extends _i1.Mock implements _i2.DatabaseDelegate {
       );
 
   @override
-  _i2.DbVersionDelegate get versionDelegate => (super.noSuchMethod(
+  _i3.DbVersionDelegate get versionDelegate => (super.noSuchMethod(
         Invocation.getter(#versionDelegate),
-        returnValue: _FakeDbVersionDelegate_0(
+        returnValue: _i4.dummyValue<_i3.DbVersionDelegate>(
           this,
           Invocation.getter(#versionDelegate),
         ),
-        returnValueForMissingStub: _FakeDbVersionDelegate_0(
+        returnValueForMissingStub: _i4.dummyValue<_i3.DbVersionDelegate>(
           this,
           Invocation.getter(#versionDelegate),
         ),
-      ) as _i2.DbVersionDelegate);
+      ) as _i3.DbVersionDelegate);
 
   @override
-  _i2.TransactionDelegate get transactionDelegate => (super.noSuchMethod(
+  _i3.TransactionDelegate get transactionDelegate => (super.noSuchMethod(
         Invocation.getter(#transactionDelegate),
-        returnValue: _FakeTransactionDelegate_1(
+        returnValue: _i4.dummyValue<_i3.TransactionDelegate>(
           this,
           Invocation.getter(#transactionDelegate),
         ),
-        returnValueForMissingStub: _FakeTransactionDelegate_1(
+        returnValueForMissingStub: _i4.dummyValue<_i3.TransactionDelegate>(
           this,
           Invocation.getter(#transactionDelegate),
         ),
-      ) as _i2.TransactionDelegate);
+      ) as _i3.TransactionDelegate);
 
   @override
-  _i4.FutureOr<bool> get isOpen => (super.noSuchMethod(
+  _i5.FutureOr<bool> get isOpen => (super.noSuchMethod(
         Invocation.getter(#isOpen),
-        returnValue: _i4.Future<bool>.value(false),
-        returnValueForMissingStub: _i4.Future<bool>.value(false),
-      ) as _i4.FutureOr<bool>);
+        returnValue: _i5.Future<bool>.value(false),
+        returnValueForMissingStub: _i5.Future<bool>.value(false),
+      ) as _i5.FutureOr<bool>);
 
   @override
-  _i4.Future<void> open(_i5.QueryExecutorUser? db) => (super.noSuchMethod(
+  _i5.Future<void> open(_i6.QueryExecutorUser? db) => (super.noSuchMethod(
         Invocation.method(
           #open,
           [db],
         ),
-        returnValue: _i4.Future<void>.value(),
-        returnValueForMissingStub: _i4.Future<void>.value(),
-      ) as _i4.Future<void>);
+        returnValue: _i5.Future<void>.value(),
+        returnValueForMissingStub: _i5.Future<void>.value(),
+      ) as _i5.Future<void>);
 
   @override
-  _i4.Future<void> close() => (super.noSuchMethod(
+  _i5.Future<void> close() => (super.noSuchMethod(
         Invocation.method(
           #close,
           [],
         ),
-        returnValue: _i4.Future<void>.value(),
-        returnValueForMissingStub: _i4.Future<void>.value(),
-      ) as _i4.Future<void>);
+        returnValue: _i5.Future<void>.value(),
+        returnValueForMissingStub: _i5.Future<void>.value(),
+      ) as _i5.Future<void>);
 
   @override
-  void notifyDatabaseOpened(_i5.OpeningDetails? details) => super.noSuchMethod(
+  void notifyDatabaseOpened(_i6.OpeningDetails? details) => super.noSuchMethod(
         Invocation.method(
           #notifyDatabaseOpened,
           [details],
@@ -139,7 +118,7 @@ class MockDatabaseDelegate extends _i1.Mock implements _i2.DatabaseDelegate {
       );
 
   @override
-  _i4.Future<_i3.QueryResult> runSelect(
+  _i5.Future<_i2.QueryResult> runSelect(
     String? statement,
     List<Object?>? args,
   ) =>
@@ -151,7 +130,7 @@ class MockDatabaseDelegate extends _i1.Mock implements _i2.DatabaseDelegate {
             args,
           ],
         ),
-        returnValue: _i4.Future<_i3.QueryResult>.value(_FakeQueryResult_2(
+        returnValue: _i5.Future<_i2.QueryResult>.value(_FakeQueryResult_0(
           this,
           Invocation.method(
             #runSelect,
@@ -162,7 +141,7 @@ class MockDatabaseDelegate extends _i1.Mock implements _i2.DatabaseDelegate {
           ),
         )),
         returnValueForMissingStub:
-            _i4.Future<_i3.QueryResult>.value(_FakeQueryResult_2(
+            _i5.Future<_i2.QueryResult>.value(_FakeQueryResult_0(
           this,
           Invocation.method(
             #runSelect,
@@ -172,10 +151,10 @@ class MockDatabaseDelegate extends _i1.Mock implements _i2.DatabaseDelegate {
             ],
           ),
         )),
-      ) as _i4.Future<_i3.QueryResult>);
+      ) as _i5.Future<_i2.QueryResult>);
 
   @override
-  _i4.Future<int> runUpdate(
+  _i5.Future<int> runUpdate(
     String? statement,
     List<Object?>? args,
   ) =>
@@ -187,12 +166,12 @@ class MockDatabaseDelegate extends _i1.Mock implements _i2.DatabaseDelegate {
             args,
           ],
         ),
-        returnValue: _i4.Future<int>.value(0),
-        returnValueForMissingStub: _i4.Future<int>.value(0),
-      ) as _i4.Future<int>);
+        returnValue: _i5.Future<int>.value(0),
+        returnValueForMissingStub: _i5.Future<int>.value(0),
+      ) as _i5.Future<int>);
 
   @override
-  _i4.Future<int> runInsert(
+  _i5.Future<int> runInsert(
     String? statement,
     List<Object?>? args,
   ) =>
@@ -204,12 +183,12 @@ class MockDatabaseDelegate extends _i1.Mock implements _i2.DatabaseDelegate {
             args,
           ],
         ),
-        returnValue: _i4.Future<int>.value(0),
-        returnValueForMissingStub: _i4.Future<int>.value(0),
-      ) as _i4.Future<int>);
+        returnValue: _i5.Future<int>.value(0),
+        returnValueForMissingStub: _i5.Future<int>.value(0),
+      ) as _i5.Future<int>);
 
   @override
-  _i4.Future<void> runCustom(
+  _i5.Future<void> runCustom(
     String? statement,
     List<Object?>? args,
   ) =>
@@ -221,50 +200,50 @@ class MockDatabaseDelegate extends _i1.Mock implements _i2.DatabaseDelegate {
             args,
           ],
         ),
-        returnValue: _i4.Future<void>.value(),
-        returnValueForMissingStub: _i4.Future<void>.value(),
-      ) as _i4.Future<void>);
+        returnValue: _i5.Future<void>.value(),
+        returnValueForMissingStub: _i5.Future<void>.value(),
+      ) as _i5.Future<void>);
 
   @override
-  _i4.Future<void> runBatched(_i5.BatchedStatements? statements) =>
+  _i5.Future<void> runBatched(_i6.BatchedStatements? statements) =>
       (super.noSuchMethod(
         Invocation.method(
           #runBatched,
           [statements],
         ),
-        returnValue: _i4.Future<void>.value(),
-        returnValueForMissingStub: _i4.Future<void>.value(),
-      ) as _i4.Future<void>);
+        returnValue: _i5.Future<void>.value(),
+        returnValueForMissingStub: _i5.Future<void>.value(),
+      ) as _i5.Future<void>);
 }
 
 /// A class which mocks [DynamicVersionDelegate].
 ///
 /// See the documentation for Mockito's code generation for more information.
 class MockDynamicVersionDelegate extends _i1.Mock
-    implements _i2.DynamicVersionDelegate {
+    implements _i3.DynamicVersionDelegate {
   @override
-  _i4.Future<int> get schemaVersion => (super.noSuchMethod(
+  _i5.Future<int> get schemaVersion => (super.noSuchMethod(
         Invocation.getter(#schemaVersion),
-        returnValue: _i4.Future<int>.value(0),
-        returnValueForMissingStub: _i4.Future<int>.value(0),
-      ) as _i4.Future<int>);
+        returnValue: _i5.Future<int>.value(0),
+        returnValueForMissingStub: _i5.Future<int>.value(0),
+      ) as _i5.Future<int>);
 
   @override
-  _i4.Future<void> setSchemaVersion(int? version) => (super.noSuchMethod(
+  _i5.Future<void> setSchemaVersion(int? version) => (super.noSuchMethod(
         Invocation.method(
           #setSchemaVersion,
           [version],
         ),
-        returnValue: _i4.Future<void>.value(),
-        returnValueForMissingStub: _i4.Future<void>.value(),
-      ) as _i4.Future<void>);
+        returnValue: _i5.Future<void>.value(),
+        returnValueForMissingStub: _i5.Future<void>.value(),
+      ) as _i5.Future<void>);
 }
 
 /// A class which mocks [SupportedTransactionDelegate].
 ///
 /// See the documentation for Mockito's code generation for more information.
 class MockSupportedTransactionDelegate extends _i1.Mock
-    implements _i2.SupportedTransactionDelegate {
+    implements _i3.SupportedTransactionDelegate {
   @override
   bool get managesLockInternally => (super.noSuchMethod(
         Invocation.getter(#managesLockInternally),
@@ -273,48 +252,48 @@ class MockSupportedTransactionDelegate extends _i1.Mock
       ) as bool);
 
   @override
-  _i4.FutureOr<void> startTransaction(
-          _i4.Future<dynamic> Function(_i2.QueryDelegate)? run) =>
+  _i5.FutureOr<void> startTransaction(
+          _i5.Future<dynamic> Function(_i3.QueryDelegate)? run) =>
       (super.noSuchMethod(
         Invocation.method(
           #startTransaction,
           [run],
         ),
         returnValueForMissingStub: null,
-      ) as _i4.FutureOr<void>);
+      ) as _i5.FutureOr<void>);
 }
 
 /// A class which mocks [StreamQueryStore].
 ///
 /// See the documentation for Mockito's code generation for more information.
-class MockStreamQueries extends _i1.Mock implements _i6.StreamQueryStore {
+class MockStreamQueries extends _i1.Mock implements _i7.StreamQueryStore {
   @override
-  _i4.Stream<List<Map<String, Object?>>> registerStream(
-          _i6.QueryStreamFetcher? fetcher) =>
+  _i5.Stream<List<Map<String, Object?>>> registerStream(
+          _i7.QueryStreamFetcher? fetcher) =>
       (super.noSuchMethod(
         Invocation.method(
           #registerStream,
           [fetcher],
         ),
-        returnValue: _i4.Stream<List<Map<String, Object?>>>.empty(),
+        returnValue: _i5.Stream<List<Map<String, Object?>>>.empty(),
         returnValueForMissingStub:
-            _i4.Stream<List<Map<String, Object?>>>.empty(),
-      ) as _i4.Stream<List<Map<String, Object?>>>);
+            _i5.Stream<List<Map<String, Object?>>>.empty(),
+      ) as _i5.Stream<List<Map<String, Object?>>>);
 
   @override
-  _i4.Stream<Set<_i5.TableUpdate>> updatesForSync(
-          _i5.TableUpdateQuery? query) =>
+  _i5.Stream<Set<_i6.TableUpdate>> updatesForSync(
+          _i6.TableUpdateQuery? query) =>
       (super.noSuchMethod(
         Invocation.method(
           #updatesForSync,
           [query],
         ),
-        returnValue: _i4.Stream<Set<_i5.TableUpdate>>.empty(),
-        returnValueForMissingStub: _i4.Stream<Set<_i5.TableUpdate>>.empty(),
-      ) as _i4.Stream<Set<_i5.TableUpdate>>);
+        returnValue: _i5.Stream<Set<_i6.TableUpdate>>.empty(),
+        returnValueForMissingStub: _i5.Stream<Set<_i6.TableUpdate>>.empty(),
+      ) as _i5.Stream<Set<_i6.TableUpdate>>);
 
   @override
-  void handleTableUpdates(Set<_i5.TableUpdate>? updates) => super.noSuchMethod(
+  void handleTableUpdates(Set<_i6.TableUpdate>? updates) => super.noSuchMethod(
         Invocation.method(
           #handleTableUpdates,
           [updates],
@@ -324,7 +303,7 @@ class MockStreamQueries extends _i1.Mock implements _i6.StreamQueryStore {
 
   @override
   void markAsClosed(
-    _i6.QueryStream? stream,
+    _i7.QueryStream? stream,
     void Function()? whenRemoved,
   ) =>
       super.noSuchMethod(
@@ -339,7 +318,7 @@ class MockStreamQueries extends _i1.Mock implements _i6.StreamQueryStore {
       );
 
   @override
-  void markAsOpened(_i6.QueryStream? stream) => super.noSuchMethod(
+  void markAsOpened(_i7.QueryStream? stream) => super.noSuchMethod(
         Invocation.method(
           #markAsOpened,
           [stream],
@@ -348,12 +327,12 @@ class MockStreamQueries extends _i1.Mock implements _i6.StreamQueryStore {
       );
 
   @override
-  _i4.Future<void> close() => (super.noSuchMethod(
+  _i5.Future<void> close() => (super.noSuchMethod(
         Invocation.method(
           #close,
           [],
         ),
-        returnValue: _i4.Future<void>.value(),
-        returnValueForMissingStub: _i4.Future<void>.value(),
-      ) as _i4.Future<void>);
+        returnValue: _i5.Future<void>.value(),
+        returnValueForMissingStub: _i5.Future<void>.value(),
+      ) as _i5.Future<void>);
 }

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -13,10 +13,10 @@ packages:
     dependency: transitive
     description:
       name: args
-      sha256: eef6c46b622e0494a36c5a12d10d77fb4e855501a91c1b9ef9339326e58f0596
+      sha256: "7cf60b9f0cc88203c5a190b4cd62a99feea42759a7fa695010eb5de1c0b2252a"
       url: "https://pub.dev"
     source: hosted
-    version: "2.4.2"
+    version: "2.5.0"
   async:
     dependency: transitive
     description:
@@ -53,18 +53,18 @@ packages:
     dependency: transitive
     description:
       name: cli_util
-      sha256: b8db3080e59b2503ca9e7922c3df2072cf13992354d5e944074ffa836fba43b7
+      sha256: c05b7406fdabc7a49a3929d4af76bcaccbbffcbcdcf185b082e1ae07da323d19
       url: "https://pub.dev"
     source: hosted
-    version: "0.4.0"
+    version: "0.4.1"
   collection:
     dependency: transitive
     description:
       name: collection
-      sha256: f092b211a4319e98e5ff58223576de6c2803db36221657b46c82574721240687
+      sha256: ee67cb0715911d28db6bf4af1026078bd6f0128b07a5f66fb2ed94ec6783c09a
       url: "https://pub.dev"
     source: hosted
-    version: "1.17.2"
+    version: "1.18.0"
   conventional_commit:
     dependency: transitive
     description:
@@ -101,10 +101,10 @@ packages:
     dependency: transitive
     description:
       name: http
-      sha256: "5895291c13fa8a3bd82e76d5627f69e0d85ca6a30dcac95c4ea19a5d555879c2"
+      sha256: "761a297c042deedc1ffbb156d6e2af13886bb305c2a343a4d972504cd67dd938"
       url: "https://pub.dev"
     source: hosted
-    version: "0.13.6"
+    version: "1.2.1"
   http_parser:
     dependency: transitive
     description:
@@ -125,34 +125,34 @@ packages:
     dependency: transitive
     description:
       name: json_annotation
-      sha256: b10a7b2ff83d83c777edba3c6a0f97045ddadd56c944e1a23a3fdf43a1bf4467
+      sha256: "1ce844379ca14835a50d2f019a3099f419082cfdd231cd86a142af94dd5c6bb1"
       url: "https://pub.dev"
     source: hosted
-    version: "4.8.1"
+    version: "4.9.0"
   matcher:
     dependency: transitive
     description:
       name: matcher
-      sha256: "1803e76e6653768d64ed8ff2e1e67bea3ad4b923eb5c56a295c3e634bad5960e"
+      sha256: d2323aa2060500f906aa31a895b4030b6da3ebdcc5619d14ce1aada65cd161cb
       url: "https://pub.dev"
     source: hosted
-    version: "0.12.16"
+    version: "0.12.16+1"
   melos:
     dependency: "direct dev"
     description:
       name: melos
-      sha256: ccbb6ecd8bb3f08ae8f9ce22920d816bff325a98940c845eda0257cd395503ac
+      sha256: "96e64bbade5712c3f010137e195bca9f1b351fac34ab1f322af492ae34032067"
       url: "https://pub.dev"
     source: hosted
-    version: "3.1.0"
+    version: "3.4.0"
   meta:
     dependency: transitive
     description:
       name: meta
-      sha256: "3c74dbf8763d36539f114c799d8a2d87343b5067e9d796ca22b5eb8437090ee3"
+      sha256: bdb68674043280c3428e9ec998512fb681678676b3c54e773629ffe74419f8c7
       url: "https://pub.dev"
     source: hosted
-    version: "1.9.1"
+    version: "1.15.0"
   mustache_template:
     dependency: transitive
     description:
@@ -165,18 +165,18 @@ packages:
     dependency: transitive
     description:
       name: path
-      sha256: "8829d8a55c13fc0e37127c29fedf290c102f4e40ae94ada574091fe0ff96c917"
+      sha256: "087ce49c3f0dc39180befefc60fdb4acd8f8620e5682fe2476afd0b3688bb4af"
       url: "https://pub.dev"
     source: hosted
-    version: "1.8.3"
+    version: "1.9.0"
   platform:
     dependency: transitive
     description:
       name: platform
-      sha256: "4a451831508d7d6ca779f7ac6e212b4023dd5a7d08a27a63da33756410e32b76"
+      sha256: "9b71283fc13df574056616011fb138fd3b793ea47cc509c189a6c3fa5f8a1a65"
       url: "https://pub.dev"
     source: hosted
-    version: "3.1.0"
+    version: "3.1.5"
   pool:
     dependency: transitive
     description:
@@ -213,10 +213,10 @@ packages:
     dependency: transitive
     description:
       name: pub_updater
-      sha256: "42890302ab2672adf567dc2b20e55b4ecc29d7e19c63b6b98143ab68dd717d3a"
+      sha256: b06600619c8c219065a548f8f7c192b3e080beff95488ed692780f48f69c0625
       url: "https://pub.dev"
     source: hosted
-    version: "0.2.4"
+    version: "0.3.1"
   pubspec:
     dependency: transitive
     description:
@@ -245,10 +245,10 @@ packages:
     dependency: transitive
     description:
       name: stack_trace
-      sha256: c3c7d8edb15bee7f0f74debd4b9c5f3c2ea86766fe4178eb2a18eb30a0bdaed5
+      sha256: "73713990125a6d93122541237550ee3352a2d84baad52d375a4cad2eb9b7ce0b"
       url: "https://pub.dev"
     source: hosted
-    version: "1.11.0"
+    version: "1.11.1"
   stream_channel:
     dependency: transitive
     description:
@@ -277,10 +277,10 @@ packages:
     dependency: transitive
     description:
       name: test_api
-      sha256: "75760ffd7786fffdfb9597c35c5b27eaeec82be8edfb6d71d32651128ed7aab8"
+      sha256: "5b8a98dafc4d5c4c9c72d8b31ab2b23fc13422348d2997120294d3bac86b4ddb"
       url: "https://pub.dev"
     source: hosted
-    version: "0.6.0"
+    version: "0.7.2"
   typed_data:
     dependency: transitive
     description:
@@ -297,6 +297,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.0.0"
+  web:
+    dependency: transitive
+    description:
+      name: web
+      sha256: "97da13628db363c635202ad97068d47c5b8aa555808e7a9411963c533b449b27"
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.5.1"
   yaml:
     dependency: transitive
     description:
@@ -309,9 +317,9 @@ packages:
     dependency: transitive
     description:
       name: yaml_edit
-      sha256: "1579d4a0340a83cf9e4d580ea51a16329c916973bffd5bd4b45e911b25d46bfd"
+      sha256: e9c1a3543d2da0db3e90270dbb1e4eebc985ee5e3ffe468d83224472b2194a5f
       url: "https://pub.dev"
     source: hosted
-    version: "2.1.1"
+    version: "2.2.1"
 sdks:
-  dart: ">=2.19.0 <4.0.0"
+  dart: ">=3.3.0 <4.0.0"


### PR DESCRIPTION
This adds an `exclusively` method to `DatabaseConnectionUser`, which blocks the current scope without explicitly starting a transaction.
This API is useful for things that should run atomically to other concurrent contexts accessing the database while being impossible to do in a transaction, like setting the `foreign_keys` pragma. For instance, this:

```dart
await exclusively(() async {
  await customStatement('pragma foreign_keys = off;');
  await transaction(() async {
    // ...
  });
  await customStatement('pragma foreign_keys = on;');
});
```

ensures that absolutely no statements can run between the transaction and the pragma statements, even if the database is shared across isolates with `DriftIsolate`.

I still need to do some minor work here like adding changelog entries and documentation on the website about this. I don't expect that this will be used often though, `transaction` is likely good enough most of the time.

Closes https://github.com/simolus3/drift/issues/3032. cc @davidmartos96, is this what you had in mind?