### PR TITLE
Builtin support for dbstat table

### DIFF
--- a/sqlparser/lib/src/engine/builtin_tables.dart
+++ b/sqlparser/lib/src/engine/builtin_tables.dart
@@ -32,3 +32,70 @@ Table get sqliteSchema {
     resolvedColumns: sqliteMaster.resolvedColumns,
   );
 }
+
+/// The DBSTAT virtual table is a read-only eponymous virtual table that returns
+/// information about the amount of disk space used to store the content of an
+/// SQLite database
+Table get dbstat {
+  /// Name of table or index
+  final name = TableColumn('name', const ResolvedType(type: BasicType.text));
+
+  /// Path to page from root
+  final path = TableColumn('path', const ResolvedType(type: BasicType.text));
+
+  /// Page number, or page count
+  final pageno = TableColumn('pageno', const ResolvedType(type: BasicType.int));
+
+  /// 'internal', 'leaf', 'overflow', or NULL
+  final pagetype =
+      TableColumn('pagetype', const ResolvedType(type: BasicType.text));
+
+  /// Cells on page (0 for overflow pages)
+  final ncell = TableColumn('ncell', const ResolvedType(type: BasicType.int));
+
+  /// Bytes of payload on this page or btree
+  final payload =
+      TableColumn('payload', const ResolvedType(type: BasicType.int));
+
+  /// Bytes of unused space on this page or btree
+  final unused = TableColumn('unused', const ResolvedType(type: BasicType.int));
+
+  /// Bytes of unused space on this page or btree
+  final mxPayload =
+      TableColumn('mx_payload', const ResolvedType(type: BasicType.int));
+
+  /// Byte offset of the page in the database file
+  final pgoffset =
+      TableColumn('pgoffset', const ResolvedType(type: BasicType.int));
+
+  /// Size of the page, in bytes
+  final pgsize = TableColumn('pgsize', const ResolvedType(type: BasicType.int));
+
+  /// Database schema being analyzed
+  final schema = TableColumn('schema', const ResolvedType(type: BasicType.text),
+      isHidden: true);
+
+  /// True to enable aggregate mode
+  final aggregate = TableColumn(
+      'aggregate', const ResolvedType(type: BasicType.int),
+      isHidden: true);
+
+  return Table(
+    name: 'dbstat',
+    isVirtual: true,
+    resolvedColumns: [
+      name,
+      path,
+      pageno,
+      pagetype,
+      ncell,
+      payload,
+      unused,
+      mxPayload,
+      pgoffset,
+      pgsize,
+      schema,
+      aggregate,
+    ],
+  );
+}

--- a/sqlparser/lib/src/engine/sql_engine.dart
+++ b/sqlparser/lib/src/engine/sql_engine.dart
@@ -31,6 +31,8 @@ class SqlEngine {
     registerTable(sqliteSchema);
 
     registerTable(sqliteSequence);
+
+    registerTable(dbstat);
   }
 
   /// Obtain a [SchemaFromCreateTable] instance compatible with the


### PR DESCRIPTION
After https://github.com/simolus3/sqlite3.dart/issues/237 landed, I added the dbstat table as a builtin table to the sqlparser.

Open question is, shall the inclusion of the dbstat table be controlled by an option (like its the case for json or fts)? 