### PR TITLE
Refactor Manager

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -215,6 +215,9 @@ jobs:
           cache: true
           cache-key: "flutter-:os:-:channel:-:version:-:arch:-:hash:"
           cache-path: "${{ runner.tool_cache }}/flutter/:channel:-:version:-:arch:"
+      - name: Setup melos
+        run: dart pub global activate melos && dart pub get
+        shell: bash
       - name: Install dependencies in drift/example/app
         run: melos bootstrap --scope app
       - run: flutter analyze

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -216,8 +216,9 @@ jobs:
           cache-key: "flutter-:os:-:channel:-:version:-:arch:-:hash:"
           cache-path: "${{ runner.tool_cache }}/flutter/:channel:-:version:-:arch:"
       - name: Install dependencies in drift/example/app
+        run: melos bootstrap --scope app
+      - run: flutter analyze
         working-directory: examples/app
-        run: flutter pub get
       - run: flutter test
         working-directory: examples/app
   migration_integration_tests:

--- a/docs/lib/snippets/_shared/todo_tables.drift.dart
+++ b/docs/lib/snippets/_shared/todo_tables.drift.dart
@@ -388,12 +388,26 @@ typedef $$TodoItemsTableProcessedTableManager = i0.ProcessedTableManager<
 class $$TodoItemsTableFilterComposer
     extends i0.FilterComposer<i0.GeneratedDatabase, i1.$TodoItemsTable> {
   $$TodoItemsTableFilterComposer(super.$state);
-  i0.ColumnFilters<int> get id => i0.ColumnFilters($state.table.id);
-  i0.ColumnFilters<String> get title => i0.ColumnFilters($state.table.title);
-  i0.ColumnFilters<String> get content =>
-      i0.ColumnFilters($state.table.content);
-  i0.ColumnFilters<DateTime> get dueDate =>
-      i0.ColumnFilters($state.table.dueDate);
+  i0.ColumnFilters<int> get id => $state.composableBuilder(
+      column: $state.table.id,
+      builder: (column, joinBuilders) =>
+          i0.ColumnFilters(column, joinBuilders: joinBuilders));
+
+  i0.ColumnFilters<String> get title => $state.composableBuilder(
+      column: $state.table.title,
+      builder: (column, joinBuilders) =>
+          i0.ColumnFilters(column, joinBuilders: joinBuilders));
+
+  i0.ColumnFilters<String> get content => $state.composableBuilder(
+      column: $state.table.content,
+      builder: (column, joinBuilders) =>
+          i0.ColumnFilters(column, joinBuilders: joinBuilders));
+
+  i0.ColumnFilters<DateTime> get dueDate => $state.composableBuilder(
+      column: $state.table.dueDate,
+      builder: (column, joinBuilders) =>
+          i0.ColumnFilters(column, joinBuilders: joinBuilders));
+
   i1.$$CategoriesTableFilterComposer get category {
     final i1.$$CategoriesTableFilterComposer composer = $state.composerBuilder(
         composer: this,
@@ -415,13 +429,26 @@ class $$TodoItemsTableFilterComposer
 class $$TodoItemsTableOrderingComposer
     extends i0.OrderingComposer<i0.GeneratedDatabase, i1.$TodoItemsTable> {
   $$TodoItemsTableOrderingComposer(super.$state);
-  i0.ColumnOrderings<int> get id => i0.ColumnOrderings($state.table.id);
-  i0.ColumnOrderings<String> get title =>
-      i0.ColumnOrderings($state.table.title);
-  i0.ColumnOrderings<String> get content =>
-      i0.ColumnOrderings($state.table.content);
-  i0.ColumnOrderings<DateTime> get dueDate =>
-      i0.ColumnOrderings($state.table.dueDate);
+  i0.ColumnOrderings<int> get id => $state.composableBuilder(
+      column: $state.table.id,
+      builder: (column, joinBuilders) =>
+          i0.ColumnOrderings(column, joinBuilders: joinBuilders));
+
+  i0.ColumnOrderings<String> get title => $state.composableBuilder(
+      column: $state.table.title,
+      builder: (column, joinBuilders) =>
+          i0.ColumnOrderings(column, joinBuilders: joinBuilders));
+
+  i0.ColumnOrderings<String> get content => $state.composableBuilder(
+      column: $state.table.content,
+      builder: (column, joinBuilders) =>
+          i0.ColumnOrderings(column, joinBuilders: joinBuilders));
+
+  i0.ColumnOrderings<DateTime> get dueDate => $state.composableBuilder(
+      column: $state.table.dueDate,
+      builder: (column, joinBuilders) =>
+          i0.ColumnOrderings(column, joinBuilders: joinBuilders));
+
   i1.$$CategoriesTableOrderingComposer get category {
     final i1.$$CategoriesTableOrderingComposer composer =
         $state.composerBuilder(
@@ -678,15 +705,29 @@ typedef $$CategoriesTableProcessedTableManager = i0.ProcessedTableManager<
 class $$CategoriesTableFilterComposer
     extends i0.FilterComposer<i0.GeneratedDatabase, i1.$CategoriesTable> {
   $$CategoriesTableFilterComposer(super.$state);
-  i0.ColumnFilters<int> get id => i0.ColumnFilters($state.table.id);
-  i0.ColumnFilters<String> get name => i0.ColumnFilters($state.table.name);
+  i0.ColumnFilters<int> get id => $state.composableBuilder(
+      column: $state.table.id,
+      builder: (column, joinBuilders) =>
+          i0.ColumnFilters(column, joinBuilders: joinBuilders));
+
+  i0.ColumnFilters<String> get name => $state.composableBuilder(
+      column: $state.table.name,
+      builder: (column, joinBuilders) =>
+          i0.ColumnFilters(column, joinBuilders: joinBuilders));
 }
 
 class $$CategoriesTableOrderingComposer
     extends i0.OrderingComposer<i0.GeneratedDatabase, i1.$CategoriesTable> {
   $$CategoriesTableOrderingComposer(super.$state);
-  i0.ColumnOrderings<int> get id => i0.ColumnOrderings($state.table.id);
-  i0.ColumnOrderings<String> get name => i0.ColumnOrderings($state.table.name);
+  i0.ColumnOrderings<int> get id => $state.composableBuilder(
+      column: $state.table.id,
+      builder: (column, joinBuilders) =>
+          i0.ColumnOrderings(column, joinBuilders: joinBuilders));
+
+  i0.ColumnOrderings<String> get name => $state.composableBuilder(
+      column: $state.table.name,
+      builder: (column, joinBuilders) =>
+          i0.ColumnOrderings(column, joinBuilders: joinBuilders));
 }
 
 class $UsersTable extends i2.Users with i0.TableInfo<$UsersTable, i1.User> {
@@ -925,15 +966,27 @@ typedef $$UsersTableProcessedTableManager = i0.ProcessedTableManager<
 class $$UsersTableFilterComposer
     extends i0.FilterComposer<i0.GeneratedDatabase, i1.$UsersTable> {
   $$UsersTableFilterComposer(super.$state);
-  i0.ColumnFilters<int> get id => i0.ColumnFilters($state.table.id);
-  i0.ColumnFilters<DateTime> get birthDate =>
-      i0.ColumnFilters($state.table.birthDate);
+  i0.ColumnFilters<int> get id => $state.composableBuilder(
+      column: $state.table.id,
+      builder: (column, joinBuilders) =>
+          i0.ColumnFilters(column, joinBuilders: joinBuilders));
+
+  i0.ColumnFilters<DateTime> get birthDate => $state.composableBuilder(
+      column: $state.table.birthDate,
+      builder: (column, joinBuilders) =>
+          i0.ColumnFilters(column, joinBuilders: joinBuilders));
 }
 
 class $$UsersTableOrderingComposer
     extends i0.OrderingComposer<i0.GeneratedDatabase, i1.$UsersTable> {
   $$UsersTableOrderingComposer(super.$state);
-  i0.ColumnOrderings<int> get id => i0.ColumnOrderings($state.table.id);
-  i0.ColumnOrderings<DateTime> get birthDate =>
-      i0.ColumnOrderings($state.table.birthDate);
+  i0.ColumnOrderings<int> get id => $state.composableBuilder(
+      column: $state.table.id,
+      builder: (column, joinBuilders) =>
+          i0.ColumnOrderings(column, joinBuilders: joinBuilders));
+
+  i0.ColumnOrderings<DateTime> get birthDate => $state.composableBuilder(
+      column: $state.table.birthDate,
+      builder: (column, joinBuilders) =>
+          i0.ColumnOrderings(column, joinBuilders: joinBuilders));
 }

--- a/docs/lib/snippets/_shared/todo_tables.drift.dart
+++ b/docs/lib/snippets/_shared/todo_tables.drift.dart
@@ -311,7 +311,7 @@ class TodoItemsCompanion extends i0.UpdateCompanion<i1.TodoItem> {
   }
 }
 
-typedef $$TodoItemsTableInsertCompanionBuilder = i1.TodoItemsCompanion
+typedef $$TodoItemsTableCreateCompanionBuilder = i1.TodoItemsCompanion
     Function({
   i0.Value<int> id,
   required String title,
@@ -334,8 +334,7 @@ class $$TodoItemsTableTableManager extends i0.RootTableManager<
     i1.TodoItem,
     i1.$$TodoItemsTableFilterComposer,
     i1.$$TodoItemsTableOrderingComposer,
-    $$TodoItemsTableProcessedTableManager,
-    $$TodoItemsTableInsertCompanionBuilder,
+    $$TodoItemsTableCreateCompanionBuilder,
     $$TodoItemsTableUpdateCompanionBuilder> {
   $$TodoItemsTableTableManager(
       i0.GeneratedDatabase db, i1.$TodoItemsTable table)
@@ -346,9 +345,7 @@ class $$TodoItemsTableTableManager extends i0.RootTableManager<
               i1.$$TodoItemsTableFilterComposer(i0.ComposerState(db, table)),
           orderingComposer:
               i1.$$TodoItemsTableOrderingComposer(i0.ComposerState(db, table)),
-          getChildManagerBuilder: (p) =>
-              $$TodoItemsTableProcessedTableManager(p),
-          getUpdateCompanionBuilder: ({
+          updateCompanionCallback: ({
             i0.Value<int> id = const i0.Value.absent(),
             i0.Value<String> title = const i0.Value.absent(),
             i0.Value<String> content = const i0.Value.absent(),
@@ -362,7 +359,7 @@ class $$TodoItemsTableTableManager extends i0.RootTableManager<
             category: category,
             dueDate: dueDate,
           ),
-          getInsertCompanionBuilder: ({
+          createCompanionCallback: ({
             i0.Value<int> id = const i0.Value.absent(),
             required String title,
             required String content,
@@ -379,41 +376,24 @@ class $$TodoItemsTableTableManager extends i0.RootTableManager<
         ));
 }
 
-class $$TodoItemsTableProcessedTableManager extends i0.ProcessedTableManager<
+typedef $$TodoItemsTableProcessedTableManager = i0.ProcessedTableManager<
     i0.GeneratedDatabase,
     i1.$TodoItemsTable,
     i1.TodoItem,
     i1.$$TodoItemsTableFilterComposer,
     i1.$$TodoItemsTableOrderingComposer,
-    $$TodoItemsTableProcessedTableManager,
-    $$TodoItemsTableInsertCompanionBuilder,
-    $$TodoItemsTableUpdateCompanionBuilder> {
-  $$TodoItemsTableProcessedTableManager(super.$state);
-}
+    $$TodoItemsTableCreateCompanionBuilder,
+    $$TodoItemsTableUpdateCompanionBuilder>;
 
 class $$TodoItemsTableFilterComposer
     extends i0.FilterComposer<i0.GeneratedDatabase, i1.$TodoItemsTable> {
   $$TodoItemsTableFilterComposer(super.$state);
-  i0.ColumnFilters<int> get id => $state.composableBuilder(
-      column: $state.table.id,
-      builder: (column, joinBuilders) =>
-          i0.ColumnFilters(column, joinBuilders: joinBuilders));
-
-  i0.ColumnFilters<String> get title => $state.composableBuilder(
-      column: $state.table.title,
-      builder: (column, joinBuilders) =>
-          i0.ColumnFilters(column, joinBuilders: joinBuilders));
-
-  i0.ColumnFilters<String> get content => $state.composableBuilder(
-      column: $state.table.content,
-      builder: (column, joinBuilders) =>
-          i0.ColumnFilters(column, joinBuilders: joinBuilders));
-
-  i0.ColumnFilters<DateTime> get dueDate => $state.composableBuilder(
-      column: $state.table.dueDate,
-      builder: (column, joinBuilders) =>
-          i0.ColumnFilters(column, joinBuilders: joinBuilders));
-
+  i0.ColumnFilters<int> get id => i0.ColumnFilters($state.table.id);
+  i0.ColumnFilters<String> get title => i0.ColumnFilters($state.table.title);
+  i0.ColumnFilters<String> get content =>
+      i0.ColumnFilters($state.table.content);
+  i0.ColumnFilters<DateTime> get dueDate =>
+      i0.ColumnFilters($state.table.dueDate);
   i1.$$CategoriesTableFilterComposer get category {
     final i1.$$CategoriesTableFilterComposer composer = $state.composerBuilder(
         composer: this,
@@ -435,26 +415,13 @@ class $$TodoItemsTableFilterComposer
 class $$TodoItemsTableOrderingComposer
     extends i0.OrderingComposer<i0.GeneratedDatabase, i1.$TodoItemsTable> {
   $$TodoItemsTableOrderingComposer(super.$state);
-  i0.ColumnOrderings<int> get id => $state.composableBuilder(
-      column: $state.table.id,
-      builder: (column, joinBuilders) =>
-          i0.ColumnOrderings(column, joinBuilders: joinBuilders));
-
-  i0.ColumnOrderings<String> get title => $state.composableBuilder(
-      column: $state.table.title,
-      builder: (column, joinBuilders) =>
-          i0.ColumnOrderings(column, joinBuilders: joinBuilders));
-
-  i0.ColumnOrderings<String> get content => $state.composableBuilder(
-      column: $state.table.content,
-      builder: (column, joinBuilders) =>
-          i0.ColumnOrderings(column, joinBuilders: joinBuilders));
-
-  i0.ColumnOrderings<DateTime> get dueDate => $state.composableBuilder(
-      column: $state.table.dueDate,
-      builder: (column, joinBuilders) =>
-          i0.ColumnOrderings(column, joinBuilders: joinBuilders));
-
+  i0.ColumnOrderings<int> get id => i0.ColumnOrderings($state.table.id);
+  i0.ColumnOrderings<String> get title =>
+      i0.ColumnOrderings($state.table.title);
+  i0.ColumnOrderings<String> get content =>
+      i0.ColumnOrderings($state.table.content);
+  i0.ColumnOrderings<DateTime> get dueDate =>
+      i0.ColumnOrderings($state.table.dueDate);
   i1.$$CategoriesTableOrderingComposer get category {
     final i1.$$CategoriesTableOrderingComposer composer =
         $state.composerBuilder(
@@ -652,7 +619,7 @@ class CategoriesCompanion extends i0.UpdateCompanion<i1.Category> {
   }
 }
 
-typedef $$CategoriesTableInsertCompanionBuilder = i1.CategoriesCompanion
+typedef $$CategoriesTableCreateCompanionBuilder = i1.CategoriesCompanion
     Function({
   i0.Value<int> id,
   required String name,
@@ -669,8 +636,7 @@ class $$CategoriesTableTableManager extends i0.RootTableManager<
     i1.Category,
     i1.$$CategoriesTableFilterComposer,
     i1.$$CategoriesTableOrderingComposer,
-    $$CategoriesTableProcessedTableManager,
-    $$CategoriesTableInsertCompanionBuilder,
+    $$CategoriesTableCreateCompanionBuilder,
     $$CategoriesTableUpdateCompanionBuilder> {
   $$CategoriesTableTableManager(
       i0.GeneratedDatabase db, i1.$CategoriesTable table)
@@ -681,9 +647,7 @@ class $$CategoriesTableTableManager extends i0.RootTableManager<
               i1.$$CategoriesTableFilterComposer(i0.ComposerState(db, table)),
           orderingComposer:
               i1.$$CategoriesTableOrderingComposer(i0.ComposerState(db, table)),
-          getChildManagerBuilder: (p) =>
-              $$CategoriesTableProcessedTableManager(p),
-          getUpdateCompanionBuilder: ({
+          updateCompanionCallback: ({
             i0.Value<int> id = const i0.Value.absent(),
             i0.Value<String> name = const i0.Value.absent(),
           }) =>
@@ -691,7 +655,7 @@ class $$CategoriesTableTableManager extends i0.RootTableManager<
             id: id,
             name: name,
           ),
-          getInsertCompanionBuilder: ({
+          createCompanionCallback: ({
             i0.Value<int> id = const i0.Value.absent(),
             required String name,
           }) =>
@@ -702,44 +666,27 @@ class $$CategoriesTableTableManager extends i0.RootTableManager<
         ));
 }
 
-class $$CategoriesTableProcessedTableManager extends i0.ProcessedTableManager<
+typedef $$CategoriesTableProcessedTableManager = i0.ProcessedTableManager<
     i0.GeneratedDatabase,
     i1.$CategoriesTable,
     i1.Category,
     i1.$$CategoriesTableFilterComposer,
     i1.$$CategoriesTableOrderingComposer,
-    $$CategoriesTableProcessedTableManager,
-    $$CategoriesTableInsertCompanionBuilder,
-    $$CategoriesTableUpdateCompanionBuilder> {
-  $$CategoriesTableProcessedTableManager(super.$state);
-}
+    $$CategoriesTableCreateCompanionBuilder,
+    $$CategoriesTableUpdateCompanionBuilder>;
 
 class $$CategoriesTableFilterComposer
     extends i0.FilterComposer<i0.GeneratedDatabase, i1.$CategoriesTable> {
   $$CategoriesTableFilterComposer(super.$state);
-  i0.ColumnFilters<int> get id => $state.composableBuilder(
-      column: $state.table.id,
-      builder: (column, joinBuilders) =>
-          i0.ColumnFilters(column, joinBuilders: joinBuilders));
-
-  i0.ColumnFilters<String> get name => $state.composableBuilder(
-      column: $state.table.name,
-      builder: (column, joinBuilders) =>
-          i0.ColumnFilters(column, joinBuilders: joinBuilders));
+  i0.ColumnFilters<int> get id => i0.ColumnFilters($state.table.id);
+  i0.ColumnFilters<String> get name => i0.ColumnFilters($state.table.name);
 }
 
 class $$CategoriesTableOrderingComposer
     extends i0.OrderingComposer<i0.GeneratedDatabase, i1.$CategoriesTable> {
   $$CategoriesTableOrderingComposer(super.$state);
-  i0.ColumnOrderings<int> get id => $state.composableBuilder(
-      column: $state.table.id,
-      builder: (column, joinBuilders) =>
-          i0.ColumnOrderings(column, joinBuilders: joinBuilders));
-
-  i0.ColumnOrderings<String> get name => $state.composableBuilder(
-      column: $state.table.name,
-      builder: (column, joinBuilders) =>
-          i0.ColumnOrderings(column, joinBuilders: joinBuilders));
+  i0.ColumnOrderings<int> get id => i0.ColumnOrderings($state.table.id);
+  i0.ColumnOrderings<String> get name => i0.ColumnOrderings($state.table.name);
 }
 
 class $UsersTable extends i2.Users with i0.TableInfo<$UsersTable, i1.User> {
@@ -922,7 +869,7 @@ class UsersCompanion extends i0.UpdateCompanion<i1.User> {
   }
 }
 
-typedef $$UsersTableInsertCompanionBuilder = i1.UsersCompanion Function({
+typedef $$UsersTableCreateCompanionBuilder = i1.UsersCompanion Function({
   i0.Value<int> id,
   required DateTime birthDate,
 });
@@ -937,8 +884,7 @@ class $$UsersTableTableManager extends i0.RootTableManager<
     i1.User,
     i1.$$UsersTableFilterComposer,
     i1.$$UsersTableOrderingComposer,
-    $$UsersTableProcessedTableManager,
-    $$UsersTableInsertCompanionBuilder,
+    $$UsersTableCreateCompanionBuilder,
     $$UsersTableUpdateCompanionBuilder> {
   $$UsersTableTableManager(i0.GeneratedDatabase db, i1.$UsersTable table)
       : super(i0.TableManagerState(
@@ -948,8 +894,7 @@ class $$UsersTableTableManager extends i0.RootTableManager<
               i1.$$UsersTableFilterComposer(i0.ComposerState(db, table)),
           orderingComposer:
               i1.$$UsersTableOrderingComposer(i0.ComposerState(db, table)),
-          getChildManagerBuilder: (p) => $$UsersTableProcessedTableManager(p),
-          getUpdateCompanionBuilder: ({
+          updateCompanionCallback: ({
             i0.Value<int> id = const i0.Value.absent(),
             i0.Value<DateTime> birthDate = const i0.Value.absent(),
           }) =>
@@ -957,7 +902,7 @@ class $$UsersTableTableManager extends i0.RootTableManager<
             id: id,
             birthDate: birthDate,
           ),
-          getInsertCompanionBuilder: ({
+          createCompanionCallback: ({
             i0.Value<int> id = const i0.Value.absent(),
             required DateTime birthDate,
           }) =>
@@ -968,42 +913,27 @@ class $$UsersTableTableManager extends i0.RootTableManager<
         ));
 }
 
-class $$UsersTableProcessedTableManager extends i0.ProcessedTableManager<
+typedef $$UsersTableProcessedTableManager = i0.ProcessedTableManager<
     i0.GeneratedDatabase,
     i1.$UsersTable,
     i1.User,
     i1.$$UsersTableFilterComposer,
     i1.$$UsersTableOrderingComposer,
-    $$UsersTableProcessedTableManager,
-    $$UsersTableInsertCompanionBuilder,
-    $$UsersTableUpdateCompanionBuilder> {
-  $$UsersTableProcessedTableManager(super.$state);
-}
+    $$UsersTableCreateCompanionBuilder,
+    $$UsersTableUpdateCompanionBuilder>;
 
 class $$UsersTableFilterComposer
     extends i0.FilterComposer<i0.GeneratedDatabase, i1.$UsersTable> {
   $$UsersTableFilterComposer(super.$state);
-  i0.ColumnFilters<int> get id => $state.composableBuilder(
-      column: $state.table.id,
-      builder: (column, joinBuilders) =>
-          i0.ColumnFilters(column, joinBuilders: joinBuilders));
-
-  i0.ColumnFilters<DateTime> get birthDate => $state.composableBuilder(
-      column: $state.table.birthDate,
-      builder: (column, joinBuilders) =>
-          i0.ColumnFilters(column, joinBuilders: joinBuilders));
+  i0.ColumnFilters<int> get id => i0.ColumnFilters($state.table.id);
+  i0.ColumnFilters<DateTime> get birthDate =>
+      i0.ColumnFilters($state.table.birthDate);
 }
 
 class $$UsersTableOrderingComposer
     extends i0.OrderingComposer<i0.GeneratedDatabase, i1.$UsersTable> {
   $$UsersTableOrderingComposer(super.$state);
-  i0.ColumnOrderings<int> get id => $state.composableBuilder(
-      column: $state.table.id,
-      builder: (column, joinBuilders) =>
-          i0.ColumnOrderings(column, joinBuilders: joinBuilders));
-
-  i0.ColumnOrderings<DateTime> get birthDate => $state.composableBuilder(
-      column: $state.table.birthDate,
-      builder: (column, joinBuilders) =>
-          i0.ColumnOrderings(column, joinBuilders: joinBuilders));
+  i0.ColumnOrderings<int> get id => i0.ColumnOrderings($state.table.id);
+  i0.ColumnOrderings<DateTime> get birthDate =>
+      i0.ColumnOrderings($state.table.birthDate);
 }

--- a/docs/lib/snippets/_shared/todo_tables.drift.dart
+++ b/docs/lib/snippets/_shared/todo_tables.drift.dart
@@ -376,15 +376,6 @@ class $$TodoItemsTableTableManager extends i0.RootTableManager<
         ));
 }
 
-typedef $$TodoItemsTableProcessedTableManager = i0.ProcessedTableManager<
-    i0.GeneratedDatabase,
-    i1.$TodoItemsTable,
-    i1.TodoItem,
-    i1.$$TodoItemsTableFilterComposer,
-    i1.$$TodoItemsTableOrderingComposer,
-    $$TodoItemsTableCreateCompanionBuilder,
-    $$TodoItemsTableUpdateCompanionBuilder>;
-
 class $$TodoItemsTableFilterComposer
     extends i0.FilterComposer<i0.GeneratedDatabase, i1.$TodoItemsTable> {
   $$TodoItemsTableFilterComposer(super.$state);
@@ -693,15 +684,6 @@ class $$CategoriesTableTableManager extends i0.RootTableManager<
         ));
 }
 
-typedef $$CategoriesTableProcessedTableManager = i0.ProcessedTableManager<
-    i0.GeneratedDatabase,
-    i1.$CategoriesTable,
-    i1.Category,
-    i1.$$CategoriesTableFilterComposer,
-    i1.$$CategoriesTableOrderingComposer,
-    $$CategoriesTableCreateCompanionBuilder,
-    $$CategoriesTableUpdateCompanionBuilder>;
-
 class $$CategoriesTableFilterComposer
     extends i0.FilterComposer<i0.GeneratedDatabase, i1.$CategoriesTable> {
   $$CategoriesTableFilterComposer(super.$state);
@@ -953,15 +935,6 @@ class $$UsersTableTableManager extends i0.RootTableManager<
           ),
         ));
 }
-
-typedef $$UsersTableProcessedTableManager = i0.ProcessedTableManager<
-    i0.GeneratedDatabase,
-    i1.$UsersTable,
-    i1.User,
-    i1.$$UsersTableFilterComposer,
-    i1.$$UsersTableOrderingComposer,
-    $$UsersTableCreateCompanionBuilder,
-    $$UsersTableUpdateCompanionBuilder>;
 
 class $$UsersTableFilterComposer
     extends i0.FilterComposer<i0.GeneratedDatabase, i1.$UsersTable> {

--- a/docs/lib/snippets/modular/custom_types/drift_table.drift.dart
+++ b/docs/lib/snippets/modular/custom_types/drift_table.drift.dart
@@ -231,7 +231,7 @@ class PeriodicRemindersCompanion
   }
 }
 
-typedef $PeriodicRemindersInsertCompanionBuilder = i1.PeriodicRemindersCompanion
+typedef $PeriodicRemindersCreateCompanionBuilder = i1.PeriodicRemindersCompanion
     Function({
   i0.Value<int> id,
   required Duration frequency,
@@ -250,8 +250,7 @@ class $PeriodicRemindersTableManager extends i0.RootTableManager<
     i1.PeriodicReminder,
     i1.$PeriodicRemindersFilterComposer,
     i1.$PeriodicRemindersOrderingComposer,
-    $PeriodicRemindersProcessedTableManager,
-    $PeriodicRemindersInsertCompanionBuilder,
+    $PeriodicRemindersCreateCompanionBuilder,
     $PeriodicRemindersUpdateCompanionBuilder> {
   $PeriodicRemindersTableManager(
       i0.GeneratedDatabase db, i1.PeriodicReminders table)
@@ -262,9 +261,7 @@ class $PeriodicRemindersTableManager extends i0.RootTableManager<
               i1.$PeriodicRemindersFilterComposer(i0.ComposerState(db, table)),
           orderingComposer: i1
               .$PeriodicRemindersOrderingComposer(i0.ComposerState(db, table)),
-          getChildManagerBuilder: (p) =>
-              $PeriodicRemindersProcessedTableManager(p),
-          getUpdateCompanionBuilder: ({
+          updateCompanionCallback: ({
             i0.Value<int> id = const i0.Value.absent(),
             i0.Value<Duration> frequency = const i0.Value.absent(),
             i0.Value<String> reminder = const i0.Value.absent(),
@@ -274,7 +271,7 @@ class $PeriodicRemindersTableManager extends i0.RootTableManager<
             frequency: frequency,
             reminder: reminder,
           ),
-          getInsertCompanionBuilder: ({
+          createCompanionCallback: ({
             i0.Value<int> id = const i0.Value.absent(),
             required Duration frequency,
             required String reminder,
@@ -287,52 +284,31 @@ class $PeriodicRemindersTableManager extends i0.RootTableManager<
         ));
 }
 
-class $PeriodicRemindersProcessedTableManager extends i0.ProcessedTableManager<
+typedef $PeriodicRemindersProcessedTableManager = i0.ProcessedTableManager<
     i0.GeneratedDatabase,
     i1.PeriodicReminders,
     i1.PeriodicReminder,
     i1.$PeriodicRemindersFilterComposer,
     i1.$PeriodicRemindersOrderingComposer,
-    $PeriodicRemindersProcessedTableManager,
-    $PeriodicRemindersInsertCompanionBuilder,
-    $PeriodicRemindersUpdateCompanionBuilder> {
-  $PeriodicRemindersProcessedTableManager(super.$state);
-}
+    $PeriodicRemindersCreateCompanionBuilder,
+    $PeriodicRemindersUpdateCompanionBuilder>;
 
 class $PeriodicRemindersFilterComposer
     extends i0.FilterComposer<i0.GeneratedDatabase, i1.PeriodicReminders> {
   $PeriodicRemindersFilterComposer(super.$state);
-  i0.ColumnFilters<int> get id => $state.composableBuilder(
-      column: $state.table.id,
-      builder: (column, joinBuilders) =>
-          i0.ColumnFilters(column, joinBuilders: joinBuilders));
-
-  i0.ColumnFilters<Duration> get frequency => $state.composableBuilder(
-      column: $state.table.frequency,
-      builder: (column, joinBuilders) =>
-          i0.ColumnFilters(column, joinBuilders: joinBuilders));
-
-  i0.ColumnFilters<String> get reminder => $state.composableBuilder(
-      column: $state.table.reminder,
-      builder: (column, joinBuilders) =>
-          i0.ColumnFilters(column, joinBuilders: joinBuilders));
+  i0.ColumnFilters<int> get id => i0.ColumnFilters($state.table.id);
+  i0.ColumnFilters<Duration> get frequency =>
+      i0.ColumnFilters($state.table.frequency);
+  i0.ColumnFilters<String> get reminder =>
+      i0.ColumnFilters($state.table.reminder);
 }
 
 class $PeriodicRemindersOrderingComposer
     extends i0.OrderingComposer<i0.GeneratedDatabase, i1.PeriodicReminders> {
   $PeriodicRemindersOrderingComposer(super.$state);
-  i0.ColumnOrderings<int> get id => $state.composableBuilder(
-      column: $state.table.id,
-      builder: (column, joinBuilders) =>
-          i0.ColumnOrderings(column, joinBuilders: joinBuilders));
-
-  i0.ColumnOrderings<Duration> get frequency => $state.composableBuilder(
-      column: $state.table.frequency,
-      builder: (column, joinBuilders) =>
-          i0.ColumnOrderings(column, joinBuilders: joinBuilders));
-
-  i0.ColumnOrderings<String> get reminder => $state.composableBuilder(
-      column: $state.table.reminder,
-      builder: (column, joinBuilders) =>
-          i0.ColumnOrderings(column, joinBuilders: joinBuilders));
+  i0.ColumnOrderings<int> get id => i0.ColumnOrderings($state.table.id);
+  i0.ColumnOrderings<Duration> get frequency =>
+      i0.ColumnOrderings($state.table.frequency);
+  i0.ColumnOrderings<String> get reminder =>
+      i0.ColumnOrderings($state.table.reminder);
 }

--- a/docs/lib/snippets/modular/custom_types/drift_table.drift.dart
+++ b/docs/lib/snippets/modular/custom_types/drift_table.drift.dart
@@ -284,15 +284,6 @@ class $PeriodicRemindersTableManager extends i0.RootTableManager<
         ));
 }
 
-typedef $PeriodicRemindersProcessedTableManager = i0.ProcessedTableManager<
-    i0.GeneratedDatabase,
-    i1.PeriodicReminders,
-    i1.PeriodicReminder,
-    i1.$PeriodicRemindersFilterComposer,
-    i1.$PeriodicRemindersOrderingComposer,
-    $PeriodicRemindersCreateCompanionBuilder,
-    $PeriodicRemindersUpdateCompanionBuilder>;
-
 class $PeriodicRemindersFilterComposer
     extends i0.FilterComposer<i0.GeneratedDatabase, i1.PeriodicReminders> {
   $PeriodicRemindersFilterComposer(super.$state);

--- a/docs/lib/snippets/modular/custom_types/drift_table.drift.dart
+++ b/docs/lib/snippets/modular/custom_types/drift_table.drift.dart
@@ -296,19 +296,37 @@ typedef $PeriodicRemindersProcessedTableManager = i0.ProcessedTableManager<
 class $PeriodicRemindersFilterComposer
     extends i0.FilterComposer<i0.GeneratedDatabase, i1.PeriodicReminders> {
   $PeriodicRemindersFilterComposer(super.$state);
-  i0.ColumnFilters<int> get id => i0.ColumnFilters($state.table.id);
-  i0.ColumnFilters<Duration> get frequency =>
-      i0.ColumnFilters($state.table.frequency);
-  i0.ColumnFilters<String> get reminder =>
-      i0.ColumnFilters($state.table.reminder);
+  i0.ColumnFilters<int> get id => $state.composableBuilder(
+      column: $state.table.id,
+      builder: (column, joinBuilders) =>
+          i0.ColumnFilters(column, joinBuilders: joinBuilders));
+
+  i0.ColumnFilters<Duration> get frequency => $state.composableBuilder(
+      column: $state.table.frequency,
+      builder: (column, joinBuilders) =>
+          i0.ColumnFilters(column, joinBuilders: joinBuilders));
+
+  i0.ColumnFilters<String> get reminder => $state.composableBuilder(
+      column: $state.table.reminder,
+      builder: (column, joinBuilders) =>
+          i0.ColumnFilters(column, joinBuilders: joinBuilders));
 }
 
 class $PeriodicRemindersOrderingComposer
     extends i0.OrderingComposer<i0.GeneratedDatabase, i1.PeriodicReminders> {
   $PeriodicRemindersOrderingComposer(super.$state);
-  i0.ColumnOrderings<int> get id => i0.ColumnOrderings($state.table.id);
-  i0.ColumnOrderings<Duration> get frequency =>
-      i0.ColumnOrderings($state.table.frequency);
-  i0.ColumnOrderings<String> get reminder =>
-      i0.ColumnOrderings($state.table.reminder);
+  i0.ColumnOrderings<int> get id => $state.composableBuilder(
+      column: $state.table.id,
+      builder: (column, joinBuilders) =>
+          i0.ColumnOrderings(column, joinBuilders: joinBuilders));
+
+  i0.ColumnOrderings<Duration> get frequency => $state.composableBuilder(
+      column: $state.table.frequency,
+      builder: (column, joinBuilders) =>
+          i0.ColumnOrderings(column, joinBuilders: joinBuilders));
+
+  i0.ColumnOrderings<String> get reminder => $state.composableBuilder(
+      column: $state.table.reminder,
+      builder: (column, joinBuilders) =>
+          i0.ColumnOrderings(column, joinBuilders: joinBuilders));
 }

--- a/docs/lib/snippets/modular/custom_types/table.drift.dart
+++ b/docs/lib/snippets/modular/custom_types/table.drift.dart
@@ -295,19 +295,37 @@ typedef $$PeriodicRemindersTableProcessedTableManager
 class $$PeriodicRemindersTableFilterComposer extends i0
     .FilterComposer<i0.GeneratedDatabase, i1.$PeriodicRemindersTable> {
   $$PeriodicRemindersTableFilterComposer(super.$state);
-  i0.ColumnFilters<int> get id => i0.ColumnFilters($state.table.id);
-  i0.ColumnFilters<Duration> get frequency =>
-      i0.ColumnFilters($state.table.frequency);
-  i0.ColumnFilters<String> get reminder =>
-      i0.ColumnFilters($state.table.reminder);
+  i0.ColumnFilters<int> get id => $state.composableBuilder(
+      column: $state.table.id,
+      builder: (column, joinBuilders) =>
+          i0.ColumnFilters(column, joinBuilders: joinBuilders));
+
+  i0.ColumnFilters<Duration> get frequency => $state.composableBuilder(
+      column: $state.table.frequency,
+      builder: (column, joinBuilders) =>
+          i0.ColumnFilters(column, joinBuilders: joinBuilders));
+
+  i0.ColumnFilters<String> get reminder => $state.composableBuilder(
+      column: $state.table.reminder,
+      builder: (column, joinBuilders) =>
+          i0.ColumnFilters(column, joinBuilders: joinBuilders));
 }
 
 class $$PeriodicRemindersTableOrderingComposer extends i0
     .OrderingComposer<i0.GeneratedDatabase, i1.$PeriodicRemindersTable> {
   $$PeriodicRemindersTableOrderingComposer(super.$state);
-  i0.ColumnOrderings<int> get id => i0.ColumnOrderings($state.table.id);
-  i0.ColumnOrderings<Duration> get frequency =>
-      i0.ColumnOrderings($state.table.frequency);
-  i0.ColumnOrderings<String> get reminder =>
-      i0.ColumnOrderings($state.table.reminder);
+  i0.ColumnOrderings<int> get id => $state.composableBuilder(
+      column: $state.table.id,
+      builder: (column, joinBuilders) =>
+          i0.ColumnOrderings(column, joinBuilders: joinBuilders));
+
+  i0.ColumnOrderings<Duration> get frequency => $state.composableBuilder(
+      column: $state.table.frequency,
+      builder: (column, joinBuilders) =>
+          i0.ColumnOrderings(column, joinBuilders: joinBuilders));
+
+  i0.ColumnOrderings<String> get reminder => $state.composableBuilder(
+      column: $state.table.reminder,
+      builder: (column, joinBuilders) =>
+          i0.ColumnOrderings(column, joinBuilders: joinBuilders));
 }

--- a/docs/lib/snippets/modular/custom_types/table.drift.dart
+++ b/docs/lib/snippets/modular/custom_types/table.drift.dart
@@ -282,16 +282,6 @@ class $$PeriodicRemindersTableTableManager extends i0.RootTableManager<
         ));
 }
 
-typedef $$PeriodicRemindersTableProcessedTableManager
-    = i0.ProcessedTableManager<
-        i0.GeneratedDatabase,
-        i1.$PeriodicRemindersTable,
-        i1.PeriodicReminder,
-        i1.$$PeriodicRemindersTableFilterComposer,
-        i1.$$PeriodicRemindersTableOrderingComposer,
-        $$PeriodicRemindersTableCreateCompanionBuilder,
-        $$PeriodicRemindersTableUpdateCompanionBuilder>;
-
 class $$PeriodicRemindersTableFilterComposer extends i0
     .FilterComposer<i0.GeneratedDatabase, i1.$PeriodicRemindersTable> {
   $$PeriodicRemindersTableFilterComposer(super.$state);

--- a/docs/lib/snippets/modular/custom_types/table.drift.dart
+++ b/docs/lib/snippets/modular/custom_types/table.drift.dart
@@ -229,7 +229,7 @@ class PeriodicRemindersCompanion
   }
 }
 
-typedef $$PeriodicRemindersTableInsertCompanionBuilder
+typedef $$PeriodicRemindersTableCreateCompanionBuilder
     = i1.PeriodicRemindersCompanion Function({
   i0.Value<int> id,
   i0.Value<Duration> frequency,
@@ -248,8 +248,7 @@ class $$PeriodicRemindersTableTableManager extends i0.RootTableManager<
     i1.PeriodicReminder,
     i1.$$PeriodicRemindersTableFilterComposer,
     i1.$$PeriodicRemindersTableOrderingComposer,
-    $$PeriodicRemindersTableProcessedTableManager,
-    $$PeriodicRemindersTableInsertCompanionBuilder,
+    $$PeriodicRemindersTableCreateCompanionBuilder,
     $$PeriodicRemindersTableUpdateCompanionBuilder> {
   $$PeriodicRemindersTableTableManager(
       i0.GeneratedDatabase db, i1.$PeriodicRemindersTable table)
@@ -260,9 +259,7 @@ class $$PeriodicRemindersTableTableManager extends i0.RootTableManager<
               i0.ComposerState(db, table)),
           orderingComposer: i1.$$PeriodicRemindersTableOrderingComposer(
               i0.ComposerState(db, table)),
-          getChildManagerBuilder: (p) =>
-              $$PeriodicRemindersTableProcessedTableManager(p),
-          getUpdateCompanionBuilder: ({
+          updateCompanionCallback: ({
             i0.Value<int> id = const i0.Value.absent(),
             i0.Value<Duration> frequency = const i0.Value.absent(),
             i0.Value<String> reminder = const i0.Value.absent(),
@@ -272,7 +269,7 @@ class $$PeriodicRemindersTableTableManager extends i0.RootTableManager<
             frequency: frequency,
             reminder: reminder,
           ),
-          getInsertCompanionBuilder: ({
+          createCompanionCallback: ({
             i0.Value<int> id = const i0.Value.absent(),
             i0.Value<Duration> frequency = const i0.Value.absent(),
             required String reminder,
@@ -285,53 +282,32 @@ class $$PeriodicRemindersTableTableManager extends i0.RootTableManager<
         ));
 }
 
-class $$PeriodicRemindersTableProcessedTableManager
-    extends i0.ProcessedTableManager<
+typedef $$PeriodicRemindersTableProcessedTableManager
+    = i0.ProcessedTableManager<
         i0.GeneratedDatabase,
         i1.$PeriodicRemindersTable,
         i1.PeriodicReminder,
         i1.$$PeriodicRemindersTableFilterComposer,
         i1.$$PeriodicRemindersTableOrderingComposer,
-        $$PeriodicRemindersTableProcessedTableManager,
-        $$PeriodicRemindersTableInsertCompanionBuilder,
-        $$PeriodicRemindersTableUpdateCompanionBuilder> {
-  $$PeriodicRemindersTableProcessedTableManager(super.$state);
-}
+        $$PeriodicRemindersTableCreateCompanionBuilder,
+        $$PeriodicRemindersTableUpdateCompanionBuilder>;
 
 class $$PeriodicRemindersTableFilterComposer extends i0
     .FilterComposer<i0.GeneratedDatabase, i1.$PeriodicRemindersTable> {
   $$PeriodicRemindersTableFilterComposer(super.$state);
-  i0.ColumnFilters<int> get id => $state.composableBuilder(
-      column: $state.table.id,
-      builder: (column, joinBuilders) =>
-          i0.ColumnFilters(column, joinBuilders: joinBuilders));
-
-  i0.ColumnFilters<Duration> get frequency => $state.composableBuilder(
-      column: $state.table.frequency,
-      builder: (column, joinBuilders) =>
-          i0.ColumnFilters(column, joinBuilders: joinBuilders));
-
-  i0.ColumnFilters<String> get reminder => $state.composableBuilder(
-      column: $state.table.reminder,
-      builder: (column, joinBuilders) =>
-          i0.ColumnFilters(column, joinBuilders: joinBuilders));
+  i0.ColumnFilters<int> get id => i0.ColumnFilters($state.table.id);
+  i0.ColumnFilters<Duration> get frequency =>
+      i0.ColumnFilters($state.table.frequency);
+  i0.ColumnFilters<String> get reminder =>
+      i0.ColumnFilters($state.table.reminder);
 }
 
 class $$PeriodicRemindersTableOrderingComposer extends i0
     .OrderingComposer<i0.GeneratedDatabase, i1.$PeriodicRemindersTable> {
   $$PeriodicRemindersTableOrderingComposer(super.$state);
-  i0.ColumnOrderings<int> get id => $state.composableBuilder(
-      column: $state.table.id,
-      builder: (column, joinBuilders) =>
-          i0.ColumnOrderings(column, joinBuilders: joinBuilders));
-
-  i0.ColumnOrderings<Duration> get frequency => $state.composableBuilder(
-      column: $state.table.frequency,
-      builder: (column, joinBuilders) =>
-          i0.ColumnOrderings(column, joinBuilders: joinBuilders));
-
-  i0.ColumnOrderings<String> get reminder => $state.composableBuilder(
-      column: $state.table.reminder,
-      builder: (column, joinBuilders) =>
-          i0.ColumnOrderings(column, joinBuilders: joinBuilders));
+  i0.ColumnOrderings<int> get id => i0.ColumnOrderings($state.table.id);
+  i0.ColumnOrderings<Duration> get frequency =>
+      i0.ColumnOrderings($state.table.frequency);
+  i0.ColumnOrderings<String> get reminder =>
+      i0.ColumnOrderings($state.table.reminder);
 }

--- a/docs/lib/snippets/modular/drift/example.drift.dart
+++ b/docs/lib/snippets/modular/drift/example.drift.dart
@@ -268,7 +268,7 @@ class TodosCompanion extends i0.UpdateCompanion<i1.Todo> {
   }
 }
 
-typedef $TodosInsertCompanionBuilder = i1.TodosCompanion Function({
+typedef $TodosCreateCompanionBuilder = i1.TodosCompanion Function({
   i0.Value<int> id,
   required String title,
   required String content,
@@ -287,8 +287,7 @@ class $TodosTableManager extends i0.RootTableManager<
     i1.Todo,
     i1.$TodosFilterComposer,
     i1.$TodosOrderingComposer,
-    $TodosProcessedTableManager,
-    $TodosInsertCompanionBuilder,
+    $TodosCreateCompanionBuilder,
     $TodosUpdateCompanionBuilder> {
   $TodosTableManager(i0.GeneratedDatabase db, i1.Todos table)
       : super(i0.TableManagerState(
@@ -298,8 +297,7 @@ class $TodosTableManager extends i0.RootTableManager<
               i1.$TodosFilterComposer(i0.ComposerState(db, table)),
           orderingComposer:
               i1.$TodosOrderingComposer(i0.ComposerState(db, table)),
-          getChildManagerBuilder: (p) => $TodosProcessedTableManager(p),
-          getUpdateCompanionBuilder: ({
+          updateCompanionCallback: ({
             i0.Value<int> id = const i0.Value.absent(),
             i0.Value<String> title = const i0.Value.absent(),
             i0.Value<String> content = const i0.Value.absent(),
@@ -311,7 +309,7 @@ class $TodosTableManager extends i0.RootTableManager<
             content: content,
             category: category,
           ),
-          getInsertCompanionBuilder: ({
+          createCompanionCallback: ({
             i0.Value<int> id = const i0.Value.absent(),
             required String title,
             required String content,
@@ -326,36 +324,22 @@ class $TodosTableManager extends i0.RootTableManager<
         ));
 }
 
-class $TodosProcessedTableManager extends i0.ProcessedTableManager<
+typedef $TodosProcessedTableManager = i0.ProcessedTableManager<
     i0.GeneratedDatabase,
     i1.Todos,
     i1.Todo,
     i1.$TodosFilterComposer,
     i1.$TodosOrderingComposer,
-    $TodosProcessedTableManager,
-    $TodosInsertCompanionBuilder,
-    $TodosUpdateCompanionBuilder> {
-  $TodosProcessedTableManager(super.$state);
-}
+    $TodosCreateCompanionBuilder,
+    $TodosUpdateCompanionBuilder>;
 
 class $TodosFilterComposer
     extends i0.FilterComposer<i0.GeneratedDatabase, i1.Todos> {
   $TodosFilterComposer(super.$state);
-  i0.ColumnFilters<int> get id => $state.composableBuilder(
-      column: $state.table.id,
-      builder: (column, joinBuilders) =>
-          i0.ColumnFilters(column, joinBuilders: joinBuilders));
-
-  i0.ColumnFilters<String> get title => $state.composableBuilder(
-      column: $state.table.title,
-      builder: (column, joinBuilders) =>
-          i0.ColumnFilters(column, joinBuilders: joinBuilders));
-
-  i0.ColumnFilters<String> get content => $state.composableBuilder(
-      column: $state.table.content,
-      builder: (column, joinBuilders) =>
-          i0.ColumnFilters(column, joinBuilders: joinBuilders));
-
+  i0.ColumnFilters<int> get id => i0.ColumnFilters($state.table.id);
+  i0.ColumnFilters<String> get title => i0.ColumnFilters($state.table.title);
+  i0.ColumnFilters<String> get content =>
+      i0.ColumnFilters($state.table.content);
   i1.$CategoriesFilterComposer get category {
     final i1.$CategoriesFilterComposer composer = $state.composerBuilder(
         composer: this,
@@ -377,21 +361,11 @@ class $TodosFilterComposer
 class $TodosOrderingComposer
     extends i0.OrderingComposer<i0.GeneratedDatabase, i1.Todos> {
   $TodosOrderingComposer(super.$state);
-  i0.ColumnOrderings<int> get id => $state.composableBuilder(
-      column: $state.table.id,
-      builder: (column, joinBuilders) =>
-          i0.ColumnOrderings(column, joinBuilders: joinBuilders));
-
-  i0.ColumnOrderings<String> get title => $state.composableBuilder(
-      column: $state.table.title,
-      builder: (column, joinBuilders) =>
-          i0.ColumnOrderings(column, joinBuilders: joinBuilders));
-
-  i0.ColumnOrderings<String> get content => $state.composableBuilder(
-      column: $state.table.content,
-      builder: (column, joinBuilders) =>
-          i0.ColumnOrderings(column, joinBuilders: joinBuilders));
-
+  i0.ColumnOrderings<int> get id => i0.ColumnOrderings($state.table.id);
+  i0.ColumnOrderings<String> get title =>
+      i0.ColumnOrderings($state.table.title);
+  i0.ColumnOrderings<String> get content =>
+      i0.ColumnOrderings($state.table.content);
   i1.$CategoriesOrderingComposer get category {
     final i1.$CategoriesOrderingComposer composer = $state.composerBuilder(
         composer: this,
@@ -595,7 +569,7 @@ class CategoriesCompanion extends i0.UpdateCompanion<i1.Category> {
   }
 }
 
-typedef $CategoriesInsertCompanionBuilder = i1.CategoriesCompanion Function({
+typedef $CategoriesCreateCompanionBuilder = i1.CategoriesCompanion Function({
   i0.Value<int> id,
   required String description,
 });
@@ -610,8 +584,7 @@ class $CategoriesTableManager extends i0.RootTableManager<
     i1.Category,
     i1.$CategoriesFilterComposer,
     i1.$CategoriesOrderingComposer,
-    $CategoriesProcessedTableManager,
-    $CategoriesInsertCompanionBuilder,
+    $CategoriesCreateCompanionBuilder,
     $CategoriesUpdateCompanionBuilder> {
   $CategoriesTableManager(i0.GeneratedDatabase db, i1.Categories table)
       : super(i0.TableManagerState(
@@ -621,8 +594,7 @@ class $CategoriesTableManager extends i0.RootTableManager<
               i1.$CategoriesFilterComposer(i0.ComposerState(db, table)),
           orderingComposer:
               i1.$CategoriesOrderingComposer(i0.ComposerState(db, table)),
-          getChildManagerBuilder: (p) => $CategoriesProcessedTableManager(p),
-          getUpdateCompanionBuilder: ({
+          updateCompanionCallback: ({
             i0.Value<int> id = const i0.Value.absent(),
             i0.Value<String> description = const i0.Value.absent(),
           }) =>
@@ -630,7 +602,7 @@ class $CategoriesTableManager extends i0.RootTableManager<
             id: id,
             description: description,
           ),
-          getInsertCompanionBuilder: ({
+          createCompanionCallback: ({
             i0.Value<int> id = const i0.Value.absent(),
             required String description,
           }) =>
@@ -641,44 +613,29 @@ class $CategoriesTableManager extends i0.RootTableManager<
         ));
 }
 
-class $CategoriesProcessedTableManager extends i0.ProcessedTableManager<
+typedef $CategoriesProcessedTableManager = i0.ProcessedTableManager<
     i0.GeneratedDatabase,
     i1.Categories,
     i1.Category,
     i1.$CategoriesFilterComposer,
     i1.$CategoriesOrderingComposer,
-    $CategoriesProcessedTableManager,
-    $CategoriesInsertCompanionBuilder,
-    $CategoriesUpdateCompanionBuilder> {
-  $CategoriesProcessedTableManager(super.$state);
-}
+    $CategoriesCreateCompanionBuilder,
+    $CategoriesUpdateCompanionBuilder>;
 
 class $CategoriesFilterComposer
     extends i0.FilterComposer<i0.GeneratedDatabase, i1.Categories> {
   $CategoriesFilterComposer(super.$state);
-  i0.ColumnFilters<int> get id => $state.composableBuilder(
-      column: $state.table.id,
-      builder: (column, joinBuilders) =>
-          i0.ColumnFilters(column, joinBuilders: joinBuilders));
-
-  i0.ColumnFilters<String> get description => $state.composableBuilder(
-      column: $state.table.description,
-      builder: (column, joinBuilders) =>
-          i0.ColumnFilters(column, joinBuilders: joinBuilders));
+  i0.ColumnFilters<int> get id => i0.ColumnFilters($state.table.id);
+  i0.ColumnFilters<String> get description =>
+      i0.ColumnFilters($state.table.description);
 }
 
 class $CategoriesOrderingComposer
     extends i0.OrderingComposer<i0.GeneratedDatabase, i1.Categories> {
   $CategoriesOrderingComposer(super.$state);
-  i0.ColumnOrderings<int> get id => $state.composableBuilder(
-      column: $state.table.id,
-      builder: (column, joinBuilders) =>
-          i0.ColumnOrderings(column, joinBuilders: joinBuilders));
-
-  i0.ColumnOrderings<String> get description => $state.composableBuilder(
-      column: $state.table.description,
-      builder: (column, joinBuilders) =>
-          i0.ColumnOrderings(column, joinBuilders: joinBuilders));
+  i0.ColumnOrderings<int> get id => i0.ColumnOrderings($state.table.id);
+  i0.ColumnOrderings<String> get description =>
+      i0.ColumnOrderings($state.table.description);
 }
 
 class ExampleDrift extends i2.ModularAccessor {

--- a/docs/lib/snippets/modular/drift/example.drift.dart
+++ b/docs/lib/snippets/modular/drift/example.drift.dart
@@ -336,10 +336,21 @@ typedef $TodosProcessedTableManager = i0.ProcessedTableManager<
 class $TodosFilterComposer
     extends i0.FilterComposer<i0.GeneratedDatabase, i1.Todos> {
   $TodosFilterComposer(super.$state);
-  i0.ColumnFilters<int> get id => i0.ColumnFilters($state.table.id);
-  i0.ColumnFilters<String> get title => i0.ColumnFilters($state.table.title);
-  i0.ColumnFilters<String> get content =>
-      i0.ColumnFilters($state.table.content);
+  i0.ColumnFilters<int> get id => $state.composableBuilder(
+      column: $state.table.id,
+      builder: (column, joinBuilders) =>
+          i0.ColumnFilters(column, joinBuilders: joinBuilders));
+
+  i0.ColumnFilters<String> get title => $state.composableBuilder(
+      column: $state.table.title,
+      builder: (column, joinBuilders) =>
+          i0.ColumnFilters(column, joinBuilders: joinBuilders));
+
+  i0.ColumnFilters<String> get content => $state.composableBuilder(
+      column: $state.table.content,
+      builder: (column, joinBuilders) =>
+          i0.ColumnFilters(column, joinBuilders: joinBuilders));
+
   i1.$CategoriesFilterComposer get category {
     final i1.$CategoriesFilterComposer composer = $state.composerBuilder(
         composer: this,
@@ -361,11 +372,21 @@ class $TodosFilterComposer
 class $TodosOrderingComposer
     extends i0.OrderingComposer<i0.GeneratedDatabase, i1.Todos> {
   $TodosOrderingComposer(super.$state);
-  i0.ColumnOrderings<int> get id => i0.ColumnOrderings($state.table.id);
-  i0.ColumnOrderings<String> get title =>
-      i0.ColumnOrderings($state.table.title);
-  i0.ColumnOrderings<String> get content =>
-      i0.ColumnOrderings($state.table.content);
+  i0.ColumnOrderings<int> get id => $state.composableBuilder(
+      column: $state.table.id,
+      builder: (column, joinBuilders) =>
+          i0.ColumnOrderings(column, joinBuilders: joinBuilders));
+
+  i0.ColumnOrderings<String> get title => $state.composableBuilder(
+      column: $state.table.title,
+      builder: (column, joinBuilders) =>
+          i0.ColumnOrderings(column, joinBuilders: joinBuilders));
+
+  i0.ColumnOrderings<String> get content => $state.composableBuilder(
+      column: $state.table.content,
+      builder: (column, joinBuilders) =>
+          i0.ColumnOrderings(column, joinBuilders: joinBuilders));
+
   i1.$CategoriesOrderingComposer get category {
     final i1.$CategoriesOrderingComposer composer = $state.composerBuilder(
         composer: this,
@@ -625,17 +646,29 @@ typedef $CategoriesProcessedTableManager = i0.ProcessedTableManager<
 class $CategoriesFilterComposer
     extends i0.FilterComposer<i0.GeneratedDatabase, i1.Categories> {
   $CategoriesFilterComposer(super.$state);
-  i0.ColumnFilters<int> get id => i0.ColumnFilters($state.table.id);
-  i0.ColumnFilters<String> get description =>
-      i0.ColumnFilters($state.table.description);
+  i0.ColumnFilters<int> get id => $state.composableBuilder(
+      column: $state.table.id,
+      builder: (column, joinBuilders) =>
+          i0.ColumnFilters(column, joinBuilders: joinBuilders));
+
+  i0.ColumnFilters<String> get description => $state.composableBuilder(
+      column: $state.table.description,
+      builder: (column, joinBuilders) =>
+          i0.ColumnFilters(column, joinBuilders: joinBuilders));
 }
 
 class $CategoriesOrderingComposer
     extends i0.OrderingComposer<i0.GeneratedDatabase, i1.Categories> {
   $CategoriesOrderingComposer(super.$state);
-  i0.ColumnOrderings<int> get id => i0.ColumnOrderings($state.table.id);
-  i0.ColumnOrderings<String> get description =>
-      i0.ColumnOrderings($state.table.description);
+  i0.ColumnOrderings<int> get id => $state.composableBuilder(
+      column: $state.table.id,
+      builder: (column, joinBuilders) =>
+          i0.ColumnOrderings(column, joinBuilders: joinBuilders));
+
+  i0.ColumnOrderings<String> get description => $state.composableBuilder(
+      column: $state.table.description,
+      builder: (column, joinBuilders) =>
+          i0.ColumnOrderings(column, joinBuilders: joinBuilders));
 }
 
 class ExampleDrift extends i2.ModularAccessor {

--- a/docs/lib/snippets/modular/drift/example.drift.dart
+++ b/docs/lib/snippets/modular/drift/example.drift.dart
@@ -324,15 +324,6 @@ class $TodosTableManager extends i0.RootTableManager<
         ));
 }
 
-typedef $TodosProcessedTableManager = i0.ProcessedTableManager<
-    i0.GeneratedDatabase,
-    i1.Todos,
-    i1.Todo,
-    i1.$TodosFilterComposer,
-    i1.$TodosOrderingComposer,
-    $TodosCreateCompanionBuilder,
-    $TodosUpdateCompanionBuilder>;
-
 class $TodosFilterComposer
     extends i0.FilterComposer<i0.GeneratedDatabase, i1.Todos> {
   $TodosFilterComposer(super.$state);
@@ -633,15 +624,6 @@ class $CategoriesTableManager extends i0.RootTableManager<
           ),
         ));
 }
-
-typedef $CategoriesProcessedTableManager = i0.ProcessedTableManager<
-    i0.GeneratedDatabase,
-    i1.Categories,
-    i1.Category,
-    i1.$CategoriesFilterComposer,
-    i1.$CategoriesOrderingComposer,
-    $CategoriesCreateCompanionBuilder,
-    $CategoriesUpdateCompanionBuilder>;
 
 class $CategoriesFilterComposer
     extends i0.FilterComposer<i0.GeneratedDatabase, i1.Categories> {

--- a/docs/lib/snippets/modular/drift/with_existing.drift.dart
+++ b/docs/lib/snippets/modular/drift/with_existing.drift.dart
@@ -163,15 +163,6 @@ class $UsersTableManager extends i0.RootTableManager<
         ));
 }
 
-typedef $UsersProcessedTableManager = i0.ProcessedTableManager<
-    i0.GeneratedDatabase,
-    i2.Users,
-    i1.User,
-    i2.$UsersFilterComposer,
-    i2.$UsersOrderingComposer,
-    $UsersCreateCompanionBuilder,
-    $UsersUpdateCompanionBuilder>;
-
 class $UsersFilterComposer
     extends i0.FilterComposer<i0.GeneratedDatabase, i2.Users> {
   $UsersFilterComposer(super.$state);
@@ -447,15 +438,6 @@ class $FriendsTableManager extends i0.RootTableManager<
           ),
         ));
 }
-
-typedef $FriendsProcessedTableManager = i0.ProcessedTableManager<
-    i0.GeneratedDatabase,
-    i2.Friends,
-    i2.Friend,
-    i2.$FriendsFilterComposer,
-    i2.$FriendsOrderingComposer,
-    $FriendsCreateCompanionBuilder,
-    $FriendsUpdateCompanionBuilder>;
 
 class $FriendsFilterComposer
     extends i0.FilterComposer<i0.GeneratedDatabase, i2.Friends> {

--- a/docs/lib/snippets/modular/drift/with_existing.drift.dart
+++ b/docs/lib/snippets/modular/drift/with_existing.drift.dart
@@ -175,15 +175,29 @@ typedef $UsersProcessedTableManager = i0.ProcessedTableManager<
 class $UsersFilterComposer
     extends i0.FilterComposer<i0.GeneratedDatabase, i2.Users> {
   $UsersFilterComposer(super.$state);
-  i0.ColumnFilters<int> get id => i0.ColumnFilters($state.table.id);
-  i0.ColumnFilters<String> get name => i0.ColumnFilters($state.table.name);
+  i0.ColumnFilters<int> get id => $state.composableBuilder(
+      column: $state.table.id,
+      builder: (column, joinBuilders) =>
+          i0.ColumnFilters(column, joinBuilders: joinBuilders));
+
+  i0.ColumnFilters<String> get name => $state.composableBuilder(
+      column: $state.table.name,
+      builder: (column, joinBuilders) =>
+          i0.ColumnFilters(column, joinBuilders: joinBuilders));
 }
 
 class $UsersOrderingComposer
     extends i0.OrderingComposer<i0.GeneratedDatabase, i2.Users> {
   $UsersOrderingComposer(super.$state);
-  i0.ColumnOrderings<int> get id => i0.ColumnOrderings($state.table.id);
-  i0.ColumnOrderings<String> get name => i0.ColumnOrderings($state.table.name);
+  i0.ColumnOrderings<int> get id => $state.composableBuilder(
+      column: $state.table.id,
+      builder: (column, joinBuilders) =>
+          i0.ColumnOrderings(column, joinBuilders: joinBuilders));
+
+  i0.ColumnOrderings<String> get name => $state.composableBuilder(
+      column: $state.table.name,
+      builder: (column, joinBuilders) =>
+          i0.ColumnOrderings(column, joinBuilders: joinBuilders));
 }
 
 class Friends extends i0.Table with i0.TableInfo<Friends, i2.Friend> {

--- a/docs/lib/snippets/modular/drift/with_existing.drift.dart
+++ b/docs/lib/snippets/modular/drift/with_existing.drift.dart
@@ -119,7 +119,7 @@ class UsersCompanion extends i0.UpdateCompanion<i1.User> {
   }
 }
 
-typedef $UsersInsertCompanionBuilder = i2.UsersCompanion Function({
+typedef $UsersCreateCompanionBuilder = i2.UsersCompanion Function({
   i0.Value<int> id,
   required String name,
 });
@@ -134,8 +134,7 @@ class $UsersTableManager extends i0.RootTableManager<
     i1.User,
     i2.$UsersFilterComposer,
     i2.$UsersOrderingComposer,
-    $UsersProcessedTableManager,
-    $UsersInsertCompanionBuilder,
+    $UsersCreateCompanionBuilder,
     $UsersUpdateCompanionBuilder> {
   $UsersTableManager(i0.GeneratedDatabase db, i2.Users table)
       : super(i0.TableManagerState(
@@ -145,8 +144,7 @@ class $UsersTableManager extends i0.RootTableManager<
               i2.$UsersFilterComposer(i0.ComposerState(db, table)),
           orderingComposer:
               i2.$UsersOrderingComposer(i0.ComposerState(db, table)),
-          getChildManagerBuilder: (p) => $UsersProcessedTableManager(p),
-          getUpdateCompanionBuilder: ({
+          updateCompanionCallback: ({
             i0.Value<int> id = const i0.Value.absent(),
             i0.Value<String> name = const i0.Value.absent(),
           }) =>
@@ -154,7 +152,7 @@ class $UsersTableManager extends i0.RootTableManager<
             id: id,
             name: name,
           ),
-          getInsertCompanionBuilder: ({
+          createCompanionCallback: ({
             i0.Value<int> id = const i0.Value.absent(),
             required String name,
           }) =>
@@ -165,44 +163,27 @@ class $UsersTableManager extends i0.RootTableManager<
         ));
 }
 
-class $UsersProcessedTableManager extends i0.ProcessedTableManager<
+typedef $UsersProcessedTableManager = i0.ProcessedTableManager<
     i0.GeneratedDatabase,
     i2.Users,
     i1.User,
     i2.$UsersFilterComposer,
     i2.$UsersOrderingComposer,
-    $UsersProcessedTableManager,
-    $UsersInsertCompanionBuilder,
-    $UsersUpdateCompanionBuilder> {
-  $UsersProcessedTableManager(super.$state);
-}
+    $UsersCreateCompanionBuilder,
+    $UsersUpdateCompanionBuilder>;
 
 class $UsersFilterComposer
     extends i0.FilterComposer<i0.GeneratedDatabase, i2.Users> {
   $UsersFilterComposer(super.$state);
-  i0.ColumnFilters<int> get id => $state.composableBuilder(
-      column: $state.table.id,
-      builder: (column, joinBuilders) =>
-          i0.ColumnFilters(column, joinBuilders: joinBuilders));
-
-  i0.ColumnFilters<String> get name => $state.composableBuilder(
-      column: $state.table.name,
-      builder: (column, joinBuilders) =>
-          i0.ColumnFilters(column, joinBuilders: joinBuilders));
+  i0.ColumnFilters<int> get id => i0.ColumnFilters($state.table.id);
+  i0.ColumnFilters<String> get name => i0.ColumnFilters($state.table.name);
 }
 
 class $UsersOrderingComposer
     extends i0.OrderingComposer<i0.GeneratedDatabase, i2.Users> {
   $UsersOrderingComposer(super.$state);
-  i0.ColumnOrderings<int> get id => $state.composableBuilder(
-      column: $state.table.id,
-      builder: (column, joinBuilders) =>
-          i0.ColumnOrderings(column, joinBuilders: joinBuilders));
-
-  i0.ColumnOrderings<String> get name => $state.composableBuilder(
-      column: $state.table.name,
-      builder: (column, joinBuilders) =>
-          i0.ColumnOrderings(column, joinBuilders: joinBuilders));
+  i0.ColumnOrderings<int> get id => i0.ColumnOrderings($state.table.id);
+  i0.ColumnOrderings<String> get name => i0.ColumnOrderings($state.table.name);
 }
 
 class Friends extends i0.Table with i0.TableInfo<Friends, i2.Friend> {
@@ -403,7 +384,7 @@ class FriendsCompanion extends i0.UpdateCompanion<i2.Friend> {
   }
 }
 
-typedef $FriendsInsertCompanionBuilder = i2.FriendsCompanion Function({
+typedef $FriendsCreateCompanionBuilder = i2.FriendsCompanion Function({
   required int userA,
   required int userB,
   i0.Value<int> rowid,
@@ -420,8 +401,7 @@ class $FriendsTableManager extends i0.RootTableManager<
     i2.Friend,
     i2.$FriendsFilterComposer,
     i2.$FriendsOrderingComposer,
-    $FriendsProcessedTableManager,
-    $FriendsInsertCompanionBuilder,
+    $FriendsCreateCompanionBuilder,
     $FriendsUpdateCompanionBuilder> {
   $FriendsTableManager(i0.GeneratedDatabase db, i2.Friends table)
       : super(i0.TableManagerState(
@@ -431,8 +411,7 @@ class $FriendsTableManager extends i0.RootTableManager<
               i2.$FriendsFilterComposer(i0.ComposerState(db, table)),
           orderingComposer:
               i2.$FriendsOrderingComposer(i0.ComposerState(db, table)),
-          getChildManagerBuilder: (p) => $FriendsProcessedTableManager(p),
-          getUpdateCompanionBuilder: ({
+          updateCompanionCallback: ({
             i0.Value<int> userA = const i0.Value.absent(),
             i0.Value<int> userB = const i0.Value.absent(),
             i0.Value<int> rowid = const i0.Value.absent(),
@@ -442,7 +421,7 @@ class $FriendsTableManager extends i0.RootTableManager<
             userB: userB,
             rowid: rowid,
           ),
-          getInsertCompanionBuilder: ({
+          createCompanionCallback: ({
             required int userA,
             required int userB,
             i0.Value<int> rowid = const i0.Value.absent(),
@@ -455,17 +434,14 @@ class $FriendsTableManager extends i0.RootTableManager<
         ));
 }
 
-class $FriendsProcessedTableManager extends i0.ProcessedTableManager<
+typedef $FriendsProcessedTableManager = i0.ProcessedTableManager<
     i0.GeneratedDatabase,
     i2.Friends,
     i2.Friend,
     i2.$FriendsFilterComposer,
     i2.$FriendsOrderingComposer,
-    $FriendsProcessedTableManager,
-    $FriendsInsertCompanionBuilder,
-    $FriendsUpdateCompanionBuilder> {
-  $FriendsProcessedTableManager(super.$state);
-}
+    $FriendsCreateCompanionBuilder,
+    $FriendsUpdateCompanionBuilder>;
 
 class $FriendsFilterComposer
     extends i0.FilterComposer<i0.GeneratedDatabase, i2.Friends> {

--- a/docs/lib/snippets/modular/many_to_many/json.drift.dart
+++ b/docs/lib/snippets/modular/many_to_many/json.drift.dart
@@ -219,7 +219,7 @@ class ShoppingCartsCompanion extends i0.UpdateCompanion<i2.ShoppingCart> {
   }
 }
 
-typedef $$ShoppingCartsTableInsertCompanionBuilder = i2.ShoppingCartsCompanion
+typedef $$ShoppingCartsTableCreateCompanionBuilder = i2.ShoppingCartsCompanion
     Function({
   i0.Value<int> id,
   required i3.ShoppingCartEntries entries,
@@ -236,8 +236,7 @@ class $$ShoppingCartsTableTableManager extends i0.RootTableManager<
     i2.ShoppingCart,
     i2.$$ShoppingCartsTableFilterComposer,
     i2.$$ShoppingCartsTableOrderingComposer,
-    $$ShoppingCartsTableProcessedTableManager,
-    $$ShoppingCartsTableInsertCompanionBuilder,
+    $$ShoppingCartsTableCreateCompanionBuilder,
     $$ShoppingCartsTableUpdateCompanionBuilder> {
   $$ShoppingCartsTableTableManager(
       i0.GeneratedDatabase db, i2.$ShoppingCartsTable table)
@@ -248,9 +247,7 @@ class $$ShoppingCartsTableTableManager extends i0.RootTableManager<
               .$$ShoppingCartsTableFilterComposer(i0.ComposerState(db, table)),
           orderingComposer: i2.$$ShoppingCartsTableOrderingComposer(
               i0.ComposerState(db, table)),
-          getChildManagerBuilder: (p) =>
-              $$ShoppingCartsTableProcessedTableManager(p),
-          getUpdateCompanionBuilder: ({
+          updateCompanionCallback: ({
             i0.Value<int> id = const i0.Value.absent(),
             i0.Value<i3.ShoppingCartEntries> entries = const i0.Value.absent(),
           }) =>
@@ -258,7 +255,7 @@ class $$ShoppingCartsTableTableManager extends i0.RootTableManager<
             id: id,
             entries: entries,
           ),
-          getInsertCompanionBuilder: ({
+          createCompanionCallback: ({
             i0.Value<int> id = const i0.Value.absent(),
             required i3.ShoppingCartEntries entries,
           }) =>
@@ -269,46 +266,28 @@ class $$ShoppingCartsTableTableManager extends i0.RootTableManager<
         ));
 }
 
-class $$ShoppingCartsTableProcessedTableManager
-    extends i0.ProcessedTableManager<
-        i0.GeneratedDatabase,
-        i2.$ShoppingCartsTable,
-        i2.ShoppingCart,
-        i2.$$ShoppingCartsTableFilterComposer,
-        i2.$$ShoppingCartsTableOrderingComposer,
-        $$ShoppingCartsTableProcessedTableManager,
-        $$ShoppingCartsTableInsertCompanionBuilder,
-        $$ShoppingCartsTableUpdateCompanionBuilder> {
-  $$ShoppingCartsTableProcessedTableManager(super.$state);
-}
+typedef $$ShoppingCartsTableProcessedTableManager = i0.ProcessedTableManager<
+    i0.GeneratedDatabase,
+    i2.$ShoppingCartsTable,
+    i2.ShoppingCart,
+    i2.$$ShoppingCartsTableFilterComposer,
+    i2.$$ShoppingCartsTableOrderingComposer,
+    $$ShoppingCartsTableCreateCompanionBuilder,
+    $$ShoppingCartsTableUpdateCompanionBuilder>;
 
 class $$ShoppingCartsTableFilterComposer
     extends i0.FilterComposer<i0.GeneratedDatabase, i2.$ShoppingCartsTable> {
   $$ShoppingCartsTableFilterComposer(super.$state);
-  i0.ColumnFilters<int> get id => $state.composableBuilder(
-      column: $state.table.id,
-      builder: (column, joinBuilders) =>
-          i0.ColumnFilters(column, joinBuilders: joinBuilders));
-
+  i0.ColumnFilters<int> get id => i0.ColumnFilters($state.table.id);
   i0.ColumnWithTypeConverterFilters<i3.ShoppingCartEntries,
           i3.ShoppingCartEntries, String>
-      get entries => $state.composableBuilder(
-          column: $state.table.entries,
-          builder: (column, joinBuilders) => i0.ColumnWithTypeConverterFilters(
-              column,
-              joinBuilders: joinBuilders));
+      get entries => i0.ColumnWithTypeConverterFilters($state.table.entries);
 }
 
 class $$ShoppingCartsTableOrderingComposer
     extends i0.OrderingComposer<i0.GeneratedDatabase, i2.$ShoppingCartsTable> {
   $$ShoppingCartsTableOrderingComposer(super.$state);
-  i0.ColumnOrderings<int> get id => $state.composableBuilder(
-      column: $state.table.id,
-      builder: (column, joinBuilders) =>
-          i0.ColumnOrderings(column, joinBuilders: joinBuilders));
-
-  i0.ColumnOrderings<String> get entries => $state.composableBuilder(
-      column: $state.table.entries,
-      builder: (column, joinBuilders) =>
-          i0.ColumnOrderings(column, joinBuilders: joinBuilders));
+  i0.ColumnOrderings<int> get id => i0.ColumnOrderings($state.table.id);
+  i0.ColumnOrderings<String> get entries =>
+      i0.ColumnOrderings($state.table.entries);
 }

--- a/docs/lib/snippets/modular/many_to_many/json.drift.dart
+++ b/docs/lib/snippets/modular/many_to_many/json.drift.dart
@@ -266,15 +266,6 @@ class $$ShoppingCartsTableTableManager extends i0.RootTableManager<
         ));
 }
 
-typedef $$ShoppingCartsTableProcessedTableManager = i0.ProcessedTableManager<
-    i0.GeneratedDatabase,
-    i2.$ShoppingCartsTable,
-    i2.ShoppingCart,
-    i2.$$ShoppingCartsTableFilterComposer,
-    i2.$$ShoppingCartsTableOrderingComposer,
-    $$ShoppingCartsTableCreateCompanionBuilder,
-    $$ShoppingCartsTableUpdateCompanionBuilder>;
-
 class $$ShoppingCartsTableFilterComposer
     extends i0.FilterComposer<i0.GeneratedDatabase, i2.$ShoppingCartsTable> {
   $$ShoppingCartsTableFilterComposer(super.$state);

--- a/docs/lib/snippets/modular/many_to_many/json.drift.dart
+++ b/docs/lib/snippets/modular/many_to_many/json.drift.dart
@@ -278,16 +278,30 @@ typedef $$ShoppingCartsTableProcessedTableManager = i0.ProcessedTableManager<
 class $$ShoppingCartsTableFilterComposer
     extends i0.FilterComposer<i0.GeneratedDatabase, i2.$ShoppingCartsTable> {
   $$ShoppingCartsTableFilterComposer(super.$state);
-  i0.ColumnFilters<int> get id => i0.ColumnFilters($state.table.id);
+  i0.ColumnFilters<int> get id => $state.composableBuilder(
+      column: $state.table.id,
+      builder: (column, joinBuilders) =>
+          i0.ColumnFilters(column, joinBuilders: joinBuilders));
+
   i0.ColumnWithTypeConverterFilters<i3.ShoppingCartEntries,
           i3.ShoppingCartEntries, String>
-      get entries => i0.ColumnWithTypeConverterFilters($state.table.entries);
+      get entries => $state.composableBuilder(
+          column: $state.table.entries,
+          builder: (column, joinBuilders) => i0.ColumnWithTypeConverterFilters(
+              column,
+              joinBuilders: joinBuilders));
 }
 
 class $$ShoppingCartsTableOrderingComposer
     extends i0.OrderingComposer<i0.GeneratedDatabase, i2.$ShoppingCartsTable> {
   $$ShoppingCartsTableOrderingComposer(super.$state);
-  i0.ColumnOrderings<int> get id => i0.ColumnOrderings($state.table.id);
-  i0.ColumnOrderings<String> get entries =>
-      i0.ColumnOrderings($state.table.entries);
+  i0.ColumnOrderings<int> get id => $state.composableBuilder(
+      column: $state.table.id,
+      builder: (column, joinBuilders) =>
+          i0.ColumnOrderings(column, joinBuilders: joinBuilders));
+
+  i0.ColumnOrderings<String> get entries => $state.composableBuilder(
+      column: $state.table.entries,
+      builder: (column, joinBuilders) =>
+          i0.ColumnOrderings(column, joinBuilders: joinBuilders));
 }

--- a/docs/lib/snippets/modular/many_to_many/relational.drift.dart
+++ b/docs/lib/snippets/modular/many_to_many/relational.drift.dart
@@ -235,13 +235,19 @@ typedef $$ShoppingCartsTableProcessedTableManager = i0.ProcessedTableManager<
 class $$ShoppingCartsTableFilterComposer
     extends i0.FilterComposer<i0.GeneratedDatabase, i2.$ShoppingCartsTable> {
   $$ShoppingCartsTableFilterComposer(super.$state);
-  i0.ColumnFilters<int> get id => i0.ColumnFilters($state.table.id);
+  i0.ColumnFilters<int> get id => $state.composableBuilder(
+      column: $state.table.id,
+      builder: (column, joinBuilders) =>
+          i0.ColumnFilters(column, joinBuilders: joinBuilders));
 }
 
 class $$ShoppingCartsTableOrderingComposer
     extends i0.OrderingComposer<i0.GeneratedDatabase, i2.$ShoppingCartsTable> {
   $$ShoppingCartsTableOrderingComposer(super.$state);
-  i0.ColumnOrderings<int> get id => i0.ColumnOrderings($state.table.id);
+  i0.ColumnOrderings<int> get id => $state.composableBuilder(
+      column: $state.table.id,
+      builder: (column, joinBuilders) =>
+          i0.ColumnOrderings(column, joinBuilders: joinBuilders));
 }
 
 class $ShoppingCartEntriesTable extends i3.ShoppingCartEntries

--- a/docs/lib/snippets/modular/many_to_many/relational.drift.dart
+++ b/docs/lib/snippets/modular/many_to_many/relational.drift.dart
@@ -223,15 +223,6 @@ class $$ShoppingCartsTableTableManager extends i0.RootTableManager<
         ));
 }
 
-typedef $$ShoppingCartsTableProcessedTableManager = i0.ProcessedTableManager<
-    i0.GeneratedDatabase,
-    i2.$ShoppingCartsTable,
-    i2.ShoppingCart,
-    i2.$$ShoppingCartsTableFilterComposer,
-    i2.$$ShoppingCartsTableOrderingComposer,
-    $$ShoppingCartsTableCreateCompanionBuilder,
-    $$ShoppingCartsTableUpdateCompanionBuilder>;
-
 class $$ShoppingCartsTableFilterComposer
     extends i0.FilterComposer<i0.GeneratedDatabase, i2.$ShoppingCartsTable> {
   $$ShoppingCartsTableFilterComposer(super.$state);
@@ -510,16 +501,6 @@ class $$ShoppingCartEntriesTableTableManager extends i0.RootTableManager<
           ),
         ));
 }
-
-typedef $$ShoppingCartEntriesTableProcessedTableManager
-    = i0.ProcessedTableManager<
-        i0.GeneratedDatabase,
-        i2.$ShoppingCartEntriesTable,
-        i2.ShoppingCartEntry,
-        i2.$$ShoppingCartEntriesTableFilterComposer,
-        i2.$$ShoppingCartEntriesTableOrderingComposer,
-        $$ShoppingCartEntriesTableCreateCompanionBuilder,
-        $$ShoppingCartEntriesTableUpdateCompanionBuilder>;
 
 class $$ShoppingCartEntriesTableFilterComposer extends i0
     .FilterComposer<i0.GeneratedDatabase, i2.$ShoppingCartEntriesTable> {

--- a/docs/lib/snippets/modular/many_to_many/relational.drift.dart
+++ b/docs/lib/snippets/modular/many_to_many/relational.drift.dart
@@ -182,7 +182,7 @@ class ShoppingCartsCompanion extends i0.UpdateCompanion<i2.ShoppingCart> {
   }
 }
 
-typedef $$ShoppingCartsTableInsertCompanionBuilder = i2.ShoppingCartsCompanion
+typedef $$ShoppingCartsTableCreateCompanionBuilder = i2.ShoppingCartsCompanion
     Function({
   i0.Value<int> id,
 });
@@ -197,8 +197,7 @@ class $$ShoppingCartsTableTableManager extends i0.RootTableManager<
     i2.ShoppingCart,
     i2.$$ShoppingCartsTableFilterComposer,
     i2.$$ShoppingCartsTableOrderingComposer,
-    $$ShoppingCartsTableProcessedTableManager,
-    $$ShoppingCartsTableInsertCompanionBuilder,
+    $$ShoppingCartsTableCreateCompanionBuilder,
     $$ShoppingCartsTableUpdateCompanionBuilder> {
   $$ShoppingCartsTableTableManager(
       i0.GeneratedDatabase db, i2.$ShoppingCartsTable table)
@@ -209,15 +208,13 @@ class $$ShoppingCartsTableTableManager extends i0.RootTableManager<
               .$$ShoppingCartsTableFilterComposer(i0.ComposerState(db, table)),
           orderingComposer: i2.$$ShoppingCartsTableOrderingComposer(
               i0.ComposerState(db, table)),
-          getChildManagerBuilder: (p) =>
-              $$ShoppingCartsTableProcessedTableManager(p),
-          getUpdateCompanionBuilder: ({
+          updateCompanionCallback: ({
             i0.Value<int> id = const i0.Value.absent(),
           }) =>
               i2.ShoppingCartsCompanion(
             id: id,
           ),
-          getInsertCompanionBuilder: ({
+          createCompanionCallback: ({
             i0.Value<int> id = const i0.Value.absent(),
           }) =>
               i2.ShoppingCartsCompanion.insert(
@@ -226,35 +223,25 @@ class $$ShoppingCartsTableTableManager extends i0.RootTableManager<
         ));
 }
 
-class $$ShoppingCartsTableProcessedTableManager
-    extends i0.ProcessedTableManager<
-        i0.GeneratedDatabase,
-        i2.$ShoppingCartsTable,
-        i2.ShoppingCart,
-        i2.$$ShoppingCartsTableFilterComposer,
-        i2.$$ShoppingCartsTableOrderingComposer,
-        $$ShoppingCartsTableProcessedTableManager,
-        $$ShoppingCartsTableInsertCompanionBuilder,
-        $$ShoppingCartsTableUpdateCompanionBuilder> {
-  $$ShoppingCartsTableProcessedTableManager(super.$state);
-}
+typedef $$ShoppingCartsTableProcessedTableManager = i0.ProcessedTableManager<
+    i0.GeneratedDatabase,
+    i2.$ShoppingCartsTable,
+    i2.ShoppingCart,
+    i2.$$ShoppingCartsTableFilterComposer,
+    i2.$$ShoppingCartsTableOrderingComposer,
+    $$ShoppingCartsTableCreateCompanionBuilder,
+    $$ShoppingCartsTableUpdateCompanionBuilder>;
 
 class $$ShoppingCartsTableFilterComposer
     extends i0.FilterComposer<i0.GeneratedDatabase, i2.$ShoppingCartsTable> {
   $$ShoppingCartsTableFilterComposer(super.$state);
-  i0.ColumnFilters<int> get id => $state.composableBuilder(
-      column: $state.table.id,
-      builder: (column, joinBuilders) =>
-          i0.ColumnFilters(column, joinBuilders: joinBuilders));
+  i0.ColumnFilters<int> get id => i0.ColumnFilters($state.table.id);
 }
 
 class $$ShoppingCartsTableOrderingComposer
     extends i0.OrderingComposer<i0.GeneratedDatabase, i2.$ShoppingCartsTable> {
   $$ShoppingCartsTableOrderingComposer(super.$state);
-  i0.ColumnOrderings<int> get id => $state.composableBuilder(
-      column: $state.table.id,
-      builder: (column, joinBuilders) =>
-          i0.ColumnOrderings(column, joinBuilders: joinBuilders));
+  i0.ColumnOrderings<int> get id => i0.ColumnOrderings($state.table.id);
 }
 
 class $ShoppingCartEntriesTable extends i3.ShoppingCartEntries
@@ -465,7 +452,7 @@ class ShoppingCartEntriesCompanion
   }
 }
 
-typedef $$ShoppingCartEntriesTableInsertCompanionBuilder
+typedef $$ShoppingCartEntriesTableCreateCompanionBuilder
     = i2.ShoppingCartEntriesCompanion Function({
   required int shoppingCart,
   required int item,
@@ -484,8 +471,7 @@ class $$ShoppingCartEntriesTableTableManager extends i0.RootTableManager<
     i2.ShoppingCartEntry,
     i2.$$ShoppingCartEntriesTableFilterComposer,
     i2.$$ShoppingCartEntriesTableOrderingComposer,
-    $$ShoppingCartEntriesTableProcessedTableManager,
-    $$ShoppingCartEntriesTableInsertCompanionBuilder,
+    $$ShoppingCartEntriesTableCreateCompanionBuilder,
     $$ShoppingCartEntriesTableUpdateCompanionBuilder> {
   $$ShoppingCartEntriesTableTableManager(
       i0.GeneratedDatabase db, i2.$ShoppingCartEntriesTable table)
@@ -496,9 +482,7 @@ class $$ShoppingCartEntriesTableTableManager extends i0.RootTableManager<
               i0.ComposerState(db, table)),
           orderingComposer: i2.$$ShoppingCartEntriesTableOrderingComposer(
               i0.ComposerState(db, table)),
-          getChildManagerBuilder: (p) =>
-              $$ShoppingCartEntriesTableProcessedTableManager(p),
-          getUpdateCompanionBuilder: ({
+          updateCompanionCallback: ({
             i0.Value<int> shoppingCart = const i0.Value.absent(),
             i0.Value<int> item = const i0.Value.absent(),
             i0.Value<int> rowid = const i0.Value.absent(),
@@ -508,7 +492,7 @@ class $$ShoppingCartEntriesTableTableManager extends i0.RootTableManager<
             item: item,
             rowid: rowid,
           ),
-          getInsertCompanionBuilder: ({
+          createCompanionCallback: ({
             required int shoppingCart,
             required int item,
             i0.Value<int> rowid = const i0.Value.absent(),
@@ -521,18 +505,15 @@ class $$ShoppingCartEntriesTableTableManager extends i0.RootTableManager<
         ));
 }
 
-class $$ShoppingCartEntriesTableProcessedTableManager
-    extends i0.ProcessedTableManager<
+typedef $$ShoppingCartEntriesTableProcessedTableManager
+    = i0.ProcessedTableManager<
         i0.GeneratedDatabase,
         i2.$ShoppingCartEntriesTable,
         i2.ShoppingCartEntry,
         i2.$$ShoppingCartEntriesTableFilterComposer,
         i2.$$ShoppingCartEntriesTableOrderingComposer,
-        $$ShoppingCartEntriesTableProcessedTableManager,
-        $$ShoppingCartEntriesTableInsertCompanionBuilder,
-        $$ShoppingCartEntriesTableUpdateCompanionBuilder> {
-  $$ShoppingCartEntriesTableProcessedTableManager(super.$state);
-}
+        $$ShoppingCartEntriesTableCreateCompanionBuilder,
+        $$ShoppingCartEntriesTableUpdateCompanionBuilder>;
 
 class $$ShoppingCartEntriesTableFilterComposer extends i0
     .FilterComposer<i0.GeneratedDatabase, i2.$ShoppingCartEntriesTable> {

--- a/docs/lib/snippets/modular/many_to_many/shared.drift.dart
+++ b/docs/lib/snippets/modular/many_to_many/shared.drift.dart
@@ -293,17 +293,37 @@ typedef $$BuyableItemsTableProcessedTableManager = i0.ProcessedTableManager<
 class $$BuyableItemsTableFilterComposer
     extends i0.FilterComposer<i0.GeneratedDatabase, i1.$BuyableItemsTable> {
   $$BuyableItemsTableFilterComposer(super.$state);
-  i0.ColumnFilters<int> get id => i0.ColumnFilters($state.table.id);
-  i0.ColumnFilters<String> get description =>
-      i0.ColumnFilters($state.table.description);
-  i0.ColumnFilters<int> get price => i0.ColumnFilters($state.table.price);
+  i0.ColumnFilters<int> get id => $state.composableBuilder(
+      column: $state.table.id,
+      builder: (column, joinBuilders) =>
+          i0.ColumnFilters(column, joinBuilders: joinBuilders));
+
+  i0.ColumnFilters<String> get description => $state.composableBuilder(
+      column: $state.table.description,
+      builder: (column, joinBuilders) =>
+          i0.ColumnFilters(column, joinBuilders: joinBuilders));
+
+  i0.ColumnFilters<int> get price => $state.composableBuilder(
+      column: $state.table.price,
+      builder: (column, joinBuilders) =>
+          i0.ColumnFilters(column, joinBuilders: joinBuilders));
 }
 
 class $$BuyableItemsTableOrderingComposer
     extends i0.OrderingComposer<i0.GeneratedDatabase, i1.$BuyableItemsTable> {
   $$BuyableItemsTableOrderingComposer(super.$state);
-  i0.ColumnOrderings<int> get id => i0.ColumnOrderings($state.table.id);
-  i0.ColumnOrderings<String> get description =>
-      i0.ColumnOrderings($state.table.description);
-  i0.ColumnOrderings<int> get price => i0.ColumnOrderings($state.table.price);
+  i0.ColumnOrderings<int> get id => $state.composableBuilder(
+      column: $state.table.id,
+      builder: (column, joinBuilders) =>
+          i0.ColumnOrderings(column, joinBuilders: joinBuilders));
+
+  i0.ColumnOrderings<String> get description => $state.composableBuilder(
+      column: $state.table.description,
+      builder: (column, joinBuilders) =>
+          i0.ColumnOrderings(column, joinBuilders: joinBuilders));
+
+  i0.ColumnOrderings<int> get price => $state.composableBuilder(
+      column: $state.table.price,
+      builder: (column, joinBuilders) =>
+          i0.ColumnOrderings(column, joinBuilders: joinBuilders));
 }

--- a/docs/lib/snippets/modular/many_to_many/shared.drift.dart
+++ b/docs/lib/snippets/modular/many_to_many/shared.drift.dart
@@ -228,7 +228,7 @@ class BuyableItemsCompanion extends i0.UpdateCompanion<i1.BuyableItem> {
   }
 }
 
-typedef $$BuyableItemsTableInsertCompanionBuilder = i1.BuyableItemsCompanion
+typedef $$BuyableItemsTableCreateCompanionBuilder = i1.BuyableItemsCompanion
     Function({
   i0.Value<int> id,
   required String description,
@@ -247,8 +247,7 @@ class $$BuyableItemsTableTableManager extends i0.RootTableManager<
     i1.BuyableItem,
     i1.$$BuyableItemsTableFilterComposer,
     i1.$$BuyableItemsTableOrderingComposer,
-    $$BuyableItemsTableProcessedTableManager,
-    $$BuyableItemsTableInsertCompanionBuilder,
+    $$BuyableItemsTableCreateCompanionBuilder,
     $$BuyableItemsTableUpdateCompanionBuilder> {
   $$BuyableItemsTableTableManager(
       i0.GeneratedDatabase db, i1.$BuyableItemsTable table)
@@ -259,9 +258,7 @@ class $$BuyableItemsTableTableManager extends i0.RootTableManager<
               i1.$$BuyableItemsTableFilterComposer(i0.ComposerState(db, table)),
           orderingComposer: i1
               .$$BuyableItemsTableOrderingComposer(i0.ComposerState(db, table)),
-          getChildManagerBuilder: (p) =>
-              $$BuyableItemsTableProcessedTableManager(p),
-          getUpdateCompanionBuilder: ({
+          updateCompanionCallback: ({
             i0.Value<int> id = const i0.Value.absent(),
             i0.Value<String> description = const i0.Value.absent(),
             i0.Value<int> price = const i0.Value.absent(),
@@ -271,7 +268,7 @@ class $$BuyableItemsTableTableManager extends i0.RootTableManager<
             description: description,
             price: price,
           ),
-          getInsertCompanionBuilder: ({
+          createCompanionCallback: ({
             i0.Value<int> id = const i0.Value.absent(),
             required String description,
             required int price,
@@ -284,52 +281,29 @@ class $$BuyableItemsTableTableManager extends i0.RootTableManager<
         ));
 }
 
-class $$BuyableItemsTableProcessedTableManager extends i0.ProcessedTableManager<
+typedef $$BuyableItemsTableProcessedTableManager = i0.ProcessedTableManager<
     i0.GeneratedDatabase,
     i1.$BuyableItemsTable,
     i1.BuyableItem,
     i1.$$BuyableItemsTableFilterComposer,
     i1.$$BuyableItemsTableOrderingComposer,
-    $$BuyableItemsTableProcessedTableManager,
-    $$BuyableItemsTableInsertCompanionBuilder,
-    $$BuyableItemsTableUpdateCompanionBuilder> {
-  $$BuyableItemsTableProcessedTableManager(super.$state);
-}
+    $$BuyableItemsTableCreateCompanionBuilder,
+    $$BuyableItemsTableUpdateCompanionBuilder>;
 
 class $$BuyableItemsTableFilterComposer
     extends i0.FilterComposer<i0.GeneratedDatabase, i1.$BuyableItemsTable> {
   $$BuyableItemsTableFilterComposer(super.$state);
-  i0.ColumnFilters<int> get id => $state.composableBuilder(
-      column: $state.table.id,
-      builder: (column, joinBuilders) =>
-          i0.ColumnFilters(column, joinBuilders: joinBuilders));
-
-  i0.ColumnFilters<String> get description => $state.composableBuilder(
-      column: $state.table.description,
-      builder: (column, joinBuilders) =>
-          i0.ColumnFilters(column, joinBuilders: joinBuilders));
-
-  i0.ColumnFilters<int> get price => $state.composableBuilder(
-      column: $state.table.price,
-      builder: (column, joinBuilders) =>
-          i0.ColumnFilters(column, joinBuilders: joinBuilders));
+  i0.ColumnFilters<int> get id => i0.ColumnFilters($state.table.id);
+  i0.ColumnFilters<String> get description =>
+      i0.ColumnFilters($state.table.description);
+  i0.ColumnFilters<int> get price => i0.ColumnFilters($state.table.price);
 }
 
 class $$BuyableItemsTableOrderingComposer
     extends i0.OrderingComposer<i0.GeneratedDatabase, i1.$BuyableItemsTable> {
   $$BuyableItemsTableOrderingComposer(super.$state);
-  i0.ColumnOrderings<int> get id => $state.composableBuilder(
-      column: $state.table.id,
-      builder: (column, joinBuilders) =>
-          i0.ColumnOrderings(column, joinBuilders: joinBuilders));
-
-  i0.ColumnOrderings<String> get description => $state.composableBuilder(
-      column: $state.table.description,
-      builder: (column, joinBuilders) =>
-          i0.ColumnOrderings(column, joinBuilders: joinBuilders));
-
-  i0.ColumnOrderings<int> get price => $state.composableBuilder(
-      column: $state.table.price,
-      builder: (column, joinBuilders) =>
-          i0.ColumnOrderings(column, joinBuilders: joinBuilders));
+  i0.ColumnOrderings<int> get id => i0.ColumnOrderings($state.table.id);
+  i0.ColumnOrderings<String> get description =>
+      i0.ColumnOrderings($state.table.description);
+  i0.ColumnOrderings<int> get price => i0.ColumnOrderings($state.table.price);
 }

--- a/docs/lib/snippets/modular/many_to_many/shared.drift.dart
+++ b/docs/lib/snippets/modular/many_to_many/shared.drift.dart
@@ -281,15 +281,6 @@ class $$BuyableItemsTableTableManager extends i0.RootTableManager<
         ));
 }
 
-typedef $$BuyableItemsTableProcessedTableManager = i0.ProcessedTableManager<
-    i0.GeneratedDatabase,
-    i1.$BuyableItemsTable,
-    i1.BuyableItem,
-    i1.$$BuyableItemsTableFilterComposer,
-    i1.$$BuyableItemsTableOrderingComposer,
-    $$BuyableItemsTableCreateCompanionBuilder,
-    $$BuyableItemsTableUpdateCompanionBuilder>;
-
 class $$BuyableItemsTableFilterComposer
     extends i0.FilterComposer<i0.GeneratedDatabase, i1.$BuyableItemsTable> {
   $$BuyableItemsTableFilterComposer(super.$state);

--- a/docs/lib/snippets/modular/upserts.drift.dart
+++ b/docs/lib/snippets/modular/upserts.drift.dart
@@ -256,15 +256,29 @@ typedef $$WordsTableProcessedTableManager = i0.ProcessedTableManager<
 class $$WordsTableFilterComposer
     extends i0.FilterComposer<i0.GeneratedDatabase, i1.$WordsTable> {
   $$WordsTableFilterComposer(super.$state);
-  i0.ColumnFilters<String> get word => i0.ColumnFilters($state.table.word);
-  i0.ColumnFilters<int> get usages => i0.ColumnFilters($state.table.usages);
+  i0.ColumnFilters<String> get word => $state.composableBuilder(
+      column: $state.table.word,
+      builder: (column, joinBuilders) =>
+          i0.ColumnFilters(column, joinBuilders: joinBuilders));
+
+  i0.ColumnFilters<int> get usages => $state.composableBuilder(
+      column: $state.table.usages,
+      builder: (column, joinBuilders) =>
+          i0.ColumnFilters(column, joinBuilders: joinBuilders));
 }
 
 class $$WordsTableOrderingComposer
     extends i0.OrderingComposer<i0.GeneratedDatabase, i1.$WordsTable> {
   $$WordsTableOrderingComposer(super.$state);
-  i0.ColumnOrderings<String> get word => i0.ColumnOrderings($state.table.word);
-  i0.ColumnOrderings<int> get usages => i0.ColumnOrderings($state.table.usages);
+  i0.ColumnOrderings<String> get word => $state.composableBuilder(
+      column: $state.table.word,
+      builder: (column, joinBuilders) =>
+          i0.ColumnOrderings(column, joinBuilders: joinBuilders));
+
+  i0.ColumnOrderings<int> get usages => $state.composableBuilder(
+      column: $state.table.usages,
+      builder: (column, joinBuilders) =>
+          i0.ColumnOrderings(column, joinBuilders: joinBuilders));
 }
 
 class $MatchResultsTable extends i2.MatchResults
@@ -605,21 +619,47 @@ typedef $$MatchResultsTableProcessedTableManager = i0.ProcessedTableManager<
 class $$MatchResultsTableFilterComposer
     extends i0.FilterComposer<i0.GeneratedDatabase, i1.$MatchResultsTable> {
   $$MatchResultsTableFilterComposer(super.$state);
-  i0.ColumnFilters<int> get id => i0.ColumnFilters($state.table.id);
-  i0.ColumnFilters<String> get teamA => i0.ColumnFilters($state.table.teamA);
-  i0.ColumnFilters<String> get teamB => i0.ColumnFilters($state.table.teamB);
-  i0.ColumnFilters<bool> get teamAWon =>
-      i0.ColumnFilters($state.table.teamAWon);
+  i0.ColumnFilters<int> get id => $state.composableBuilder(
+      column: $state.table.id,
+      builder: (column, joinBuilders) =>
+          i0.ColumnFilters(column, joinBuilders: joinBuilders));
+
+  i0.ColumnFilters<String> get teamA => $state.composableBuilder(
+      column: $state.table.teamA,
+      builder: (column, joinBuilders) =>
+          i0.ColumnFilters(column, joinBuilders: joinBuilders));
+
+  i0.ColumnFilters<String> get teamB => $state.composableBuilder(
+      column: $state.table.teamB,
+      builder: (column, joinBuilders) =>
+          i0.ColumnFilters(column, joinBuilders: joinBuilders));
+
+  i0.ColumnFilters<bool> get teamAWon => $state.composableBuilder(
+      column: $state.table.teamAWon,
+      builder: (column, joinBuilders) =>
+          i0.ColumnFilters(column, joinBuilders: joinBuilders));
 }
 
 class $$MatchResultsTableOrderingComposer
     extends i0.OrderingComposer<i0.GeneratedDatabase, i1.$MatchResultsTable> {
   $$MatchResultsTableOrderingComposer(super.$state);
-  i0.ColumnOrderings<int> get id => i0.ColumnOrderings($state.table.id);
-  i0.ColumnOrderings<String> get teamA =>
-      i0.ColumnOrderings($state.table.teamA);
-  i0.ColumnOrderings<String> get teamB =>
-      i0.ColumnOrderings($state.table.teamB);
-  i0.ColumnOrderings<bool> get teamAWon =>
-      i0.ColumnOrderings($state.table.teamAWon);
+  i0.ColumnOrderings<int> get id => $state.composableBuilder(
+      column: $state.table.id,
+      builder: (column, joinBuilders) =>
+          i0.ColumnOrderings(column, joinBuilders: joinBuilders));
+
+  i0.ColumnOrderings<String> get teamA => $state.composableBuilder(
+      column: $state.table.teamA,
+      builder: (column, joinBuilders) =>
+          i0.ColumnOrderings(column, joinBuilders: joinBuilders));
+
+  i0.ColumnOrderings<String> get teamB => $state.composableBuilder(
+      column: $state.table.teamB,
+      builder: (column, joinBuilders) =>
+          i0.ColumnOrderings(column, joinBuilders: joinBuilders));
+
+  i0.ColumnOrderings<bool> get teamAWon => $state.composableBuilder(
+      column: $state.table.teamAWon,
+      builder: (column, joinBuilders) =>
+          i0.ColumnOrderings(column, joinBuilders: joinBuilders));
 }

--- a/docs/lib/snippets/modular/upserts.drift.dart
+++ b/docs/lib/snippets/modular/upserts.drift.dart
@@ -244,15 +244,6 @@ class $$WordsTableTableManager extends i0.RootTableManager<
         ));
 }
 
-typedef $$WordsTableProcessedTableManager = i0.ProcessedTableManager<
-    i0.GeneratedDatabase,
-    i1.$WordsTable,
-    i1.Word,
-    i1.$$WordsTableFilterComposer,
-    i1.$$WordsTableOrderingComposer,
-    $$WordsTableCreateCompanionBuilder,
-    $$WordsTableUpdateCompanionBuilder>;
-
 class $$WordsTableFilterComposer
     extends i0.FilterComposer<i0.GeneratedDatabase, i1.$WordsTable> {
   $$WordsTableFilterComposer(super.$state);
@@ -606,15 +597,6 @@ class $$MatchResultsTableTableManager extends i0.RootTableManager<
           ),
         ));
 }
-
-typedef $$MatchResultsTableProcessedTableManager = i0.ProcessedTableManager<
-    i0.GeneratedDatabase,
-    i1.$MatchResultsTable,
-    i1.MatchResult,
-    i1.$$MatchResultsTableFilterComposer,
-    i1.$$MatchResultsTableOrderingComposer,
-    $$MatchResultsTableCreateCompanionBuilder,
-    $$MatchResultsTableUpdateCompanionBuilder>;
 
 class $$MatchResultsTableFilterComposer
     extends i0.FilterComposer<i0.GeneratedDatabase, i1.$MatchResultsTable> {

--- a/docs/lib/snippets/modular/upserts.drift.dart
+++ b/docs/lib/snippets/modular/upserts.drift.dart
@@ -194,7 +194,7 @@ class WordsCompanion extends i0.UpdateCompanion<i1.Word> {
   }
 }
 
-typedef $$WordsTableInsertCompanionBuilder = i1.WordsCompanion Function({
+typedef $$WordsTableCreateCompanionBuilder = i1.WordsCompanion Function({
   required String word,
   i0.Value<int> usages,
   i0.Value<int> rowid,
@@ -211,8 +211,7 @@ class $$WordsTableTableManager extends i0.RootTableManager<
     i1.Word,
     i1.$$WordsTableFilterComposer,
     i1.$$WordsTableOrderingComposer,
-    $$WordsTableProcessedTableManager,
-    $$WordsTableInsertCompanionBuilder,
+    $$WordsTableCreateCompanionBuilder,
     $$WordsTableUpdateCompanionBuilder> {
   $$WordsTableTableManager(i0.GeneratedDatabase db, i1.$WordsTable table)
       : super(i0.TableManagerState(
@@ -222,8 +221,7 @@ class $$WordsTableTableManager extends i0.RootTableManager<
               i1.$$WordsTableFilterComposer(i0.ComposerState(db, table)),
           orderingComposer:
               i1.$$WordsTableOrderingComposer(i0.ComposerState(db, table)),
-          getChildManagerBuilder: (p) => $$WordsTableProcessedTableManager(p),
-          getUpdateCompanionBuilder: ({
+          updateCompanionCallback: ({
             i0.Value<String> word = const i0.Value.absent(),
             i0.Value<int> usages = const i0.Value.absent(),
             i0.Value<int> rowid = const i0.Value.absent(),
@@ -233,7 +231,7 @@ class $$WordsTableTableManager extends i0.RootTableManager<
             usages: usages,
             rowid: rowid,
           ),
-          getInsertCompanionBuilder: ({
+          createCompanionCallback: ({
             required String word,
             i0.Value<int> usages = const i0.Value.absent(),
             i0.Value<int> rowid = const i0.Value.absent(),
@@ -246,44 +244,27 @@ class $$WordsTableTableManager extends i0.RootTableManager<
         ));
 }
 
-class $$WordsTableProcessedTableManager extends i0.ProcessedTableManager<
+typedef $$WordsTableProcessedTableManager = i0.ProcessedTableManager<
     i0.GeneratedDatabase,
     i1.$WordsTable,
     i1.Word,
     i1.$$WordsTableFilterComposer,
     i1.$$WordsTableOrderingComposer,
-    $$WordsTableProcessedTableManager,
-    $$WordsTableInsertCompanionBuilder,
-    $$WordsTableUpdateCompanionBuilder> {
-  $$WordsTableProcessedTableManager(super.$state);
-}
+    $$WordsTableCreateCompanionBuilder,
+    $$WordsTableUpdateCompanionBuilder>;
 
 class $$WordsTableFilterComposer
     extends i0.FilterComposer<i0.GeneratedDatabase, i1.$WordsTable> {
   $$WordsTableFilterComposer(super.$state);
-  i0.ColumnFilters<String> get word => $state.composableBuilder(
-      column: $state.table.word,
-      builder: (column, joinBuilders) =>
-          i0.ColumnFilters(column, joinBuilders: joinBuilders));
-
-  i0.ColumnFilters<int> get usages => $state.composableBuilder(
-      column: $state.table.usages,
-      builder: (column, joinBuilders) =>
-          i0.ColumnFilters(column, joinBuilders: joinBuilders));
+  i0.ColumnFilters<String> get word => i0.ColumnFilters($state.table.word);
+  i0.ColumnFilters<int> get usages => i0.ColumnFilters($state.table.usages);
 }
 
 class $$WordsTableOrderingComposer
     extends i0.OrderingComposer<i0.GeneratedDatabase, i1.$WordsTable> {
   $$WordsTableOrderingComposer(super.$state);
-  i0.ColumnOrderings<String> get word => $state.composableBuilder(
-      column: $state.table.word,
-      builder: (column, joinBuilders) =>
-          i0.ColumnOrderings(column, joinBuilders: joinBuilders));
-
-  i0.ColumnOrderings<int> get usages => $state.composableBuilder(
-      column: $state.table.usages,
-      builder: (column, joinBuilders) =>
-          i0.ColumnOrderings(column, joinBuilders: joinBuilders));
+  i0.ColumnOrderings<String> get word => i0.ColumnOrderings($state.table.word);
+  i0.ColumnOrderings<int> get usages => i0.ColumnOrderings($state.table.usages);
 }
 
 class $MatchResultsTable extends i2.MatchResults
@@ -553,7 +534,7 @@ class MatchResultsCompanion extends i0.UpdateCompanion<i1.MatchResult> {
   }
 }
 
-typedef $$MatchResultsTableInsertCompanionBuilder = i1.MatchResultsCompanion
+typedef $$MatchResultsTableCreateCompanionBuilder = i1.MatchResultsCompanion
     Function({
   i0.Value<int> id,
   required String teamA,
@@ -574,8 +555,7 @@ class $$MatchResultsTableTableManager extends i0.RootTableManager<
     i1.MatchResult,
     i1.$$MatchResultsTableFilterComposer,
     i1.$$MatchResultsTableOrderingComposer,
-    $$MatchResultsTableProcessedTableManager,
-    $$MatchResultsTableInsertCompanionBuilder,
+    $$MatchResultsTableCreateCompanionBuilder,
     $$MatchResultsTableUpdateCompanionBuilder> {
   $$MatchResultsTableTableManager(
       i0.GeneratedDatabase db, i1.$MatchResultsTable table)
@@ -586,9 +566,7 @@ class $$MatchResultsTableTableManager extends i0.RootTableManager<
               i1.$$MatchResultsTableFilterComposer(i0.ComposerState(db, table)),
           orderingComposer: i1
               .$$MatchResultsTableOrderingComposer(i0.ComposerState(db, table)),
-          getChildManagerBuilder: (p) =>
-              $$MatchResultsTableProcessedTableManager(p),
-          getUpdateCompanionBuilder: ({
+          updateCompanionCallback: ({
             i0.Value<int> id = const i0.Value.absent(),
             i0.Value<String> teamA = const i0.Value.absent(),
             i0.Value<String> teamB = const i0.Value.absent(),
@@ -600,7 +578,7 @@ class $$MatchResultsTableTableManager extends i0.RootTableManager<
             teamB: teamB,
             teamAWon: teamAWon,
           ),
-          getInsertCompanionBuilder: ({
+          createCompanionCallback: ({
             i0.Value<int> id = const i0.Value.absent(),
             required String teamA,
             required String teamB,
@@ -615,62 +593,33 @@ class $$MatchResultsTableTableManager extends i0.RootTableManager<
         ));
 }
 
-class $$MatchResultsTableProcessedTableManager extends i0.ProcessedTableManager<
+typedef $$MatchResultsTableProcessedTableManager = i0.ProcessedTableManager<
     i0.GeneratedDatabase,
     i1.$MatchResultsTable,
     i1.MatchResult,
     i1.$$MatchResultsTableFilterComposer,
     i1.$$MatchResultsTableOrderingComposer,
-    $$MatchResultsTableProcessedTableManager,
-    $$MatchResultsTableInsertCompanionBuilder,
-    $$MatchResultsTableUpdateCompanionBuilder> {
-  $$MatchResultsTableProcessedTableManager(super.$state);
-}
+    $$MatchResultsTableCreateCompanionBuilder,
+    $$MatchResultsTableUpdateCompanionBuilder>;
 
 class $$MatchResultsTableFilterComposer
     extends i0.FilterComposer<i0.GeneratedDatabase, i1.$MatchResultsTable> {
   $$MatchResultsTableFilterComposer(super.$state);
-  i0.ColumnFilters<int> get id => $state.composableBuilder(
-      column: $state.table.id,
-      builder: (column, joinBuilders) =>
-          i0.ColumnFilters(column, joinBuilders: joinBuilders));
-
-  i0.ColumnFilters<String> get teamA => $state.composableBuilder(
-      column: $state.table.teamA,
-      builder: (column, joinBuilders) =>
-          i0.ColumnFilters(column, joinBuilders: joinBuilders));
-
-  i0.ColumnFilters<String> get teamB => $state.composableBuilder(
-      column: $state.table.teamB,
-      builder: (column, joinBuilders) =>
-          i0.ColumnFilters(column, joinBuilders: joinBuilders));
-
-  i0.ColumnFilters<bool> get teamAWon => $state.composableBuilder(
-      column: $state.table.teamAWon,
-      builder: (column, joinBuilders) =>
-          i0.ColumnFilters(column, joinBuilders: joinBuilders));
+  i0.ColumnFilters<int> get id => i0.ColumnFilters($state.table.id);
+  i0.ColumnFilters<String> get teamA => i0.ColumnFilters($state.table.teamA);
+  i0.ColumnFilters<String> get teamB => i0.ColumnFilters($state.table.teamB);
+  i0.ColumnFilters<bool> get teamAWon =>
+      i0.ColumnFilters($state.table.teamAWon);
 }
 
 class $$MatchResultsTableOrderingComposer
     extends i0.OrderingComposer<i0.GeneratedDatabase, i1.$MatchResultsTable> {
   $$MatchResultsTableOrderingComposer(super.$state);
-  i0.ColumnOrderings<int> get id => $state.composableBuilder(
-      column: $state.table.id,
-      builder: (column, joinBuilders) =>
-          i0.ColumnOrderings(column, joinBuilders: joinBuilders));
-
-  i0.ColumnOrderings<String> get teamA => $state.composableBuilder(
-      column: $state.table.teamA,
-      builder: (column, joinBuilders) =>
-          i0.ColumnOrderings(column, joinBuilders: joinBuilders));
-
-  i0.ColumnOrderings<String> get teamB => $state.composableBuilder(
-      column: $state.table.teamB,
-      builder: (column, joinBuilders) =>
-          i0.ColumnOrderings(column, joinBuilders: joinBuilders));
-
-  i0.ColumnOrderings<bool> get teamAWon => $state.composableBuilder(
-      column: $state.table.teamAWon,
-      builder: (column, joinBuilders) =>
-          i0.ColumnOrderings(column, joinBuilders: joinBuilders));
+  i0.ColumnOrderings<int> get id => i0.ColumnOrderings($state.table.id);
+  i0.ColumnOrderings<String> get teamA =>
+      i0.ColumnOrderings($state.table.teamA);
+  i0.ColumnOrderings<String> get teamB =>
+      i0.ColumnOrderings($state.table.teamB);
+  i0.ColumnOrderings<bool> get teamAWon =>
+      i0.ColumnOrderings($state.table.teamAWon);
 }

--- a/drift/example/main.g.dart
+++ b/drift/example/main.g.dart
@@ -772,8 +772,16 @@ typedef $$TodoCategoriesTableProcessedTableManager = ProcessedTableManager<
 class $$TodoCategoriesTableFilterComposer
     extends FilterComposer<_$Database, $TodoCategoriesTable> {
   $$TodoCategoriesTableFilterComposer(super.$state);
-  ColumnFilters<int> get id => ColumnFilters($state.table.id);
-  ColumnFilters<String> get name => ColumnFilters($state.table.name);
+  ColumnFilters<int> get id => $state.composableBuilder(
+      column: $state.table.id,
+      builder: (column, joinBuilders) =>
+          ColumnFilters(column, joinBuilders: joinBuilders));
+
+  ColumnFilters<String> get name => $state.composableBuilder(
+      column: $state.table.name,
+      builder: (column, joinBuilders) =>
+          ColumnFilters(column, joinBuilders: joinBuilders));
+
   ComposableFilter todoItemsRefs(
       ComposableFilter Function($$TodoItemsTableFilterComposer f) f) {
     final $$TodoItemsTableFilterComposer composer = $state.composerBuilder(
@@ -791,8 +799,15 @@ class $$TodoCategoriesTableFilterComposer
 class $$TodoCategoriesTableOrderingComposer
     extends OrderingComposer<_$Database, $TodoCategoriesTable> {
   $$TodoCategoriesTableOrderingComposer(super.$state);
-  ColumnOrderings<int> get id => ColumnOrderings($state.table.id);
-  ColumnOrderings<String> get name => ColumnOrderings($state.table.name);
+  ColumnOrderings<int> get id => $state.composableBuilder(
+      column: $state.table.id,
+      builder: (column, joinBuilders) =>
+          ColumnOrderings(column, joinBuilders: joinBuilders));
+
+  ColumnOrderings<String> get name => $state.composableBuilder(
+      column: $state.table.name,
+      builder: (column, joinBuilders) =>
+          ColumnOrderings(column, joinBuilders: joinBuilders));
 }
 
 typedef $$TodoItemsTableCreateCompanionBuilder = TodoItemsCompanion Function({
@@ -863,11 +878,26 @@ typedef $$TodoItemsTableProcessedTableManager = ProcessedTableManager<
 class $$TodoItemsTableFilterComposer
     extends FilterComposer<_$Database, $TodoItemsTable> {
   $$TodoItemsTableFilterComposer(super.$state);
-  ColumnFilters<int> get id => ColumnFilters($state.table.id);
-  ColumnFilters<String> get title => ColumnFilters($state.table.title);
-  ColumnFilters<String> get content => ColumnFilters($state.table.content);
-  ColumnFilters<String> get generatedText =>
-      ColumnFilters($state.table.generatedText);
+  ColumnFilters<int> get id => $state.composableBuilder(
+      column: $state.table.id,
+      builder: (column, joinBuilders) =>
+          ColumnFilters(column, joinBuilders: joinBuilders));
+
+  ColumnFilters<String> get title => $state.composableBuilder(
+      column: $state.table.title,
+      builder: (column, joinBuilders) =>
+          ColumnFilters(column, joinBuilders: joinBuilders));
+
+  ColumnFilters<String> get content => $state.composableBuilder(
+      column: $state.table.content,
+      builder: (column, joinBuilders) =>
+          ColumnFilters(column, joinBuilders: joinBuilders));
+
+  ColumnFilters<String> get generatedText => $state.composableBuilder(
+      column: $state.table.generatedText,
+      builder: (column, joinBuilders) =>
+          ColumnFilters(column, joinBuilders: joinBuilders));
+
   $$TodoCategoriesTableFilterComposer get categoryId {
     final $$TodoCategoriesTableFilterComposer composer = $state.composerBuilder(
         composer: this,
@@ -884,11 +914,26 @@ class $$TodoItemsTableFilterComposer
 class $$TodoItemsTableOrderingComposer
     extends OrderingComposer<_$Database, $TodoItemsTable> {
   $$TodoItemsTableOrderingComposer(super.$state);
-  ColumnOrderings<int> get id => ColumnOrderings($state.table.id);
-  ColumnOrderings<String> get title => ColumnOrderings($state.table.title);
-  ColumnOrderings<String> get content => ColumnOrderings($state.table.content);
-  ColumnOrderings<String> get generatedText =>
-      ColumnOrderings($state.table.generatedText);
+  ColumnOrderings<int> get id => $state.composableBuilder(
+      column: $state.table.id,
+      builder: (column, joinBuilders) =>
+          ColumnOrderings(column, joinBuilders: joinBuilders));
+
+  ColumnOrderings<String> get title => $state.composableBuilder(
+      column: $state.table.title,
+      builder: (column, joinBuilders) =>
+          ColumnOrderings(column, joinBuilders: joinBuilders));
+
+  ColumnOrderings<String> get content => $state.composableBuilder(
+      column: $state.table.content,
+      builder: (column, joinBuilders) =>
+          ColumnOrderings(column, joinBuilders: joinBuilders));
+
+  ColumnOrderings<String> get generatedText => $state.composableBuilder(
+      column: $state.table.generatedText,
+      builder: (column, joinBuilders) =>
+          ColumnOrderings(column, joinBuilders: joinBuilders));
+
   $$TodoCategoriesTableOrderingComposer get categoryId {
     final $$TodoCategoriesTableOrderingComposer composer =
         $state.composerBuilder(

--- a/drift/example/main.g.dart
+++ b/drift/example/main.g.dart
@@ -714,7 +714,7 @@ abstract class _$Database extends GeneratedDatabase {
       ];
 }
 
-typedef $$TodoCategoriesTableInsertCompanionBuilder = TodoCategoriesCompanion
+typedef $$TodoCategoriesTableCreateCompanionBuilder = TodoCategoriesCompanion
     Function({
   Value<int> id,
   required String name,
@@ -731,8 +731,7 @@ class $$TodoCategoriesTableTableManager extends RootTableManager<
     TodoCategory,
     $$TodoCategoriesTableFilterComposer,
     $$TodoCategoriesTableOrderingComposer,
-    $$TodoCategoriesTableProcessedTableManager,
-    $$TodoCategoriesTableInsertCompanionBuilder,
+    $$TodoCategoriesTableCreateCompanionBuilder,
     $$TodoCategoriesTableUpdateCompanionBuilder> {
   $$TodoCategoriesTableTableManager(_$Database db, $TodoCategoriesTable table)
       : super(TableManagerState(
@@ -742,9 +741,7 @@ class $$TodoCategoriesTableTableManager extends RootTableManager<
               $$TodoCategoriesTableFilterComposer(ComposerState(db, table)),
           orderingComposer:
               $$TodoCategoriesTableOrderingComposer(ComposerState(db, table)),
-          getChildManagerBuilder: (p) =>
-              $$TodoCategoriesTableProcessedTableManager(p),
-          getUpdateCompanionBuilder: ({
+          updateCompanionCallback: ({
             Value<int> id = const Value.absent(),
             Value<String> name = const Value.absent(),
           }) =>
@@ -752,7 +749,7 @@ class $$TodoCategoriesTableTableManager extends RootTableManager<
             id: id,
             name: name,
           ),
-          getInsertCompanionBuilder: ({
+          createCompanionCallback: ({
             Value<int> id = const Value.absent(),
             required String name,
           }) =>
@@ -763,31 +760,20 @@ class $$TodoCategoriesTableTableManager extends RootTableManager<
         ));
 }
 
-class $$TodoCategoriesTableProcessedTableManager extends ProcessedTableManager<
+typedef $$TodoCategoriesTableProcessedTableManager = ProcessedTableManager<
     _$Database,
     $TodoCategoriesTable,
     TodoCategory,
     $$TodoCategoriesTableFilterComposer,
     $$TodoCategoriesTableOrderingComposer,
-    $$TodoCategoriesTableProcessedTableManager,
-    $$TodoCategoriesTableInsertCompanionBuilder,
-    $$TodoCategoriesTableUpdateCompanionBuilder> {
-  $$TodoCategoriesTableProcessedTableManager(super.$state);
-}
+    $$TodoCategoriesTableCreateCompanionBuilder,
+    $$TodoCategoriesTableUpdateCompanionBuilder>;
 
 class $$TodoCategoriesTableFilterComposer
     extends FilterComposer<_$Database, $TodoCategoriesTable> {
   $$TodoCategoriesTableFilterComposer(super.$state);
-  ColumnFilters<int> get id => $state.composableBuilder(
-      column: $state.table.id,
-      builder: (column, joinBuilders) =>
-          ColumnFilters(column, joinBuilders: joinBuilders));
-
-  ColumnFilters<String> get name => $state.composableBuilder(
-      column: $state.table.name,
-      builder: (column, joinBuilders) =>
-          ColumnFilters(column, joinBuilders: joinBuilders));
-
+  ColumnFilters<int> get id => ColumnFilters($state.table.id);
+  ColumnFilters<String> get name => ColumnFilters($state.table.name);
   ComposableFilter todoItemsRefs(
       ComposableFilter Function($$TodoItemsTableFilterComposer f) f) {
     final $$TodoItemsTableFilterComposer composer = $state.composerBuilder(
@@ -805,18 +791,11 @@ class $$TodoCategoriesTableFilterComposer
 class $$TodoCategoriesTableOrderingComposer
     extends OrderingComposer<_$Database, $TodoCategoriesTable> {
   $$TodoCategoriesTableOrderingComposer(super.$state);
-  ColumnOrderings<int> get id => $state.composableBuilder(
-      column: $state.table.id,
-      builder: (column, joinBuilders) =>
-          ColumnOrderings(column, joinBuilders: joinBuilders));
-
-  ColumnOrderings<String> get name => $state.composableBuilder(
-      column: $state.table.name,
-      builder: (column, joinBuilders) =>
-          ColumnOrderings(column, joinBuilders: joinBuilders));
+  ColumnOrderings<int> get id => ColumnOrderings($state.table.id);
+  ColumnOrderings<String> get name => ColumnOrderings($state.table.name);
 }
 
-typedef $$TodoItemsTableInsertCompanionBuilder = TodoItemsCompanion Function({
+typedef $$TodoItemsTableCreateCompanionBuilder = TodoItemsCompanion Function({
   Value<int> id,
   required String title,
   Value<String?> content,
@@ -835,8 +814,7 @@ class $$TodoItemsTableTableManager extends RootTableManager<
     TodoItem,
     $$TodoItemsTableFilterComposer,
     $$TodoItemsTableOrderingComposer,
-    $$TodoItemsTableProcessedTableManager,
-    $$TodoItemsTableInsertCompanionBuilder,
+    $$TodoItemsTableCreateCompanionBuilder,
     $$TodoItemsTableUpdateCompanionBuilder> {
   $$TodoItemsTableTableManager(_$Database db, $TodoItemsTable table)
       : super(TableManagerState(
@@ -846,9 +824,7 @@ class $$TodoItemsTableTableManager extends RootTableManager<
               $$TodoItemsTableFilterComposer(ComposerState(db, table)),
           orderingComposer:
               $$TodoItemsTableOrderingComposer(ComposerState(db, table)),
-          getChildManagerBuilder: (p) =>
-              $$TodoItemsTableProcessedTableManager(p),
-          getUpdateCompanionBuilder: ({
+          updateCompanionCallback: ({
             Value<int> id = const Value.absent(),
             Value<String> title = const Value.absent(),
             Value<String?> content = const Value.absent(),
@@ -860,7 +836,7 @@ class $$TodoItemsTableTableManager extends RootTableManager<
             content: content,
             categoryId: categoryId,
           ),
-          getInsertCompanionBuilder: ({
+          createCompanionCallback: ({
             Value<int> id = const Value.absent(),
             required String title,
             Value<String?> content = const Value.absent(),
@@ -875,41 +851,23 @@ class $$TodoItemsTableTableManager extends RootTableManager<
         ));
 }
 
-class $$TodoItemsTableProcessedTableManager extends ProcessedTableManager<
+typedef $$TodoItemsTableProcessedTableManager = ProcessedTableManager<
     _$Database,
     $TodoItemsTable,
     TodoItem,
     $$TodoItemsTableFilterComposer,
     $$TodoItemsTableOrderingComposer,
-    $$TodoItemsTableProcessedTableManager,
-    $$TodoItemsTableInsertCompanionBuilder,
-    $$TodoItemsTableUpdateCompanionBuilder> {
-  $$TodoItemsTableProcessedTableManager(super.$state);
-}
+    $$TodoItemsTableCreateCompanionBuilder,
+    $$TodoItemsTableUpdateCompanionBuilder>;
 
 class $$TodoItemsTableFilterComposer
     extends FilterComposer<_$Database, $TodoItemsTable> {
   $$TodoItemsTableFilterComposer(super.$state);
-  ColumnFilters<int> get id => $state.composableBuilder(
-      column: $state.table.id,
-      builder: (column, joinBuilders) =>
-          ColumnFilters(column, joinBuilders: joinBuilders));
-
-  ColumnFilters<String> get title => $state.composableBuilder(
-      column: $state.table.title,
-      builder: (column, joinBuilders) =>
-          ColumnFilters(column, joinBuilders: joinBuilders));
-
-  ColumnFilters<String> get content => $state.composableBuilder(
-      column: $state.table.content,
-      builder: (column, joinBuilders) =>
-          ColumnFilters(column, joinBuilders: joinBuilders));
-
-  ColumnFilters<String> get generatedText => $state.composableBuilder(
-      column: $state.table.generatedText,
-      builder: (column, joinBuilders) =>
-          ColumnFilters(column, joinBuilders: joinBuilders));
-
+  ColumnFilters<int> get id => ColumnFilters($state.table.id);
+  ColumnFilters<String> get title => ColumnFilters($state.table.title);
+  ColumnFilters<String> get content => ColumnFilters($state.table.content);
+  ColumnFilters<String> get generatedText =>
+      ColumnFilters($state.table.generatedText);
   $$TodoCategoriesTableFilterComposer get categoryId {
     final $$TodoCategoriesTableFilterComposer composer = $state.composerBuilder(
         composer: this,
@@ -926,26 +884,11 @@ class $$TodoItemsTableFilterComposer
 class $$TodoItemsTableOrderingComposer
     extends OrderingComposer<_$Database, $TodoItemsTable> {
   $$TodoItemsTableOrderingComposer(super.$state);
-  ColumnOrderings<int> get id => $state.composableBuilder(
-      column: $state.table.id,
-      builder: (column, joinBuilders) =>
-          ColumnOrderings(column, joinBuilders: joinBuilders));
-
-  ColumnOrderings<String> get title => $state.composableBuilder(
-      column: $state.table.title,
-      builder: (column, joinBuilders) =>
-          ColumnOrderings(column, joinBuilders: joinBuilders));
-
-  ColumnOrderings<String> get content => $state.composableBuilder(
-      column: $state.table.content,
-      builder: (column, joinBuilders) =>
-          ColumnOrderings(column, joinBuilders: joinBuilders));
-
-  ColumnOrderings<String> get generatedText => $state.composableBuilder(
-      column: $state.table.generatedText,
-      builder: (column, joinBuilders) =>
-          ColumnOrderings(column, joinBuilders: joinBuilders));
-
+  ColumnOrderings<int> get id => ColumnOrderings($state.table.id);
+  ColumnOrderings<String> get title => ColumnOrderings($state.table.title);
+  ColumnOrderings<String> get content => ColumnOrderings($state.table.content);
+  ColumnOrderings<String> get generatedText =>
+      ColumnOrderings($state.table.generatedText);
   $$TodoCategoriesTableOrderingComposer get categoryId {
     final $$TodoCategoriesTableOrderingComposer composer =
         $state.composerBuilder(

--- a/drift/example/main.g.dart
+++ b/drift/example/main.g.dart
@@ -760,15 +760,6 @@ class $$TodoCategoriesTableTableManager extends RootTableManager<
         ));
 }
 
-typedef $$TodoCategoriesTableProcessedTableManager = ProcessedTableManager<
-    _$Database,
-    $TodoCategoriesTable,
-    TodoCategory,
-    $$TodoCategoriesTableFilterComposer,
-    $$TodoCategoriesTableOrderingComposer,
-    $$TodoCategoriesTableCreateCompanionBuilder,
-    $$TodoCategoriesTableUpdateCompanionBuilder>;
-
 class $$TodoCategoriesTableFilterComposer
     extends FilterComposer<_$Database, $TodoCategoriesTable> {
   $$TodoCategoriesTableFilterComposer(super.$state);
@@ -865,15 +856,6 @@ class $$TodoItemsTableTableManager extends RootTableManager<
           ),
         ));
 }
-
-typedef $$TodoItemsTableProcessedTableManager = ProcessedTableManager<
-    _$Database,
-    $TodoItemsTable,
-    TodoItem,
-    $$TodoItemsTableFilterComposer,
-    $$TodoItemsTableOrderingComposer,
-    $$TodoItemsTableCreateCompanionBuilder,
-    $$TodoItemsTableUpdateCompanionBuilder>;
 
 class $$TodoItemsTableFilterComposer
     extends FilterComposer<_$Database, $TodoItemsTable> {

--- a/drift/lib/src/runtime/manager/filter.dart
+++ b/drift/lib/src/runtime/manager/filter.dart
@@ -285,7 +285,7 @@ extension DateFilters<T extends DateTime> on ColumnFilters<T> {
 }
 
 ///  Enum of the possible boolean operators
-enum BooleanOperator {
+enum _BooleanOperator {
   /// Combine the existing filters to the new filter with an AND
   and,
 
@@ -311,22 +311,22 @@ class ComposableFilter extends _Composable {
 
   /// Combine two filters with an AND
   ComposableFilter operator &(ComposableFilter other) =>
-      _combineFilter(BooleanOperator.and, other);
+      _combineFilter(_BooleanOperator.and, other);
 
   /// Combine two filters with an OR
   ComposableFilter operator |(ComposableFilter other) =>
-      _combineFilter(BooleanOperator.or, other);
+      _combineFilter(_BooleanOperator.or, other);
 
   /// A helper function to combine two filters
   ComposableFilter _combineFilter(
-      BooleanOperator opperator, ComposableFilter otherFilter) {
+      _BooleanOperator opperator, ComposableFilter otherFilter) {
     final combinedExpression = switch ((expression, otherFilter.expression)) {
       (null, null) => null,
       (null, var expression) => expression,
       (var expression, null) => expression,
       (_, _) => switch (opperator) {
-          BooleanOperator.and => expression! & otherFilter.expression!,
-          BooleanOperator.or => expression! | otherFilter.expression!,
+          _BooleanOperator.and => expression! & otherFilter.expression!,
+          _BooleanOperator.or => expression! | otherFilter.expression!,
         },
     };
     return ComposableFilter._(

--- a/drift/lib/src/runtime/manager/filter.dart
+++ b/drift/lib/src/runtime/manager/filter.dart
@@ -31,7 +31,7 @@ abstract class _BaseColumnFilters<T extends Object> {
   /// This helper method is used internally to create a new [ComposableFilter]s
   /// that respects the inverted state of the current filter
   ComposableFilter $composableFilter(Expression<bool>? expression) {
-    return ComposableFilter.$_(
+    return ComposableFilter._(
         inverted ? expression?.not() : expression, joinBuilders);
   }
 
@@ -307,7 +307,7 @@ class ComposableFilter extends _Composable {
   Expression<bool>? expression;
 
   /// Create a new [ComposableFilter] for a column with joins
-  ComposableFilter.$_(this.expression, this.joinBuilders);
+  ComposableFilter._(this.expression, this.joinBuilders);
 
   /// Combine two filters with an AND
   ComposableFilter operator &(ComposableFilter other) =>
@@ -329,7 +329,7 @@ class ComposableFilter extends _Composable {
           BooleanOperator.or => expression! | otherFilter.expression!,
         },
     };
-    return ComposableFilter.$_(
+    return ComposableFilter._(
       combinedExpression,
       joinBuilders.union(otherFilter.joinBuilders),
     );

--- a/drift/lib/src/runtime/manager/filter.dart
+++ b/drift/lib/src/runtime/manager/filter.dart
@@ -31,7 +31,7 @@ abstract class _BaseColumnFilters<T extends Object> {
   /// This helper method is used internally to create a new [ComposableFilter]s
   /// that respects the inverted state of the current filter
   ComposableFilter $composableFilter(Expression<bool>? expression) {
-    return ComposableFilter._(
+    return ComposableFilter.$_(
         inverted ? expression?.not() : expression, joinBuilders);
   }
 
@@ -284,7 +284,14 @@ extension DateFilters<T extends DateTime> on ColumnFilters<T> {
       $composableFilter(column.isBetweenValues(lower, higher));
 }
 
-enum _BooleanOperator { and, or }
+///  Enum of the possible boolean operators
+enum BooleanOperator {
+  /// Combine the existing filters to the new filter with an AND
+  and,
+
+  /// Combine the existing filters to the new filter with an OR
+  or;
+}
 
 /// This class is used to compose filters together
 ///
@@ -300,29 +307,29 @@ class ComposableFilter extends _Composable {
   Expression<bool>? expression;
 
   /// Create a new [ComposableFilter] for a column with joins
-  ComposableFilter._(this.expression, this.joinBuilders);
+  ComposableFilter.$_(this.expression, this.joinBuilders);
 
   /// Combine two filters with an AND
   ComposableFilter operator &(ComposableFilter other) =>
-      _combineFilter(_BooleanOperator.and, other);
+      _combineFilter(BooleanOperator.and, other);
 
   /// Combine two filters with an OR
   ComposableFilter operator |(ComposableFilter other) =>
-      _combineFilter(_BooleanOperator.or, other);
+      _combineFilter(BooleanOperator.or, other);
 
   /// A helper function to combine two filters
   ComposableFilter _combineFilter(
-      _BooleanOperator opperator, ComposableFilter otherFilter) {
+      BooleanOperator opperator, ComposableFilter otherFilter) {
     final combinedExpression = switch ((expression, otherFilter.expression)) {
       (null, null) => null,
       (null, var expression) => expression,
       (var expression, null) => expression,
       (_, _) => switch (opperator) {
-          _BooleanOperator.and => expression! & otherFilter.expression!,
-          _BooleanOperator.or => expression! | otherFilter.expression!,
+          BooleanOperator.and => expression! & otherFilter.expression!,
+          BooleanOperator.or => expression! | otherFilter.expression!,
         },
     };
-    return ComposableFilter._(
+    return ComposableFilter.$_(
       combinedExpression,
       joinBuilders.union(otherFilter.joinBuilders),
     );

--- a/drift/lib/src/runtime/manager/manager.dart
+++ b/drift/lib/src/runtime/manager/manager.dart
@@ -16,6 +16,7 @@ part 'ordering.dart';
 ///
 /// It also holds the [$CreateCompanionCallback] and [$UpdateCompanionCallback] functions that are used to create companion builders for inserting and updating data.
 /// E.G Instead of `CategoriesCompanion.insert(name: "School")` you would use `(f) => f(name: "School")`
+@immutable
 class TableManagerState<
     $Database extends GeneratedDatabase,
     $Table extends Table,
@@ -73,7 +74,8 @@ class TableManagerState<
   /// This is held in a seperate class than the [BaseTableManager] so that the state can be passed down from the root manager to the lower level managers
   ///
   /// This class is used internally by the [BaseTableManager] and should not be used directly
-  const TableManagerState(
+
+  TableManagerState(
       {required this.db,
       required this.table,
       required this.filteringComposer,
@@ -273,18 +275,15 @@ class TableManagerState<
 /// Base class for all table managers
 /// Most of this classes functionality is kept in a seperate [TableManagerState] class
 /// This is so that the state can be passed down to lower level managers
+@immutable
 abstract class BaseTableManager<
-        $Database extends GeneratedDatabase,
-        $Table extends Table,
-        $Dataclass,
-        $FilterComposer extends FilterComposer<$Database, $Table>,
-        $OrderingComposer extends OrderingComposer<$Database, $Table>,
-        $CreateCompanionCallback extends Function,
-        $UpdateCompanionCallback extends Function>
-    implements
-        MultiSelectable<$Dataclass>,
-        SingleSelectable<$Dataclass>,
-        SingleOrNullSelectable<$Dataclass> {
+    $Database extends GeneratedDatabase,
+    $Table extends Table,
+    $Dataclass,
+    $FilterComposer extends FilterComposer<$Database, $Table>,
+    $OrderingComposer extends OrderingComposer<$Database, $Table>,
+    $CreateCompanionCallback extends Function,
+    $UpdateCompanionCallback extends Function> extends Selectable<$Dataclass> {
   /// The state for this manager
   final TableManagerState<
       $Database,
@@ -298,7 +297,7 @@ abstract class BaseTableManager<
   /// Create a new [BaseTableManager] instance
   ///
   /// {@macro manager_internal_use_only}
-  const BaseTableManager(this.$state);
+  BaseTableManager(this.$state);
 
   /// Add a limit to the statement
   ProcessedTableManager<
@@ -460,6 +459,7 @@ abstract class BaseTableManager<
 
 /// A table manager that exposes methods to a table manager that already has filters/orderings/limit applied
 //  As of now this is identical to [BaseTableManager] but it's kept seperate for future extensibility
+@immutable
 class ProcessedTableManager<
         $Database extends GeneratedDatabase,
         $Table extends Table,
@@ -469,17 +469,14 @@ class ProcessedTableManager<
         $CreateCompanionCallback extends Function,
         $UpdateCompanionCallback extends Function>
     extends BaseTableManager<$Database, $Table, $Dataclass, $FilterComposer,
-        $OrderingComposer, $CreateCompanionCallback, $UpdateCompanionCallback>
-    implements
-        MultiSelectable<$Dataclass>,
-        SingleSelectable<$Dataclass>,
-        SingleOrNullSelectable<$Dataclass> {
+        $OrderingComposer, $CreateCompanionCallback, $UpdateCompanionCallback> {
   /// Create a new [ProcessedTableManager] instance
   @internal
-  const ProcessedTableManager(super.$state);
+  ProcessedTableManager(super.$state);
 }
 
 /// A table manager with top level function for creating, reading, updating, and deleting items
+@immutable
 abstract class RootTableManager<
         $Database extends GeneratedDatabase,
         $Table extends Table,
@@ -496,7 +493,7 @@ abstract class RootTableManager<
   /// This class is implemented by the code generator and should
   /// not be instantiated or extended manually.
   /// {@endtemplate}
-  const RootTableManager(super.$state);
+  RootTableManager(super.$state);
 
   /// Creates a new row in the table using the given function
   ///

--- a/drift/lib/src/runtime/manager/manager.dart
+++ b/drift/lib/src/runtime/manager/manager.dart
@@ -16,9 +16,6 @@ part 'ordering.dart';
 ///
 /// It also holds the [$CreateCompanionCallback] and [$UpdateCompanionCallback] functions that are used to create companion builders for inserting and updating data.
 /// E.G Instead of `CategoriesCompanion.insert(name: "School")` you would use `(f) => f(name: "School")`
-///
-/// The [$ChildManager] generic refers to the type of the child manager that will be created when a filter/ordering is applied
-
 class TableManagerState<
     $Database extends GeneratedDatabase,
     $Table extends Table,
@@ -30,7 +27,7 @@ class TableManagerState<
   /// The database used to run the query.
   final $Database db;
 
-  /// The table primary table from which to select from.
+  /// The table that the manager is for
   final $Table table;
 
   /// The expression that will be applied to the query

--- a/drift/lib/src/runtime/manager/manager.dart
+++ b/drift/lib/src/runtime/manager/manager.dart
@@ -324,21 +324,36 @@ abstract class BaseTableManager<
 
   /// Add a filter to the statement
   ///
-  /// The [combineWith] parameter can be used to combine the new filter with any existing filters
+  /// Any filters that were previously applied will be combined with an AND operator
+  ProcessedTableManager<
+      $Database,
+      $Table,
+      $Dataclass,
+      $FilterComposer,
+      $OrderingComposer,
+      $CreateCompanionCallback,
+      $UpdateCompanionCallback> filter(
+    ComposableFilter Function($FilterComposer f) f,
+  ) {
+    return _filter(f, _BooleanOperator.and);
+  }
+
+  /// Add a filter to the statement
+  ///
+  /// The [combineWith] parameter can be used to specify how the new filter should be combined with the existing filter
   ProcessedTableManager<$Database, $Table, $Dataclass, $FilterComposer,
           $OrderingComposer, $CreateCompanionCallback, $UpdateCompanionCallback>
-      filter(ComposableFilter Function($FilterComposer f) f,
-          {BooleanOperator combineWith = BooleanOperator.and}) {
+      _filter(ComposableFilter Function($FilterComposer f) f,
+          _BooleanOperator combineWith) {
     final filter = f($state.filteringComposer);
     final combinedFilter = switch (($state.filter, filter.expression)) {
       (null, null) => null,
       (null, var filter) => filter,
       (var filter, null) => filter,
-      (var filter1, var filter2) => combineWith == BooleanOperator.and
+      (var filter1, var filter2) => combineWith == _BooleanOperator.and
           ? (filter1!) & (filter2!)
           : (filter1!) | (filter2!)
     };
-
     return ProcessedTableManager($state.copyWith(
         filter: combinedFilter,
         joinBuilders: $state.joinBuilders.union(filter.joinBuilders)));

--- a/drift/lib/src/runtime/manager/manager.dart
+++ b/drift/lib/src/runtime/manager/manager.dart
@@ -485,8 +485,18 @@ abstract class BaseTableManager<
       .watchSingleOrNull();
 }
 
-/// A table manager that exposes methods to a table manager that already has filters/orderings/limit applied
-//  As of now this is identical to [BaseTableManager] but it's kept seperate for future extensibility
+/// A table manager that exposes methods to a table manager that already has
+/// filters/orderings/limit applied.
+///
+/// Some methods, like [RootTableManager.create] are intentionally not present
+/// on [ProcessedTableManager] because combining e.g. [BaseTableManager.filter]
+/// with [RootTableManager.create] makes little sense - there is no `WHERE`
+/// clause on inserts.
+/// By introducing a separate interface for managers with filters applied to
+/// them, the API doesn't allow combining incompatible clauses and operations.
+///
+// As of now this is identical to [BaseTableManager] but it's kept seperate for
+// future extensibility.
 @immutable
 class ProcessedTableManager<
         $Database extends GeneratedDatabase,
@@ -503,7 +513,8 @@ class ProcessedTableManager<
   ProcessedTableManager(super.$state);
 }
 
-/// A table manager with top level function for creating, reading, updating, and deleting items
+/// A table manager with top level function for creating, reading, updating, and
+/// deleting items.
 @immutable
 abstract class RootTableManager<
         $Database extends GeneratedDatabase,

--- a/drift/lib/src/runtime/manager/manager.dart
+++ b/drift/lib/src/runtime/manager/manager.dart
@@ -389,7 +389,8 @@ abstract class BaseTableManager<
   /// See also: [getSingleOrNull], which returns `null` instead of
   /// throwing if the query completes with no rows.
   ///
-  /// Uses the distinct flag to ensure that only distinct rows are returned
+  /// The [distinct] parameter (enabled by default) controls whether to generate
+  /// a `SELECT DISTINCT` query, removing duplicates from the result.
   @override
   Future<$Dataclass> getSingle({bool distinct = true}) =>
       $state.copyWith(distinct: distinct).buildSelectStatement().getSingle();
@@ -400,7 +401,8 @@ abstract class BaseTableManager<
   /// `Stream<D>`. If, at any point, the query emits no or more than one rows,
   /// an error will be added to the stream instead.
   ///
-  /// Uses the distinct flag to ensure that only distinct rows are returned
+  /// The [distinct] parameter (enabled by default) controls whether to generate
+  /// a `SELECT DISTINCT` query, removing duplicates from the result.
   @override
   Stream<$Dataclass> watchSingle({bool distinct = true}) =>
       $state.copyWith(distinct: distinct).buildSelectStatement().watchSingle();
@@ -409,7 +411,9 @@ abstract class BaseTableManager<
   ///
   /// Use [limit] and [offset] to limit the number of rows returned
   /// An offset will only be applied if a limit is also set
-  /// Set [distinct] to true to ensure that only distinct rows are returned
+  ///
+  /// The [distinct] parameter (disabled by default) controls whether to generate
+  /// a `SELECT DISTINCT` query, removing duplicates from the result.
   @override
   Future<List<$Dataclass>> get(
           {bool distinct = false, int? limit, int? offset}) =>
@@ -423,7 +427,9 @@ abstract class BaseTableManager<
   ///
   /// Use [limit] and [offset] to limit the number of rows returned
   /// An offset will only be applied if a limit is also set
-  /// Set [distinct] to true to ensure that only distinct rows are returned
+  ///
+  /// The [distinct] parameter (disabled by default) controls whether to generate
+  /// a `SELECT DISTINCT` query, removing duplicates from the result.
   @override
   Stream<List<$Dataclass>> watch(
           {bool distinct = false, int? limit, int? offset}) =>
@@ -439,7 +445,8 @@ abstract class BaseTableManager<
   /// See also: [getSingle], which can be used if the query will
   /// always evaluate to exactly one row.
   ///
-  /// Uses the distinct flag to ensure that only distinct rows are returned
+  /// The [distinct] parameter (enabled by default) controls whether to generate
+  /// a `SELECT DISTINCT` query, removing duplicates from the result.
   @override
   Future<$Dataclass?> getSingleOrNull({bool distinct = true}) => $state
       .copyWith(distinct: distinct)
@@ -454,7 +461,8 @@ abstract class BaseTableManager<
   /// If the query emits zero rows at some point, `null` will be added
   /// to the stream instead.
   ///
-  /// Uses the distinct flag to ensure that only distinct rows are returned
+  /// The [distinct] parameter (enabled by default) controls whether to generate
+  /// a `SELECT DISTINCT` query, removing duplicates from the result.
   @override
   Stream<$Dataclass?> watchSingleOrNull({bool distinct = true}) => $state
       .copyWith(distinct: distinct)

--- a/drift/lib/src/runtime/manager/manager.dart
+++ b/drift/lib/src/runtime/manager/manager.dart
@@ -323,15 +323,20 @@ abstract class BaseTableManager<
   }
 
   /// Add a filter to the statement
+  ///
+  /// The [combineWith] parameter can be used to combine the new filter with any existing filters
   ProcessedTableManager<$Database, $Table, $Dataclass, $FilterComposer,
           $OrderingComposer, $CreateCompanionCallback, $UpdateCompanionCallback>
-      filter(ComposableFilter Function($FilterComposer f) f) {
+      filter(ComposableFilter Function($FilterComposer f) f,
+          {BooleanOperator combineWith = BooleanOperator.and}) {
     final filter = f($state.filteringComposer);
     final combinedFilter = switch (($state.filter, filter.expression)) {
       (null, null) => null,
       (null, var filter) => filter,
       (var filter, null) => filter,
-      (var filter1, var filter2) => (filter1!) & (filter2!)
+      (var filter1, var filter2) => combineWith == BooleanOperator.and
+          ? (filter1!) & (filter2!)
+          : (filter1!) | (filter2!)
     };
 
     return ProcessedTableManager($state.copyWith(

--- a/drift/lib/src/runtime/manager/manager.dart
+++ b/drift/lib/src/runtime/manager/manager.dart
@@ -390,8 +390,8 @@ abstract class BaseTableManager<
   ///
   /// Uses the distinct flag to ensure that only distinct rows are returned
   @override
-  Future<$Dataclass> getSingle() =>
-      $state.copyWith(distinct: true).buildSelectStatement().getSingle();
+  Future<$Dataclass> getSingle({bool distinct = true}) =>
+      $state.copyWith(distinct: distinct).buildSelectStatement().getSingle();
 
   /// Creates an auto-updating stream of this statement, similar to
   /// [watch]. However, it is assumed that the query will only emit
@@ -401,8 +401,8 @@ abstract class BaseTableManager<
   ///
   /// Uses the distinct flag to ensure that only distinct rows are returned
   @override
-  Stream<$Dataclass> watchSingle() =>
-      $state.copyWith(distinct: true).buildSelectStatement().watchSingle();
+  Stream<$Dataclass> watchSingle({bool distinct = true}) =>
+      $state.copyWith(distinct: distinct).buildSelectStatement().watchSingle();
 
   /// Executes the statement and returns all rows as a list.
   ///
@@ -440,8 +440,10 @@ abstract class BaseTableManager<
   ///
   /// Uses the distinct flag to ensure that only distinct rows are returned
   @override
-  Future<$Dataclass?> getSingleOrNull() =>
-      $state.copyWith(distinct: true).buildSelectStatement().getSingleOrNull();
+  Future<$Dataclass?> getSingleOrNull({bool distinct = true}) => $state
+      .copyWith(distinct: distinct)
+      .buildSelectStatement()
+      .getSingleOrNull();
 
   /// Creates an auto-updating stream of this statement, similar to
   /// [watch]. However, it is assumed that the query will only
@@ -453,8 +455,8 @@ abstract class BaseTableManager<
   ///
   /// Uses the distinct flag to ensure that only distinct rows are returned
   @override
-  Stream<$Dataclass?> watchSingleOrNull() => $state
-      .copyWith(distinct: true)
+  Stream<$Dataclass?> watchSingleOrNull({bool distinct = true}) => $state
+      .copyWith(distinct: distinct)
       .buildSelectStatement()
       .watchSingleOrNull();
 }

--- a/drift/test/extensions/geopoly_integration_test.g.dart
+++ b/drift/test/extensions/geopoly_integration_test.g.dart
@@ -296,16 +296,29 @@ typedef $GeopolyTestProcessedTableManager = ProcessedTableManager<
 class $GeopolyTestFilterComposer
     extends FilterComposer<_$_GeopolyTestDatabase, GeopolyTest> {
   $GeopolyTestFilterComposer(super.$state);
-  ColumnFilters<GeopolyPolygon> get shape => ColumnFilters($state.table.shape);
-  ColumnFilters<DriftAny> get a => ColumnFilters($state.table.a);
+  ColumnFilters<GeopolyPolygon> get shape => $state.composableBuilder(
+      column: $state.table.shape,
+      builder: (column, joinBuilders) =>
+          ColumnFilters(column, joinBuilders: joinBuilders));
+
+  ColumnFilters<DriftAny> get a => $state.composableBuilder(
+      column: $state.table.a,
+      builder: (column, joinBuilders) =>
+          ColumnFilters(column, joinBuilders: joinBuilders));
 }
 
 class $GeopolyTestOrderingComposer
     extends OrderingComposer<_$_GeopolyTestDatabase, GeopolyTest> {
   $GeopolyTestOrderingComposer(super.$state);
-  ColumnOrderings<GeopolyPolygon> get shape =>
-      ColumnOrderings($state.table.shape);
-  ColumnOrderings<DriftAny> get a => ColumnOrderings($state.table.a);
+  ColumnOrderings<GeopolyPolygon> get shape => $state.composableBuilder(
+      column: $state.table.shape,
+      builder: (column, joinBuilders) =>
+          ColumnOrderings(column, joinBuilders: joinBuilders));
+
+  ColumnOrderings<DriftAny> get a => $state.composableBuilder(
+      column: $state.table.a,
+      builder: (column, joinBuilders) =>
+          ColumnOrderings(column, joinBuilders: joinBuilders));
 }
 
 class $_GeopolyTestDatabaseManager {

--- a/drift/test/extensions/geopoly_integration_test.g.dart
+++ b/drift/test/extensions/geopoly_integration_test.g.dart
@@ -284,15 +284,6 @@ class $GeopolyTestTableManager extends RootTableManager<
         ));
 }
 
-typedef $GeopolyTestProcessedTableManager = ProcessedTableManager<
-    _$_GeopolyTestDatabase,
-    GeopolyTest,
-    GeopolyTestData,
-    $GeopolyTestFilterComposer,
-    $GeopolyTestOrderingComposer,
-    $GeopolyTestCreateCompanionBuilder,
-    $GeopolyTestUpdateCompanionBuilder>;
-
 class $GeopolyTestFilterComposer
     extends FilterComposer<_$_GeopolyTestDatabase, GeopolyTest> {
   $GeopolyTestFilterComposer(super.$state);

--- a/drift/test/extensions/geopoly_integration_test.g.dart
+++ b/drift/test/extensions/geopoly_integration_test.g.dart
@@ -234,7 +234,7 @@ abstract class _$_GeopolyTestDatabase extends GeneratedDatabase {
   List<DatabaseSchemaEntity> get allSchemaEntities => [geopolyTest];
 }
 
-typedef $GeopolyTestInsertCompanionBuilder = GeopolyTestCompanion Function({
+typedef $GeopolyTestCreateCompanionBuilder = GeopolyTestCompanion Function({
   Value<GeopolyPolygon?> shape,
   Value<DriftAny?> a,
   Value<int> rowid,
@@ -251,8 +251,7 @@ class $GeopolyTestTableManager extends RootTableManager<
     GeopolyTestData,
     $GeopolyTestFilterComposer,
     $GeopolyTestOrderingComposer,
-    $GeopolyTestProcessedTableManager,
-    $GeopolyTestInsertCompanionBuilder,
+    $GeopolyTestCreateCompanionBuilder,
     $GeopolyTestUpdateCompanionBuilder> {
   $GeopolyTestTableManager(_$_GeopolyTestDatabase db, GeopolyTest table)
       : super(TableManagerState(
@@ -262,8 +261,7 @@ class $GeopolyTestTableManager extends RootTableManager<
               $GeopolyTestFilterComposer(ComposerState(db, table)),
           orderingComposer:
               $GeopolyTestOrderingComposer(ComposerState(db, table)),
-          getChildManagerBuilder: (p) => $GeopolyTestProcessedTableManager(p),
-          getUpdateCompanionBuilder: ({
+          updateCompanionCallback: ({
             Value<GeopolyPolygon?> shape = const Value.absent(),
             Value<DriftAny?> a = const Value.absent(),
             Value<int> rowid = const Value.absent(),
@@ -273,7 +271,7 @@ class $GeopolyTestTableManager extends RootTableManager<
             a: a,
             rowid: rowid,
           ),
-          getInsertCompanionBuilder: ({
+          createCompanionCallback: ({
             Value<GeopolyPolygon?> shape = const Value.absent(),
             Value<DriftAny?> a = const Value.absent(),
             Value<int> rowid = const Value.absent(),
@@ -286,44 +284,28 @@ class $GeopolyTestTableManager extends RootTableManager<
         ));
 }
 
-class $GeopolyTestProcessedTableManager extends ProcessedTableManager<
+typedef $GeopolyTestProcessedTableManager = ProcessedTableManager<
     _$_GeopolyTestDatabase,
     GeopolyTest,
     GeopolyTestData,
     $GeopolyTestFilterComposer,
     $GeopolyTestOrderingComposer,
-    $GeopolyTestProcessedTableManager,
-    $GeopolyTestInsertCompanionBuilder,
-    $GeopolyTestUpdateCompanionBuilder> {
-  $GeopolyTestProcessedTableManager(super.$state);
-}
+    $GeopolyTestCreateCompanionBuilder,
+    $GeopolyTestUpdateCompanionBuilder>;
 
 class $GeopolyTestFilterComposer
     extends FilterComposer<_$_GeopolyTestDatabase, GeopolyTest> {
   $GeopolyTestFilterComposer(super.$state);
-  ColumnFilters<GeopolyPolygon> get shape => $state.composableBuilder(
-      column: $state.table.shape,
-      builder: (column, joinBuilders) =>
-          ColumnFilters(column, joinBuilders: joinBuilders));
-
-  ColumnFilters<DriftAny> get a => $state.composableBuilder(
-      column: $state.table.a,
-      builder: (column, joinBuilders) =>
-          ColumnFilters(column, joinBuilders: joinBuilders));
+  ColumnFilters<GeopolyPolygon> get shape => ColumnFilters($state.table.shape);
+  ColumnFilters<DriftAny> get a => ColumnFilters($state.table.a);
 }
 
 class $GeopolyTestOrderingComposer
     extends OrderingComposer<_$_GeopolyTestDatabase, GeopolyTest> {
   $GeopolyTestOrderingComposer(super.$state);
-  ColumnOrderings<GeopolyPolygon> get shape => $state.composableBuilder(
-      column: $state.table.shape,
-      builder: (column, joinBuilders) =>
-          ColumnOrderings(column, joinBuilders: joinBuilders));
-
-  ColumnOrderings<DriftAny> get a => $state.composableBuilder(
-      column: $state.table.a,
-      builder: (column, joinBuilders) =>
-          ColumnOrderings(column, joinBuilders: joinBuilders));
+  ColumnOrderings<GeopolyPolygon> get shape =>
+      ColumnOrderings($state.table.shape);
+  ColumnOrderings<DriftAny> get a => ColumnOrderings($state.table.a);
 }
 
 class $_GeopolyTestDatabaseManager {

--- a/drift/test/generated/custom_tables.g.dart
+++ b/drift/test/generated/custom_tables.g.dart
@@ -2071,13 +2071,18 @@ typedef $NoIdsProcessedTableManager = ProcessedTableManager<
 
 class $NoIdsFilterComposer extends FilterComposer<_$CustomTablesDb, NoIds> {
   $NoIdsFilterComposer(super.$state);
-  ColumnFilters<Uint8List> get payload => ColumnFilters($state.table.payload);
+  ColumnFilters<Uint8List> get payload => $state.composableBuilder(
+      column: $state.table.payload,
+      builder: (column, joinBuilders) =>
+          ColumnFilters(column, joinBuilders: joinBuilders));
 }
 
 class $NoIdsOrderingComposer extends OrderingComposer<_$CustomTablesDb, NoIds> {
   $NoIdsOrderingComposer(super.$state);
-  ColumnOrderings<Uint8List> get payload =>
-      ColumnOrderings($state.table.payload);
+  ColumnOrderings<Uint8List> get payload => $state.composableBuilder(
+      column: $state.table.payload,
+      builder: (column, joinBuilders) =>
+          ColumnOrderings(column, joinBuilders: joinBuilders));
 }
 
 typedef $WithDefaultsCreateCompanionBuilder = WithDefaultsCompanion Function({
@@ -2142,15 +2147,29 @@ typedef $WithDefaultsProcessedTableManager = ProcessedTableManager<
 class $WithDefaultsFilterComposer
     extends FilterComposer<_$CustomTablesDb, WithDefaults> {
   $WithDefaultsFilterComposer(super.$state);
-  ColumnFilters<String> get a => ColumnFilters($state.table.a);
-  ColumnFilters<int> get b => ColumnFilters($state.table.b);
+  ColumnFilters<String> get a => $state.composableBuilder(
+      column: $state.table.a,
+      builder: (column, joinBuilders) =>
+          ColumnFilters(column, joinBuilders: joinBuilders));
+
+  ColumnFilters<int> get b => $state.composableBuilder(
+      column: $state.table.b,
+      builder: (column, joinBuilders) =>
+          ColumnFilters(column, joinBuilders: joinBuilders));
 }
 
 class $WithDefaultsOrderingComposer
     extends OrderingComposer<_$CustomTablesDb, WithDefaults> {
   $WithDefaultsOrderingComposer(super.$state);
-  ColumnOrderings<String> get a => ColumnOrderings($state.table.a);
-  ColumnOrderings<int> get b => ColumnOrderings($state.table.b);
+  ColumnOrderings<String> get a => $state.composableBuilder(
+      column: $state.table.a,
+      builder: (column, joinBuilders) =>
+          ColumnOrderings(column, joinBuilders: joinBuilders));
+
+  ColumnOrderings<int> get b => $state.composableBuilder(
+      column: $state.table.b,
+      builder: (column, joinBuilders) =>
+          ColumnOrderings(column, joinBuilders: joinBuilders));
 }
 
 typedef $WithConstraintsCreateCompanionBuilder = WithConstraintsCompanion
@@ -2223,17 +2242,39 @@ typedef $WithConstraintsProcessedTableManager = ProcessedTableManager<
 class $WithConstraintsFilterComposer
     extends FilterComposer<_$CustomTablesDb, WithConstraints> {
   $WithConstraintsFilterComposer(super.$state);
-  ColumnFilters<String> get a => ColumnFilters($state.table.a);
-  ColumnFilters<int> get b => ColumnFilters($state.table.b);
-  ColumnFilters<double> get c => ColumnFilters($state.table.c);
+  ColumnFilters<String> get a => $state.composableBuilder(
+      column: $state.table.a,
+      builder: (column, joinBuilders) =>
+          ColumnFilters(column, joinBuilders: joinBuilders));
+
+  ColumnFilters<int> get b => $state.composableBuilder(
+      column: $state.table.b,
+      builder: (column, joinBuilders) =>
+          ColumnFilters(column, joinBuilders: joinBuilders));
+
+  ColumnFilters<double> get c => $state.composableBuilder(
+      column: $state.table.c,
+      builder: (column, joinBuilders) =>
+          ColumnFilters(column, joinBuilders: joinBuilders));
 }
 
 class $WithConstraintsOrderingComposer
     extends OrderingComposer<_$CustomTablesDb, WithConstraints> {
   $WithConstraintsOrderingComposer(super.$state);
-  ColumnOrderings<String> get a => ColumnOrderings($state.table.a);
-  ColumnOrderings<int> get b => ColumnOrderings($state.table.b);
-  ColumnOrderings<double> get c => ColumnOrderings($state.table.c);
+  ColumnOrderings<String> get a => $state.composableBuilder(
+      column: $state.table.a,
+      builder: (column, joinBuilders) =>
+          ColumnOrderings(column, joinBuilders: joinBuilders));
+
+  ColumnOrderings<int> get b => $state.composableBuilder(
+      column: $state.table.b,
+      builder: (column, joinBuilders) =>
+          ColumnOrderings(column, joinBuilders: joinBuilders));
+
+  ColumnOrderings<double> get c => $state.composableBuilder(
+      column: $state.table.c,
+      builder: (column, joinBuilders) =>
+          ColumnOrderings(column, joinBuilders: joinBuilders));
 }
 
 typedef $ConfigTableCreateCompanionBuilder = ConfigCompanion Function({
@@ -2310,26 +2351,53 @@ typedef $ConfigTableProcessedTableManager = ProcessedTableManager<
 class $ConfigTableFilterComposer
     extends FilterComposer<_$CustomTablesDb, ConfigTable> {
   $ConfigTableFilterComposer(super.$state);
-  ColumnFilters<String> get configKey => ColumnFilters($state.table.configKey);
-  ColumnFilters<DriftAny> get configValue =>
-      ColumnFilters($state.table.configValue);
+  ColumnFilters<String> get configKey => $state.composableBuilder(
+      column: $state.table.configKey,
+      builder: (column, joinBuilders) =>
+          ColumnFilters(column, joinBuilders: joinBuilders));
+
+  ColumnFilters<DriftAny> get configValue => $state.composableBuilder(
+      column: $state.table.configValue,
+      builder: (column, joinBuilders) =>
+          ColumnFilters(column, joinBuilders: joinBuilders));
+
   ColumnWithTypeConverterFilters<SyncType?, SyncType, int> get syncState =>
-      ColumnWithTypeConverterFilters($state.table.syncState);
+      $state.composableBuilder(
+          column: $state.table.syncState,
+          builder: (column, joinBuilders) => ColumnWithTypeConverterFilters(
+              column,
+              joinBuilders: joinBuilders));
+
   ColumnWithTypeConverterFilters<SyncType?, SyncType, int>
-      get syncStateImplicit =>
-          ColumnWithTypeConverterFilters($state.table.syncStateImplicit);
+      get syncStateImplicit => $state.composableBuilder(
+          column: $state.table.syncStateImplicit,
+          builder: (column, joinBuilders) => ColumnWithTypeConverterFilters(
+              column,
+              joinBuilders: joinBuilders));
 }
 
 class $ConfigTableOrderingComposer
     extends OrderingComposer<_$CustomTablesDb, ConfigTable> {
   $ConfigTableOrderingComposer(super.$state);
-  ColumnOrderings<String> get configKey =>
-      ColumnOrderings($state.table.configKey);
-  ColumnOrderings<DriftAny> get configValue =>
-      ColumnOrderings($state.table.configValue);
-  ColumnOrderings<int> get syncState => ColumnOrderings($state.table.syncState);
-  ColumnOrderings<int> get syncStateImplicit =>
-      ColumnOrderings($state.table.syncStateImplicit);
+  ColumnOrderings<String> get configKey => $state.composableBuilder(
+      column: $state.table.configKey,
+      builder: (column, joinBuilders) =>
+          ColumnOrderings(column, joinBuilders: joinBuilders));
+
+  ColumnOrderings<DriftAny> get configValue => $state.composableBuilder(
+      column: $state.table.configValue,
+      builder: (column, joinBuilders) =>
+          ColumnOrderings(column, joinBuilders: joinBuilders));
+
+  ColumnOrderings<int> get syncState => $state.composableBuilder(
+      column: $state.table.syncState,
+      builder: (column, joinBuilders) =>
+          ColumnOrderings(column, joinBuilders: joinBuilders));
+
+  ColumnOrderings<int> get syncStateImplicit => $state.composableBuilder(
+      column: $state.table.syncStateImplicit,
+      builder: (column, joinBuilders) =>
+          ColumnOrderings(column, joinBuilders: joinBuilders));
 }
 
 typedef $MytableCreateCompanionBuilder = MytableCompanion Function({
@@ -2397,23 +2465,49 @@ typedef $MytableProcessedTableManager = ProcessedTableManager<
 
 class $MytableFilterComposer extends FilterComposer<_$CustomTablesDb, Mytable> {
   $MytableFilterComposer(super.$state);
-  ColumnFilters<int> get someid => ColumnFilters($state.table.someid);
-  ColumnFilters<String> get sometext => ColumnFilters($state.table.sometext);
-  ColumnFilters<bool> get isInserting =>
-      ColumnFilters($state.table.isInserting);
-  ColumnFilters<DateTime> get somedate => ColumnFilters($state.table.somedate);
+  ColumnFilters<int> get someid => $state.composableBuilder(
+      column: $state.table.someid,
+      builder: (column, joinBuilders) =>
+          ColumnFilters(column, joinBuilders: joinBuilders));
+
+  ColumnFilters<String> get sometext => $state.composableBuilder(
+      column: $state.table.sometext,
+      builder: (column, joinBuilders) =>
+          ColumnFilters(column, joinBuilders: joinBuilders));
+
+  ColumnFilters<bool> get isInserting => $state.composableBuilder(
+      column: $state.table.isInserting,
+      builder: (column, joinBuilders) =>
+          ColumnFilters(column, joinBuilders: joinBuilders));
+
+  ColumnFilters<DateTime> get somedate => $state.composableBuilder(
+      column: $state.table.somedate,
+      builder: (column, joinBuilders) =>
+          ColumnFilters(column, joinBuilders: joinBuilders));
 }
 
 class $MytableOrderingComposer
     extends OrderingComposer<_$CustomTablesDb, Mytable> {
   $MytableOrderingComposer(super.$state);
-  ColumnOrderings<int> get someid => ColumnOrderings($state.table.someid);
-  ColumnOrderings<String> get sometext =>
-      ColumnOrderings($state.table.sometext);
-  ColumnOrderings<bool> get isInserting =>
-      ColumnOrderings($state.table.isInserting);
-  ColumnOrderings<DateTime> get somedate =>
-      ColumnOrderings($state.table.somedate);
+  ColumnOrderings<int> get someid => $state.composableBuilder(
+      column: $state.table.someid,
+      builder: (column, joinBuilders) =>
+          ColumnOrderings(column, joinBuilders: joinBuilders));
+
+  ColumnOrderings<String> get sometext => $state.composableBuilder(
+      column: $state.table.sometext,
+      builder: (column, joinBuilders) =>
+          ColumnOrderings(column, joinBuilders: joinBuilders));
+
+  ColumnOrderings<bool> get isInserting => $state.composableBuilder(
+      column: $state.table.isInserting,
+      builder: (column, joinBuilders) =>
+          ColumnOrderings(column, joinBuilders: joinBuilders));
+
+  ColumnOrderings<DateTime> get somedate => $state.composableBuilder(
+      column: $state.table.somedate,
+      builder: (column, joinBuilders) =>
+          ColumnOrderings(column, joinBuilders: joinBuilders));
 }
 
 typedef $EmailCreateCompanionBuilder = EmailCompanion Function({
@@ -2481,16 +2575,38 @@ typedef $EmailProcessedTableManager = ProcessedTableManager<
 
 class $EmailFilterComposer extends FilterComposer<_$CustomTablesDb, Email> {
   $EmailFilterComposer(super.$state);
-  ColumnFilters<String> get sender => ColumnFilters($state.table.sender);
-  ColumnFilters<String> get title => ColumnFilters($state.table.title);
-  ColumnFilters<String> get body => ColumnFilters($state.table.body);
+  ColumnFilters<String> get sender => $state.composableBuilder(
+      column: $state.table.sender,
+      builder: (column, joinBuilders) =>
+          ColumnFilters(column, joinBuilders: joinBuilders));
+
+  ColumnFilters<String> get title => $state.composableBuilder(
+      column: $state.table.title,
+      builder: (column, joinBuilders) =>
+          ColumnFilters(column, joinBuilders: joinBuilders));
+
+  ColumnFilters<String> get body => $state.composableBuilder(
+      column: $state.table.body,
+      builder: (column, joinBuilders) =>
+          ColumnFilters(column, joinBuilders: joinBuilders));
 }
 
 class $EmailOrderingComposer extends OrderingComposer<_$CustomTablesDb, Email> {
   $EmailOrderingComposer(super.$state);
-  ColumnOrderings<String> get sender => ColumnOrderings($state.table.sender);
-  ColumnOrderings<String> get title => ColumnOrderings($state.table.title);
-  ColumnOrderings<String> get body => ColumnOrderings($state.table.body);
+  ColumnOrderings<String> get sender => $state.composableBuilder(
+      column: $state.table.sender,
+      builder: (column, joinBuilders) =>
+          ColumnOrderings(column, joinBuilders: joinBuilders));
+
+  ColumnOrderings<String> get title => $state.composableBuilder(
+      column: $state.table.title,
+      builder: (column, joinBuilders) =>
+          ColumnOrderings(column, joinBuilders: joinBuilders));
+
+  ColumnOrderings<String> get body => $state.composableBuilder(
+      column: $state.table.body,
+      builder: (column, joinBuilders) =>
+          ColumnOrderings(column, joinBuilders: joinBuilders));
 }
 
 typedef $WeirdTableCreateCompanionBuilder = WeirdTableCompanion Function({
@@ -2555,17 +2671,29 @@ typedef $WeirdTableProcessedTableManager = ProcessedTableManager<
 class $WeirdTableFilterComposer
     extends FilterComposer<_$CustomTablesDb, WeirdTable> {
   $WeirdTableFilterComposer(super.$state);
-  ColumnFilters<int> get sqlClass => ColumnFilters($state.table.sqlClass);
-  ColumnFilters<String> get textColumn =>
-      ColumnFilters($state.table.textColumn);
+  ColumnFilters<int> get sqlClass => $state.composableBuilder(
+      column: $state.table.sqlClass,
+      builder: (column, joinBuilders) =>
+          ColumnFilters(column, joinBuilders: joinBuilders));
+
+  ColumnFilters<String> get textColumn => $state.composableBuilder(
+      column: $state.table.textColumn,
+      builder: (column, joinBuilders) =>
+          ColumnFilters(column, joinBuilders: joinBuilders));
 }
 
 class $WeirdTableOrderingComposer
     extends OrderingComposer<_$CustomTablesDb, WeirdTable> {
   $WeirdTableOrderingComposer(super.$state);
-  ColumnOrderings<int> get sqlClass => ColumnOrderings($state.table.sqlClass);
-  ColumnOrderings<String> get textColumn =>
-      ColumnOrderings($state.table.textColumn);
+  ColumnOrderings<int> get sqlClass => $state.composableBuilder(
+      column: $state.table.sqlClass,
+      builder: (column, joinBuilders) =>
+          ColumnOrderings(column, joinBuilders: joinBuilders));
+
+  ColumnOrderings<String> get textColumn => $state.composableBuilder(
+      column: $state.table.textColumn,
+      builder: (column, joinBuilders) =>
+          ColumnOrderings(column, joinBuilders: joinBuilders));
 }
 
 class $CustomTablesDbManager {

--- a/drift/test/generated/custom_tables.g.dart
+++ b/drift/test/generated/custom_tables.g.dart
@@ -2024,7 +2024,7 @@ abstract class _$CustomTablesDb extends GeneratedDatabase {
       const DriftDatabaseOptions(storeDateTimeAsText: true);
 }
 
-typedef $NoIdsInsertCompanionBuilder = NoIdsCompanion Function({
+typedef $NoIdsCreateCompanionBuilder = NoIdsCompanion Function({
   required Uint8List payload,
 });
 typedef $NoIdsUpdateCompanionBuilder = NoIdsCompanion Function({
@@ -2037,8 +2037,7 @@ class $NoIdsTableManager extends RootTableManager<
     NoIdRow,
     $NoIdsFilterComposer,
     $NoIdsOrderingComposer,
-    $NoIdsProcessedTableManager,
-    $NoIdsInsertCompanionBuilder,
+    $NoIdsCreateCompanionBuilder,
     $NoIdsUpdateCompanionBuilder> {
   $NoIdsTableManager(_$CustomTablesDb db, NoIds table)
       : super(TableManagerState(
@@ -2046,14 +2045,13 @@ class $NoIdsTableManager extends RootTableManager<
           table: table,
           filteringComposer: $NoIdsFilterComposer(ComposerState(db, table)),
           orderingComposer: $NoIdsOrderingComposer(ComposerState(db, table)),
-          getChildManagerBuilder: (p) => $NoIdsProcessedTableManager(p),
-          getUpdateCompanionBuilder: ({
+          updateCompanionCallback: ({
             Value<Uint8List> payload = const Value.absent(),
           }) =>
               NoIdsCompanion(
             payload: payload,
           ),
-          getInsertCompanionBuilder: ({
+          createCompanionCallback: ({
             required Uint8List payload,
           }) =>
               NoIdsCompanion.insert(
@@ -2062,35 +2060,27 @@ class $NoIdsTableManager extends RootTableManager<
         ));
 }
 
-class $NoIdsProcessedTableManager extends ProcessedTableManager<
+typedef $NoIdsProcessedTableManager = ProcessedTableManager<
     _$CustomTablesDb,
     NoIds,
     NoIdRow,
     $NoIdsFilterComposer,
     $NoIdsOrderingComposer,
-    $NoIdsProcessedTableManager,
-    $NoIdsInsertCompanionBuilder,
-    $NoIdsUpdateCompanionBuilder> {
-  $NoIdsProcessedTableManager(super.$state);
-}
+    $NoIdsCreateCompanionBuilder,
+    $NoIdsUpdateCompanionBuilder>;
 
 class $NoIdsFilterComposer extends FilterComposer<_$CustomTablesDb, NoIds> {
   $NoIdsFilterComposer(super.$state);
-  ColumnFilters<Uint8List> get payload => $state.composableBuilder(
-      column: $state.table.payload,
-      builder: (column, joinBuilders) =>
-          ColumnFilters(column, joinBuilders: joinBuilders));
+  ColumnFilters<Uint8List> get payload => ColumnFilters($state.table.payload);
 }
 
 class $NoIdsOrderingComposer extends OrderingComposer<_$CustomTablesDb, NoIds> {
   $NoIdsOrderingComposer(super.$state);
-  ColumnOrderings<Uint8List> get payload => $state.composableBuilder(
-      column: $state.table.payload,
-      builder: (column, joinBuilders) =>
-          ColumnOrderings(column, joinBuilders: joinBuilders));
+  ColumnOrderings<Uint8List> get payload =>
+      ColumnOrderings($state.table.payload);
 }
 
-typedef $WithDefaultsInsertCompanionBuilder = WithDefaultsCompanion Function({
+typedef $WithDefaultsCreateCompanionBuilder = WithDefaultsCompanion Function({
   Value<String?> a,
   Value<int?> b,
   Value<int> rowid,
@@ -2107,8 +2097,7 @@ class $WithDefaultsTableManager extends RootTableManager<
     WithDefault,
     $WithDefaultsFilterComposer,
     $WithDefaultsOrderingComposer,
-    $WithDefaultsProcessedTableManager,
-    $WithDefaultsInsertCompanionBuilder,
+    $WithDefaultsCreateCompanionBuilder,
     $WithDefaultsUpdateCompanionBuilder> {
   $WithDefaultsTableManager(_$CustomTablesDb db, WithDefaults table)
       : super(TableManagerState(
@@ -2118,8 +2107,7 @@ class $WithDefaultsTableManager extends RootTableManager<
               $WithDefaultsFilterComposer(ComposerState(db, table)),
           orderingComposer:
               $WithDefaultsOrderingComposer(ComposerState(db, table)),
-          getChildManagerBuilder: (p) => $WithDefaultsProcessedTableManager(p),
-          getUpdateCompanionBuilder: ({
+          updateCompanionCallback: ({
             Value<String?> a = const Value.absent(),
             Value<int?> b = const Value.absent(),
             Value<int> rowid = const Value.absent(),
@@ -2129,7 +2117,7 @@ class $WithDefaultsTableManager extends RootTableManager<
             b: b,
             rowid: rowid,
           ),
-          getInsertCompanionBuilder: ({
+          createCompanionCallback: ({
             Value<String?> a = const Value.absent(),
             Value<int?> b = const Value.absent(),
             Value<int> rowid = const Value.absent(),
@@ -2142,47 +2130,30 @@ class $WithDefaultsTableManager extends RootTableManager<
         ));
 }
 
-class $WithDefaultsProcessedTableManager extends ProcessedTableManager<
+typedef $WithDefaultsProcessedTableManager = ProcessedTableManager<
     _$CustomTablesDb,
     WithDefaults,
     WithDefault,
     $WithDefaultsFilterComposer,
     $WithDefaultsOrderingComposer,
-    $WithDefaultsProcessedTableManager,
-    $WithDefaultsInsertCompanionBuilder,
-    $WithDefaultsUpdateCompanionBuilder> {
-  $WithDefaultsProcessedTableManager(super.$state);
-}
+    $WithDefaultsCreateCompanionBuilder,
+    $WithDefaultsUpdateCompanionBuilder>;
 
 class $WithDefaultsFilterComposer
     extends FilterComposer<_$CustomTablesDb, WithDefaults> {
   $WithDefaultsFilterComposer(super.$state);
-  ColumnFilters<String> get a => $state.composableBuilder(
-      column: $state.table.a,
-      builder: (column, joinBuilders) =>
-          ColumnFilters(column, joinBuilders: joinBuilders));
-
-  ColumnFilters<int> get b => $state.composableBuilder(
-      column: $state.table.b,
-      builder: (column, joinBuilders) =>
-          ColumnFilters(column, joinBuilders: joinBuilders));
+  ColumnFilters<String> get a => ColumnFilters($state.table.a);
+  ColumnFilters<int> get b => ColumnFilters($state.table.b);
 }
 
 class $WithDefaultsOrderingComposer
     extends OrderingComposer<_$CustomTablesDb, WithDefaults> {
   $WithDefaultsOrderingComposer(super.$state);
-  ColumnOrderings<String> get a => $state.composableBuilder(
-      column: $state.table.a,
-      builder: (column, joinBuilders) =>
-          ColumnOrderings(column, joinBuilders: joinBuilders));
-
-  ColumnOrderings<int> get b => $state.composableBuilder(
-      column: $state.table.b,
-      builder: (column, joinBuilders) =>
-          ColumnOrderings(column, joinBuilders: joinBuilders));
+  ColumnOrderings<String> get a => ColumnOrderings($state.table.a);
+  ColumnOrderings<int> get b => ColumnOrderings($state.table.b);
 }
 
-typedef $WithConstraintsInsertCompanionBuilder = WithConstraintsCompanion
+typedef $WithConstraintsCreateCompanionBuilder = WithConstraintsCompanion
     Function({
   Value<String?> a,
   required int b,
@@ -2203,8 +2174,7 @@ class $WithConstraintsTableManager extends RootTableManager<
     WithConstraint,
     $WithConstraintsFilterComposer,
     $WithConstraintsOrderingComposer,
-    $WithConstraintsProcessedTableManager,
-    $WithConstraintsInsertCompanionBuilder,
+    $WithConstraintsCreateCompanionBuilder,
     $WithConstraintsUpdateCompanionBuilder> {
   $WithConstraintsTableManager(_$CustomTablesDb db, WithConstraints table)
       : super(TableManagerState(
@@ -2214,9 +2184,7 @@ class $WithConstraintsTableManager extends RootTableManager<
               $WithConstraintsFilterComposer(ComposerState(db, table)),
           orderingComposer:
               $WithConstraintsOrderingComposer(ComposerState(db, table)),
-          getChildManagerBuilder: (p) =>
-              $WithConstraintsProcessedTableManager(p),
-          getUpdateCompanionBuilder: ({
+          updateCompanionCallback: ({
             Value<String?> a = const Value.absent(),
             Value<int> b = const Value.absent(),
             Value<double?> c = const Value.absent(),
@@ -2228,7 +2196,7 @@ class $WithConstraintsTableManager extends RootTableManager<
             c: c,
             rowid: rowid,
           ),
-          getInsertCompanionBuilder: ({
+          createCompanionCallback: ({
             Value<String?> a = const Value.absent(),
             required int b,
             Value<double?> c = const Value.absent(),
@@ -2243,57 +2211,32 @@ class $WithConstraintsTableManager extends RootTableManager<
         ));
 }
 
-class $WithConstraintsProcessedTableManager extends ProcessedTableManager<
+typedef $WithConstraintsProcessedTableManager = ProcessedTableManager<
     _$CustomTablesDb,
     WithConstraints,
     WithConstraint,
     $WithConstraintsFilterComposer,
     $WithConstraintsOrderingComposer,
-    $WithConstraintsProcessedTableManager,
-    $WithConstraintsInsertCompanionBuilder,
-    $WithConstraintsUpdateCompanionBuilder> {
-  $WithConstraintsProcessedTableManager(super.$state);
-}
+    $WithConstraintsCreateCompanionBuilder,
+    $WithConstraintsUpdateCompanionBuilder>;
 
 class $WithConstraintsFilterComposer
     extends FilterComposer<_$CustomTablesDb, WithConstraints> {
   $WithConstraintsFilterComposer(super.$state);
-  ColumnFilters<String> get a => $state.composableBuilder(
-      column: $state.table.a,
-      builder: (column, joinBuilders) =>
-          ColumnFilters(column, joinBuilders: joinBuilders));
-
-  ColumnFilters<int> get b => $state.composableBuilder(
-      column: $state.table.b,
-      builder: (column, joinBuilders) =>
-          ColumnFilters(column, joinBuilders: joinBuilders));
-
-  ColumnFilters<double> get c => $state.composableBuilder(
-      column: $state.table.c,
-      builder: (column, joinBuilders) =>
-          ColumnFilters(column, joinBuilders: joinBuilders));
+  ColumnFilters<String> get a => ColumnFilters($state.table.a);
+  ColumnFilters<int> get b => ColumnFilters($state.table.b);
+  ColumnFilters<double> get c => ColumnFilters($state.table.c);
 }
 
 class $WithConstraintsOrderingComposer
     extends OrderingComposer<_$CustomTablesDb, WithConstraints> {
   $WithConstraintsOrderingComposer(super.$state);
-  ColumnOrderings<String> get a => $state.composableBuilder(
-      column: $state.table.a,
-      builder: (column, joinBuilders) =>
-          ColumnOrderings(column, joinBuilders: joinBuilders));
-
-  ColumnOrderings<int> get b => $state.composableBuilder(
-      column: $state.table.b,
-      builder: (column, joinBuilders) =>
-          ColumnOrderings(column, joinBuilders: joinBuilders));
-
-  ColumnOrderings<double> get c => $state.composableBuilder(
-      column: $state.table.c,
-      builder: (column, joinBuilders) =>
-          ColumnOrderings(column, joinBuilders: joinBuilders));
+  ColumnOrderings<String> get a => ColumnOrderings($state.table.a);
+  ColumnOrderings<int> get b => ColumnOrderings($state.table.b);
+  ColumnOrderings<double> get c => ColumnOrderings($state.table.c);
 }
 
-typedef $ConfigTableInsertCompanionBuilder = ConfigCompanion Function({
+typedef $ConfigTableCreateCompanionBuilder = ConfigCompanion Function({
   required String configKey,
   Value<DriftAny?> configValue,
   Value<SyncType?> syncState,
@@ -2314,8 +2257,7 @@ class $ConfigTableTableManager extends RootTableManager<
     Config,
     $ConfigTableFilterComposer,
     $ConfigTableOrderingComposer,
-    $ConfigTableProcessedTableManager,
-    $ConfigTableInsertCompanionBuilder,
+    $ConfigTableCreateCompanionBuilder,
     $ConfigTableUpdateCompanionBuilder> {
   $ConfigTableTableManager(_$CustomTablesDb db, ConfigTable table)
       : super(TableManagerState(
@@ -2325,8 +2267,7 @@ class $ConfigTableTableManager extends RootTableManager<
               $ConfigTableFilterComposer(ComposerState(db, table)),
           orderingComposer:
               $ConfigTableOrderingComposer(ComposerState(db, table)),
-          getChildManagerBuilder: (p) => $ConfigTableProcessedTableManager(p),
-          getUpdateCompanionBuilder: ({
+          updateCompanionCallback: ({
             Value<String> configKey = const Value.absent(),
             Value<DriftAny?> configValue = const Value.absent(),
             Value<SyncType?> syncState = const Value.absent(),
@@ -2340,7 +2281,7 @@ class $ConfigTableTableManager extends RootTableManager<
             syncStateImplicit: syncStateImplicit,
             rowid: rowid,
           ),
-          getInsertCompanionBuilder: ({
+          createCompanionCallback: ({
             required String configKey,
             Value<DriftAny?> configValue = const Value.absent(),
             Value<SyncType?> syncState = const Value.absent(),
@@ -2357,71 +2298,41 @@ class $ConfigTableTableManager extends RootTableManager<
         ));
 }
 
-class $ConfigTableProcessedTableManager extends ProcessedTableManager<
+typedef $ConfigTableProcessedTableManager = ProcessedTableManager<
     _$CustomTablesDb,
     ConfigTable,
     Config,
     $ConfigTableFilterComposer,
     $ConfigTableOrderingComposer,
-    $ConfigTableProcessedTableManager,
-    $ConfigTableInsertCompanionBuilder,
-    $ConfigTableUpdateCompanionBuilder> {
-  $ConfigTableProcessedTableManager(super.$state);
-}
+    $ConfigTableCreateCompanionBuilder,
+    $ConfigTableUpdateCompanionBuilder>;
 
 class $ConfigTableFilterComposer
     extends FilterComposer<_$CustomTablesDb, ConfigTable> {
   $ConfigTableFilterComposer(super.$state);
-  ColumnFilters<String> get configKey => $state.composableBuilder(
-      column: $state.table.configKey,
-      builder: (column, joinBuilders) =>
-          ColumnFilters(column, joinBuilders: joinBuilders));
-
-  ColumnFilters<DriftAny> get configValue => $state.composableBuilder(
-      column: $state.table.configValue,
-      builder: (column, joinBuilders) =>
-          ColumnFilters(column, joinBuilders: joinBuilders));
-
+  ColumnFilters<String> get configKey => ColumnFilters($state.table.configKey);
+  ColumnFilters<DriftAny> get configValue =>
+      ColumnFilters($state.table.configValue);
   ColumnWithTypeConverterFilters<SyncType?, SyncType, int> get syncState =>
-      $state.composableBuilder(
-          column: $state.table.syncState,
-          builder: (column, joinBuilders) => ColumnWithTypeConverterFilters(
-              column,
-              joinBuilders: joinBuilders));
-
+      ColumnWithTypeConverterFilters($state.table.syncState);
   ColumnWithTypeConverterFilters<SyncType?, SyncType, int>
-      get syncStateImplicit => $state.composableBuilder(
-          column: $state.table.syncStateImplicit,
-          builder: (column, joinBuilders) => ColumnWithTypeConverterFilters(
-              column,
-              joinBuilders: joinBuilders));
+      get syncStateImplicit =>
+          ColumnWithTypeConverterFilters($state.table.syncStateImplicit);
 }
 
 class $ConfigTableOrderingComposer
     extends OrderingComposer<_$CustomTablesDb, ConfigTable> {
   $ConfigTableOrderingComposer(super.$state);
-  ColumnOrderings<String> get configKey => $state.composableBuilder(
-      column: $state.table.configKey,
-      builder: (column, joinBuilders) =>
-          ColumnOrderings(column, joinBuilders: joinBuilders));
-
-  ColumnOrderings<DriftAny> get configValue => $state.composableBuilder(
-      column: $state.table.configValue,
-      builder: (column, joinBuilders) =>
-          ColumnOrderings(column, joinBuilders: joinBuilders));
-
-  ColumnOrderings<int> get syncState => $state.composableBuilder(
-      column: $state.table.syncState,
-      builder: (column, joinBuilders) =>
-          ColumnOrderings(column, joinBuilders: joinBuilders));
-
-  ColumnOrderings<int> get syncStateImplicit => $state.composableBuilder(
-      column: $state.table.syncStateImplicit,
-      builder: (column, joinBuilders) =>
-          ColumnOrderings(column, joinBuilders: joinBuilders));
+  ColumnOrderings<String> get configKey =>
+      ColumnOrderings($state.table.configKey);
+  ColumnOrderings<DriftAny> get configValue =>
+      ColumnOrderings($state.table.configValue);
+  ColumnOrderings<int> get syncState => ColumnOrderings($state.table.syncState);
+  ColumnOrderings<int> get syncStateImplicit =>
+      ColumnOrderings($state.table.syncStateImplicit);
 }
 
-typedef $MytableInsertCompanionBuilder = MytableCompanion Function({
+typedef $MytableCreateCompanionBuilder = MytableCompanion Function({
   Value<int> someid,
   Value<String?> sometext,
   Value<bool?> isInserting,
@@ -2440,8 +2351,7 @@ class $MytableTableManager extends RootTableManager<
     MytableData,
     $MytableFilterComposer,
     $MytableOrderingComposer,
-    $MytableProcessedTableManager,
-    $MytableInsertCompanionBuilder,
+    $MytableCreateCompanionBuilder,
     $MytableUpdateCompanionBuilder> {
   $MytableTableManager(_$CustomTablesDb db, Mytable table)
       : super(TableManagerState(
@@ -2449,8 +2359,7 @@ class $MytableTableManager extends RootTableManager<
           table: table,
           filteringComposer: $MytableFilterComposer(ComposerState(db, table)),
           orderingComposer: $MytableOrderingComposer(ComposerState(db, table)),
-          getChildManagerBuilder: (p) => $MytableProcessedTableManager(p),
-          getUpdateCompanionBuilder: ({
+          updateCompanionCallback: ({
             Value<int> someid = const Value.absent(),
             Value<String?> sometext = const Value.absent(),
             Value<bool?> isInserting = const Value.absent(),
@@ -2462,7 +2371,7 @@ class $MytableTableManager extends RootTableManager<
             isInserting: isInserting,
             somedate: somedate,
           ),
-          getInsertCompanionBuilder: ({
+          createCompanionCallback: ({
             Value<int> someid = const Value.absent(),
             Value<String?> sometext = const Value.absent(),
             Value<bool?> isInserting = const Value.absent(),
@@ -2477,66 +2386,37 @@ class $MytableTableManager extends RootTableManager<
         ));
 }
 
-class $MytableProcessedTableManager extends ProcessedTableManager<
+typedef $MytableProcessedTableManager = ProcessedTableManager<
     _$CustomTablesDb,
     Mytable,
     MytableData,
     $MytableFilterComposer,
     $MytableOrderingComposer,
-    $MytableProcessedTableManager,
-    $MytableInsertCompanionBuilder,
-    $MytableUpdateCompanionBuilder> {
-  $MytableProcessedTableManager(super.$state);
-}
+    $MytableCreateCompanionBuilder,
+    $MytableUpdateCompanionBuilder>;
 
 class $MytableFilterComposer extends FilterComposer<_$CustomTablesDb, Mytable> {
   $MytableFilterComposer(super.$state);
-  ColumnFilters<int> get someid => $state.composableBuilder(
-      column: $state.table.someid,
-      builder: (column, joinBuilders) =>
-          ColumnFilters(column, joinBuilders: joinBuilders));
-
-  ColumnFilters<String> get sometext => $state.composableBuilder(
-      column: $state.table.sometext,
-      builder: (column, joinBuilders) =>
-          ColumnFilters(column, joinBuilders: joinBuilders));
-
-  ColumnFilters<bool> get isInserting => $state.composableBuilder(
-      column: $state.table.isInserting,
-      builder: (column, joinBuilders) =>
-          ColumnFilters(column, joinBuilders: joinBuilders));
-
-  ColumnFilters<DateTime> get somedate => $state.composableBuilder(
-      column: $state.table.somedate,
-      builder: (column, joinBuilders) =>
-          ColumnFilters(column, joinBuilders: joinBuilders));
+  ColumnFilters<int> get someid => ColumnFilters($state.table.someid);
+  ColumnFilters<String> get sometext => ColumnFilters($state.table.sometext);
+  ColumnFilters<bool> get isInserting =>
+      ColumnFilters($state.table.isInserting);
+  ColumnFilters<DateTime> get somedate => ColumnFilters($state.table.somedate);
 }
 
 class $MytableOrderingComposer
     extends OrderingComposer<_$CustomTablesDb, Mytable> {
   $MytableOrderingComposer(super.$state);
-  ColumnOrderings<int> get someid => $state.composableBuilder(
-      column: $state.table.someid,
-      builder: (column, joinBuilders) =>
-          ColumnOrderings(column, joinBuilders: joinBuilders));
-
-  ColumnOrderings<String> get sometext => $state.composableBuilder(
-      column: $state.table.sometext,
-      builder: (column, joinBuilders) =>
-          ColumnOrderings(column, joinBuilders: joinBuilders));
-
-  ColumnOrderings<bool> get isInserting => $state.composableBuilder(
-      column: $state.table.isInserting,
-      builder: (column, joinBuilders) =>
-          ColumnOrderings(column, joinBuilders: joinBuilders));
-
-  ColumnOrderings<DateTime> get somedate => $state.composableBuilder(
-      column: $state.table.somedate,
-      builder: (column, joinBuilders) =>
-          ColumnOrderings(column, joinBuilders: joinBuilders));
+  ColumnOrderings<int> get someid => ColumnOrderings($state.table.someid);
+  ColumnOrderings<String> get sometext =>
+      ColumnOrderings($state.table.sometext);
+  ColumnOrderings<bool> get isInserting =>
+      ColumnOrderings($state.table.isInserting);
+  ColumnOrderings<DateTime> get somedate =>
+      ColumnOrderings($state.table.somedate);
 }
 
-typedef $EmailInsertCompanionBuilder = EmailCompanion Function({
+typedef $EmailCreateCompanionBuilder = EmailCompanion Function({
   required String sender,
   required String title,
   required String body,
@@ -2555,8 +2435,7 @@ class $EmailTableManager extends RootTableManager<
     EMail,
     $EmailFilterComposer,
     $EmailOrderingComposer,
-    $EmailProcessedTableManager,
-    $EmailInsertCompanionBuilder,
+    $EmailCreateCompanionBuilder,
     $EmailUpdateCompanionBuilder> {
   $EmailTableManager(_$CustomTablesDb db, Email table)
       : super(TableManagerState(
@@ -2564,8 +2443,7 @@ class $EmailTableManager extends RootTableManager<
           table: table,
           filteringComposer: $EmailFilterComposer(ComposerState(db, table)),
           orderingComposer: $EmailOrderingComposer(ComposerState(db, table)),
-          getChildManagerBuilder: (p) => $EmailProcessedTableManager(p),
-          getUpdateCompanionBuilder: ({
+          updateCompanionCallback: ({
             Value<String> sender = const Value.absent(),
             Value<String> title = const Value.absent(),
             Value<String> body = const Value.absent(),
@@ -2577,7 +2455,7 @@ class $EmailTableManager extends RootTableManager<
             body: body,
             rowid: rowid,
           ),
-          getInsertCompanionBuilder: ({
+          createCompanionCallback: ({
             required String sender,
             required String title,
             required String body,
@@ -2592,55 +2470,30 @@ class $EmailTableManager extends RootTableManager<
         ));
 }
 
-class $EmailProcessedTableManager extends ProcessedTableManager<
+typedef $EmailProcessedTableManager = ProcessedTableManager<
     _$CustomTablesDb,
     Email,
     EMail,
     $EmailFilterComposer,
     $EmailOrderingComposer,
-    $EmailProcessedTableManager,
-    $EmailInsertCompanionBuilder,
-    $EmailUpdateCompanionBuilder> {
-  $EmailProcessedTableManager(super.$state);
-}
+    $EmailCreateCompanionBuilder,
+    $EmailUpdateCompanionBuilder>;
 
 class $EmailFilterComposer extends FilterComposer<_$CustomTablesDb, Email> {
   $EmailFilterComposer(super.$state);
-  ColumnFilters<String> get sender => $state.composableBuilder(
-      column: $state.table.sender,
-      builder: (column, joinBuilders) =>
-          ColumnFilters(column, joinBuilders: joinBuilders));
-
-  ColumnFilters<String> get title => $state.composableBuilder(
-      column: $state.table.title,
-      builder: (column, joinBuilders) =>
-          ColumnFilters(column, joinBuilders: joinBuilders));
-
-  ColumnFilters<String> get body => $state.composableBuilder(
-      column: $state.table.body,
-      builder: (column, joinBuilders) =>
-          ColumnFilters(column, joinBuilders: joinBuilders));
+  ColumnFilters<String> get sender => ColumnFilters($state.table.sender);
+  ColumnFilters<String> get title => ColumnFilters($state.table.title);
+  ColumnFilters<String> get body => ColumnFilters($state.table.body);
 }
 
 class $EmailOrderingComposer extends OrderingComposer<_$CustomTablesDb, Email> {
   $EmailOrderingComposer(super.$state);
-  ColumnOrderings<String> get sender => $state.composableBuilder(
-      column: $state.table.sender,
-      builder: (column, joinBuilders) =>
-          ColumnOrderings(column, joinBuilders: joinBuilders));
-
-  ColumnOrderings<String> get title => $state.composableBuilder(
-      column: $state.table.title,
-      builder: (column, joinBuilders) =>
-          ColumnOrderings(column, joinBuilders: joinBuilders));
-
-  ColumnOrderings<String> get body => $state.composableBuilder(
-      column: $state.table.body,
-      builder: (column, joinBuilders) =>
-          ColumnOrderings(column, joinBuilders: joinBuilders));
+  ColumnOrderings<String> get sender => ColumnOrderings($state.table.sender);
+  ColumnOrderings<String> get title => ColumnOrderings($state.table.title);
+  ColumnOrderings<String> get body => ColumnOrderings($state.table.body);
 }
 
-typedef $WeirdTableInsertCompanionBuilder = WeirdTableCompanion Function({
+typedef $WeirdTableCreateCompanionBuilder = WeirdTableCompanion Function({
   required int sqlClass,
   required String textColumn,
   Value<int> rowid,
@@ -2657,8 +2510,7 @@ class $WeirdTableTableManager extends RootTableManager<
     WeirdData,
     $WeirdTableFilterComposer,
     $WeirdTableOrderingComposer,
-    $WeirdTableProcessedTableManager,
-    $WeirdTableInsertCompanionBuilder,
+    $WeirdTableCreateCompanionBuilder,
     $WeirdTableUpdateCompanionBuilder> {
   $WeirdTableTableManager(_$CustomTablesDb db, WeirdTable table)
       : super(TableManagerState(
@@ -2668,8 +2520,7 @@ class $WeirdTableTableManager extends RootTableManager<
               $WeirdTableFilterComposer(ComposerState(db, table)),
           orderingComposer:
               $WeirdTableOrderingComposer(ComposerState(db, table)),
-          getChildManagerBuilder: (p) => $WeirdTableProcessedTableManager(p),
-          getUpdateCompanionBuilder: ({
+          updateCompanionCallback: ({
             Value<int> sqlClass = const Value.absent(),
             Value<String> textColumn = const Value.absent(),
             Value<int> rowid = const Value.absent(),
@@ -2679,7 +2530,7 @@ class $WeirdTableTableManager extends RootTableManager<
             textColumn: textColumn,
             rowid: rowid,
           ),
-          getInsertCompanionBuilder: ({
+          createCompanionCallback: ({
             required int sqlClass,
             required String textColumn,
             Value<int> rowid = const Value.absent(),
@@ -2692,44 +2543,29 @@ class $WeirdTableTableManager extends RootTableManager<
         ));
 }
 
-class $WeirdTableProcessedTableManager extends ProcessedTableManager<
+typedef $WeirdTableProcessedTableManager = ProcessedTableManager<
     _$CustomTablesDb,
     WeirdTable,
     WeirdData,
     $WeirdTableFilterComposer,
     $WeirdTableOrderingComposer,
-    $WeirdTableProcessedTableManager,
-    $WeirdTableInsertCompanionBuilder,
-    $WeirdTableUpdateCompanionBuilder> {
-  $WeirdTableProcessedTableManager(super.$state);
-}
+    $WeirdTableCreateCompanionBuilder,
+    $WeirdTableUpdateCompanionBuilder>;
 
 class $WeirdTableFilterComposer
     extends FilterComposer<_$CustomTablesDb, WeirdTable> {
   $WeirdTableFilterComposer(super.$state);
-  ColumnFilters<int> get sqlClass => $state.composableBuilder(
-      column: $state.table.sqlClass,
-      builder: (column, joinBuilders) =>
-          ColumnFilters(column, joinBuilders: joinBuilders));
-
-  ColumnFilters<String> get textColumn => $state.composableBuilder(
-      column: $state.table.textColumn,
-      builder: (column, joinBuilders) =>
-          ColumnFilters(column, joinBuilders: joinBuilders));
+  ColumnFilters<int> get sqlClass => ColumnFilters($state.table.sqlClass);
+  ColumnFilters<String> get textColumn =>
+      ColumnFilters($state.table.textColumn);
 }
 
 class $WeirdTableOrderingComposer
     extends OrderingComposer<_$CustomTablesDb, WeirdTable> {
   $WeirdTableOrderingComposer(super.$state);
-  ColumnOrderings<int> get sqlClass => $state.composableBuilder(
-      column: $state.table.sqlClass,
-      builder: (column, joinBuilders) =>
-          ColumnOrderings(column, joinBuilders: joinBuilders));
-
-  ColumnOrderings<String> get textColumn => $state.composableBuilder(
-      column: $state.table.textColumn,
-      builder: (column, joinBuilders) =>
-          ColumnOrderings(column, joinBuilders: joinBuilders));
+  ColumnOrderings<int> get sqlClass => ColumnOrderings($state.table.sqlClass);
+  ColumnOrderings<String> get textColumn =>
+      ColumnOrderings($state.table.textColumn);
 }
 
 class $CustomTablesDbManager {

--- a/drift/test/generated/custom_tables.g.dart
+++ b/drift/test/generated/custom_tables.g.dart
@@ -2060,15 +2060,6 @@ class $NoIdsTableManager extends RootTableManager<
         ));
 }
 
-typedef $NoIdsProcessedTableManager = ProcessedTableManager<
-    _$CustomTablesDb,
-    NoIds,
-    NoIdRow,
-    $NoIdsFilterComposer,
-    $NoIdsOrderingComposer,
-    $NoIdsCreateCompanionBuilder,
-    $NoIdsUpdateCompanionBuilder>;
-
 class $NoIdsFilterComposer extends FilterComposer<_$CustomTablesDb, NoIds> {
   $NoIdsFilterComposer(super.$state);
   ColumnFilters<Uint8List> get payload => $state.composableBuilder(
@@ -2134,15 +2125,6 @@ class $WithDefaultsTableManager extends RootTableManager<
           ),
         ));
 }
-
-typedef $WithDefaultsProcessedTableManager = ProcessedTableManager<
-    _$CustomTablesDb,
-    WithDefaults,
-    WithDefault,
-    $WithDefaultsFilterComposer,
-    $WithDefaultsOrderingComposer,
-    $WithDefaultsCreateCompanionBuilder,
-    $WithDefaultsUpdateCompanionBuilder>;
 
 class $WithDefaultsFilterComposer
     extends FilterComposer<_$CustomTablesDb, WithDefaults> {
@@ -2229,15 +2211,6 @@ class $WithConstraintsTableManager extends RootTableManager<
           ),
         ));
 }
-
-typedef $WithConstraintsProcessedTableManager = ProcessedTableManager<
-    _$CustomTablesDb,
-    WithConstraints,
-    WithConstraint,
-    $WithConstraintsFilterComposer,
-    $WithConstraintsOrderingComposer,
-    $WithConstraintsCreateCompanionBuilder,
-    $WithConstraintsUpdateCompanionBuilder>;
 
 class $WithConstraintsFilterComposer
     extends FilterComposer<_$CustomTablesDb, WithConstraints> {
@@ -2338,15 +2311,6 @@ class $ConfigTableTableManager extends RootTableManager<
           ),
         ));
 }
-
-typedef $ConfigTableProcessedTableManager = ProcessedTableManager<
-    _$CustomTablesDb,
-    ConfigTable,
-    Config,
-    $ConfigTableFilterComposer,
-    $ConfigTableOrderingComposer,
-    $ConfigTableCreateCompanionBuilder,
-    $ConfigTableUpdateCompanionBuilder>;
 
 class $ConfigTableFilterComposer
     extends FilterComposer<_$CustomTablesDb, ConfigTable> {
@@ -2454,15 +2418,6 @@ class $MytableTableManager extends RootTableManager<
         ));
 }
 
-typedef $MytableProcessedTableManager = ProcessedTableManager<
-    _$CustomTablesDb,
-    Mytable,
-    MytableData,
-    $MytableFilterComposer,
-    $MytableOrderingComposer,
-    $MytableCreateCompanionBuilder,
-    $MytableUpdateCompanionBuilder>;
-
 class $MytableFilterComposer extends FilterComposer<_$CustomTablesDb, Mytable> {
   $MytableFilterComposer(super.$state);
   ColumnFilters<int> get someid => $state.composableBuilder(
@@ -2564,15 +2519,6 @@ class $EmailTableManager extends RootTableManager<
         ));
 }
 
-typedef $EmailProcessedTableManager = ProcessedTableManager<
-    _$CustomTablesDb,
-    Email,
-    EMail,
-    $EmailFilterComposer,
-    $EmailOrderingComposer,
-    $EmailCreateCompanionBuilder,
-    $EmailUpdateCompanionBuilder>;
-
 class $EmailFilterComposer extends FilterComposer<_$CustomTablesDb, Email> {
   $EmailFilterComposer(super.$state);
   ColumnFilters<String> get sender => $state.composableBuilder(
@@ -2658,15 +2604,6 @@ class $WeirdTableTableManager extends RootTableManager<
           ),
         ));
 }
-
-typedef $WeirdTableProcessedTableManager = ProcessedTableManager<
-    _$CustomTablesDb,
-    WeirdTable,
-    WeirdData,
-    $WeirdTableFilterComposer,
-    $WeirdTableOrderingComposer,
-    $WeirdTableCreateCompanionBuilder,
-    $WeirdTableUpdateCompanionBuilder>;
 
 class $WeirdTableFilterComposer
     extends FilterComposer<_$CustomTablesDb, WeirdTable> {

--- a/drift/test/generated/todos.g.dart
+++ b/drift/test/generated/todos.g.dart
@@ -3483,15 +3483,6 @@ class $$CategoriesTableTableManager extends RootTableManager<
         ));
 }
 
-typedef $$CategoriesTableProcessedTableManager = ProcessedTableManager<
-    _$TodoDb,
-    $CategoriesTable,
-    Category,
-    $$CategoriesTableFilterComposer,
-    $$CategoriesTableOrderingComposer,
-    $$CategoriesTableCreateCompanionBuilder,
-    $$CategoriesTableUpdateCompanionBuilder>;
-
 class $$CategoriesTableFilterComposer
     extends FilterComposer<_$TodoDb, $CategoriesTable> {
   $$CategoriesTableFilterComposer(super.$state);
@@ -3625,15 +3616,6 @@ class $$TodosTableTableTableManager extends RootTableManager<
           ),
         ));
 }
-
-typedef $$TodosTableTableProcessedTableManager = ProcessedTableManager<
-    _$TodoDb,
-    $TodosTableTable,
-    TodoEntry,
-    $$TodosTableTableFilterComposer,
-    $$TodosTableTableOrderingComposer,
-    $$TodosTableTableCreateCompanionBuilder,
-    $$TodosTableTableUpdateCompanionBuilder>;
 
 class $$TodosTableTableFilterComposer
     extends FilterComposer<_$TodoDb, $TodosTableTable> {
@@ -3783,15 +3765,6 @@ class $$UsersTableTableManager extends RootTableManager<
         ));
 }
 
-typedef $$UsersTableProcessedTableManager = ProcessedTableManager<
-    _$TodoDb,
-    $UsersTable,
-    User,
-    $$UsersTableFilterComposer,
-    $$UsersTableOrderingComposer,
-    $$UsersTableCreateCompanionBuilder,
-    $$UsersTableUpdateCompanionBuilder>;
-
 class $$UsersTableFilterComposer extends FilterComposer<_$TodoDb, $UsersTable> {
   $$UsersTableFilterComposer(super.$state);
   ColumnWithTypeConverterFilters<RowId, RowId, int> get id =>
@@ -3903,15 +3876,6 @@ class $$SharedTodosTableTableManager extends RootTableManager<
         ));
 }
 
-typedef $$SharedTodosTableProcessedTableManager = ProcessedTableManager<
-    _$TodoDb,
-    $SharedTodosTable,
-    SharedTodo,
-    $$SharedTodosTableFilterComposer,
-    $$SharedTodosTableOrderingComposer,
-    $$SharedTodosTableCreateCompanionBuilder,
-    $$SharedTodosTableUpdateCompanionBuilder>;
-
 class $$SharedTodosTableFilterComposer
     extends FilterComposer<_$TodoDb, $SharedTodosTable> {
   $$SharedTodosTableFilterComposer(super.$state);
@@ -4003,15 +3967,6 @@ class $$TableWithoutPKTableTableManager extends RootTableManager<
           ),
         ));
 }
-
-typedef $$TableWithoutPKTableProcessedTableManager = ProcessedTableManager<
-    _$TodoDb,
-    $TableWithoutPKTable,
-    CustomRowClass,
-    $$TableWithoutPKTableFilterComposer,
-    $$TableWithoutPKTableOrderingComposer,
-    $$TableWithoutPKTableCreateCompanionBuilder,
-    $$TableWithoutPKTableUpdateCompanionBuilder>;
 
 class $$TableWithoutPKTableFilterComposer
     extends FilterComposer<_$TodoDb, $TableWithoutPKTable> {
@@ -4109,15 +4064,6 @@ class $$PureDefaultsTableTableManager extends RootTableManager<
         ));
 }
 
-typedef $$PureDefaultsTableProcessedTableManager = ProcessedTableManager<
-    _$TodoDb,
-    $PureDefaultsTable,
-    PureDefault,
-    $$PureDefaultsTableFilterComposer,
-    $$PureDefaultsTableOrderingComposer,
-    $$PureDefaultsTableCreateCompanionBuilder,
-    $$PureDefaultsTableUpdateCompanionBuilder>;
-
 class $$PureDefaultsTableFilterComposer
     extends FilterComposer<_$TodoDb, $PureDefaultsTable> {
   $$PureDefaultsTableFilterComposer(super.$state);
@@ -4183,15 +4129,6 @@ class $$WithCustomTypeTableTableManager extends RootTableManager<
           ),
         ));
 }
-
-typedef $$WithCustomTypeTableProcessedTableManager = ProcessedTableManager<
-    _$TodoDb,
-    $WithCustomTypeTable,
-    WithCustomTypeData,
-    $$WithCustomTypeTableFilterComposer,
-    $$WithCustomTypeTableOrderingComposer,
-    $$WithCustomTypeTableCreateCompanionBuilder,
-    $$WithCustomTypeTableUpdateCompanionBuilder>;
 
 class $$WithCustomTypeTableFilterComposer
     extends FilterComposer<_$TodoDb, $WithCustomTypeTable> {
@@ -4305,16 +4242,6 @@ class $$TableWithEveryColumnTypeTableTableManager extends RootTableManager<
           ),
         ));
 }
-
-typedef $$TableWithEveryColumnTypeTableProcessedTableManager
-    = ProcessedTableManager<
-        _$TodoDb,
-        $TableWithEveryColumnTypeTable,
-        TableWithEveryColumnTypeData,
-        $$TableWithEveryColumnTypeTableFilterComposer,
-        $$TableWithEveryColumnTypeTableOrderingComposer,
-        $$TableWithEveryColumnTypeTableCreateCompanionBuilder,
-        $$TableWithEveryColumnTypeTableUpdateCompanionBuilder>;
 
 class $$TableWithEveryColumnTypeTableFilterComposer
     extends FilterComposer<_$TodoDb, $TableWithEveryColumnTypeTable> {
@@ -4474,15 +4401,6 @@ class $$DepartmentTableTableManager extends RootTableManager<
         ));
 }
 
-typedef $$DepartmentTableProcessedTableManager = ProcessedTableManager<
-    _$TodoDb,
-    $DepartmentTable,
-    DepartmentData,
-    $$DepartmentTableFilterComposer,
-    $$DepartmentTableOrderingComposer,
-    $$DepartmentTableCreateCompanionBuilder,
-    $$DepartmentTableUpdateCompanionBuilder>;
-
 class $$DepartmentTableFilterComposer
     extends FilterComposer<_$TodoDb, $DepartmentTable> {
   $$DepartmentTableFilterComposer(super.$state);
@@ -4573,15 +4491,6 @@ class $$ProductTableTableManager extends RootTableManager<
           ),
         ));
 }
-
-typedef $$ProductTableProcessedTableManager = ProcessedTableManager<
-    _$TodoDb,
-    $ProductTable,
-    ProductData,
-    $$ProductTableFilterComposer,
-    $$ProductTableOrderingComposer,
-    $$ProductTableCreateCompanionBuilder,
-    $$ProductTableUpdateCompanionBuilder>;
 
 class $$ProductTableFilterComposer
     extends FilterComposer<_$TodoDb, $ProductTable> {
@@ -4692,15 +4601,6 @@ class $$StoreTableTableManager extends RootTableManager<
         ));
 }
 
-typedef $$StoreTableProcessedTableManager = ProcessedTableManager<
-    _$TodoDb,
-    $StoreTable,
-    StoreData,
-    $$StoreTableFilterComposer,
-    $$StoreTableOrderingComposer,
-    $$StoreTableCreateCompanionBuilder,
-    $$StoreTableUpdateCompanionBuilder>;
-
 class $$StoreTableFilterComposer extends FilterComposer<_$TodoDb, $StoreTable> {
   $$StoreTableFilterComposer(super.$state);
   ColumnFilters<int> get id => $state.composableBuilder(
@@ -4796,15 +4696,6 @@ class $$ListingTableTableManager extends RootTableManager<
           ),
         ));
 }
-
-typedef $$ListingTableProcessedTableManager = ProcessedTableManager<
-    _$TodoDb,
-    $ListingTable,
-    ListingData,
-    $$ListingTableFilterComposer,
-    $$ListingTableOrderingComposer,
-    $$ListingTableCreateCompanionBuilder,
-    $$ListingTableUpdateCompanionBuilder>;
 
 class $$ListingTableFilterComposer
     extends FilterComposer<_$TodoDb, $ListingTable> {

--- a/drift/test/generated/todos.g.dart
+++ b/drift/test/generated/todos.g.dart
@@ -3433,7 +3433,7 @@ abstract class _$TodoDb extends GeneratedDatabase {
       ];
 }
 
-typedef $$CategoriesTableInsertCompanionBuilder = CategoriesCompanion Function({
+typedef $$CategoriesTableCreateCompanionBuilder = CategoriesCompanion Function({
   Value<RowId> id,
   required String description,
   Value<CategoryPriority> priority,
@@ -3450,8 +3450,7 @@ class $$CategoriesTableTableManager extends RootTableManager<
     Category,
     $$CategoriesTableFilterComposer,
     $$CategoriesTableOrderingComposer,
-    $$CategoriesTableProcessedTableManager,
-    $$CategoriesTableInsertCompanionBuilder,
+    $$CategoriesTableCreateCompanionBuilder,
     $$CategoriesTableUpdateCompanionBuilder> {
   $$CategoriesTableTableManager(_$TodoDb db, $CategoriesTable table)
       : super(TableManagerState(
@@ -3461,9 +3460,7 @@ class $$CategoriesTableTableManager extends RootTableManager<
               $$CategoriesTableFilterComposer(ComposerState(db, table)),
           orderingComposer:
               $$CategoriesTableOrderingComposer(ComposerState(db, table)),
-          getChildManagerBuilder: (p) =>
-              $$CategoriesTableProcessedTableManager(p),
-          getUpdateCompanionBuilder: ({
+          updateCompanionCallback: ({
             Value<RowId> id = const Value.absent(),
             Value<String> description = const Value.absent(),
             Value<CategoryPriority> priority = const Value.absent(),
@@ -3473,7 +3470,7 @@ class $$CategoriesTableTableManager extends RootTableManager<
             description: description,
             priority: priority,
           ),
-          getInsertCompanionBuilder: ({
+          createCompanionCallback: ({
             Value<RowId> id = const Value.absent(),
             required String description,
             Value<CategoryPriority> priority = const Value.absent(),
@@ -3486,45 +3483,26 @@ class $$CategoriesTableTableManager extends RootTableManager<
         ));
 }
 
-class $$CategoriesTableProcessedTableManager extends ProcessedTableManager<
+typedef $$CategoriesTableProcessedTableManager = ProcessedTableManager<
     _$TodoDb,
     $CategoriesTable,
     Category,
     $$CategoriesTableFilterComposer,
     $$CategoriesTableOrderingComposer,
-    $$CategoriesTableProcessedTableManager,
-    $$CategoriesTableInsertCompanionBuilder,
-    $$CategoriesTableUpdateCompanionBuilder> {
-  $$CategoriesTableProcessedTableManager(super.$state);
-}
+    $$CategoriesTableCreateCompanionBuilder,
+    $$CategoriesTableUpdateCompanionBuilder>;
 
 class $$CategoriesTableFilterComposer
     extends FilterComposer<_$TodoDb, $CategoriesTable> {
   $$CategoriesTableFilterComposer(super.$state);
   ColumnWithTypeConverterFilters<RowId, RowId, int> get id =>
-      $state.composableBuilder(
-          column: $state.table.id,
-          builder: (column, joinBuilders) => ColumnWithTypeConverterFilters(
-              column,
-              joinBuilders: joinBuilders));
-
-  ColumnFilters<String> get description => $state.composableBuilder(
-      column: $state.table.description,
-      builder: (column, joinBuilders) =>
-          ColumnFilters(column, joinBuilders: joinBuilders));
-
+      ColumnWithTypeConverterFilters($state.table.id);
+  ColumnFilters<String> get description =>
+      ColumnFilters($state.table.description);
   ColumnWithTypeConverterFilters<CategoryPriority, CategoryPriority, int>
-      get priority => $state.composableBuilder(
-          column: $state.table.priority,
-          builder: (column, joinBuilders) => ColumnWithTypeConverterFilters(
-              column,
-              joinBuilders: joinBuilders));
-
-  ColumnFilters<String> get descriptionInUpperCase => $state.composableBuilder(
-      column: $state.table.descriptionInUpperCase,
-      builder: (column, joinBuilders) =>
-          ColumnFilters(column, joinBuilders: joinBuilders));
-
+      get priority => ColumnWithTypeConverterFilters($state.table.priority);
+  ColumnFilters<String> get descriptionInUpperCase =>
+      ColumnFilters($state.table.descriptionInUpperCase);
   ComposableFilter todos(
       ComposableFilter Function($$TodosTableTableFilterComposer f) f) {
     final $$TodosTableTableFilterComposer composer = $state.composerBuilder(
@@ -3542,29 +3520,15 @@ class $$CategoriesTableFilterComposer
 class $$CategoriesTableOrderingComposer
     extends OrderingComposer<_$TodoDb, $CategoriesTable> {
   $$CategoriesTableOrderingComposer(super.$state);
-  ColumnOrderings<int> get id => $state.composableBuilder(
-      column: $state.table.id,
-      builder: (column, joinBuilders) =>
-          ColumnOrderings(column, joinBuilders: joinBuilders));
-
-  ColumnOrderings<String> get description => $state.composableBuilder(
-      column: $state.table.description,
-      builder: (column, joinBuilders) =>
-          ColumnOrderings(column, joinBuilders: joinBuilders));
-
-  ColumnOrderings<int> get priority => $state.composableBuilder(
-      column: $state.table.priority,
-      builder: (column, joinBuilders) =>
-          ColumnOrderings(column, joinBuilders: joinBuilders));
-
+  ColumnOrderings<int> get id => ColumnOrderings($state.table.id);
+  ColumnOrderings<String> get description =>
+      ColumnOrderings($state.table.description);
+  ColumnOrderings<int> get priority => ColumnOrderings($state.table.priority);
   ColumnOrderings<String> get descriptionInUpperCase =>
-      $state.composableBuilder(
-          column: $state.table.descriptionInUpperCase,
-          builder: (column, joinBuilders) =>
-              ColumnOrderings(column, joinBuilders: joinBuilders));
+      ColumnOrderings($state.table.descriptionInUpperCase);
 }
 
-typedef $$TodosTableTableInsertCompanionBuilder = TodosTableCompanion Function({
+typedef $$TodosTableTableCreateCompanionBuilder = TodosTableCompanion Function({
   Value<RowId> id,
   Value<String?> title,
   required String content,
@@ -3587,8 +3551,7 @@ class $$TodosTableTableTableManager extends RootTableManager<
     TodoEntry,
     $$TodosTableTableFilterComposer,
     $$TodosTableTableOrderingComposer,
-    $$TodosTableTableProcessedTableManager,
-    $$TodosTableTableInsertCompanionBuilder,
+    $$TodosTableTableCreateCompanionBuilder,
     $$TodosTableTableUpdateCompanionBuilder> {
   $$TodosTableTableTableManager(_$TodoDb db, $TodosTableTable table)
       : super(TableManagerState(
@@ -3598,9 +3561,7 @@ class $$TodosTableTableTableManager extends RootTableManager<
               $$TodosTableTableFilterComposer(ComposerState(db, table)),
           orderingComposer:
               $$TodosTableTableOrderingComposer(ComposerState(db, table)),
-          getChildManagerBuilder: (p) =>
-              $$TodosTableTableProcessedTableManager(p),
-          getUpdateCompanionBuilder: ({
+          updateCompanionCallback: ({
             Value<RowId> id = const Value.absent(),
             Value<String?> title = const Value.absent(),
             Value<String> content = const Value.absent(),
@@ -3616,7 +3577,7 @@ class $$TodosTableTableTableManager extends RootTableManager<
             category: category,
             status: status,
           ),
-          getInsertCompanionBuilder: ({
+          createCompanionCallback: ({
             Value<RowId> id = const Value.absent(),
             Value<String?> title = const Value.absent(),
             required String content,
@@ -3635,50 +3596,26 @@ class $$TodosTableTableTableManager extends RootTableManager<
         ));
 }
 
-class $$TodosTableTableProcessedTableManager extends ProcessedTableManager<
+typedef $$TodosTableTableProcessedTableManager = ProcessedTableManager<
     _$TodoDb,
     $TodosTableTable,
     TodoEntry,
     $$TodosTableTableFilterComposer,
     $$TodosTableTableOrderingComposer,
-    $$TodosTableTableProcessedTableManager,
-    $$TodosTableTableInsertCompanionBuilder,
-    $$TodosTableTableUpdateCompanionBuilder> {
-  $$TodosTableTableProcessedTableManager(super.$state);
-}
+    $$TodosTableTableCreateCompanionBuilder,
+    $$TodosTableTableUpdateCompanionBuilder>;
 
 class $$TodosTableTableFilterComposer
     extends FilterComposer<_$TodoDb, $TodosTableTable> {
   $$TodosTableTableFilterComposer(super.$state);
   ColumnWithTypeConverterFilters<RowId, RowId, int> get id =>
-      $state.composableBuilder(
-          column: $state.table.id,
-          builder: (column, joinBuilders) => ColumnWithTypeConverterFilters(
-              column,
-              joinBuilders: joinBuilders));
-
-  ColumnFilters<String> get title => $state.composableBuilder(
-      column: $state.table.title,
-      builder: (column, joinBuilders) =>
-          ColumnFilters(column, joinBuilders: joinBuilders));
-
-  ColumnFilters<String> get content => $state.composableBuilder(
-      column: $state.table.content,
-      builder: (column, joinBuilders) =>
-          ColumnFilters(column, joinBuilders: joinBuilders));
-
-  ColumnFilters<DateTime> get targetDate => $state.composableBuilder(
-      column: $state.table.targetDate,
-      builder: (column, joinBuilders) =>
-          ColumnFilters(column, joinBuilders: joinBuilders));
-
+      ColumnWithTypeConverterFilters($state.table.id);
+  ColumnFilters<String> get title => ColumnFilters($state.table.title);
+  ColumnFilters<String> get content => ColumnFilters($state.table.content);
+  ColumnFilters<DateTime> get targetDate =>
+      ColumnFilters($state.table.targetDate);
   ColumnWithTypeConverterFilters<TodoStatus?, TodoStatus, String> get status =>
-      $state.composableBuilder(
-          column: $state.table.status,
-          builder: (column, joinBuilders) => ColumnWithTypeConverterFilters(
-              column,
-              joinBuilders: joinBuilders));
-
+      ColumnWithTypeConverterFilters($state.table.status);
   $$CategoriesTableFilterComposer get category {
     final $$CategoriesTableFilterComposer composer = $state.composerBuilder(
         composer: this,
@@ -3695,31 +3632,12 @@ class $$TodosTableTableFilterComposer
 class $$TodosTableTableOrderingComposer
     extends OrderingComposer<_$TodoDb, $TodosTableTable> {
   $$TodosTableTableOrderingComposer(super.$state);
-  ColumnOrderings<int> get id => $state.composableBuilder(
-      column: $state.table.id,
-      builder: (column, joinBuilders) =>
-          ColumnOrderings(column, joinBuilders: joinBuilders));
-
-  ColumnOrderings<String> get title => $state.composableBuilder(
-      column: $state.table.title,
-      builder: (column, joinBuilders) =>
-          ColumnOrderings(column, joinBuilders: joinBuilders));
-
-  ColumnOrderings<String> get content => $state.composableBuilder(
-      column: $state.table.content,
-      builder: (column, joinBuilders) =>
-          ColumnOrderings(column, joinBuilders: joinBuilders));
-
-  ColumnOrderings<DateTime> get targetDate => $state.composableBuilder(
-      column: $state.table.targetDate,
-      builder: (column, joinBuilders) =>
-          ColumnOrderings(column, joinBuilders: joinBuilders));
-
-  ColumnOrderings<String> get status => $state.composableBuilder(
-      column: $state.table.status,
-      builder: (column, joinBuilders) =>
-          ColumnOrderings(column, joinBuilders: joinBuilders));
-
+  ColumnOrderings<int> get id => ColumnOrderings($state.table.id);
+  ColumnOrderings<String> get title => ColumnOrderings($state.table.title);
+  ColumnOrderings<String> get content => ColumnOrderings($state.table.content);
+  ColumnOrderings<DateTime> get targetDate =>
+      ColumnOrderings($state.table.targetDate);
+  ColumnOrderings<String> get status => ColumnOrderings($state.table.status);
   $$CategoriesTableOrderingComposer get category {
     final $$CategoriesTableOrderingComposer composer = $state.composerBuilder(
         composer: this,
@@ -3733,7 +3651,7 @@ class $$TodosTableTableOrderingComposer
   }
 }
 
-typedef $$UsersTableInsertCompanionBuilder = UsersCompanion Function({
+typedef $$UsersTableCreateCompanionBuilder = UsersCompanion Function({
   Value<RowId> id,
   required String name,
   Value<bool> isAwesome,
@@ -3754,8 +3672,7 @@ class $$UsersTableTableManager extends RootTableManager<
     User,
     $$UsersTableFilterComposer,
     $$UsersTableOrderingComposer,
-    $$UsersTableProcessedTableManager,
-    $$UsersTableInsertCompanionBuilder,
+    $$UsersTableCreateCompanionBuilder,
     $$UsersTableUpdateCompanionBuilder> {
   $$UsersTableTableManager(_$TodoDb db, $UsersTable table)
       : super(TableManagerState(
@@ -3765,8 +3682,7 @@ class $$UsersTableTableManager extends RootTableManager<
               $$UsersTableFilterComposer(ComposerState(db, table)),
           orderingComposer:
               $$UsersTableOrderingComposer(ComposerState(db, table)),
-          getChildManagerBuilder: (p) => $$UsersTableProcessedTableManager(p),
-          getUpdateCompanionBuilder: ({
+          updateCompanionCallback: ({
             Value<RowId> id = const Value.absent(),
             Value<String> name = const Value.absent(),
             Value<bool> isAwesome = const Value.absent(),
@@ -3780,7 +3696,7 @@ class $$UsersTableTableManager extends RootTableManager<
             profilePicture: profilePicture,
             creationTime: creationTime,
           ),
-          getInsertCompanionBuilder: ({
+          createCompanionCallback: ({
             Value<RowId> id = const Value.absent(),
             required String name,
             Value<bool> isAwesome = const Value.absent(),
@@ -3797,78 +3713,41 @@ class $$UsersTableTableManager extends RootTableManager<
         ));
 }
 
-class $$UsersTableProcessedTableManager extends ProcessedTableManager<
+typedef $$UsersTableProcessedTableManager = ProcessedTableManager<
     _$TodoDb,
     $UsersTable,
     User,
     $$UsersTableFilterComposer,
     $$UsersTableOrderingComposer,
-    $$UsersTableProcessedTableManager,
-    $$UsersTableInsertCompanionBuilder,
-    $$UsersTableUpdateCompanionBuilder> {
-  $$UsersTableProcessedTableManager(super.$state);
-}
+    $$UsersTableCreateCompanionBuilder,
+    $$UsersTableUpdateCompanionBuilder>;
 
 class $$UsersTableFilterComposer extends FilterComposer<_$TodoDb, $UsersTable> {
   $$UsersTableFilterComposer(super.$state);
   ColumnWithTypeConverterFilters<RowId, RowId, int> get id =>
-      $state.composableBuilder(
-          column: $state.table.id,
-          builder: (column, joinBuilders) => ColumnWithTypeConverterFilters(
-              column,
-              joinBuilders: joinBuilders));
-
-  ColumnFilters<String> get name => $state.composableBuilder(
-      column: $state.table.name,
-      builder: (column, joinBuilders) =>
-          ColumnFilters(column, joinBuilders: joinBuilders));
-
-  ColumnFilters<bool> get isAwesome => $state.composableBuilder(
-      column: $state.table.isAwesome,
-      builder: (column, joinBuilders) =>
-          ColumnFilters(column, joinBuilders: joinBuilders));
-
-  ColumnFilters<Uint8List> get profilePicture => $state.composableBuilder(
-      column: $state.table.profilePicture,
-      builder: (column, joinBuilders) =>
-          ColumnFilters(column, joinBuilders: joinBuilders));
-
-  ColumnFilters<DateTime> get creationTime => $state.composableBuilder(
-      column: $state.table.creationTime,
-      builder: (column, joinBuilders) =>
-          ColumnFilters(column, joinBuilders: joinBuilders));
+      ColumnWithTypeConverterFilters($state.table.id);
+  ColumnFilters<String> get name => ColumnFilters($state.table.name);
+  ColumnFilters<bool> get isAwesome => ColumnFilters($state.table.isAwesome);
+  ColumnFilters<Uint8List> get profilePicture =>
+      ColumnFilters($state.table.profilePicture);
+  ColumnFilters<DateTime> get creationTime =>
+      ColumnFilters($state.table.creationTime);
 }
 
 class $$UsersTableOrderingComposer
     extends OrderingComposer<_$TodoDb, $UsersTable> {
   $$UsersTableOrderingComposer(super.$state);
-  ColumnOrderings<int> get id => $state.composableBuilder(
-      column: $state.table.id,
-      builder: (column, joinBuilders) =>
-          ColumnOrderings(column, joinBuilders: joinBuilders));
-
-  ColumnOrderings<String> get name => $state.composableBuilder(
-      column: $state.table.name,
-      builder: (column, joinBuilders) =>
-          ColumnOrderings(column, joinBuilders: joinBuilders));
-
-  ColumnOrderings<bool> get isAwesome => $state.composableBuilder(
-      column: $state.table.isAwesome,
-      builder: (column, joinBuilders) =>
-          ColumnOrderings(column, joinBuilders: joinBuilders));
-
-  ColumnOrderings<Uint8List> get profilePicture => $state.composableBuilder(
-      column: $state.table.profilePicture,
-      builder: (column, joinBuilders) =>
-          ColumnOrderings(column, joinBuilders: joinBuilders));
-
-  ColumnOrderings<DateTime> get creationTime => $state.composableBuilder(
-      column: $state.table.creationTime,
-      builder: (column, joinBuilders) =>
-          ColumnOrderings(column, joinBuilders: joinBuilders));
+  ColumnOrderings<int> get id => ColumnOrderings($state.table.id);
+  ColumnOrderings<String> get name => ColumnOrderings($state.table.name);
+  ColumnOrderings<bool> get isAwesome =>
+      ColumnOrderings($state.table.isAwesome);
+  ColumnOrderings<Uint8List> get profilePicture =>
+      ColumnOrderings($state.table.profilePicture);
+  ColumnOrderings<DateTime> get creationTime =>
+      ColumnOrderings($state.table.creationTime);
 }
 
-typedef $$SharedTodosTableInsertCompanionBuilder = SharedTodosCompanion
+typedef $$SharedTodosTableCreateCompanionBuilder = SharedTodosCompanion
     Function({
   required int todo,
   required int user,
@@ -3887,8 +3766,7 @@ class $$SharedTodosTableTableManager extends RootTableManager<
     SharedTodo,
     $$SharedTodosTableFilterComposer,
     $$SharedTodosTableOrderingComposer,
-    $$SharedTodosTableProcessedTableManager,
-    $$SharedTodosTableInsertCompanionBuilder,
+    $$SharedTodosTableCreateCompanionBuilder,
     $$SharedTodosTableUpdateCompanionBuilder> {
   $$SharedTodosTableTableManager(_$TodoDb db, $SharedTodosTable table)
       : super(TableManagerState(
@@ -3898,9 +3776,7 @@ class $$SharedTodosTableTableManager extends RootTableManager<
               $$SharedTodosTableFilterComposer(ComposerState(db, table)),
           orderingComposer:
               $$SharedTodosTableOrderingComposer(ComposerState(db, table)),
-          getChildManagerBuilder: (p) =>
-              $$SharedTodosTableProcessedTableManager(p),
-          getUpdateCompanionBuilder: ({
+          updateCompanionCallback: ({
             Value<int> todo = const Value.absent(),
             Value<int> user = const Value.absent(),
             Value<int> rowid = const Value.absent(),
@@ -3910,7 +3786,7 @@ class $$SharedTodosTableTableManager extends RootTableManager<
             user: user,
             rowid: rowid,
           ),
-          getInsertCompanionBuilder: ({
+          createCompanionCallback: ({
             required int todo,
             required int user,
             Value<int> rowid = const Value.absent(),
@@ -3923,47 +3799,30 @@ class $$SharedTodosTableTableManager extends RootTableManager<
         ));
 }
 
-class $$SharedTodosTableProcessedTableManager extends ProcessedTableManager<
+typedef $$SharedTodosTableProcessedTableManager = ProcessedTableManager<
     _$TodoDb,
     $SharedTodosTable,
     SharedTodo,
     $$SharedTodosTableFilterComposer,
     $$SharedTodosTableOrderingComposer,
-    $$SharedTodosTableProcessedTableManager,
-    $$SharedTodosTableInsertCompanionBuilder,
-    $$SharedTodosTableUpdateCompanionBuilder> {
-  $$SharedTodosTableProcessedTableManager(super.$state);
-}
+    $$SharedTodosTableCreateCompanionBuilder,
+    $$SharedTodosTableUpdateCompanionBuilder>;
 
 class $$SharedTodosTableFilterComposer
     extends FilterComposer<_$TodoDb, $SharedTodosTable> {
   $$SharedTodosTableFilterComposer(super.$state);
-  ColumnFilters<int> get todo => $state.composableBuilder(
-      column: $state.table.todo,
-      builder: (column, joinBuilders) =>
-          ColumnFilters(column, joinBuilders: joinBuilders));
-
-  ColumnFilters<int> get user => $state.composableBuilder(
-      column: $state.table.user,
-      builder: (column, joinBuilders) =>
-          ColumnFilters(column, joinBuilders: joinBuilders));
+  ColumnFilters<int> get todo => ColumnFilters($state.table.todo);
+  ColumnFilters<int> get user => ColumnFilters($state.table.user);
 }
 
 class $$SharedTodosTableOrderingComposer
     extends OrderingComposer<_$TodoDb, $SharedTodosTable> {
   $$SharedTodosTableOrderingComposer(super.$state);
-  ColumnOrderings<int> get todo => $state.composableBuilder(
-      column: $state.table.todo,
-      builder: (column, joinBuilders) =>
-          ColumnOrderings(column, joinBuilders: joinBuilders));
-
-  ColumnOrderings<int> get user => $state.composableBuilder(
-      column: $state.table.user,
-      builder: (column, joinBuilders) =>
-          ColumnOrderings(column, joinBuilders: joinBuilders));
+  ColumnOrderings<int> get todo => ColumnOrderings($state.table.todo);
+  ColumnOrderings<int> get user => ColumnOrderings($state.table.user);
 }
 
-typedef $$TableWithoutPKTableInsertCompanionBuilder = TableWithoutPKCompanion
+typedef $$TableWithoutPKTableCreateCompanionBuilder = TableWithoutPKCompanion
     Function({
   required int notReallyAnId,
   required double someFloat,
@@ -3986,8 +3845,7 @@ class $$TableWithoutPKTableTableManager extends RootTableManager<
     CustomRowClass,
     $$TableWithoutPKTableFilterComposer,
     $$TableWithoutPKTableOrderingComposer,
-    $$TableWithoutPKTableProcessedTableManager,
-    $$TableWithoutPKTableInsertCompanionBuilder,
+    $$TableWithoutPKTableCreateCompanionBuilder,
     $$TableWithoutPKTableUpdateCompanionBuilder> {
   $$TableWithoutPKTableTableManager(_$TodoDb db, $TableWithoutPKTable table)
       : super(TableManagerState(
@@ -3997,9 +3855,7 @@ class $$TableWithoutPKTableTableManager extends RootTableManager<
               $$TableWithoutPKTableFilterComposer(ComposerState(db, table)),
           orderingComposer:
               $$TableWithoutPKTableOrderingComposer(ComposerState(db, table)),
-          getChildManagerBuilder: (p) =>
-              $$TableWithoutPKTableProcessedTableManager(p),
-          getUpdateCompanionBuilder: ({
+          updateCompanionCallback: ({
             Value<int> notReallyAnId = const Value.absent(),
             Value<double> someFloat = const Value.absent(),
             Value<BigInt?> webSafeInt = const Value.absent(),
@@ -4013,7 +3869,7 @@ class $$TableWithoutPKTableTableManager extends RootTableManager<
             custom: custom,
             rowid: rowid,
           ),
-          getInsertCompanionBuilder: ({
+          createCompanionCallback: ({
             required int notReallyAnId,
             required double someFloat,
             Value<BigInt?> webSafeInt = const Value.absent(),
@@ -4030,69 +3886,40 @@ class $$TableWithoutPKTableTableManager extends RootTableManager<
         ));
 }
 
-class $$TableWithoutPKTableProcessedTableManager extends ProcessedTableManager<
+typedef $$TableWithoutPKTableProcessedTableManager = ProcessedTableManager<
     _$TodoDb,
     $TableWithoutPKTable,
     CustomRowClass,
     $$TableWithoutPKTableFilterComposer,
     $$TableWithoutPKTableOrderingComposer,
-    $$TableWithoutPKTableProcessedTableManager,
-    $$TableWithoutPKTableInsertCompanionBuilder,
-    $$TableWithoutPKTableUpdateCompanionBuilder> {
-  $$TableWithoutPKTableProcessedTableManager(super.$state);
-}
+    $$TableWithoutPKTableCreateCompanionBuilder,
+    $$TableWithoutPKTableUpdateCompanionBuilder>;
 
 class $$TableWithoutPKTableFilterComposer
     extends FilterComposer<_$TodoDb, $TableWithoutPKTable> {
   $$TableWithoutPKTableFilterComposer(super.$state);
-  ColumnFilters<int> get notReallyAnId => $state.composableBuilder(
-      column: $state.table.notReallyAnId,
-      builder: (column, joinBuilders) =>
-          ColumnFilters(column, joinBuilders: joinBuilders));
-
-  ColumnFilters<double> get someFloat => $state.composableBuilder(
-      column: $state.table.someFloat,
-      builder: (column, joinBuilders) =>
-          ColumnFilters(column, joinBuilders: joinBuilders));
-
-  ColumnFilters<BigInt> get webSafeInt => $state.composableBuilder(
-      column: $state.table.webSafeInt,
-      builder: (column, joinBuilders) =>
-          ColumnFilters(column, joinBuilders: joinBuilders));
-
+  ColumnFilters<int> get notReallyAnId =>
+      ColumnFilters($state.table.notReallyAnId);
+  ColumnFilters<double> get someFloat => ColumnFilters($state.table.someFloat);
+  ColumnFilters<BigInt> get webSafeInt =>
+      ColumnFilters($state.table.webSafeInt);
   ColumnWithTypeConverterFilters<MyCustomObject, MyCustomObject, String>
-      get custom => $state.composableBuilder(
-          column: $state.table.custom,
-          builder: (column, joinBuilders) => ColumnWithTypeConverterFilters(
-              column,
-              joinBuilders: joinBuilders));
+      get custom => ColumnWithTypeConverterFilters($state.table.custom);
 }
 
 class $$TableWithoutPKTableOrderingComposer
     extends OrderingComposer<_$TodoDb, $TableWithoutPKTable> {
   $$TableWithoutPKTableOrderingComposer(super.$state);
-  ColumnOrderings<int> get notReallyAnId => $state.composableBuilder(
-      column: $state.table.notReallyAnId,
-      builder: (column, joinBuilders) =>
-          ColumnOrderings(column, joinBuilders: joinBuilders));
-
-  ColumnOrderings<double> get someFloat => $state.composableBuilder(
-      column: $state.table.someFloat,
-      builder: (column, joinBuilders) =>
-          ColumnOrderings(column, joinBuilders: joinBuilders));
-
-  ColumnOrderings<BigInt> get webSafeInt => $state.composableBuilder(
-      column: $state.table.webSafeInt,
-      builder: (column, joinBuilders) =>
-          ColumnOrderings(column, joinBuilders: joinBuilders));
-
-  ColumnOrderings<String> get custom => $state.composableBuilder(
-      column: $state.table.custom,
-      builder: (column, joinBuilders) =>
-          ColumnOrderings(column, joinBuilders: joinBuilders));
+  ColumnOrderings<int> get notReallyAnId =>
+      ColumnOrderings($state.table.notReallyAnId);
+  ColumnOrderings<double> get someFloat =>
+      ColumnOrderings($state.table.someFloat);
+  ColumnOrderings<BigInt> get webSafeInt =>
+      ColumnOrderings($state.table.webSafeInt);
+  ColumnOrderings<String> get custom => ColumnOrderings($state.table.custom);
 }
 
-typedef $$PureDefaultsTableInsertCompanionBuilder = PureDefaultsCompanion
+typedef $$PureDefaultsTableCreateCompanionBuilder = PureDefaultsCompanion
     Function({
   Value<MyCustomObject?> txt,
   Value<int> rowid,
@@ -4109,8 +3936,7 @@ class $$PureDefaultsTableTableManager extends RootTableManager<
     PureDefault,
     $$PureDefaultsTableFilterComposer,
     $$PureDefaultsTableOrderingComposer,
-    $$PureDefaultsTableProcessedTableManager,
-    $$PureDefaultsTableInsertCompanionBuilder,
+    $$PureDefaultsTableCreateCompanionBuilder,
     $$PureDefaultsTableUpdateCompanionBuilder> {
   $$PureDefaultsTableTableManager(_$TodoDb db, $PureDefaultsTable table)
       : super(TableManagerState(
@@ -4120,9 +3946,7 @@ class $$PureDefaultsTableTableManager extends RootTableManager<
               $$PureDefaultsTableFilterComposer(ComposerState(db, table)),
           orderingComposer:
               $$PureDefaultsTableOrderingComposer(ComposerState(db, table)),
-          getChildManagerBuilder: (p) =>
-              $$PureDefaultsTableProcessedTableManager(p),
-          getUpdateCompanionBuilder: ({
+          updateCompanionCallback: ({
             Value<MyCustomObject?> txt = const Value.absent(),
             Value<int> rowid = const Value.absent(),
           }) =>
@@ -4130,7 +3954,7 @@ class $$PureDefaultsTableTableManager extends RootTableManager<
             txt: txt,
             rowid: rowid,
           ),
-          getInsertCompanionBuilder: ({
+          createCompanionCallback: ({
             Value<MyCustomObject?> txt = const Value.absent(),
             Value<int> rowid = const Value.absent(),
           }) =>
@@ -4141,39 +3965,29 @@ class $$PureDefaultsTableTableManager extends RootTableManager<
         ));
 }
 
-class $$PureDefaultsTableProcessedTableManager extends ProcessedTableManager<
+typedef $$PureDefaultsTableProcessedTableManager = ProcessedTableManager<
     _$TodoDb,
     $PureDefaultsTable,
     PureDefault,
     $$PureDefaultsTableFilterComposer,
     $$PureDefaultsTableOrderingComposer,
-    $$PureDefaultsTableProcessedTableManager,
-    $$PureDefaultsTableInsertCompanionBuilder,
-    $$PureDefaultsTableUpdateCompanionBuilder> {
-  $$PureDefaultsTableProcessedTableManager(super.$state);
-}
+    $$PureDefaultsTableCreateCompanionBuilder,
+    $$PureDefaultsTableUpdateCompanionBuilder>;
 
 class $$PureDefaultsTableFilterComposer
     extends FilterComposer<_$TodoDb, $PureDefaultsTable> {
   $$PureDefaultsTableFilterComposer(super.$state);
   ColumnWithTypeConverterFilters<MyCustomObject?, MyCustomObject, String>
-      get txt => $state.composableBuilder(
-          column: $state.table.txt,
-          builder: (column, joinBuilders) => ColumnWithTypeConverterFilters(
-              column,
-              joinBuilders: joinBuilders));
+      get txt => ColumnWithTypeConverterFilters($state.table.txt);
 }
 
 class $$PureDefaultsTableOrderingComposer
     extends OrderingComposer<_$TodoDb, $PureDefaultsTable> {
   $$PureDefaultsTableOrderingComposer(super.$state);
-  ColumnOrderings<String> get txt => $state.composableBuilder(
-      column: $state.table.txt,
-      builder: (column, joinBuilders) =>
-          ColumnOrderings(column, joinBuilders: joinBuilders));
+  ColumnOrderings<String> get txt => ColumnOrderings($state.table.txt);
 }
 
-typedef $$WithCustomTypeTableInsertCompanionBuilder = WithCustomTypeCompanion
+typedef $$WithCustomTypeTableCreateCompanionBuilder = WithCustomTypeCompanion
     Function({
   required UuidValue id,
   Value<int> rowid,
@@ -4190,8 +4004,7 @@ class $$WithCustomTypeTableTableManager extends RootTableManager<
     WithCustomTypeData,
     $$WithCustomTypeTableFilterComposer,
     $$WithCustomTypeTableOrderingComposer,
-    $$WithCustomTypeTableProcessedTableManager,
-    $$WithCustomTypeTableInsertCompanionBuilder,
+    $$WithCustomTypeTableCreateCompanionBuilder,
     $$WithCustomTypeTableUpdateCompanionBuilder> {
   $$WithCustomTypeTableTableManager(_$TodoDb db, $WithCustomTypeTable table)
       : super(TableManagerState(
@@ -4201,9 +4014,7 @@ class $$WithCustomTypeTableTableManager extends RootTableManager<
               $$WithCustomTypeTableFilterComposer(ComposerState(db, table)),
           orderingComposer:
               $$WithCustomTypeTableOrderingComposer(ComposerState(db, table)),
-          getChildManagerBuilder: (p) =>
-              $$WithCustomTypeTableProcessedTableManager(p),
-          getUpdateCompanionBuilder: ({
+          updateCompanionCallback: ({
             Value<UuidValue> id = const Value.absent(),
             Value<int> rowid = const Value.absent(),
           }) =>
@@ -4211,7 +4022,7 @@ class $$WithCustomTypeTableTableManager extends RootTableManager<
             id: id,
             rowid: rowid,
           ),
-          getInsertCompanionBuilder: ({
+          createCompanionCallback: ({
             required UuidValue id,
             Value<int> rowid = const Value.absent(),
           }) =>
@@ -4222,37 +4033,28 @@ class $$WithCustomTypeTableTableManager extends RootTableManager<
         ));
 }
 
-class $$WithCustomTypeTableProcessedTableManager extends ProcessedTableManager<
+typedef $$WithCustomTypeTableProcessedTableManager = ProcessedTableManager<
     _$TodoDb,
     $WithCustomTypeTable,
     WithCustomTypeData,
     $$WithCustomTypeTableFilterComposer,
     $$WithCustomTypeTableOrderingComposer,
-    $$WithCustomTypeTableProcessedTableManager,
-    $$WithCustomTypeTableInsertCompanionBuilder,
-    $$WithCustomTypeTableUpdateCompanionBuilder> {
-  $$WithCustomTypeTableProcessedTableManager(super.$state);
-}
+    $$WithCustomTypeTableCreateCompanionBuilder,
+    $$WithCustomTypeTableUpdateCompanionBuilder>;
 
 class $$WithCustomTypeTableFilterComposer
     extends FilterComposer<_$TodoDb, $WithCustomTypeTable> {
   $$WithCustomTypeTableFilterComposer(super.$state);
-  ColumnFilters<UuidValue> get id => $state.composableBuilder(
-      column: $state.table.id,
-      builder: (column, joinBuilders) =>
-          ColumnFilters(column, joinBuilders: joinBuilders));
+  ColumnFilters<UuidValue> get id => ColumnFilters($state.table.id);
 }
 
 class $$WithCustomTypeTableOrderingComposer
     extends OrderingComposer<_$TodoDb, $WithCustomTypeTable> {
   $$WithCustomTypeTableOrderingComposer(super.$state);
-  ColumnOrderings<UuidValue> get id => $state.composableBuilder(
-      column: $state.table.id,
-      builder: (column, joinBuilders) =>
-          ColumnOrderings(column, joinBuilders: joinBuilders));
+  ColumnOrderings<UuidValue> get id => ColumnOrderings($state.table.id);
 }
 
-typedef $$TableWithEveryColumnTypeTableInsertCompanionBuilder
+typedef $$TableWithEveryColumnTypeTableCreateCompanionBuilder
     = TableWithEveryColumnTypeCompanion Function({
   Value<RowId> id,
   Value<bool?> aBool,
@@ -4285,8 +4087,7 @@ class $$TableWithEveryColumnTypeTableTableManager extends RootTableManager<
     TableWithEveryColumnTypeData,
     $$TableWithEveryColumnTypeTableFilterComposer,
     $$TableWithEveryColumnTypeTableOrderingComposer,
-    $$TableWithEveryColumnTypeTableProcessedTableManager,
-    $$TableWithEveryColumnTypeTableInsertCompanionBuilder,
+    $$TableWithEveryColumnTypeTableCreateCompanionBuilder,
     $$TableWithEveryColumnTypeTableUpdateCompanionBuilder> {
   $$TableWithEveryColumnTypeTableTableManager(
       _$TodoDb db, $TableWithEveryColumnTypeTable table)
@@ -4297,9 +4098,7 @@ class $$TableWithEveryColumnTypeTableTableManager extends RootTableManager<
               ComposerState(db, table)),
           orderingComposer: $$TableWithEveryColumnTypeTableOrderingComposer(
               ComposerState(db, table)),
-          getChildManagerBuilder: (p) =>
-              $$TableWithEveryColumnTypeTableProcessedTableManager(p),
-          getUpdateCompanionBuilder: ({
+          updateCompanionCallback: ({
             Value<RowId> id = const Value.absent(),
             Value<bool?> aBool = const Value.absent(),
             Value<DateTime?> aDateTime = const Value.absent(),
@@ -4323,7 +4122,7 @@ class $$TableWithEveryColumnTypeTableTableManager extends RootTableManager<
             anIntEnum: anIntEnum,
             aTextWithConverter: aTextWithConverter,
           ),
-          getInsertCompanionBuilder: ({
+          createCompanionCallback: ({
             Value<RowId> id = const Value.absent(),
             Value<bool?> aBool = const Value.absent(),
             Value<DateTime?> aDateTime = const Value.absent(),
@@ -4350,134 +4149,54 @@ class $$TableWithEveryColumnTypeTableTableManager extends RootTableManager<
         ));
 }
 
-class $$TableWithEveryColumnTypeTableProcessedTableManager
-    extends ProcessedTableManager<
+typedef $$TableWithEveryColumnTypeTableProcessedTableManager
+    = ProcessedTableManager<
         _$TodoDb,
         $TableWithEveryColumnTypeTable,
         TableWithEveryColumnTypeData,
         $$TableWithEveryColumnTypeTableFilterComposer,
         $$TableWithEveryColumnTypeTableOrderingComposer,
-        $$TableWithEveryColumnTypeTableProcessedTableManager,
-        $$TableWithEveryColumnTypeTableInsertCompanionBuilder,
-        $$TableWithEveryColumnTypeTableUpdateCompanionBuilder> {
-  $$TableWithEveryColumnTypeTableProcessedTableManager(super.$state);
-}
+        $$TableWithEveryColumnTypeTableCreateCompanionBuilder,
+        $$TableWithEveryColumnTypeTableUpdateCompanionBuilder>;
 
 class $$TableWithEveryColumnTypeTableFilterComposer
     extends FilterComposer<_$TodoDb, $TableWithEveryColumnTypeTable> {
   $$TableWithEveryColumnTypeTableFilterComposer(super.$state);
   ColumnWithTypeConverterFilters<RowId, RowId, int> get id =>
-      $state.composableBuilder(
-          column: $state.table.id,
-          builder: (column, joinBuilders) => ColumnWithTypeConverterFilters(
-              column,
-              joinBuilders: joinBuilders));
-
-  ColumnFilters<bool> get aBool => $state.composableBuilder(
-      column: $state.table.aBool,
-      builder: (column, joinBuilders) =>
-          ColumnFilters(column, joinBuilders: joinBuilders));
-
-  ColumnFilters<DateTime> get aDateTime => $state.composableBuilder(
-      column: $state.table.aDateTime,
-      builder: (column, joinBuilders) =>
-          ColumnFilters(column, joinBuilders: joinBuilders));
-
-  ColumnFilters<String> get aText => $state.composableBuilder(
-      column: $state.table.aText,
-      builder: (column, joinBuilders) =>
-          ColumnFilters(column, joinBuilders: joinBuilders));
-
-  ColumnFilters<int> get anInt => $state.composableBuilder(
-      column: $state.table.anInt,
-      builder: (column, joinBuilders) =>
-          ColumnFilters(column, joinBuilders: joinBuilders));
-
-  ColumnFilters<BigInt> get anInt64 => $state.composableBuilder(
-      column: $state.table.anInt64,
-      builder: (column, joinBuilders) =>
-          ColumnFilters(column, joinBuilders: joinBuilders));
-
-  ColumnFilters<double> get aReal => $state.composableBuilder(
-      column: $state.table.aReal,
-      builder: (column, joinBuilders) =>
-          ColumnFilters(column, joinBuilders: joinBuilders));
-
-  ColumnFilters<Uint8List> get aBlob => $state.composableBuilder(
-      column: $state.table.aBlob,
-      builder: (column, joinBuilders) =>
-          ColumnFilters(column, joinBuilders: joinBuilders));
-
+      ColumnWithTypeConverterFilters($state.table.id);
+  ColumnFilters<bool> get aBool => ColumnFilters($state.table.aBool);
+  ColumnFilters<DateTime> get aDateTime =>
+      ColumnFilters($state.table.aDateTime);
+  ColumnFilters<String> get aText => ColumnFilters($state.table.aText);
+  ColumnFilters<int> get anInt => ColumnFilters($state.table.anInt);
+  ColumnFilters<BigInt> get anInt64 => ColumnFilters($state.table.anInt64);
+  ColumnFilters<double> get aReal => ColumnFilters($state.table.aReal);
+  ColumnFilters<Uint8List> get aBlob => ColumnFilters($state.table.aBlob);
   ColumnWithTypeConverterFilters<TodoStatus?, TodoStatus, int> get anIntEnum =>
-      $state.composableBuilder(
-          column: $state.table.anIntEnum,
-          builder: (column, joinBuilders) => ColumnWithTypeConverterFilters(
-              column,
-              joinBuilders: joinBuilders));
-
+      ColumnWithTypeConverterFilters($state.table.anIntEnum);
   ColumnWithTypeConverterFilters<MyCustomObject?, MyCustomObject, String>
-      get aTextWithConverter => $state.composableBuilder(
-          column: $state.table.aTextWithConverter,
-          builder: (column, joinBuilders) => ColumnWithTypeConverterFilters(
-              column,
-              joinBuilders: joinBuilders));
+      get aTextWithConverter =>
+          ColumnWithTypeConverterFilters($state.table.aTextWithConverter);
 }
 
 class $$TableWithEveryColumnTypeTableOrderingComposer
     extends OrderingComposer<_$TodoDb, $TableWithEveryColumnTypeTable> {
   $$TableWithEveryColumnTypeTableOrderingComposer(super.$state);
-  ColumnOrderings<int> get id => $state.composableBuilder(
-      column: $state.table.id,
-      builder: (column, joinBuilders) =>
-          ColumnOrderings(column, joinBuilders: joinBuilders));
-
-  ColumnOrderings<bool> get aBool => $state.composableBuilder(
-      column: $state.table.aBool,
-      builder: (column, joinBuilders) =>
-          ColumnOrderings(column, joinBuilders: joinBuilders));
-
-  ColumnOrderings<DateTime> get aDateTime => $state.composableBuilder(
-      column: $state.table.aDateTime,
-      builder: (column, joinBuilders) =>
-          ColumnOrderings(column, joinBuilders: joinBuilders));
-
-  ColumnOrderings<String> get aText => $state.composableBuilder(
-      column: $state.table.aText,
-      builder: (column, joinBuilders) =>
-          ColumnOrderings(column, joinBuilders: joinBuilders));
-
-  ColumnOrderings<int> get anInt => $state.composableBuilder(
-      column: $state.table.anInt,
-      builder: (column, joinBuilders) =>
-          ColumnOrderings(column, joinBuilders: joinBuilders));
-
-  ColumnOrderings<BigInt> get anInt64 => $state.composableBuilder(
-      column: $state.table.anInt64,
-      builder: (column, joinBuilders) =>
-          ColumnOrderings(column, joinBuilders: joinBuilders));
-
-  ColumnOrderings<double> get aReal => $state.composableBuilder(
-      column: $state.table.aReal,
-      builder: (column, joinBuilders) =>
-          ColumnOrderings(column, joinBuilders: joinBuilders));
-
-  ColumnOrderings<Uint8List> get aBlob => $state.composableBuilder(
-      column: $state.table.aBlob,
-      builder: (column, joinBuilders) =>
-          ColumnOrderings(column, joinBuilders: joinBuilders));
-
-  ColumnOrderings<int> get anIntEnum => $state.composableBuilder(
-      column: $state.table.anIntEnum,
-      builder: (column, joinBuilders) =>
-          ColumnOrderings(column, joinBuilders: joinBuilders));
-
-  ColumnOrderings<String> get aTextWithConverter => $state.composableBuilder(
-      column: $state.table.aTextWithConverter,
-      builder: (column, joinBuilders) =>
-          ColumnOrderings(column, joinBuilders: joinBuilders));
+  ColumnOrderings<int> get id => ColumnOrderings($state.table.id);
+  ColumnOrderings<bool> get aBool => ColumnOrderings($state.table.aBool);
+  ColumnOrderings<DateTime> get aDateTime =>
+      ColumnOrderings($state.table.aDateTime);
+  ColumnOrderings<String> get aText => ColumnOrderings($state.table.aText);
+  ColumnOrderings<int> get anInt => ColumnOrderings($state.table.anInt);
+  ColumnOrderings<BigInt> get anInt64 => ColumnOrderings($state.table.anInt64);
+  ColumnOrderings<double> get aReal => ColumnOrderings($state.table.aReal);
+  ColumnOrderings<Uint8List> get aBlob => ColumnOrderings($state.table.aBlob);
+  ColumnOrderings<int> get anIntEnum => ColumnOrderings($state.table.anIntEnum);
+  ColumnOrderings<String> get aTextWithConverter =>
+      ColumnOrderings($state.table.aTextWithConverter);
 }
 
-typedef $$DepartmentTableInsertCompanionBuilder = DepartmentCompanion Function({
+typedef $$DepartmentTableCreateCompanionBuilder = DepartmentCompanion Function({
   Value<int> id,
   Value<String?> name,
 });
@@ -4492,8 +4211,7 @@ class $$DepartmentTableTableManager extends RootTableManager<
     DepartmentData,
     $$DepartmentTableFilterComposer,
     $$DepartmentTableOrderingComposer,
-    $$DepartmentTableProcessedTableManager,
-    $$DepartmentTableInsertCompanionBuilder,
+    $$DepartmentTableCreateCompanionBuilder,
     $$DepartmentTableUpdateCompanionBuilder> {
   $$DepartmentTableTableManager(_$TodoDb db, $DepartmentTable table)
       : super(TableManagerState(
@@ -4503,9 +4221,7 @@ class $$DepartmentTableTableManager extends RootTableManager<
               $$DepartmentTableFilterComposer(ComposerState(db, table)),
           orderingComposer:
               $$DepartmentTableOrderingComposer(ComposerState(db, table)),
-          getChildManagerBuilder: (p) =>
-              $$DepartmentTableProcessedTableManager(p),
-          getUpdateCompanionBuilder: ({
+          updateCompanionCallback: ({
             Value<int> id = const Value.absent(),
             Value<String?> name = const Value.absent(),
           }) =>
@@ -4513,7 +4229,7 @@ class $$DepartmentTableTableManager extends RootTableManager<
             id: id,
             name: name,
           ),
-          getInsertCompanionBuilder: ({
+          createCompanionCallback: ({
             Value<int> id = const Value.absent(),
             Value<String?> name = const Value.absent(),
           }) =>
@@ -4524,31 +4240,20 @@ class $$DepartmentTableTableManager extends RootTableManager<
         ));
 }
 
-class $$DepartmentTableProcessedTableManager extends ProcessedTableManager<
+typedef $$DepartmentTableProcessedTableManager = ProcessedTableManager<
     _$TodoDb,
     $DepartmentTable,
     DepartmentData,
     $$DepartmentTableFilterComposer,
     $$DepartmentTableOrderingComposer,
-    $$DepartmentTableProcessedTableManager,
-    $$DepartmentTableInsertCompanionBuilder,
-    $$DepartmentTableUpdateCompanionBuilder> {
-  $$DepartmentTableProcessedTableManager(super.$state);
-}
+    $$DepartmentTableCreateCompanionBuilder,
+    $$DepartmentTableUpdateCompanionBuilder>;
 
 class $$DepartmentTableFilterComposer
     extends FilterComposer<_$TodoDb, $DepartmentTable> {
   $$DepartmentTableFilterComposer(super.$state);
-  ColumnFilters<int> get id => $state.composableBuilder(
-      column: $state.table.id,
-      builder: (column, joinBuilders) =>
-          ColumnFilters(column, joinBuilders: joinBuilders));
-
-  ColumnFilters<String> get name => $state.composableBuilder(
-      column: $state.table.name,
-      builder: (column, joinBuilders) =>
-          ColumnFilters(column, joinBuilders: joinBuilders));
-
+  ColumnFilters<int> get id => ColumnFilters($state.table.id);
+  ColumnFilters<String> get name => ColumnFilters($state.table.name);
   ComposableFilter productRefs(
       ComposableFilter Function($$ProductTableFilterComposer f) f) {
     final $$ProductTableFilterComposer composer = $state.composerBuilder(
@@ -4566,18 +4271,11 @@ class $$DepartmentTableFilterComposer
 class $$DepartmentTableOrderingComposer
     extends OrderingComposer<_$TodoDb, $DepartmentTable> {
   $$DepartmentTableOrderingComposer(super.$state);
-  ColumnOrderings<int> get id => $state.composableBuilder(
-      column: $state.table.id,
-      builder: (column, joinBuilders) =>
-          ColumnOrderings(column, joinBuilders: joinBuilders));
-
-  ColumnOrderings<String> get name => $state.composableBuilder(
-      column: $state.table.name,
-      builder: (column, joinBuilders) =>
-          ColumnOrderings(column, joinBuilders: joinBuilders));
+  ColumnOrderings<int> get id => ColumnOrderings($state.table.id);
+  ColumnOrderings<String> get name => ColumnOrderings($state.table.name);
 }
 
-typedef $$ProductTableInsertCompanionBuilder = ProductCompanion Function({
+typedef $$ProductTableCreateCompanionBuilder = ProductCompanion Function({
   Value<int> id,
   Value<String?> name,
   Value<int?> department,
@@ -4594,8 +4292,7 @@ class $$ProductTableTableManager extends RootTableManager<
     ProductData,
     $$ProductTableFilterComposer,
     $$ProductTableOrderingComposer,
-    $$ProductTableProcessedTableManager,
-    $$ProductTableInsertCompanionBuilder,
+    $$ProductTableCreateCompanionBuilder,
     $$ProductTableUpdateCompanionBuilder> {
   $$ProductTableTableManager(_$TodoDb db, $ProductTable table)
       : super(TableManagerState(
@@ -4605,8 +4302,7 @@ class $$ProductTableTableManager extends RootTableManager<
               $$ProductTableFilterComposer(ComposerState(db, table)),
           orderingComposer:
               $$ProductTableOrderingComposer(ComposerState(db, table)),
-          getChildManagerBuilder: (p) => $$ProductTableProcessedTableManager(p),
-          getUpdateCompanionBuilder: ({
+          updateCompanionCallback: ({
             Value<int> id = const Value.absent(),
             Value<String?> name = const Value.absent(),
             Value<int?> department = const Value.absent(),
@@ -4616,7 +4312,7 @@ class $$ProductTableTableManager extends RootTableManager<
             name: name,
             department: department,
           ),
-          getInsertCompanionBuilder: ({
+          createCompanionCallback: ({
             Value<int> id = const Value.absent(),
             Value<String?> name = const Value.absent(),
             Value<int?> department = const Value.absent(),
@@ -4629,31 +4325,20 @@ class $$ProductTableTableManager extends RootTableManager<
         ));
 }
 
-class $$ProductTableProcessedTableManager extends ProcessedTableManager<
+typedef $$ProductTableProcessedTableManager = ProcessedTableManager<
     _$TodoDb,
     $ProductTable,
     ProductData,
     $$ProductTableFilterComposer,
     $$ProductTableOrderingComposer,
-    $$ProductTableProcessedTableManager,
-    $$ProductTableInsertCompanionBuilder,
-    $$ProductTableUpdateCompanionBuilder> {
-  $$ProductTableProcessedTableManager(super.$state);
-}
+    $$ProductTableCreateCompanionBuilder,
+    $$ProductTableUpdateCompanionBuilder>;
 
 class $$ProductTableFilterComposer
     extends FilterComposer<_$TodoDb, $ProductTable> {
   $$ProductTableFilterComposer(super.$state);
-  ColumnFilters<int> get id => $state.composableBuilder(
-      column: $state.table.id,
-      builder: (column, joinBuilders) =>
-          ColumnFilters(column, joinBuilders: joinBuilders));
-
-  ColumnFilters<String> get name => $state.composableBuilder(
-      column: $state.table.name,
-      builder: (column, joinBuilders) =>
-          ColumnFilters(column, joinBuilders: joinBuilders));
-
+  ColumnFilters<int> get id => ColumnFilters($state.table.id);
+  ColumnFilters<String> get name => ColumnFilters($state.table.name);
   $$DepartmentTableFilterComposer get department {
     final $$DepartmentTableFilterComposer composer = $state.composerBuilder(
         composer: this,
@@ -4683,16 +4368,8 @@ class $$ProductTableFilterComposer
 class $$ProductTableOrderingComposer
     extends OrderingComposer<_$TodoDb, $ProductTable> {
   $$ProductTableOrderingComposer(super.$state);
-  ColumnOrderings<int> get id => $state.composableBuilder(
-      column: $state.table.id,
-      builder: (column, joinBuilders) =>
-          ColumnOrderings(column, joinBuilders: joinBuilders));
-
-  ColumnOrderings<String> get name => $state.composableBuilder(
-      column: $state.table.name,
-      builder: (column, joinBuilders) =>
-          ColumnOrderings(column, joinBuilders: joinBuilders));
-
+  ColumnOrderings<int> get id => ColumnOrderings($state.table.id);
+  ColumnOrderings<String> get name => ColumnOrderings($state.table.name);
   $$DepartmentTableOrderingComposer get department {
     final $$DepartmentTableOrderingComposer composer = $state.composerBuilder(
         composer: this,
@@ -4706,7 +4383,7 @@ class $$ProductTableOrderingComposer
   }
 }
 
-typedef $$StoreTableInsertCompanionBuilder = StoreCompanion Function({
+typedef $$StoreTableCreateCompanionBuilder = StoreCompanion Function({
   Value<int> id,
   Value<String?> name,
 });
@@ -4721,8 +4398,7 @@ class $$StoreTableTableManager extends RootTableManager<
     StoreData,
     $$StoreTableFilterComposer,
     $$StoreTableOrderingComposer,
-    $$StoreTableProcessedTableManager,
-    $$StoreTableInsertCompanionBuilder,
+    $$StoreTableCreateCompanionBuilder,
     $$StoreTableUpdateCompanionBuilder> {
   $$StoreTableTableManager(_$TodoDb db, $StoreTable table)
       : super(TableManagerState(
@@ -4732,8 +4408,7 @@ class $$StoreTableTableManager extends RootTableManager<
               $$StoreTableFilterComposer(ComposerState(db, table)),
           orderingComposer:
               $$StoreTableOrderingComposer(ComposerState(db, table)),
-          getChildManagerBuilder: (p) => $$StoreTableProcessedTableManager(p),
-          getUpdateCompanionBuilder: ({
+          updateCompanionCallback: ({
             Value<int> id = const Value.absent(),
             Value<String?> name = const Value.absent(),
           }) =>
@@ -4741,7 +4416,7 @@ class $$StoreTableTableManager extends RootTableManager<
             id: id,
             name: name,
           ),
-          getInsertCompanionBuilder: ({
+          createCompanionCallback: ({
             Value<int> id = const Value.absent(),
             Value<String?> name = const Value.absent(),
           }) =>
@@ -4752,30 +4427,19 @@ class $$StoreTableTableManager extends RootTableManager<
         ));
 }
 
-class $$StoreTableProcessedTableManager extends ProcessedTableManager<
+typedef $$StoreTableProcessedTableManager = ProcessedTableManager<
     _$TodoDb,
     $StoreTable,
     StoreData,
     $$StoreTableFilterComposer,
     $$StoreTableOrderingComposer,
-    $$StoreTableProcessedTableManager,
-    $$StoreTableInsertCompanionBuilder,
-    $$StoreTableUpdateCompanionBuilder> {
-  $$StoreTableProcessedTableManager(super.$state);
-}
+    $$StoreTableCreateCompanionBuilder,
+    $$StoreTableUpdateCompanionBuilder>;
 
 class $$StoreTableFilterComposer extends FilterComposer<_$TodoDb, $StoreTable> {
   $$StoreTableFilterComposer(super.$state);
-  ColumnFilters<int> get id => $state.composableBuilder(
-      column: $state.table.id,
-      builder: (column, joinBuilders) =>
-          ColumnFilters(column, joinBuilders: joinBuilders));
-
-  ColumnFilters<String> get name => $state.composableBuilder(
-      column: $state.table.name,
-      builder: (column, joinBuilders) =>
-          ColumnFilters(column, joinBuilders: joinBuilders));
-
+  ColumnFilters<int> get id => ColumnFilters($state.table.id);
+  ColumnFilters<String> get name => ColumnFilters($state.table.name);
   ComposableFilter listings(
       ComposableFilter Function($$ListingTableFilterComposer f) f) {
     final $$ListingTableFilterComposer composer = $state.composerBuilder(
@@ -4793,18 +4457,11 @@ class $$StoreTableFilterComposer extends FilterComposer<_$TodoDb, $StoreTable> {
 class $$StoreTableOrderingComposer
     extends OrderingComposer<_$TodoDb, $StoreTable> {
   $$StoreTableOrderingComposer(super.$state);
-  ColumnOrderings<int> get id => $state.composableBuilder(
-      column: $state.table.id,
-      builder: (column, joinBuilders) =>
-          ColumnOrderings(column, joinBuilders: joinBuilders));
-
-  ColumnOrderings<String> get name => $state.composableBuilder(
-      column: $state.table.name,
-      builder: (column, joinBuilders) =>
-          ColumnOrderings(column, joinBuilders: joinBuilders));
+  ColumnOrderings<int> get id => ColumnOrderings($state.table.id);
+  ColumnOrderings<String> get name => ColumnOrderings($state.table.name);
 }
 
-typedef $$ListingTableInsertCompanionBuilder = ListingCompanion Function({
+typedef $$ListingTableCreateCompanionBuilder = ListingCompanion Function({
   Value<int> id,
   Value<int?> product,
   Value<int?> store,
@@ -4823,8 +4480,7 @@ class $$ListingTableTableManager extends RootTableManager<
     ListingData,
     $$ListingTableFilterComposer,
     $$ListingTableOrderingComposer,
-    $$ListingTableProcessedTableManager,
-    $$ListingTableInsertCompanionBuilder,
+    $$ListingTableCreateCompanionBuilder,
     $$ListingTableUpdateCompanionBuilder> {
   $$ListingTableTableManager(_$TodoDb db, $ListingTable table)
       : super(TableManagerState(
@@ -4834,8 +4490,7 @@ class $$ListingTableTableManager extends RootTableManager<
               $$ListingTableFilterComposer(ComposerState(db, table)),
           orderingComposer:
               $$ListingTableOrderingComposer(ComposerState(db, table)),
-          getChildManagerBuilder: (p) => $$ListingTableProcessedTableManager(p),
-          getUpdateCompanionBuilder: ({
+          updateCompanionCallback: ({
             Value<int> id = const Value.absent(),
             Value<int?> product = const Value.absent(),
             Value<int?> store = const Value.absent(),
@@ -4847,7 +4502,7 @@ class $$ListingTableTableManager extends RootTableManager<
             store: store,
             price: price,
           ),
-          getInsertCompanionBuilder: ({
+          createCompanionCallback: ({
             Value<int> id = const Value.absent(),
             Value<int?> product = const Value.absent(),
             Value<int?> store = const Value.absent(),
@@ -4862,31 +4517,20 @@ class $$ListingTableTableManager extends RootTableManager<
         ));
 }
 
-class $$ListingTableProcessedTableManager extends ProcessedTableManager<
+typedef $$ListingTableProcessedTableManager = ProcessedTableManager<
     _$TodoDb,
     $ListingTable,
     ListingData,
     $$ListingTableFilterComposer,
     $$ListingTableOrderingComposer,
-    $$ListingTableProcessedTableManager,
-    $$ListingTableInsertCompanionBuilder,
-    $$ListingTableUpdateCompanionBuilder> {
-  $$ListingTableProcessedTableManager(super.$state);
-}
+    $$ListingTableCreateCompanionBuilder,
+    $$ListingTableUpdateCompanionBuilder>;
 
 class $$ListingTableFilterComposer
     extends FilterComposer<_$TodoDb, $ListingTable> {
   $$ListingTableFilterComposer(super.$state);
-  ColumnFilters<int> get id => $state.composableBuilder(
-      column: $state.table.id,
-      builder: (column, joinBuilders) =>
-          ColumnFilters(column, joinBuilders: joinBuilders));
-
-  ColumnFilters<double> get price => $state.composableBuilder(
-      column: $state.table.price,
-      builder: (column, joinBuilders) =>
-          ColumnFilters(column, joinBuilders: joinBuilders));
-
+  ColumnFilters<int> get id => ColumnFilters($state.table.id);
+  ColumnFilters<double> get price => ColumnFilters($state.table.price);
   $$ProductTableFilterComposer get product {
     final $$ProductTableFilterComposer composer = $state.composerBuilder(
         composer: this,
@@ -4915,16 +4559,8 @@ class $$ListingTableFilterComposer
 class $$ListingTableOrderingComposer
     extends OrderingComposer<_$TodoDb, $ListingTable> {
   $$ListingTableOrderingComposer(super.$state);
-  ColumnOrderings<int> get id => $state.composableBuilder(
-      column: $state.table.id,
-      builder: (column, joinBuilders) =>
-          ColumnOrderings(column, joinBuilders: joinBuilders));
-
-  ColumnOrderings<double> get price => $state.composableBuilder(
-      column: $state.table.price,
-      builder: (column, joinBuilders) =>
-          ColumnOrderings(column, joinBuilders: joinBuilders));
-
+  ColumnOrderings<int> get id => ColumnOrderings($state.table.id);
+  ColumnOrderings<double> get price => ColumnOrderings($state.table.price);
   $$ProductTableOrderingComposer get product {
     final $$ProductTableOrderingComposer composer = $state.composerBuilder(
         composer: this,

--- a/drift/test/generated/todos.g.dart
+++ b/drift/test/generated/todos.g.dart
@@ -3496,13 +3496,29 @@ class $$CategoriesTableFilterComposer
     extends FilterComposer<_$TodoDb, $CategoriesTable> {
   $$CategoriesTableFilterComposer(super.$state);
   ColumnWithTypeConverterFilters<RowId, RowId, int> get id =>
-      ColumnWithTypeConverterFilters($state.table.id);
-  ColumnFilters<String> get description =>
-      ColumnFilters($state.table.description);
+      $state.composableBuilder(
+          column: $state.table.id,
+          builder: (column, joinBuilders) => ColumnWithTypeConverterFilters(
+              column,
+              joinBuilders: joinBuilders));
+
+  ColumnFilters<String> get description => $state.composableBuilder(
+      column: $state.table.description,
+      builder: (column, joinBuilders) =>
+          ColumnFilters(column, joinBuilders: joinBuilders));
+
   ColumnWithTypeConverterFilters<CategoryPriority, CategoryPriority, int>
-      get priority => ColumnWithTypeConverterFilters($state.table.priority);
-  ColumnFilters<String> get descriptionInUpperCase =>
-      ColumnFilters($state.table.descriptionInUpperCase);
+      get priority => $state.composableBuilder(
+          column: $state.table.priority,
+          builder: (column, joinBuilders) => ColumnWithTypeConverterFilters(
+              column,
+              joinBuilders: joinBuilders));
+
+  ColumnFilters<String> get descriptionInUpperCase => $state.composableBuilder(
+      column: $state.table.descriptionInUpperCase,
+      builder: (column, joinBuilders) =>
+          ColumnFilters(column, joinBuilders: joinBuilders));
+
   ComposableFilter todos(
       ComposableFilter Function($$TodosTableTableFilterComposer f) f) {
     final $$TodosTableTableFilterComposer composer = $state.composerBuilder(
@@ -3520,12 +3536,26 @@ class $$CategoriesTableFilterComposer
 class $$CategoriesTableOrderingComposer
     extends OrderingComposer<_$TodoDb, $CategoriesTable> {
   $$CategoriesTableOrderingComposer(super.$state);
-  ColumnOrderings<int> get id => ColumnOrderings($state.table.id);
-  ColumnOrderings<String> get description =>
-      ColumnOrderings($state.table.description);
-  ColumnOrderings<int> get priority => ColumnOrderings($state.table.priority);
+  ColumnOrderings<int> get id => $state.composableBuilder(
+      column: $state.table.id,
+      builder: (column, joinBuilders) =>
+          ColumnOrderings(column, joinBuilders: joinBuilders));
+
+  ColumnOrderings<String> get description => $state.composableBuilder(
+      column: $state.table.description,
+      builder: (column, joinBuilders) =>
+          ColumnOrderings(column, joinBuilders: joinBuilders));
+
+  ColumnOrderings<int> get priority => $state.composableBuilder(
+      column: $state.table.priority,
+      builder: (column, joinBuilders) =>
+          ColumnOrderings(column, joinBuilders: joinBuilders));
+
   ColumnOrderings<String> get descriptionInUpperCase =>
-      ColumnOrderings($state.table.descriptionInUpperCase);
+      $state.composableBuilder(
+          column: $state.table.descriptionInUpperCase,
+          builder: (column, joinBuilders) =>
+              ColumnOrderings(column, joinBuilders: joinBuilders));
 }
 
 typedef $$TodosTableTableCreateCompanionBuilder = TodosTableCompanion Function({
@@ -3609,13 +3639,34 @@ class $$TodosTableTableFilterComposer
     extends FilterComposer<_$TodoDb, $TodosTableTable> {
   $$TodosTableTableFilterComposer(super.$state);
   ColumnWithTypeConverterFilters<RowId, RowId, int> get id =>
-      ColumnWithTypeConverterFilters($state.table.id);
-  ColumnFilters<String> get title => ColumnFilters($state.table.title);
-  ColumnFilters<String> get content => ColumnFilters($state.table.content);
-  ColumnFilters<DateTime> get targetDate =>
-      ColumnFilters($state.table.targetDate);
+      $state.composableBuilder(
+          column: $state.table.id,
+          builder: (column, joinBuilders) => ColumnWithTypeConverterFilters(
+              column,
+              joinBuilders: joinBuilders));
+
+  ColumnFilters<String> get title => $state.composableBuilder(
+      column: $state.table.title,
+      builder: (column, joinBuilders) =>
+          ColumnFilters(column, joinBuilders: joinBuilders));
+
+  ColumnFilters<String> get content => $state.composableBuilder(
+      column: $state.table.content,
+      builder: (column, joinBuilders) =>
+          ColumnFilters(column, joinBuilders: joinBuilders));
+
+  ColumnFilters<DateTime> get targetDate => $state.composableBuilder(
+      column: $state.table.targetDate,
+      builder: (column, joinBuilders) =>
+          ColumnFilters(column, joinBuilders: joinBuilders));
+
   ColumnWithTypeConverterFilters<TodoStatus?, TodoStatus, String> get status =>
-      ColumnWithTypeConverterFilters($state.table.status);
+      $state.composableBuilder(
+          column: $state.table.status,
+          builder: (column, joinBuilders) => ColumnWithTypeConverterFilters(
+              column,
+              joinBuilders: joinBuilders));
+
   $$CategoriesTableFilterComposer get category {
     final $$CategoriesTableFilterComposer composer = $state.composerBuilder(
         composer: this,
@@ -3632,12 +3683,31 @@ class $$TodosTableTableFilterComposer
 class $$TodosTableTableOrderingComposer
     extends OrderingComposer<_$TodoDb, $TodosTableTable> {
   $$TodosTableTableOrderingComposer(super.$state);
-  ColumnOrderings<int> get id => ColumnOrderings($state.table.id);
-  ColumnOrderings<String> get title => ColumnOrderings($state.table.title);
-  ColumnOrderings<String> get content => ColumnOrderings($state.table.content);
-  ColumnOrderings<DateTime> get targetDate =>
-      ColumnOrderings($state.table.targetDate);
-  ColumnOrderings<String> get status => ColumnOrderings($state.table.status);
+  ColumnOrderings<int> get id => $state.composableBuilder(
+      column: $state.table.id,
+      builder: (column, joinBuilders) =>
+          ColumnOrderings(column, joinBuilders: joinBuilders));
+
+  ColumnOrderings<String> get title => $state.composableBuilder(
+      column: $state.table.title,
+      builder: (column, joinBuilders) =>
+          ColumnOrderings(column, joinBuilders: joinBuilders));
+
+  ColumnOrderings<String> get content => $state.composableBuilder(
+      column: $state.table.content,
+      builder: (column, joinBuilders) =>
+          ColumnOrderings(column, joinBuilders: joinBuilders));
+
+  ColumnOrderings<DateTime> get targetDate => $state.composableBuilder(
+      column: $state.table.targetDate,
+      builder: (column, joinBuilders) =>
+          ColumnOrderings(column, joinBuilders: joinBuilders));
+
+  ColumnOrderings<String> get status => $state.composableBuilder(
+      column: $state.table.status,
+      builder: (column, joinBuilders) =>
+          ColumnOrderings(column, joinBuilders: joinBuilders));
+
   $$CategoriesTableOrderingComposer get category {
     final $$CategoriesTableOrderingComposer composer = $state.composerBuilder(
         composer: this,
@@ -3725,26 +3795,60 @@ typedef $$UsersTableProcessedTableManager = ProcessedTableManager<
 class $$UsersTableFilterComposer extends FilterComposer<_$TodoDb, $UsersTable> {
   $$UsersTableFilterComposer(super.$state);
   ColumnWithTypeConverterFilters<RowId, RowId, int> get id =>
-      ColumnWithTypeConverterFilters($state.table.id);
-  ColumnFilters<String> get name => ColumnFilters($state.table.name);
-  ColumnFilters<bool> get isAwesome => ColumnFilters($state.table.isAwesome);
-  ColumnFilters<Uint8List> get profilePicture =>
-      ColumnFilters($state.table.profilePicture);
-  ColumnFilters<DateTime> get creationTime =>
-      ColumnFilters($state.table.creationTime);
+      $state.composableBuilder(
+          column: $state.table.id,
+          builder: (column, joinBuilders) => ColumnWithTypeConverterFilters(
+              column,
+              joinBuilders: joinBuilders));
+
+  ColumnFilters<String> get name => $state.composableBuilder(
+      column: $state.table.name,
+      builder: (column, joinBuilders) =>
+          ColumnFilters(column, joinBuilders: joinBuilders));
+
+  ColumnFilters<bool> get isAwesome => $state.composableBuilder(
+      column: $state.table.isAwesome,
+      builder: (column, joinBuilders) =>
+          ColumnFilters(column, joinBuilders: joinBuilders));
+
+  ColumnFilters<Uint8List> get profilePicture => $state.composableBuilder(
+      column: $state.table.profilePicture,
+      builder: (column, joinBuilders) =>
+          ColumnFilters(column, joinBuilders: joinBuilders));
+
+  ColumnFilters<DateTime> get creationTime => $state.composableBuilder(
+      column: $state.table.creationTime,
+      builder: (column, joinBuilders) =>
+          ColumnFilters(column, joinBuilders: joinBuilders));
 }
 
 class $$UsersTableOrderingComposer
     extends OrderingComposer<_$TodoDb, $UsersTable> {
   $$UsersTableOrderingComposer(super.$state);
-  ColumnOrderings<int> get id => ColumnOrderings($state.table.id);
-  ColumnOrderings<String> get name => ColumnOrderings($state.table.name);
-  ColumnOrderings<bool> get isAwesome =>
-      ColumnOrderings($state.table.isAwesome);
-  ColumnOrderings<Uint8List> get profilePicture =>
-      ColumnOrderings($state.table.profilePicture);
-  ColumnOrderings<DateTime> get creationTime =>
-      ColumnOrderings($state.table.creationTime);
+  ColumnOrderings<int> get id => $state.composableBuilder(
+      column: $state.table.id,
+      builder: (column, joinBuilders) =>
+          ColumnOrderings(column, joinBuilders: joinBuilders));
+
+  ColumnOrderings<String> get name => $state.composableBuilder(
+      column: $state.table.name,
+      builder: (column, joinBuilders) =>
+          ColumnOrderings(column, joinBuilders: joinBuilders));
+
+  ColumnOrderings<bool> get isAwesome => $state.composableBuilder(
+      column: $state.table.isAwesome,
+      builder: (column, joinBuilders) =>
+          ColumnOrderings(column, joinBuilders: joinBuilders));
+
+  ColumnOrderings<Uint8List> get profilePicture => $state.composableBuilder(
+      column: $state.table.profilePicture,
+      builder: (column, joinBuilders) =>
+          ColumnOrderings(column, joinBuilders: joinBuilders));
+
+  ColumnOrderings<DateTime> get creationTime => $state.composableBuilder(
+      column: $state.table.creationTime,
+      builder: (column, joinBuilders) =>
+          ColumnOrderings(column, joinBuilders: joinBuilders));
 }
 
 typedef $$SharedTodosTableCreateCompanionBuilder = SharedTodosCompanion
@@ -3811,15 +3915,29 @@ typedef $$SharedTodosTableProcessedTableManager = ProcessedTableManager<
 class $$SharedTodosTableFilterComposer
     extends FilterComposer<_$TodoDb, $SharedTodosTable> {
   $$SharedTodosTableFilterComposer(super.$state);
-  ColumnFilters<int> get todo => ColumnFilters($state.table.todo);
-  ColumnFilters<int> get user => ColumnFilters($state.table.user);
+  ColumnFilters<int> get todo => $state.composableBuilder(
+      column: $state.table.todo,
+      builder: (column, joinBuilders) =>
+          ColumnFilters(column, joinBuilders: joinBuilders));
+
+  ColumnFilters<int> get user => $state.composableBuilder(
+      column: $state.table.user,
+      builder: (column, joinBuilders) =>
+          ColumnFilters(column, joinBuilders: joinBuilders));
 }
 
 class $$SharedTodosTableOrderingComposer
     extends OrderingComposer<_$TodoDb, $SharedTodosTable> {
   $$SharedTodosTableOrderingComposer(super.$state);
-  ColumnOrderings<int> get todo => ColumnOrderings($state.table.todo);
-  ColumnOrderings<int> get user => ColumnOrderings($state.table.user);
+  ColumnOrderings<int> get todo => $state.composableBuilder(
+      column: $state.table.todo,
+      builder: (column, joinBuilders) =>
+          ColumnOrderings(column, joinBuilders: joinBuilders));
+
+  ColumnOrderings<int> get user => $state.composableBuilder(
+      column: $state.table.user,
+      builder: (column, joinBuilders) =>
+          ColumnOrderings(column, joinBuilders: joinBuilders));
 }
 
 typedef $$TableWithoutPKTableCreateCompanionBuilder = TableWithoutPKCompanion
@@ -3898,25 +4016,51 @@ typedef $$TableWithoutPKTableProcessedTableManager = ProcessedTableManager<
 class $$TableWithoutPKTableFilterComposer
     extends FilterComposer<_$TodoDb, $TableWithoutPKTable> {
   $$TableWithoutPKTableFilterComposer(super.$state);
-  ColumnFilters<int> get notReallyAnId =>
-      ColumnFilters($state.table.notReallyAnId);
-  ColumnFilters<double> get someFloat => ColumnFilters($state.table.someFloat);
-  ColumnFilters<BigInt> get webSafeInt =>
-      ColumnFilters($state.table.webSafeInt);
+  ColumnFilters<int> get notReallyAnId => $state.composableBuilder(
+      column: $state.table.notReallyAnId,
+      builder: (column, joinBuilders) =>
+          ColumnFilters(column, joinBuilders: joinBuilders));
+
+  ColumnFilters<double> get someFloat => $state.composableBuilder(
+      column: $state.table.someFloat,
+      builder: (column, joinBuilders) =>
+          ColumnFilters(column, joinBuilders: joinBuilders));
+
+  ColumnFilters<BigInt> get webSafeInt => $state.composableBuilder(
+      column: $state.table.webSafeInt,
+      builder: (column, joinBuilders) =>
+          ColumnFilters(column, joinBuilders: joinBuilders));
+
   ColumnWithTypeConverterFilters<MyCustomObject, MyCustomObject, String>
-      get custom => ColumnWithTypeConverterFilters($state.table.custom);
+      get custom => $state.composableBuilder(
+          column: $state.table.custom,
+          builder: (column, joinBuilders) => ColumnWithTypeConverterFilters(
+              column,
+              joinBuilders: joinBuilders));
 }
 
 class $$TableWithoutPKTableOrderingComposer
     extends OrderingComposer<_$TodoDb, $TableWithoutPKTable> {
   $$TableWithoutPKTableOrderingComposer(super.$state);
-  ColumnOrderings<int> get notReallyAnId =>
-      ColumnOrderings($state.table.notReallyAnId);
-  ColumnOrderings<double> get someFloat =>
-      ColumnOrderings($state.table.someFloat);
-  ColumnOrderings<BigInt> get webSafeInt =>
-      ColumnOrderings($state.table.webSafeInt);
-  ColumnOrderings<String> get custom => ColumnOrderings($state.table.custom);
+  ColumnOrderings<int> get notReallyAnId => $state.composableBuilder(
+      column: $state.table.notReallyAnId,
+      builder: (column, joinBuilders) =>
+          ColumnOrderings(column, joinBuilders: joinBuilders));
+
+  ColumnOrderings<double> get someFloat => $state.composableBuilder(
+      column: $state.table.someFloat,
+      builder: (column, joinBuilders) =>
+          ColumnOrderings(column, joinBuilders: joinBuilders));
+
+  ColumnOrderings<BigInt> get webSafeInt => $state.composableBuilder(
+      column: $state.table.webSafeInt,
+      builder: (column, joinBuilders) =>
+          ColumnOrderings(column, joinBuilders: joinBuilders));
+
+  ColumnOrderings<String> get custom => $state.composableBuilder(
+      column: $state.table.custom,
+      builder: (column, joinBuilders) =>
+          ColumnOrderings(column, joinBuilders: joinBuilders));
 }
 
 typedef $$PureDefaultsTableCreateCompanionBuilder = PureDefaultsCompanion
@@ -3978,13 +4122,20 @@ class $$PureDefaultsTableFilterComposer
     extends FilterComposer<_$TodoDb, $PureDefaultsTable> {
   $$PureDefaultsTableFilterComposer(super.$state);
   ColumnWithTypeConverterFilters<MyCustomObject?, MyCustomObject, String>
-      get txt => ColumnWithTypeConverterFilters($state.table.txt);
+      get txt => $state.composableBuilder(
+          column: $state.table.txt,
+          builder: (column, joinBuilders) => ColumnWithTypeConverterFilters(
+              column,
+              joinBuilders: joinBuilders));
 }
 
 class $$PureDefaultsTableOrderingComposer
     extends OrderingComposer<_$TodoDb, $PureDefaultsTable> {
   $$PureDefaultsTableOrderingComposer(super.$state);
-  ColumnOrderings<String> get txt => ColumnOrderings($state.table.txt);
+  ColumnOrderings<String> get txt => $state.composableBuilder(
+      column: $state.table.txt,
+      builder: (column, joinBuilders) =>
+          ColumnOrderings(column, joinBuilders: joinBuilders));
 }
 
 typedef $$WithCustomTypeTableCreateCompanionBuilder = WithCustomTypeCompanion
@@ -4045,13 +4196,19 @@ typedef $$WithCustomTypeTableProcessedTableManager = ProcessedTableManager<
 class $$WithCustomTypeTableFilterComposer
     extends FilterComposer<_$TodoDb, $WithCustomTypeTable> {
   $$WithCustomTypeTableFilterComposer(super.$state);
-  ColumnFilters<UuidValue> get id => ColumnFilters($state.table.id);
+  ColumnFilters<UuidValue> get id => $state.composableBuilder(
+      column: $state.table.id,
+      builder: (column, joinBuilders) =>
+          ColumnFilters(column, joinBuilders: joinBuilders));
 }
 
 class $$WithCustomTypeTableOrderingComposer
     extends OrderingComposer<_$TodoDb, $WithCustomTypeTable> {
   $$WithCustomTypeTableOrderingComposer(super.$state);
-  ColumnOrderings<UuidValue> get id => ColumnOrderings($state.table.id);
+  ColumnOrderings<UuidValue> get id => $state.composableBuilder(
+      column: $state.table.id,
+      builder: (column, joinBuilders) =>
+          ColumnOrderings(column, joinBuilders: joinBuilders));
 }
 
 typedef $$TableWithEveryColumnTypeTableCreateCompanionBuilder
@@ -4163,37 +4320,114 @@ class $$TableWithEveryColumnTypeTableFilterComposer
     extends FilterComposer<_$TodoDb, $TableWithEveryColumnTypeTable> {
   $$TableWithEveryColumnTypeTableFilterComposer(super.$state);
   ColumnWithTypeConverterFilters<RowId, RowId, int> get id =>
-      ColumnWithTypeConverterFilters($state.table.id);
-  ColumnFilters<bool> get aBool => ColumnFilters($state.table.aBool);
-  ColumnFilters<DateTime> get aDateTime =>
-      ColumnFilters($state.table.aDateTime);
-  ColumnFilters<String> get aText => ColumnFilters($state.table.aText);
-  ColumnFilters<int> get anInt => ColumnFilters($state.table.anInt);
-  ColumnFilters<BigInt> get anInt64 => ColumnFilters($state.table.anInt64);
-  ColumnFilters<double> get aReal => ColumnFilters($state.table.aReal);
-  ColumnFilters<Uint8List> get aBlob => ColumnFilters($state.table.aBlob);
+      $state.composableBuilder(
+          column: $state.table.id,
+          builder: (column, joinBuilders) => ColumnWithTypeConverterFilters(
+              column,
+              joinBuilders: joinBuilders));
+
+  ColumnFilters<bool> get aBool => $state.composableBuilder(
+      column: $state.table.aBool,
+      builder: (column, joinBuilders) =>
+          ColumnFilters(column, joinBuilders: joinBuilders));
+
+  ColumnFilters<DateTime> get aDateTime => $state.composableBuilder(
+      column: $state.table.aDateTime,
+      builder: (column, joinBuilders) =>
+          ColumnFilters(column, joinBuilders: joinBuilders));
+
+  ColumnFilters<String> get aText => $state.composableBuilder(
+      column: $state.table.aText,
+      builder: (column, joinBuilders) =>
+          ColumnFilters(column, joinBuilders: joinBuilders));
+
+  ColumnFilters<int> get anInt => $state.composableBuilder(
+      column: $state.table.anInt,
+      builder: (column, joinBuilders) =>
+          ColumnFilters(column, joinBuilders: joinBuilders));
+
+  ColumnFilters<BigInt> get anInt64 => $state.composableBuilder(
+      column: $state.table.anInt64,
+      builder: (column, joinBuilders) =>
+          ColumnFilters(column, joinBuilders: joinBuilders));
+
+  ColumnFilters<double> get aReal => $state.composableBuilder(
+      column: $state.table.aReal,
+      builder: (column, joinBuilders) =>
+          ColumnFilters(column, joinBuilders: joinBuilders));
+
+  ColumnFilters<Uint8List> get aBlob => $state.composableBuilder(
+      column: $state.table.aBlob,
+      builder: (column, joinBuilders) =>
+          ColumnFilters(column, joinBuilders: joinBuilders));
+
   ColumnWithTypeConverterFilters<TodoStatus?, TodoStatus, int> get anIntEnum =>
-      ColumnWithTypeConverterFilters($state.table.anIntEnum);
+      $state.composableBuilder(
+          column: $state.table.anIntEnum,
+          builder: (column, joinBuilders) => ColumnWithTypeConverterFilters(
+              column,
+              joinBuilders: joinBuilders));
+
   ColumnWithTypeConverterFilters<MyCustomObject?, MyCustomObject, String>
-      get aTextWithConverter =>
-          ColumnWithTypeConverterFilters($state.table.aTextWithConverter);
+      get aTextWithConverter => $state.composableBuilder(
+          column: $state.table.aTextWithConverter,
+          builder: (column, joinBuilders) => ColumnWithTypeConverterFilters(
+              column,
+              joinBuilders: joinBuilders));
 }
 
 class $$TableWithEveryColumnTypeTableOrderingComposer
     extends OrderingComposer<_$TodoDb, $TableWithEveryColumnTypeTable> {
   $$TableWithEveryColumnTypeTableOrderingComposer(super.$state);
-  ColumnOrderings<int> get id => ColumnOrderings($state.table.id);
-  ColumnOrderings<bool> get aBool => ColumnOrderings($state.table.aBool);
-  ColumnOrderings<DateTime> get aDateTime =>
-      ColumnOrderings($state.table.aDateTime);
-  ColumnOrderings<String> get aText => ColumnOrderings($state.table.aText);
-  ColumnOrderings<int> get anInt => ColumnOrderings($state.table.anInt);
-  ColumnOrderings<BigInt> get anInt64 => ColumnOrderings($state.table.anInt64);
-  ColumnOrderings<double> get aReal => ColumnOrderings($state.table.aReal);
-  ColumnOrderings<Uint8List> get aBlob => ColumnOrderings($state.table.aBlob);
-  ColumnOrderings<int> get anIntEnum => ColumnOrderings($state.table.anIntEnum);
-  ColumnOrderings<String> get aTextWithConverter =>
-      ColumnOrderings($state.table.aTextWithConverter);
+  ColumnOrderings<int> get id => $state.composableBuilder(
+      column: $state.table.id,
+      builder: (column, joinBuilders) =>
+          ColumnOrderings(column, joinBuilders: joinBuilders));
+
+  ColumnOrderings<bool> get aBool => $state.composableBuilder(
+      column: $state.table.aBool,
+      builder: (column, joinBuilders) =>
+          ColumnOrderings(column, joinBuilders: joinBuilders));
+
+  ColumnOrderings<DateTime> get aDateTime => $state.composableBuilder(
+      column: $state.table.aDateTime,
+      builder: (column, joinBuilders) =>
+          ColumnOrderings(column, joinBuilders: joinBuilders));
+
+  ColumnOrderings<String> get aText => $state.composableBuilder(
+      column: $state.table.aText,
+      builder: (column, joinBuilders) =>
+          ColumnOrderings(column, joinBuilders: joinBuilders));
+
+  ColumnOrderings<int> get anInt => $state.composableBuilder(
+      column: $state.table.anInt,
+      builder: (column, joinBuilders) =>
+          ColumnOrderings(column, joinBuilders: joinBuilders));
+
+  ColumnOrderings<BigInt> get anInt64 => $state.composableBuilder(
+      column: $state.table.anInt64,
+      builder: (column, joinBuilders) =>
+          ColumnOrderings(column, joinBuilders: joinBuilders));
+
+  ColumnOrderings<double> get aReal => $state.composableBuilder(
+      column: $state.table.aReal,
+      builder: (column, joinBuilders) =>
+          ColumnOrderings(column, joinBuilders: joinBuilders));
+
+  ColumnOrderings<Uint8List> get aBlob => $state.composableBuilder(
+      column: $state.table.aBlob,
+      builder: (column, joinBuilders) =>
+          ColumnOrderings(column, joinBuilders: joinBuilders));
+
+  ColumnOrderings<int> get anIntEnum => $state.composableBuilder(
+      column: $state.table.anIntEnum,
+      builder: (column, joinBuilders) =>
+          ColumnOrderings(column, joinBuilders: joinBuilders));
+
+  ColumnOrderings<String> get aTextWithConverter => $state.composableBuilder(
+      column: $state.table.aTextWithConverter,
+      builder: (column, joinBuilders) =>
+          ColumnOrderings(column, joinBuilders: joinBuilders));
 }
 
 typedef $$DepartmentTableCreateCompanionBuilder = DepartmentCompanion Function({
@@ -4252,8 +4486,16 @@ typedef $$DepartmentTableProcessedTableManager = ProcessedTableManager<
 class $$DepartmentTableFilterComposer
     extends FilterComposer<_$TodoDb, $DepartmentTable> {
   $$DepartmentTableFilterComposer(super.$state);
-  ColumnFilters<int> get id => ColumnFilters($state.table.id);
-  ColumnFilters<String> get name => ColumnFilters($state.table.name);
+  ColumnFilters<int> get id => $state.composableBuilder(
+      column: $state.table.id,
+      builder: (column, joinBuilders) =>
+          ColumnFilters(column, joinBuilders: joinBuilders));
+
+  ColumnFilters<String> get name => $state.composableBuilder(
+      column: $state.table.name,
+      builder: (column, joinBuilders) =>
+          ColumnFilters(column, joinBuilders: joinBuilders));
+
   ComposableFilter productRefs(
       ComposableFilter Function($$ProductTableFilterComposer f) f) {
     final $$ProductTableFilterComposer composer = $state.composerBuilder(
@@ -4271,8 +4513,15 @@ class $$DepartmentTableFilterComposer
 class $$DepartmentTableOrderingComposer
     extends OrderingComposer<_$TodoDb, $DepartmentTable> {
   $$DepartmentTableOrderingComposer(super.$state);
-  ColumnOrderings<int> get id => ColumnOrderings($state.table.id);
-  ColumnOrderings<String> get name => ColumnOrderings($state.table.name);
+  ColumnOrderings<int> get id => $state.composableBuilder(
+      column: $state.table.id,
+      builder: (column, joinBuilders) =>
+          ColumnOrderings(column, joinBuilders: joinBuilders));
+
+  ColumnOrderings<String> get name => $state.composableBuilder(
+      column: $state.table.name,
+      builder: (column, joinBuilders) =>
+          ColumnOrderings(column, joinBuilders: joinBuilders));
 }
 
 typedef $$ProductTableCreateCompanionBuilder = ProductCompanion Function({
@@ -4337,8 +4586,16 @@ typedef $$ProductTableProcessedTableManager = ProcessedTableManager<
 class $$ProductTableFilterComposer
     extends FilterComposer<_$TodoDb, $ProductTable> {
   $$ProductTableFilterComposer(super.$state);
-  ColumnFilters<int> get id => ColumnFilters($state.table.id);
-  ColumnFilters<String> get name => ColumnFilters($state.table.name);
+  ColumnFilters<int> get id => $state.composableBuilder(
+      column: $state.table.id,
+      builder: (column, joinBuilders) =>
+          ColumnFilters(column, joinBuilders: joinBuilders));
+
+  ColumnFilters<String> get name => $state.composableBuilder(
+      column: $state.table.name,
+      builder: (column, joinBuilders) =>
+          ColumnFilters(column, joinBuilders: joinBuilders));
+
   $$DepartmentTableFilterComposer get department {
     final $$DepartmentTableFilterComposer composer = $state.composerBuilder(
         composer: this,
@@ -4368,8 +4625,16 @@ class $$ProductTableFilterComposer
 class $$ProductTableOrderingComposer
     extends OrderingComposer<_$TodoDb, $ProductTable> {
   $$ProductTableOrderingComposer(super.$state);
-  ColumnOrderings<int> get id => ColumnOrderings($state.table.id);
-  ColumnOrderings<String> get name => ColumnOrderings($state.table.name);
+  ColumnOrderings<int> get id => $state.composableBuilder(
+      column: $state.table.id,
+      builder: (column, joinBuilders) =>
+          ColumnOrderings(column, joinBuilders: joinBuilders));
+
+  ColumnOrderings<String> get name => $state.composableBuilder(
+      column: $state.table.name,
+      builder: (column, joinBuilders) =>
+          ColumnOrderings(column, joinBuilders: joinBuilders));
+
   $$DepartmentTableOrderingComposer get department {
     final $$DepartmentTableOrderingComposer composer = $state.composerBuilder(
         composer: this,
@@ -4438,8 +4703,16 @@ typedef $$StoreTableProcessedTableManager = ProcessedTableManager<
 
 class $$StoreTableFilterComposer extends FilterComposer<_$TodoDb, $StoreTable> {
   $$StoreTableFilterComposer(super.$state);
-  ColumnFilters<int> get id => ColumnFilters($state.table.id);
-  ColumnFilters<String> get name => ColumnFilters($state.table.name);
+  ColumnFilters<int> get id => $state.composableBuilder(
+      column: $state.table.id,
+      builder: (column, joinBuilders) =>
+          ColumnFilters(column, joinBuilders: joinBuilders));
+
+  ColumnFilters<String> get name => $state.composableBuilder(
+      column: $state.table.name,
+      builder: (column, joinBuilders) =>
+          ColumnFilters(column, joinBuilders: joinBuilders));
+
   ComposableFilter listings(
       ComposableFilter Function($$ListingTableFilterComposer f) f) {
     final $$ListingTableFilterComposer composer = $state.composerBuilder(
@@ -4457,8 +4730,15 @@ class $$StoreTableFilterComposer extends FilterComposer<_$TodoDb, $StoreTable> {
 class $$StoreTableOrderingComposer
     extends OrderingComposer<_$TodoDb, $StoreTable> {
   $$StoreTableOrderingComposer(super.$state);
-  ColumnOrderings<int> get id => ColumnOrderings($state.table.id);
-  ColumnOrderings<String> get name => ColumnOrderings($state.table.name);
+  ColumnOrderings<int> get id => $state.composableBuilder(
+      column: $state.table.id,
+      builder: (column, joinBuilders) =>
+          ColumnOrderings(column, joinBuilders: joinBuilders));
+
+  ColumnOrderings<String> get name => $state.composableBuilder(
+      column: $state.table.name,
+      builder: (column, joinBuilders) =>
+          ColumnOrderings(column, joinBuilders: joinBuilders));
 }
 
 typedef $$ListingTableCreateCompanionBuilder = ListingCompanion Function({
@@ -4529,8 +4809,16 @@ typedef $$ListingTableProcessedTableManager = ProcessedTableManager<
 class $$ListingTableFilterComposer
     extends FilterComposer<_$TodoDb, $ListingTable> {
   $$ListingTableFilterComposer(super.$state);
-  ColumnFilters<int> get id => ColumnFilters($state.table.id);
-  ColumnFilters<double> get price => ColumnFilters($state.table.price);
+  ColumnFilters<int> get id => $state.composableBuilder(
+      column: $state.table.id,
+      builder: (column, joinBuilders) =>
+          ColumnFilters(column, joinBuilders: joinBuilders));
+
+  ColumnFilters<double> get price => $state.composableBuilder(
+      column: $state.table.price,
+      builder: (column, joinBuilders) =>
+          ColumnFilters(column, joinBuilders: joinBuilders));
+
   $$ProductTableFilterComposer get product {
     final $$ProductTableFilterComposer composer = $state.composerBuilder(
         composer: this,
@@ -4559,8 +4847,16 @@ class $$ListingTableFilterComposer
 class $$ListingTableOrderingComposer
     extends OrderingComposer<_$TodoDb, $ListingTable> {
   $$ListingTableOrderingComposer(super.$state);
-  ColumnOrderings<int> get id => ColumnOrderings($state.table.id);
-  ColumnOrderings<double> get price => ColumnOrderings($state.table.price);
+  ColumnOrderings<int> get id => $state.composableBuilder(
+      column: $state.table.id,
+      builder: (column, joinBuilders) =>
+          ColumnOrderings(column, joinBuilders: joinBuilders));
+
+  ColumnOrderings<double> get price => $state.composableBuilder(
+      column: $state.table.price,
+      builder: (column, joinBuilders) =>
+          ColumnOrderings(column, joinBuilders: joinBuilders));
+
   $$ProductTableOrderingComposer get product {
     final $$ProductTableOrderingComposer composer = $state.composerBuilder(
         composer: this,

--- a/drift/test/integration_tests/regress_2166_test.g.dart
+++ b/drift/test/integration_tests/regress_2166_test.g.dart
@@ -200,7 +200,7 @@ abstract class _$_SomeDb extends GeneratedDatabase {
   List<DatabaseSchemaEntity> get allSchemaEntities => [someTable];
 }
 
-typedef $$_SomeTableTableInsertCompanionBuilder = _SomeTableCompanion Function({
+typedef $$_SomeTableTableCreateCompanionBuilder = _SomeTableCompanion Function({
   Value<int> id,
   Value<String?> name,
 });
@@ -215,8 +215,7 @@ class $$_SomeTableTableTableManager extends RootTableManager<
     _SomeTableData,
     $$_SomeTableTableFilterComposer,
     $$_SomeTableTableOrderingComposer,
-    $$_SomeTableTableProcessedTableManager,
-    $$_SomeTableTableInsertCompanionBuilder,
+    $$_SomeTableTableCreateCompanionBuilder,
     $$_SomeTableTableUpdateCompanionBuilder> {
   $$_SomeTableTableTableManager(_$_SomeDb db, $_SomeTableTable table)
       : super(TableManagerState(
@@ -226,9 +225,7 @@ class $$_SomeTableTableTableManager extends RootTableManager<
               $$_SomeTableTableFilterComposer(ComposerState(db, table)),
           orderingComposer:
               $$_SomeTableTableOrderingComposer(ComposerState(db, table)),
-          getChildManagerBuilder: (p) =>
-              $$_SomeTableTableProcessedTableManager(p),
-          getUpdateCompanionBuilder: ({
+          updateCompanionCallback: ({
             Value<int> id = const Value.absent(),
             Value<String?> name = const Value.absent(),
           }) =>
@@ -236,7 +233,7 @@ class $$_SomeTableTableTableManager extends RootTableManager<
             id: id,
             name: name,
           ),
-          getInsertCompanionBuilder: ({
+          createCompanionCallback: ({
             Value<int> id = const Value.absent(),
             Value<String?> name = const Value.absent(),
           }) =>
@@ -247,44 +244,27 @@ class $$_SomeTableTableTableManager extends RootTableManager<
         ));
 }
 
-class $$_SomeTableTableProcessedTableManager extends ProcessedTableManager<
+typedef $$_SomeTableTableProcessedTableManager = ProcessedTableManager<
     _$_SomeDb,
     $_SomeTableTable,
     _SomeTableData,
     $$_SomeTableTableFilterComposer,
     $$_SomeTableTableOrderingComposer,
-    $$_SomeTableTableProcessedTableManager,
-    $$_SomeTableTableInsertCompanionBuilder,
-    $$_SomeTableTableUpdateCompanionBuilder> {
-  $$_SomeTableTableProcessedTableManager(super.$state);
-}
+    $$_SomeTableTableCreateCompanionBuilder,
+    $$_SomeTableTableUpdateCompanionBuilder>;
 
 class $$_SomeTableTableFilterComposer
     extends FilterComposer<_$_SomeDb, $_SomeTableTable> {
   $$_SomeTableTableFilterComposer(super.$state);
-  ColumnFilters<int> get id => $state.composableBuilder(
-      column: $state.table.id,
-      builder: (column, joinBuilders) =>
-          ColumnFilters(column, joinBuilders: joinBuilders));
-
-  ColumnFilters<String> get name => $state.composableBuilder(
-      column: $state.table.name,
-      builder: (column, joinBuilders) =>
-          ColumnFilters(column, joinBuilders: joinBuilders));
+  ColumnFilters<int> get id => ColumnFilters($state.table.id);
+  ColumnFilters<String> get name => ColumnFilters($state.table.name);
 }
 
 class $$_SomeTableTableOrderingComposer
     extends OrderingComposer<_$_SomeDb, $_SomeTableTable> {
   $$_SomeTableTableOrderingComposer(super.$state);
-  ColumnOrderings<int> get id => $state.composableBuilder(
-      column: $state.table.id,
-      builder: (column, joinBuilders) =>
-          ColumnOrderings(column, joinBuilders: joinBuilders));
-
-  ColumnOrderings<String> get name => $state.composableBuilder(
-      column: $state.table.name,
-      builder: (column, joinBuilders) =>
-          ColumnOrderings(column, joinBuilders: joinBuilders));
+  ColumnOrderings<int> get id => ColumnOrderings($state.table.id);
+  ColumnOrderings<String> get name => ColumnOrderings($state.table.name);
 }
 
 class $_SomeDbManager {

--- a/drift/test/integration_tests/regress_2166_test.g.dart
+++ b/drift/test/integration_tests/regress_2166_test.g.dart
@@ -244,15 +244,6 @@ class $$_SomeTableTableTableManager extends RootTableManager<
         ));
 }
 
-typedef $$_SomeTableTableProcessedTableManager = ProcessedTableManager<
-    _$_SomeDb,
-    $_SomeTableTable,
-    _SomeTableData,
-    $$_SomeTableTableFilterComposer,
-    $$_SomeTableTableOrderingComposer,
-    $$_SomeTableTableCreateCompanionBuilder,
-    $$_SomeTableTableUpdateCompanionBuilder>;
-
 class $$_SomeTableTableFilterComposer
     extends FilterComposer<_$_SomeDb, $_SomeTableTable> {
   $$_SomeTableTableFilterComposer(super.$state);

--- a/drift/test/integration_tests/regress_2166_test.g.dart
+++ b/drift/test/integration_tests/regress_2166_test.g.dart
@@ -256,15 +256,29 @@ typedef $$_SomeTableTableProcessedTableManager = ProcessedTableManager<
 class $$_SomeTableTableFilterComposer
     extends FilterComposer<_$_SomeDb, $_SomeTableTable> {
   $$_SomeTableTableFilterComposer(super.$state);
-  ColumnFilters<int> get id => ColumnFilters($state.table.id);
-  ColumnFilters<String> get name => ColumnFilters($state.table.name);
+  ColumnFilters<int> get id => $state.composableBuilder(
+      column: $state.table.id,
+      builder: (column, joinBuilders) =>
+          ColumnFilters(column, joinBuilders: joinBuilders));
+
+  ColumnFilters<String> get name => $state.composableBuilder(
+      column: $state.table.name,
+      builder: (column, joinBuilders) =>
+          ColumnFilters(column, joinBuilders: joinBuilders));
 }
 
 class $$_SomeTableTableOrderingComposer
     extends OrderingComposer<_$_SomeDb, $_SomeTableTable> {
   $$_SomeTableTableOrderingComposer(super.$state);
-  ColumnOrderings<int> get id => ColumnOrderings($state.table.id);
-  ColumnOrderings<String> get name => ColumnOrderings($state.table.name);
+  ColumnOrderings<int> get id => $state.composableBuilder(
+      column: $state.table.id,
+      builder: (column, joinBuilders) =>
+          ColumnOrderings(column, joinBuilders: joinBuilders));
+
+  ColumnOrderings<String> get name => $state.composableBuilder(
+      column: $state.table.name,
+      builder: (column, joinBuilders) =>
+          ColumnOrderings(column, joinBuilders: joinBuilders));
 }
 
 class $_SomeDbManager {

--- a/drift/test/manager/manager_filter_test.dart
+++ b/drift/test/manager/manager_filter_test.dart
@@ -383,4 +383,36 @@ void main() {
             .count(),
         completion(1));
   });
+
+  test('manager - multiple filters', () async {
+    await db.managers.tableWithEveryColumnType.create((o) => o(
+        aText: Value("person"),
+        anIntEnum: Value(TodoStatus.open),
+        aReal: Value(5.0),
+        aDateTime: Value(DateTime.now().add(Duration(days: 1)))));
+    await db.managers.tableWithEveryColumnType.create((o) => o(
+        aText: Value("person"),
+        anIntEnum: Value(TodoStatus.open),
+        aDateTime: Value(DateTime.now().add(Duration(days: 2)))));
+    await db.managers.tableWithEveryColumnType.create((o) => o(
+        aText: Value("drink"),
+        anIntEnum: Value(TodoStatus.open),
+        aReal: Value(3.0),
+        aDateTime: Value(DateTime.now().add(Duration(days: 3)))));
+
+    // By default, all filters are AND
+    expect(
+        db.managers.tableWithEveryColumnType
+            .filter((f) => f.aText("person"))
+            .filter((f) => f.aReal(5.0))
+            .count(),
+        completion(1));
+    // Passing a `combineWith` will change that
+    expect(
+        db.managers.tableWithEveryColumnType
+            .filter((f) => f.aText("person"))
+            .filter((f) => f.aReal(5.0), combineWith: BooleanOperator.or)
+            .count(),
+        completion(2));
+  });
 }

--- a/drift/test/manager/manager_filter_test.dart
+++ b/drift/test/manager/manager_filter_test.dart
@@ -407,12 +407,5 @@ void main() {
             .filter((f) => f.aReal(5.0))
             .count(),
         completion(1));
-    // Passing a `combineWith` will change that
-    expect(
-        db.managers.tableWithEveryColumnType
-            .filter((f) => f.aText("person"))
-            .filter((f) => f.aReal(5.0), combineWith: BooleanOperator.or)
-            .count(),
-        completion(2));
   });
 }

--- a/drift_dev/lib/src/generated/analysis/results/column.g.dart
+++ b/drift_dev/lib/src/generated/analysis/results/column.g.dart
@@ -38,8 +38,8 @@ Map<String, dynamic> _$DartCheckExpressionToJson(
     };
 
 LimitingTextLength _$LimitingTextLengthFromJson(Map json) => LimitingTextLength(
-      minLength: json['min_length'] as int?,
-      maxLength: json['max_length'] as int?,
+      minLength: (json['min_length'] as num?)?.toInt(),
+      maxLength: (json['max_length'] as num?)?.toInt(),
     );
 
 Map<String, dynamic> _$LimitingTextLengthToJson(LimitingTextLength instance) =>

--- a/drift_dev/lib/src/generated/analysis/results/element.g.dart
+++ b/drift_dev/lib/src/generated/analysis/results/element.g.dart
@@ -19,7 +19,7 @@ Map<String, dynamic> _$DriftElementIdToJson(DriftElementId instance) =>
 
 DriftDeclaration _$DriftDeclarationFromJson(Map json) => DriftDeclaration(
       Uri.parse(json['source_uri'] as String),
-      json['offset'] as int,
+      (json['offset'] as num).toInt(),
       json['name'] as String?,
     );
 

--- a/drift_dev/lib/src/writer/manager/manager_templates.dart
+++ b/drift_dev/lib/src/writer/manager/manager_templates.dart
@@ -100,11 +100,11 @@ class _ManagerCodeTemplates {
     return '\$${table.entityInfoName}OrderingComposer';
   }
 
-  /// Name of the typedef for the insert companion builder for a table
+  /// Name of the typedef for the create companion builder for a table
   ///
   /// This is the name of the typedef of a function that creates new rows in the table
-  String insertCompanionBuilderTypeDef(DriftTable table) {
-    return '\$${table.entityInfoName}InsertCompanionBuilder';
+  String createCompanionBuilderTypeDef(DriftTable table) {
+    return '\$${table.entityInfoName}CreateCompanionBuilder';
   }
 
   /// Name of the typedef for the update companion builder for a table
@@ -115,16 +115,16 @@ class _ManagerCodeTemplates {
   }
 
   /// Build the builder for a companion class
-  /// This is used to build the insert and update companions
+  /// This is used to build the create and update companions
   /// Returns a tuple with the typedef and the builder
-  /// Use [isUpdate] to determine if the builder is for an update or insert companion
+  /// Use [isUpdate] to determine if the builder is for an update or create companion
   ({String typeDefinition, String companionBuilder}) companionBuilder(
       DriftTable table, TextEmitter leaf,
       {required bool isUpdate}) {
     // Get the name of the typedef
     final typedefName = isUpdate
         ? updateCompanionBuilderTypeDefName(table)
-        : insertCompanionBuilderTypeDef(table);
+        : createCompanionBuilderTypeDef(table);
 
     // Get the companion class name
     final companionClassName = leaf.dartCode(leaf.companionType(table));
@@ -156,7 +156,7 @@ class _ManagerCodeTemplates {
         companionBuilderArguments
             .write('$value<$typeName> $param = const $value.absent(),');
       } else {
-        // Otherwise, for insert companions, required fields are required
+        // Otherwise, for create companions, required fields are required
         // and optional fields are defaulted to absent
         if (!column.isImplicitRowId &&
             table.isColumnRequiredForInsert(column)) {
@@ -189,7 +189,7 @@ class _ManagerCodeTemplates {
     ${filterComposerNameWithPrefix(table, leaf)},
     ${orderingComposerNameWithPrefix(table, leaf)},
     ${processedTableManagerName(table)},
-    ${insertCompanionBuilderTypeDef(table)},
+    ${createCompanionBuilderTypeDef(table)},
     ${updateCompanionBuilderTypeDefName(table)}>""";
   }
 
@@ -212,7 +212,7 @@ class _ManagerCodeTemplates {
     required String dbClassName,
     required TextEmitter leaf,
     required String updateCompanionBuilder,
-    required String insertCompanionBuilder,
+    required String createCompanionBuilder,
   }) {
     return """class ${rootTableManagerName(table)} extends ${leaf.drift("RootTableManager")}${_tableManagerTypeArguments(table, dbClassName, leaf)} {
     ${rootTableManagerName(table)}(${databaseType(leaf, dbClassName)} db, ${tableClassWithPrefix(table, leaf)} table) : super(
@@ -222,8 +222,8 @@ class _ManagerCodeTemplates {
         filteringComposer: ${filterComposerNameWithPrefix(table, leaf)}(${leaf.drift("ComposerState")}(db, table)),
         orderingComposer: ${orderingComposerNameWithPrefix(table, leaf)}(${leaf.drift("ComposerState")}(db, table)),
         getChildManagerBuilder: (p) => ${processedTableManagerName(table)}(p),
-        getUpdateCompanionBuilder: $updateCompanionBuilder,
-        getInsertCompanionBuilder:$insertCompanionBuilder,));
+        updateCompanionCallback: $updateCompanionBuilder,
+        createCompanionCallback: $createCompanionBuilder,));
         }
     """;
   }

--- a/drift_dev/lib/src/writer/manager/manager_templates.dart
+++ b/drift_dev/lib/src/writer/manager/manager_templates.dart
@@ -60,7 +60,7 @@ class _ManagerCodeTemplates {
   /// as the table manager and is not used outside of the file
   ///
   /// E.g. `$UserTableProcessedTableManager`
-  String processedTableManagerName(DriftTable table) {
+  String processedTableManagerTypedefName(DriftTable table) {
     return '\$${table.entityInfoName}ProcessedTableManager';
   }
 
@@ -188,7 +188,6 @@ class _ManagerCodeTemplates {
     ${rowClassWithPrefix(table, leaf)},
     ${filterComposerNameWithPrefix(table, leaf)},
     ${orderingComposerNameWithPrefix(table, leaf)},
-    ${processedTableManagerName(table)},
     ${createCompanionBuilderTypeDef(table)},
     ${updateCompanionBuilderTypeDefName(table)}>""";
   }
@@ -221,7 +220,6 @@ class _ManagerCodeTemplates {
         table: table,
         filteringComposer: ${filterComposerNameWithPrefix(table, leaf)}(${leaf.drift("ComposerState")}(db, table)),
         orderingComposer: ${orderingComposerNameWithPrefix(table, leaf)}(${leaf.drift("ComposerState")}(db, table)),
-        getChildManagerBuilder: (p) => ${processedTableManagerName(table)}(p),
         updateCompanionCallback: $updateCompanionBuilder,
         createCompanionCallback: $createCompanionBuilder,));
         }
@@ -229,15 +227,12 @@ class _ManagerCodeTemplates {
   }
 
   /// Returns code for the processed table manager class
-  String processedTableManager({
+  String processedTableManagerTypedef({
     required DriftTable table,
     required String dbClassName,
     required TextEmitter leaf,
   }) {
-    return """class ${processedTableManagerName(table)} extends ${leaf.drift("ProcessedTableManager")}${_tableManagerTypeArguments(table, dbClassName, leaf)} {
-    ${processedTableManagerName(table)}(super.\$state);
-      }
-    """;
+    return """typedef ${processedTableManagerTypedefName(table)} = ${leaf.drift("ProcessedTableManager")}${_tableManagerTypeArguments(table, dbClassName, leaf)};""";
   }
 
   /// Returns the code for a tables filter composer

--- a/drift_dev/lib/src/writer/manager/manager_templates.dart
+++ b/drift_dev/lib/src/writer/manager/manager_templates.dart
@@ -274,11 +274,7 @@ class _ManagerCodeTemplates {
     final filterName = column.nameInDart;
     final columnGetter = column.nameInDart;
 
-    return """${leaf.drift("ColumnFilters")}<$type> get $filterName => \$state.composableBuilder(
-      column: \$state.table.$columnGetter,
-      builder: (column, joinBuilders) => 
-      ${leaf.drift("ColumnFilters")}(column, joinBuilders: joinBuilders));
-      """;
+    return """${leaf.drift("ColumnFilters")}<$type> get $filterName => ${leaf.drift("ColumnFilters")}(\$state.table.$columnGetter);""";
   }
 
   /// Code for a filter for a column that has a type converter
@@ -291,11 +287,8 @@ class _ManagerCodeTemplates {
     final converterType = leaf.dartCode(leaf.writer.dartType(column));
     final nonNullableConverterType = converterType.replaceFirst("?", "");
     return """
-          ${leaf.drift("ColumnWithTypeConverterFilters")}<$converterType,$nonNullableConverterType,$type> get $filterName => \$state.composableBuilder(
-      column: \$state.table.$columnGetter,
-      builder: (column, joinBuilders) => 
-      ${leaf.drift("ColumnWithTypeConverterFilters")}(column, joinBuilders: joinBuilders));
-      """;
+          ${leaf.drift("ColumnWithTypeConverterFilters")}<$converterType,$nonNullableConverterType,$type> get $filterName => 
+          ${leaf.drift("ColumnWithTypeConverterFilters")}(\$state.table.$columnGetter);""";
   }
 
   /// Code for a filter which works over a reference
@@ -327,11 +320,7 @@ class _ManagerCodeTemplates {
     final filterName = column.nameInDart;
     final columnGetter = column.nameInDart;
 
-    return """${leaf.drift("ColumnOrderings")}<$type> get $filterName => \$state.composableBuilder(
-      column: \$state.table.$columnGetter,
-      builder: (column, joinBuilders) => 
-      ${leaf.drift("ColumnOrderings")}(column, joinBuilders: joinBuilders));
-      """;
+    return """${leaf.drift("ColumnOrderings")}<$type> get $filterName => ${leaf.drift("ColumnOrderings")}(\$state.table.$columnGetter);""";
   }
 
   /// Code for a ordering which works over a reference

--- a/drift_dev/lib/src/writer/manager/manager_templates.dart
+++ b/drift_dev/lib/src/writer/manager/manager_templates.dart
@@ -54,16 +54,6 @@ class _ManagerCodeTemplates {
         .dartCode(leaf.generatedElement(table, rootTableManagerName(table)));
   }
 
-  /// Returns the name of the processed table manager class for a table
-  ///
-  /// This does not contain any prefixes, as this will always be generated in the same file
-  /// as the table manager and is not used outside of the file
-  ///
-  /// E.g. `$UserTableProcessedTableManager`
-  String processedTableManagerTypedefName(DriftTable table) {
-    return '\$${table.entityInfoName}ProcessedTableManager';
-  }
-
   /// Class which represents a table in the database
   /// Contains the prefix if the generation is modular
   /// E.g. `i0.UserTable`
@@ -224,15 +214,6 @@ class _ManagerCodeTemplates {
         createCompanionCallback: $createCompanionBuilder,));
         }
     """;
-  }
-
-  /// Returns code for the processed table manager class
-  String processedTableManagerTypedef({
-    required DriftTable table,
-    required String dbClassName,
-    required TextEmitter leaf,
-  }) {
-    return """typedef ${processedTableManagerTypedefName(table)} = ${leaf.drift("ProcessedTableManager")}${_tableManagerTypeArguments(table, dbClassName, leaf)};""";
   }
 
   /// Returns the code for a tables filter composer

--- a/drift_dev/lib/src/writer/manager/manager_templates.dart
+++ b/drift_dev/lib/src/writer/manager/manager_templates.dart
@@ -274,7 +274,11 @@ class _ManagerCodeTemplates {
     final filterName = column.nameInDart;
     final columnGetter = column.nameInDart;
 
-    return """${leaf.drift("ColumnFilters")}<$type> get $filterName => ${leaf.drift("ColumnFilters")}(\$state.table.$columnGetter);""";
+    return """${leaf.drift("ColumnFilters")}<$type> get $filterName => \$state.composableBuilder(
+      column: \$state.table.$columnGetter,
+      builder: (column, joinBuilders) => 
+      ${leaf.drift("ColumnFilters")}(column, joinBuilders: joinBuilders));
+      """;
   }
 
   /// Code for a filter for a column that has a type converter
@@ -287,8 +291,11 @@ class _ManagerCodeTemplates {
     final converterType = leaf.dartCode(leaf.writer.dartType(column));
     final nonNullableConverterType = converterType.replaceFirst("?", "");
     return """
-          ${leaf.drift("ColumnWithTypeConverterFilters")}<$converterType,$nonNullableConverterType,$type> get $filterName => 
-          ${leaf.drift("ColumnWithTypeConverterFilters")}(\$state.table.$columnGetter);""";
+          ${leaf.drift("ColumnWithTypeConverterFilters")}<$converterType,$nonNullableConverterType,$type> get $filterName => \$state.composableBuilder(
+      column: \$state.table.$columnGetter,
+      builder: (column, joinBuilders) => 
+      ${leaf.drift("ColumnWithTypeConverterFilters")}(column, joinBuilders: joinBuilders));
+      """;
   }
 
   /// Code for a filter which works over a reference
@@ -320,7 +327,11 @@ class _ManagerCodeTemplates {
     final filterName = column.nameInDart;
     final columnGetter = column.nameInDart;
 
-    return """${leaf.drift("ColumnOrderings")}<$type> get $filterName => ${leaf.drift("ColumnOrderings")}(\$state.table.$columnGetter);""";
+    return """${leaf.drift("ColumnOrderings")}<$type> get $filterName => \$state.composableBuilder(
+      column: \$state.table.$columnGetter,
+      builder: (column, joinBuilders) => 
+      ${leaf.drift("ColumnOrderings")}(column, joinBuilders: joinBuilders));
+      """;
   }
 
   /// Code for a ordering which works over a reference

--- a/drift_dev/lib/src/writer/manager/table_manager_writer.dart
+++ b/drift_dev/lib/src/writer/manager/table_manager_writer.dart
@@ -45,7 +45,7 @@ class _TableManagerWriter {
         dbClassName: dbClassName,
         leaf: leaf,
         updateCompanionBuilder: updateCompanionBuilder,
-        insertCompanionBuilder: insertCompanionBuilder));
+        createCompanionBuilder: insertCompanionBuilder));
     leaf.write(_templates.processedTableManager(
         table: table, dbClassName: dbClassName, leaf: leaf));
 

--- a/drift_dev/lib/src/writer/manager/table_manager_writer.dart
+++ b/drift_dev/lib/src/writer/manager/table_manager_writer.dart
@@ -46,7 +46,7 @@ class _TableManagerWriter {
         leaf: leaf,
         updateCompanionBuilder: updateCompanionBuilder,
         createCompanionBuilder: insertCompanionBuilder));
-    leaf.write(_templates.processedTableManager(
+    leaf.write(_templates.processedTableManagerTypedef(
         table: table, dbClassName: dbClassName, leaf: leaf));
 
     // Gather the relationships to and from this table

--- a/drift_dev/lib/src/writer/manager/table_manager_writer.dart
+++ b/drift_dev/lib/src/writer/manager/table_manager_writer.dart
@@ -46,8 +46,6 @@ class _TableManagerWriter {
         leaf: leaf,
         updateCompanionBuilder: updateCompanionBuilder,
         createCompanionBuilder: insertCompanionBuilder));
-    leaf.write(_templates.processedTableManagerTypedef(
-        table: table, dbClassName: dbClassName, leaf: leaf));
 
     // Gather the relationships to and from this table
     List<_Relation> relations =

--- a/examples/app/lib/database/database.g.dart
+++ b/examples/app/lib/database/database.g.dart
@@ -127,6 +127,14 @@ class Category extends DataClass implements Insertable<Category> {
         name: name ?? this.name,
         color: color ?? this.color,
       );
+  Category copyWithCompanion(CategoriesCompanion data) {
+    return Category(
+      id: data.id.present ? data.id.value : this.id,
+      name: data.name.present ? data.name.value : this.name,
+      color: data.color.present ? data.color.value : this.color,
+    );
+  }
+
   @override
   String toString() {
     return (StringBuffer('Category(')
@@ -373,6 +381,16 @@ class TodoEntry extends DataClass implements Insertable<TodoEntry> {
         category: category.present ? category.value : this.category,
         dueDate: dueDate.present ? dueDate.value : this.dueDate,
       );
+  TodoEntry copyWithCompanion(TodoEntriesCompanion data) {
+    return TodoEntry(
+      id: data.id.present ? data.id.value : this.id,
+      description:
+          data.description.present ? data.description.value : this.description,
+      category: data.category.present ? data.category.value : this.category,
+      dueDate: data.dueDate.present ? data.dueDate.value : this.dueDate,
+    );
+  }
+
   @override
   String toString() {
     return (StringBuffer('TodoEntry(')
@@ -565,6 +583,13 @@ class TextEntry extends DataClass implements Insertable<TextEntry> {
   TextEntry copyWith({String? description}) => TextEntry(
         description: description ?? this.description,
       );
+  TextEntry copyWithCompanion(TextEntriesCompanion data) {
+    return TextEntry(
+      description:
+          data.description.present ? data.description.value : this.description,
+    );
+  }
+
   @override
   String toString() {
     return (StringBuffer('TextEntry(')
@@ -719,7 +744,7 @@ abstract class _$AppDatabase extends GeneratedDatabase {
       );
 }
 
-typedef $$CategoriesTableInsertCompanionBuilder = CategoriesCompanion Function({
+typedef $$CategoriesTableCreateCompanionBuilder = CategoriesCompanion Function({
   Value<int> id,
   required String name,
   required Color color,
@@ -736,8 +761,7 @@ class $$CategoriesTableTableManager extends RootTableManager<
     Category,
     $$CategoriesTableFilterComposer,
     $$CategoriesTableOrderingComposer,
-    $$CategoriesTableProcessedTableManager,
-    $$CategoriesTableInsertCompanionBuilder,
+    $$CategoriesTableCreateCompanionBuilder,
     $$CategoriesTableUpdateCompanionBuilder> {
   $$CategoriesTableTableManager(_$AppDatabase db, $CategoriesTable table)
       : super(TableManagerState(
@@ -747,9 +771,7 @@ class $$CategoriesTableTableManager extends RootTableManager<
               $$CategoriesTableFilterComposer(ComposerState(db, table)),
           orderingComposer:
               $$CategoriesTableOrderingComposer(ComposerState(db, table)),
-          getChildManagerBuilder: (p) =>
-              $$CategoriesTableProcessedTableManager(p),
-          getUpdateCompanionBuilder: ({
+          updateCompanionCallback: ({
             Value<int> id = const Value.absent(),
             Value<String> name = const Value.absent(),
             Value<Color> color = const Value.absent(),
@@ -759,7 +781,7 @@ class $$CategoriesTableTableManager extends RootTableManager<
             name: name,
             color: color,
           ),
-          getInsertCompanionBuilder: ({
+          createCompanionCallback: ({
             Value<int> id = const Value.absent(),
             required String name,
             required Color color,
@@ -772,38 +794,22 @@ class $$CategoriesTableTableManager extends RootTableManager<
         ));
 }
 
-class $$CategoriesTableProcessedTableManager extends ProcessedTableManager<
+typedef $$CategoriesTableProcessedTableManager = ProcessedTableManager<
     _$AppDatabase,
     $CategoriesTable,
     Category,
     $$CategoriesTableFilterComposer,
     $$CategoriesTableOrderingComposer,
-    $$CategoriesTableProcessedTableManager,
-    $$CategoriesTableInsertCompanionBuilder,
-    $$CategoriesTableUpdateCompanionBuilder> {
-  $$CategoriesTableProcessedTableManager(super.$state);
-}
+    $$CategoriesTableCreateCompanionBuilder,
+    $$CategoriesTableUpdateCompanionBuilder>;
 
 class $$CategoriesTableFilterComposer
     extends FilterComposer<_$AppDatabase, $CategoriesTable> {
   $$CategoriesTableFilterComposer(super.$state);
-  ColumnFilters<int> get id => $state.composableBuilder(
-      column: $state.table.id,
-      builder: (column, joinBuilders) =>
-          ColumnFilters(column, joinBuilders: joinBuilders));
-
-  ColumnFilters<String> get name => $state.composableBuilder(
-      column: $state.table.name,
-      builder: (column, joinBuilders) =>
-          ColumnFilters(column, joinBuilders: joinBuilders));
-
+  ColumnFilters<int> get id => ColumnFilters($state.table.id);
+  ColumnFilters<String> get name => ColumnFilters($state.table.name);
   ColumnWithTypeConverterFilters<Color, Color, int> get color =>
-      $state.composableBuilder(
-          column: $state.table.color,
-          builder: (column, joinBuilders) => ColumnWithTypeConverterFilters(
-              column,
-              joinBuilders: joinBuilders));
-
+      ColumnWithTypeConverterFilters($state.table.color);
   ComposableFilter todoEntriesRefs(
       ComposableFilter Function($$TodoEntriesTableFilterComposer f) f) {
     final $$TodoEntriesTableFilterComposer composer = $state.composerBuilder(
@@ -821,23 +827,12 @@ class $$CategoriesTableFilterComposer
 class $$CategoriesTableOrderingComposer
     extends OrderingComposer<_$AppDatabase, $CategoriesTable> {
   $$CategoriesTableOrderingComposer(super.$state);
-  ColumnOrderings<int> get id => $state.composableBuilder(
-      column: $state.table.id,
-      builder: (column, joinBuilders) =>
-          ColumnOrderings(column, joinBuilders: joinBuilders));
-
-  ColumnOrderings<String> get name => $state.composableBuilder(
-      column: $state.table.name,
-      builder: (column, joinBuilders) =>
-          ColumnOrderings(column, joinBuilders: joinBuilders));
-
-  ColumnOrderings<int> get color => $state.composableBuilder(
-      column: $state.table.color,
-      builder: (column, joinBuilders) =>
-          ColumnOrderings(column, joinBuilders: joinBuilders));
+  ColumnOrderings<int> get id => ColumnOrderings($state.table.id);
+  ColumnOrderings<String> get name => ColumnOrderings($state.table.name);
+  ColumnOrderings<int> get color => ColumnOrderings($state.table.color);
 }
 
-typedef $$TodoEntriesTableInsertCompanionBuilder = TodoEntriesCompanion
+typedef $$TodoEntriesTableCreateCompanionBuilder = TodoEntriesCompanion
     Function({
   Value<int> id,
   required String description,
@@ -858,8 +853,7 @@ class $$TodoEntriesTableTableManager extends RootTableManager<
     TodoEntry,
     $$TodoEntriesTableFilterComposer,
     $$TodoEntriesTableOrderingComposer,
-    $$TodoEntriesTableProcessedTableManager,
-    $$TodoEntriesTableInsertCompanionBuilder,
+    $$TodoEntriesTableCreateCompanionBuilder,
     $$TodoEntriesTableUpdateCompanionBuilder> {
   $$TodoEntriesTableTableManager(_$AppDatabase db, $TodoEntriesTable table)
       : super(TableManagerState(
@@ -869,9 +863,7 @@ class $$TodoEntriesTableTableManager extends RootTableManager<
               $$TodoEntriesTableFilterComposer(ComposerState(db, table)),
           orderingComposer:
               $$TodoEntriesTableOrderingComposer(ComposerState(db, table)),
-          getChildManagerBuilder: (p) =>
-              $$TodoEntriesTableProcessedTableManager(p),
-          getUpdateCompanionBuilder: ({
+          updateCompanionCallback: ({
             Value<int> id = const Value.absent(),
             Value<String> description = const Value.absent(),
             Value<int?> category = const Value.absent(),
@@ -883,7 +875,7 @@ class $$TodoEntriesTableTableManager extends RootTableManager<
             category: category,
             dueDate: dueDate,
           ),
-          getInsertCompanionBuilder: ({
+          createCompanionCallback: ({
             Value<int> id = const Value.absent(),
             required String description,
             Value<int?> category = const Value.absent(),
@@ -898,36 +890,22 @@ class $$TodoEntriesTableTableManager extends RootTableManager<
         ));
 }
 
-class $$TodoEntriesTableProcessedTableManager extends ProcessedTableManager<
+typedef $$TodoEntriesTableProcessedTableManager = ProcessedTableManager<
     _$AppDatabase,
     $TodoEntriesTable,
     TodoEntry,
     $$TodoEntriesTableFilterComposer,
     $$TodoEntriesTableOrderingComposer,
-    $$TodoEntriesTableProcessedTableManager,
-    $$TodoEntriesTableInsertCompanionBuilder,
-    $$TodoEntriesTableUpdateCompanionBuilder> {
-  $$TodoEntriesTableProcessedTableManager(super.$state);
-}
+    $$TodoEntriesTableCreateCompanionBuilder,
+    $$TodoEntriesTableUpdateCompanionBuilder>;
 
 class $$TodoEntriesTableFilterComposer
     extends FilterComposer<_$AppDatabase, $TodoEntriesTable> {
   $$TodoEntriesTableFilterComposer(super.$state);
-  ColumnFilters<int> get id => $state.composableBuilder(
-      column: $state.table.id,
-      builder: (column, joinBuilders) =>
-          ColumnFilters(column, joinBuilders: joinBuilders));
-
-  ColumnFilters<String> get description => $state.composableBuilder(
-      column: $state.table.description,
-      builder: (column, joinBuilders) =>
-          ColumnFilters(column, joinBuilders: joinBuilders));
-
-  ColumnFilters<DateTime> get dueDate => $state.composableBuilder(
-      column: $state.table.dueDate,
-      builder: (column, joinBuilders) =>
-          ColumnFilters(column, joinBuilders: joinBuilders));
-
+  ColumnFilters<int> get id => ColumnFilters($state.table.id);
+  ColumnFilters<String> get description =>
+      ColumnFilters($state.table.description);
+  ColumnFilters<DateTime> get dueDate => ColumnFilters($state.table.dueDate);
   $$CategoriesTableFilterComposer get category {
     final $$CategoriesTableFilterComposer composer = $state.composerBuilder(
         composer: this,
@@ -944,21 +922,11 @@ class $$TodoEntriesTableFilterComposer
 class $$TodoEntriesTableOrderingComposer
     extends OrderingComposer<_$AppDatabase, $TodoEntriesTable> {
   $$TodoEntriesTableOrderingComposer(super.$state);
-  ColumnOrderings<int> get id => $state.composableBuilder(
-      column: $state.table.id,
-      builder: (column, joinBuilders) =>
-          ColumnOrderings(column, joinBuilders: joinBuilders));
-
-  ColumnOrderings<String> get description => $state.composableBuilder(
-      column: $state.table.description,
-      builder: (column, joinBuilders) =>
-          ColumnOrderings(column, joinBuilders: joinBuilders));
-
-  ColumnOrderings<DateTime> get dueDate => $state.composableBuilder(
-      column: $state.table.dueDate,
-      builder: (column, joinBuilders) =>
-          ColumnOrderings(column, joinBuilders: joinBuilders));
-
+  ColumnOrderings<int> get id => ColumnOrderings($state.table.id);
+  ColumnOrderings<String> get description =>
+      ColumnOrderings($state.table.description);
+  ColumnOrderings<DateTime> get dueDate =>
+      ColumnOrderings($state.table.dueDate);
   $$CategoriesTableOrderingComposer get category {
     final $$CategoriesTableOrderingComposer composer = $state.composerBuilder(
         composer: this,
@@ -972,7 +940,7 @@ class $$TodoEntriesTableOrderingComposer
   }
 }
 
-typedef $TextEntriesInsertCompanionBuilder = TextEntriesCompanion Function({
+typedef $TextEntriesCreateCompanionBuilder = TextEntriesCompanion Function({
   required String description,
   Value<int> rowid,
 });
@@ -987,8 +955,7 @@ class $TextEntriesTableManager extends RootTableManager<
     TextEntry,
     $TextEntriesFilterComposer,
     $TextEntriesOrderingComposer,
-    $TextEntriesProcessedTableManager,
-    $TextEntriesInsertCompanionBuilder,
+    $TextEntriesCreateCompanionBuilder,
     $TextEntriesUpdateCompanionBuilder> {
   $TextEntriesTableManager(_$AppDatabase db, TextEntries table)
       : super(TableManagerState(
@@ -998,8 +965,7 @@ class $TextEntriesTableManager extends RootTableManager<
               $TextEntriesFilterComposer(ComposerState(db, table)),
           orderingComposer:
               $TextEntriesOrderingComposer(ComposerState(db, table)),
-          getChildManagerBuilder: (p) => $TextEntriesProcessedTableManager(p),
-          getUpdateCompanionBuilder: ({
+          updateCompanionCallback: ({
             Value<String> description = const Value.absent(),
             Value<int> rowid = const Value.absent(),
           }) =>
@@ -1007,7 +973,7 @@ class $TextEntriesTableManager extends RootTableManager<
             description: description,
             rowid: rowid,
           ),
-          getInsertCompanionBuilder: ({
+          createCompanionCallback: ({
             required String description,
             Value<int> rowid = const Value.absent(),
           }) =>
@@ -1018,34 +984,27 @@ class $TextEntriesTableManager extends RootTableManager<
         ));
 }
 
-class $TextEntriesProcessedTableManager extends ProcessedTableManager<
+typedef $TextEntriesProcessedTableManager = ProcessedTableManager<
     _$AppDatabase,
     TextEntries,
     TextEntry,
     $TextEntriesFilterComposer,
     $TextEntriesOrderingComposer,
-    $TextEntriesProcessedTableManager,
-    $TextEntriesInsertCompanionBuilder,
-    $TextEntriesUpdateCompanionBuilder> {
-  $TextEntriesProcessedTableManager(super.$state);
-}
+    $TextEntriesCreateCompanionBuilder,
+    $TextEntriesUpdateCompanionBuilder>;
 
 class $TextEntriesFilterComposer
     extends FilterComposer<_$AppDatabase, TextEntries> {
   $TextEntriesFilterComposer(super.$state);
-  ColumnFilters<String> get description => $state.composableBuilder(
-      column: $state.table.description,
-      builder: (column, joinBuilders) =>
-          ColumnFilters(column, joinBuilders: joinBuilders));
+  ColumnFilters<String> get description =>
+      ColumnFilters($state.table.description);
 }
 
 class $TextEntriesOrderingComposer
     extends OrderingComposer<_$AppDatabase, TextEntries> {
   $TextEntriesOrderingComposer(super.$state);
-  ColumnOrderings<String> get description => $state.composableBuilder(
-      column: $state.table.description,
-      builder: (column, joinBuilders) =>
-          ColumnOrderings(column, joinBuilders: joinBuilders));
+  ColumnOrderings<String> get description =>
+      ColumnOrderings($state.table.description);
 }
 
 class $AppDatabaseManager {

--- a/examples/app/lib/database/database.g.dart
+++ b/examples/app/lib/database/database.g.dart
@@ -806,10 +806,23 @@ typedef $$CategoriesTableProcessedTableManager = ProcessedTableManager<
 class $$CategoriesTableFilterComposer
     extends FilterComposer<_$AppDatabase, $CategoriesTable> {
   $$CategoriesTableFilterComposer(super.$state);
-  ColumnFilters<int> get id => ColumnFilters($state.table.id);
-  ColumnFilters<String> get name => ColumnFilters($state.table.name);
+  ColumnFilters<int> get id => $state.composableBuilder(
+      column: $state.table.id,
+      builder: (column, joinBuilders) =>
+          ColumnFilters(column, joinBuilders: joinBuilders));
+
+  ColumnFilters<String> get name => $state.composableBuilder(
+      column: $state.table.name,
+      builder: (column, joinBuilders) =>
+          ColumnFilters(column, joinBuilders: joinBuilders));
+
   ColumnWithTypeConverterFilters<Color, Color, int> get color =>
-      ColumnWithTypeConverterFilters($state.table.color);
+      $state.composableBuilder(
+          column: $state.table.color,
+          builder: (column, joinBuilders) => ColumnWithTypeConverterFilters(
+              column,
+              joinBuilders: joinBuilders));
+
   ComposableFilter todoEntriesRefs(
       ComposableFilter Function($$TodoEntriesTableFilterComposer f) f) {
     final $$TodoEntriesTableFilterComposer composer = $state.composerBuilder(
@@ -827,9 +840,20 @@ class $$CategoriesTableFilterComposer
 class $$CategoriesTableOrderingComposer
     extends OrderingComposer<_$AppDatabase, $CategoriesTable> {
   $$CategoriesTableOrderingComposer(super.$state);
-  ColumnOrderings<int> get id => ColumnOrderings($state.table.id);
-  ColumnOrderings<String> get name => ColumnOrderings($state.table.name);
-  ColumnOrderings<int> get color => ColumnOrderings($state.table.color);
+  ColumnOrderings<int> get id => $state.composableBuilder(
+      column: $state.table.id,
+      builder: (column, joinBuilders) =>
+          ColumnOrderings(column, joinBuilders: joinBuilders));
+
+  ColumnOrderings<String> get name => $state.composableBuilder(
+      column: $state.table.name,
+      builder: (column, joinBuilders) =>
+          ColumnOrderings(column, joinBuilders: joinBuilders));
+
+  ColumnOrderings<int> get color => $state.composableBuilder(
+      column: $state.table.color,
+      builder: (column, joinBuilders) =>
+          ColumnOrderings(column, joinBuilders: joinBuilders));
 }
 
 typedef $$TodoEntriesTableCreateCompanionBuilder = TodoEntriesCompanion
@@ -902,10 +926,21 @@ typedef $$TodoEntriesTableProcessedTableManager = ProcessedTableManager<
 class $$TodoEntriesTableFilterComposer
     extends FilterComposer<_$AppDatabase, $TodoEntriesTable> {
   $$TodoEntriesTableFilterComposer(super.$state);
-  ColumnFilters<int> get id => ColumnFilters($state.table.id);
-  ColumnFilters<String> get description =>
-      ColumnFilters($state.table.description);
-  ColumnFilters<DateTime> get dueDate => ColumnFilters($state.table.dueDate);
+  ColumnFilters<int> get id => $state.composableBuilder(
+      column: $state.table.id,
+      builder: (column, joinBuilders) =>
+          ColumnFilters(column, joinBuilders: joinBuilders));
+
+  ColumnFilters<String> get description => $state.composableBuilder(
+      column: $state.table.description,
+      builder: (column, joinBuilders) =>
+          ColumnFilters(column, joinBuilders: joinBuilders));
+
+  ColumnFilters<DateTime> get dueDate => $state.composableBuilder(
+      column: $state.table.dueDate,
+      builder: (column, joinBuilders) =>
+          ColumnFilters(column, joinBuilders: joinBuilders));
+
   $$CategoriesTableFilterComposer get category {
     final $$CategoriesTableFilterComposer composer = $state.composerBuilder(
         composer: this,
@@ -922,11 +957,21 @@ class $$TodoEntriesTableFilterComposer
 class $$TodoEntriesTableOrderingComposer
     extends OrderingComposer<_$AppDatabase, $TodoEntriesTable> {
   $$TodoEntriesTableOrderingComposer(super.$state);
-  ColumnOrderings<int> get id => ColumnOrderings($state.table.id);
-  ColumnOrderings<String> get description =>
-      ColumnOrderings($state.table.description);
-  ColumnOrderings<DateTime> get dueDate =>
-      ColumnOrderings($state.table.dueDate);
+  ColumnOrderings<int> get id => $state.composableBuilder(
+      column: $state.table.id,
+      builder: (column, joinBuilders) =>
+          ColumnOrderings(column, joinBuilders: joinBuilders));
+
+  ColumnOrderings<String> get description => $state.composableBuilder(
+      column: $state.table.description,
+      builder: (column, joinBuilders) =>
+          ColumnOrderings(column, joinBuilders: joinBuilders));
+
+  ColumnOrderings<DateTime> get dueDate => $state.composableBuilder(
+      column: $state.table.dueDate,
+      builder: (column, joinBuilders) =>
+          ColumnOrderings(column, joinBuilders: joinBuilders));
+
   $$CategoriesTableOrderingComposer get category {
     final $$CategoriesTableOrderingComposer composer = $state.composerBuilder(
         composer: this,
@@ -996,15 +1041,19 @@ typedef $TextEntriesProcessedTableManager = ProcessedTableManager<
 class $TextEntriesFilterComposer
     extends FilterComposer<_$AppDatabase, TextEntries> {
   $TextEntriesFilterComposer(super.$state);
-  ColumnFilters<String> get description =>
-      ColumnFilters($state.table.description);
+  ColumnFilters<String> get description => $state.composableBuilder(
+      column: $state.table.description,
+      builder: (column, joinBuilders) =>
+          ColumnFilters(column, joinBuilders: joinBuilders));
 }
 
 class $TextEntriesOrderingComposer
     extends OrderingComposer<_$AppDatabase, TextEntries> {
   $TextEntriesOrderingComposer(super.$state);
-  ColumnOrderings<String> get description =>
-      ColumnOrderings($state.table.description);
+  ColumnOrderings<String> get description => $state.composableBuilder(
+      column: $state.table.description,
+      builder: (column, joinBuilders) =>
+          ColumnOrderings(column, joinBuilders: joinBuilders));
 }
 
 class $AppDatabaseManager {

--- a/examples/app/lib/database/database.g.dart
+++ b/examples/app/lib/database/database.g.dart
@@ -794,15 +794,6 @@ class $$CategoriesTableTableManager extends RootTableManager<
         ));
 }
 
-typedef $$CategoriesTableProcessedTableManager = ProcessedTableManager<
-    _$AppDatabase,
-    $CategoriesTable,
-    Category,
-    $$CategoriesTableFilterComposer,
-    $$CategoriesTableOrderingComposer,
-    $$CategoriesTableCreateCompanionBuilder,
-    $$CategoriesTableUpdateCompanionBuilder>;
-
 class $$CategoriesTableFilterComposer
     extends FilterComposer<_$AppDatabase, $CategoriesTable> {
   $$CategoriesTableFilterComposer(super.$state);
@@ -914,15 +905,6 @@ class $$TodoEntriesTableTableManager extends RootTableManager<
         ));
 }
 
-typedef $$TodoEntriesTableProcessedTableManager = ProcessedTableManager<
-    _$AppDatabase,
-    $TodoEntriesTable,
-    TodoEntry,
-    $$TodoEntriesTableFilterComposer,
-    $$TodoEntriesTableOrderingComposer,
-    $$TodoEntriesTableCreateCompanionBuilder,
-    $$TodoEntriesTableUpdateCompanionBuilder>;
-
 class $$TodoEntriesTableFilterComposer
     extends FilterComposer<_$AppDatabase, $TodoEntriesTable> {
   $$TodoEntriesTableFilterComposer(super.$state);
@@ -1028,15 +1010,6 @@ class $TextEntriesTableManager extends RootTableManager<
           ),
         ));
 }
-
-typedef $TextEntriesProcessedTableManager = ProcessedTableManager<
-    _$AppDatabase,
-    TextEntries,
-    TextEntry,
-    $TextEntriesFilterComposer,
-    $TextEntriesOrderingComposer,
-    $TextEntriesCreateCompanionBuilder,
-    $TextEntriesUpdateCompanionBuilder>;
 
 class $TextEntriesFilterComposer
     extends FilterComposer<_$AppDatabase, TextEntries> {

--- a/examples/app/lib/screens/backup/supported.dart
+++ b/examples/app/lib/screens/backup/supported.dart
@@ -11,7 +11,7 @@ import 'package:path_provider/path_provider.dart';
 import 'package:sqlite3/sqlite3.dart';
 
 class BackupIcon extends StatelessWidget {
-  const BackupIcon({Key? key}) : super(key: key);
+  const BackupIcon({super.key});
 
   @override
   Widget build(BuildContext context) {
@@ -25,7 +25,7 @@ class BackupIcon extends StatelessWidget {
 }
 
 class BackupDialog extends ConsumerWidget {
-  const BackupDialog({Key? key}) : super(key: key);
+  const BackupDialog({super.key});
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {

--- a/examples/app/lib/screens/backup/unsupported.dart
+++ b/examples/app/lib/screens/backup/unsupported.dart
@@ -1,7 +1,7 @@
 import 'package:flutter/material.dart';
 
 class BackupIcon extends StatelessWidget {
-  const BackupIcon({Key? key}) : super(key: key);
+  const BackupIcon({super.key});
 
   @override
   Widget build(BuildContext context) {

--- a/examples/app/lib/screens/home.dart
+++ b/examples/app/lib/screens/home.dart
@@ -10,7 +10,7 @@ import 'home/drawer.dart';
 import 'home/state.dart';
 
 class HomePage extends ConsumerStatefulWidget {
-  const HomePage({Key? key}) : super(key: key);
+  const HomePage({super.key});
 
   @override
   ConsumerState<HomePage> createState() => _HomePageState();

--- a/examples/app/lib/screens/home/drawer.dart
+++ b/examples/app/lib/screens/home/drawer.dart
@@ -7,7 +7,7 @@ import '../../database/database.dart';
 import 'state.dart';
 
 class CategoriesDrawer extends ConsumerWidget {
-  const CategoriesDrawer({Key? key}) : super(key: key);
+  const CategoriesDrawer({super.key});
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
@@ -49,7 +49,7 @@ class CategoriesDrawer extends ConsumerWidget {
 class _CategoryDrawerEntry extends ConsumerWidget {
   final CategoryWithCount entry;
 
-  const _CategoryDrawerEntry({Key? key, required this.entry}) : super(key: key);
+  const _CategoryDrawerEntry({required this.entry});
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {

--- a/examples/app/lib/screens/home/todo_edit_dialog.dart
+++ b/examples/app/lib/screens/home/todo_edit_dialog.dart
@@ -10,7 +10,7 @@ final _dateFormat = DateFormat.yMMMd();
 class TodoEditDialog extends ConsumerStatefulWidget {
   final TodoEntry entry;
 
-  const TodoEditDialog({Key? key, required this.entry}) : super(key: key);
+  const TodoEditDialog({super.key, required this.entry});
 
   @override
   ConsumerState<TodoEditDialog> createState() => _TodoEditDialogState();

--- a/examples/app/lib/screens/search.dart
+++ b/examples/app/lib/screens/search.dart
@@ -5,7 +5,7 @@ import '../database/database.dart';
 import 'home/card.dart';
 
 class SearchPage extends ConsumerStatefulWidget {
-  const SearchPage({Key? key}) : super(key: key);
+  const SearchPage({super.key});
 
   @override
   ConsumerState<SearchPage> createState() => _SearchPageState();

--- a/examples/encryption/lib/database.g.dart
+++ b/examples/encryption/lib/database.g.dart
@@ -247,15 +247,29 @@ typedef $$NotesTableProcessedTableManager = ProcessedTableManager<
 class $$NotesTableFilterComposer
     extends FilterComposer<_$MyEncryptedDatabase, $NotesTable> {
   $$NotesTableFilterComposer(super.$state);
-  ColumnFilters<int> get id => ColumnFilters($state.table.id);
-  ColumnFilters<String> get content => ColumnFilters($state.table.content);
+  ColumnFilters<int> get id => $state.composableBuilder(
+      column: $state.table.id,
+      builder: (column, joinBuilders) =>
+          ColumnFilters(column, joinBuilders: joinBuilders));
+
+  ColumnFilters<String> get content => $state.composableBuilder(
+      column: $state.table.content,
+      builder: (column, joinBuilders) =>
+          ColumnFilters(column, joinBuilders: joinBuilders));
 }
 
 class $$NotesTableOrderingComposer
     extends OrderingComposer<_$MyEncryptedDatabase, $NotesTable> {
   $$NotesTableOrderingComposer(super.$state);
-  ColumnOrderings<int> get id => ColumnOrderings($state.table.id);
-  ColumnOrderings<String> get content => ColumnOrderings($state.table.content);
+  ColumnOrderings<int> get id => $state.composableBuilder(
+      column: $state.table.id,
+      builder: (column, joinBuilders) =>
+          ColumnOrderings(column, joinBuilders: joinBuilders));
+
+  ColumnOrderings<String> get content => $state.composableBuilder(
+      column: $state.table.content,
+      builder: (column, joinBuilders) =>
+          ColumnOrderings(column, joinBuilders: joinBuilders));
 }
 
 class $MyEncryptedDatabaseManager {

--- a/examples/encryption/lib/database.g.dart
+++ b/examples/encryption/lib/database.g.dart
@@ -235,15 +235,6 @@ class $$NotesTableTableManager extends RootTableManager<
         ));
 }
 
-typedef $$NotesTableProcessedTableManager = ProcessedTableManager<
-    _$MyEncryptedDatabase,
-    $NotesTable,
-    Note,
-    $$NotesTableFilterComposer,
-    $$NotesTableOrderingComposer,
-    $$NotesTableCreateCompanionBuilder,
-    $$NotesTableUpdateCompanionBuilder>;
-
 class $$NotesTableFilterComposer
     extends FilterComposer<_$MyEncryptedDatabase, $NotesTable> {
   $$NotesTableFilterComposer(super.$state);

--- a/examples/encryption/lib/database.g.dart
+++ b/examples/encryption/lib/database.g.dart
@@ -191,7 +191,7 @@ abstract class _$MyEncryptedDatabase extends GeneratedDatabase {
   List<DatabaseSchemaEntity> get allSchemaEntities => [notes];
 }
 
-typedef $$NotesTableInsertCompanionBuilder = NotesCompanion Function({
+typedef $$NotesTableCreateCompanionBuilder = NotesCompanion Function({
   Value<int> id,
   required String content,
 });
@@ -206,8 +206,7 @@ class $$NotesTableTableManager extends RootTableManager<
     Note,
     $$NotesTableFilterComposer,
     $$NotesTableOrderingComposer,
-    $$NotesTableProcessedTableManager,
-    $$NotesTableInsertCompanionBuilder,
+    $$NotesTableCreateCompanionBuilder,
     $$NotesTableUpdateCompanionBuilder> {
   $$NotesTableTableManager(_$MyEncryptedDatabase db, $NotesTable table)
       : super(TableManagerState(
@@ -217,8 +216,7 @@ class $$NotesTableTableManager extends RootTableManager<
               $$NotesTableFilterComposer(ComposerState(db, table)),
           orderingComposer:
               $$NotesTableOrderingComposer(ComposerState(db, table)),
-          getChildManagerBuilder: (p) => $$NotesTableProcessedTableManager(p),
-          getUpdateCompanionBuilder: ({
+          updateCompanionCallback: ({
             Value<int> id = const Value.absent(),
             Value<String> content = const Value.absent(),
           }) =>
@@ -226,7 +224,7 @@ class $$NotesTableTableManager extends RootTableManager<
             id: id,
             content: content,
           ),
-          getInsertCompanionBuilder: ({
+          createCompanionCallback: ({
             Value<int> id = const Value.absent(),
             required String content,
           }) =>
@@ -237,44 +235,27 @@ class $$NotesTableTableManager extends RootTableManager<
         ));
 }
 
-class $$NotesTableProcessedTableManager extends ProcessedTableManager<
+typedef $$NotesTableProcessedTableManager = ProcessedTableManager<
     _$MyEncryptedDatabase,
     $NotesTable,
     Note,
     $$NotesTableFilterComposer,
     $$NotesTableOrderingComposer,
-    $$NotesTableProcessedTableManager,
-    $$NotesTableInsertCompanionBuilder,
-    $$NotesTableUpdateCompanionBuilder> {
-  $$NotesTableProcessedTableManager(super.$state);
-}
+    $$NotesTableCreateCompanionBuilder,
+    $$NotesTableUpdateCompanionBuilder>;
 
 class $$NotesTableFilterComposer
     extends FilterComposer<_$MyEncryptedDatabase, $NotesTable> {
   $$NotesTableFilterComposer(super.$state);
-  ColumnFilters<int> get id => $state.composableBuilder(
-      column: $state.table.id,
-      builder: (column, joinBuilders) =>
-          ColumnFilters(column, joinBuilders: joinBuilders));
-
-  ColumnFilters<String> get content => $state.composableBuilder(
-      column: $state.table.content,
-      builder: (column, joinBuilders) =>
-          ColumnFilters(column, joinBuilders: joinBuilders));
+  ColumnFilters<int> get id => ColumnFilters($state.table.id);
+  ColumnFilters<String> get content => ColumnFilters($state.table.content);
 }
 
 class $$NotesTableOrderingComposer
     extends OrderingComposer<_$MyEncryptedDatabase, $NotesTable> {
   $$NotesTableOrderingComposer(super.$state);
-  ColumnOrderings<int> get id => $state.composableBuilder(
-      column: $state.table.id,
-      builder: (column, joinBuilders) =>
-          ColumnOrderings(column, joinBuilders: joinBuilders));
-
-  ColumnOrderings<String> get content => $state.composableBuilder(
-      column: $state.table.content,
-      builder: (column, joinBuilders) =>
-          ColumnOrderings(column, joinBuilders: joinBuilders));
+  ColumnOrderings<int> get id => ColumnOrderings($state.table.id);
+  ColumnOrderings<String> get content => ColumnOrderings($state.table.content);
 }
 
 class $MyEncryptedDatabaseManager {

--- a/examples/flutter_web_worker_example/lib/src/database/database.g.dart
+++ b/examples/flutter_web_worker_example/lib/src/database/database.g.dart
@@ -267,14 +267,28 @@ typedef $EntriesProcessedTableManager = ProcessedTableManager<
 
 class $EntriesFilterComposer extends FilterComposer<_$MyDatabase, Entries> {
   $EntriesFilterComposer(super.$state);
-  ColumnFilters<int> get id => ColumnFilters($state.table.id);
-  ColumnFilters<String> get value => ColumnFilters($state.table.value);
+  ColumnFilters<int> get id => $state.composableBuilder(
+      column: $state.table.id,
+      builder: (column, joinBuilders) =>
+          ColumnFilters(column, joinBuilders: joinBuilders));
+
+  ColumnFilters<String> get value => $state.composableBuilder(
+      column: $state.table.value,
+      builder: (column, joinBuilders) =>
+          ColumnFilters(column, joinBuilders: joinBuilders));
 }
 
 class $EntriesOrderingComposer extends OrderingComposer<_$MyDatabase, Entries> {
   $EntriesOrderingComposer(super.$state);
-  ColumnOrderings<int> get id => ColumnOrderings($state.table.id);
-  ColumnOrderings<String> get value => ColumnOrderings($state.table.value);
+  ColumnOrderings<int> get id => $state.composableBuilder(
+      column: $state.table.id,
+      builder: (column, joinBuilders) =>
+          ColumnOrderings(column, joinBuilders: joinBuilders));
+
+  ColumnOrderings<String> get value => $state.composableBuilder(
+      column: $state.table.value,
+      builder: (column, joinBuilders) =>
+          ColumnOrderings(column, joinBuilders: joinBuilders));
 }
 
 class $MyDatabaseManager {

--- a/examples/flutter_web_worker_example/lib/src/database/database.g.dart
+++ b/examples/flutter_web_worker_example/lib/src/database/database.g.dart
@@ -256,15 +256,6 @@ class $EntriesTableManager extends RootTableManager<
         ));
 }
 
-typedef $EntriesProcessedTableManager = ProcessedTableManager<
-    _$MyDatabase,
-    Entries,
-    Entry,
-    $EntriesFilterComposer,
-    $EntriesOrderingComposer,
-    $EntriesCreateCompanionBuilder,
-    $EntriesUpdateCompanionBuilder>;
-
 class $EntriesFilterComposer extends FilterComposer<_$MyDatabase, Entries> {
   $EntriesFilterComposer(super.$state);
   ColumnFilters<int> get id => $state.composableBuilder(

--- a/examples/flutter_web_worker_example/lib/src/database/database.g.dart
+++ b/examples/flutter_web_worker_example/lib/src/database/database.g.dart
@@ -214,7 +214,7 @@ abstract class _$MyDatabase extends GeneratedDatabase {
   List<DatabaseSchemaEntity> get allSchemaEntities => [entries];
 }
 
-typedef $EntriesInsertCompanionBuilder = EntriesCompanion Function({
+typedef $EntriesCreateCompanionBuilder = EntriesCompanion Function({
   Value<int> id,
   required String value,
 });
@@ -229,8 +229,7 @@ class $EntriesTableManager extends RootTableManager<
     Entry,
     $EntriesFilterComposer,
     $EntriesOrderingComposer,
-    $EntriesProcessedTableManager,
-    $EntriesInsertCompanionBuilder,
+    $EntriesCreateCompanionBuilder,
     $EntriesUpdateCompanionBuilder> {
   $EntriesTableManager(_$MyDatabase db, Entries table)
       : super(TableManagerState(
@@ -238,8 +237,7 @@ class $EntriesTableManager extends RootTableManager<
           table: table,
           filteringComposer: $EntriesFilterComposer(ComposerState(db, table)),
           orderingComposer: $EntriesOrderingComposer(ComposerState(db, table)),
-          getChildManagerBuilder: (p) => $EntriesProcessedTableManager(p),
-          getUpdateCompanionBuilder: ({
+          updateCompanionCallback: ({
             Value<int> id = const Value.absent(),
             Value<String> value = const Value.absent(),
           }) =>
@@ -247,7 +245,7 @@ class $EntriesTableManager extends RootTableManager<
             id: id,
             value: value,
           ),
-          getInsertCompanionBuilder: ({
+          createCompanionCallback: ({
             Value<int> id = const Value.absent(),
             required String value,
           }) =>
@@ -258,42 +256,25 @@ class $EntriesTableManager extends RootTableManager<
         ));
 }
 
-class $EntriesProcessedTableManager extends ProcessedTableManager<
+typedef $EntriesProcessedTableManager = ProcessedTableManager<
     _$MyDatabase,
     Entries,
     Entry,
     $EntriesFilterComposer,
     $EntriesOrderingComposer,
-    $EntriesProcessedTableManager,
-    $EntriesInsertCompanionBuilder,
-    $EntriesUpdateCompanionBuilder> {
-  $EntriesProcessedTableManager(super.$state);
-}
+    $EntriesCreateCompanionBuilder,
+    $EntriesUpdateCompanionBuilder>;
 
 class $EntriesFilterComposer extends FilterComposer<_$MyDatabase, Entries> {
   $EntriesFilterComposer(super.$state);
-  ColumnFilters<int> get id => $state.composableBuilder(
-      column: $state.table.id,
-      builder: (column, joinBuilders) =>
-          ColumnFilters(column, joinBuilders: joinBuilders));
-
-  ColumnFilters<String> get value => $state.composableBuilder(
-      column: $state.table.value,
-      builder: (column, joinBuilders) =>
-          ColumnFilters(column, joinBuilders: joinBuilders));
+  ColumnFilters<int> get id => ColumnFilters($state.table.id);
+  ColumnFilters<String> get value => ColumnFilters($state.table.value);
 }
 
 class $EntriesOrderingComposer extends OrderingComposer<_$MyDatabase, Entries> {
   $EntriesOrderingComposer(super.$state);
-  ColumnOrderings<int> get id => $state.composableBuilder(
-      column: $state.table.id,
-      builder: (column, joinBuilders) =>
-          ColumnOrderings(column, joinBuilders: joinBuilders));
-
-  ColumnOrderings<String> get value => $state.composableBuilder(
-      column: $state.table.value,
-      builder: (column, joinBuilders) =>
-          ColumnOrderings(column, joinBuilders: joinBuilders));
+  ColumnOrderings<int> get id => ColumnOrderings($state.table.id);
+  ColumnOrderings<String> get value => ColumnOrderings($state.table.value);
 }
 
 class $MyDatabaseManager {

--- a/examples/migrations_example/lib/database.g.dart
+++ b/examples/migrations_example/lib/database.g.dart
@@ -997,9 +997,21 @@ typedef $$UsersTableProcessedTableManager = ProcessedTableManager<
 class $$UsersTableFilterComposer
     extends FilterComposer<_$Database, $UsersTable> {
   $$UsersTableFilterComposer(super.$state);
-  ColumnFilters<int> get id => ColumnFilters($state.table.id);
-  ColumnFilters<String> get name => ColumnFilters($state.table.name);
-  ColumnFilters<DateTime> get birthday => ColumnFilters($state.table.birthday);
+  ColumnFilters<int> get id => $state.composableBuilder(
+      column: $state.table.id,
+      builder: (column, joinBuilders) =>
+          ColumnFilters(column, joinBuilders: joinBuilders));
+
+  ColumnFilters<String> get name => $state.composableBuilder(
+      column: $state.table.name,
+      builder: (column, joinBuilders) =>
+          ColumnFilters(column, joinBuilders: joinBuilders));
+
+  ColumnFilters<DateTime> get birthday => $state.composableBuilder(
+      column: $state.table.birthday,
+      builder: (column, joinBuilders) =>
+          ColumnFilters(column, joinBuilders: joinBuilders));
+
   $$UsersTableFilterComposer get nextUser {
     final $$UsersTableFilterComposer composer = $state.composerBuilder(
         composer: this,
@@ -1029,10 +1041,21 @@ class $$UsersTableFilterComposer
 class $$UsersTableOrderingComposer
     extends OrderingComposer<_$Database, $UsersTable> {
   $$UsersTableOrderingComposer(super.$state);
-  ColumnOrderings<int> get id => ColumnOrderings($state.table.id);
-  ColumnOrderings<String> get name => ColumnOrderings($state.table.name);
-  ColumnOrderings<DateTime> get birthday =>
-      ColumnOrderings($state.table.birthday);
+  ColumnOrderings<int> get id => $state.composableBuilder(
+      column: $state.table.id,
+      builder: (column, joinBuilders) =>
+          ColumnOrderings(column, joinBuilders: joinBuilders));
+
+  ColumnOrderings<String> get name => $state.composableBuilder(
+      column: $state.table.name,
+      builder: (column, joinBuilders) =>
+          ColumnOrderings(column, joinBuilders: joinBuilders));
+
+  ColumnOrderings<DateTime> get birthday => $state.composableBuilder(
+      column: $state.table.birthday,
+      builder: (column, joinBuilders) =>
+          ColumnOrderings(column, joinBuilders: joinBuilders));
+
   $$UsersTableOrderingComposer get nextUser {
     final $$UsersTableOrderingComposer composer = $state.composerBuilder(
         composer: this,
@@ -1111,9 +1134,21 @@ typedef $GroupsProcessedTableManager = ProcessedTableManager<
 
 class $GroupsFilterComposer extends FilterComposer<_$Database, Groups> {
   $GroupsFilterComposer(super.$state);
-  ColumnFilters<int> get id => ColumnFilters($state.table.id);
-  ColumnFilters<String> get title => ColumnFilters($state.table.title);
-  ColumnFilters<bool> get deleted => ColumnFilters($state.table.deleted);
+  ColumnFilters<int> get id => $state.composableBuilder(
+      column: $state.table.id,
+      builder: (column, joinBuilders) =>
+          ColumnFilters(column, joinBuilders: joinBuilders));
+
+  ColumnFilters<String> get title => $state.composableBuilder(
+      column: $state.table.title,
+      builder: (column, joinBuilders) =>
+          ColumnFilters(column, joinBuilders: joinBuilders));
+
+  ColumnFilters<bool> get deleted => $state.composableBuilder(
+      column: $state.table.deleted,
+      builder: (column, joinBuilders) =>
+          ColumnFilters(column, joinBuilders: joinBuilders));
+
   $$UsersTableFilterComposer get owner {
     final $$UsersTableFilterComposer composer = $state.composerBuilder(
         composer: this,
@@ -1129,9 +1164,21 @@ class $GroupsFilterComposer extends FilterComposer<_$Database, Groups> {
 
 class $GroupsOrderingComposer extends OrderingComposer<_$Database, Groups> {
   $GroupsOrderingComposer(super.$state);
-  ColumnOrderings<int> get id => ColumnOrderings($state.table.id);
-  ColumnOrderings<String> get title => ColumnOrderings($state.table.title);
-  ColumnOrderings<bool> get deleted => ColumnOrderings($state.table.deleted);
+  ColumnOrderings<int> get id => $state.composableBuilder(
+      column: $state.table.id,
+      builder: (column, joinBuilders) =>
+          ColumnOrderings(column, joinBuilders: joinBuilders));
+
+  ColumnOrderings<String> get title => $state.composableBuilder(
+      column: $state.table.title,
+      builder: (column, joinBuilders) =>
+          ColumnOrderings(column, joinBuilders: joinBuilders));
+
+  ColumnOrderings<bool> get deleted => $state.composableBuilder(
+      column: $state.table.deleted,
+      builder: (column, joinBuilders) =>
+          ColumnOrderings(column, joinBuilders: joinBuilders));
+
   $$UsersTableOrderingComposer get owner {
     final $$UsersTableOrderingComposer composer = $state.composerBuilder(
         composer: this,
@@ -1210,18 +1257,38 @@ typedef $NotesProcessedTableManager = ProcessedTableManager<
 
 class $NotesFilterComposer extends FilterComposer<_$Database, Notes> {
   $NotesFilterComposer(super.$state);
-  ColumnFilters<String> get title => ColumnFilters($state.table.title);
-  ColumnFilters<String> get content => ColumnFilters($state.table.content);
-  ColumnFilters<String> get searchTerms =>
-      ColumnFilters($state.table.searchTerms);
+  ColumnFilters<String> get title => $state.composableBuilder(
+      column: $state.table.title,
+      builder: (column, joinBuilders) =>
+          ColumnFilters(column, joinBuilders: joinBuilders));
+
+  ColumnFilters<String> get content => $state.composableBuilder(
+      column: $state.table.content,
+      builder: (column, joinBuilders) =>
+          ColumnFilters(column, joinBuilders: joinBuilders));
+
+  ColumnFilters<String> get searchTerms => $state.composableBuilder(
+      column: $state.table.searchTerms,
+      builder: (column, joinBuilders) =>
+          ColumnFilters(column, joinBuilders: joinBuilders));
 }
 
 class $NotesOrderingComposer extends OrderingComposer<_$Database, Notes> {
   $NotesOrderingComposer(super.$state);
-  ColumnOrderings<String> get title => ColumnOrderings($state.table.title);
-  ColumnOrderings<String> get content => ColumnOrderings($state.table.content);
-  ColumnOrderings<String> get searchTerms =>
-      ColumnOrderings($state.table.searchTerms);
+  ColumnOrderings<String> get title => $state.composableBuilder(
+      column: $state.table.title,
+      builder: (column, joinBuilders) =>
+          ColumnOrderings(column, joinBuilders: joinBuilders));
+
+  ColumnOrderings<String> get content => $state.composableBuilder(
+      column: $state.table.content,
+      builder: (column, joinBuilders) =>
+          ColumnOrderings(column, joinBuilders: joinBuilders));
+
+  ColumnOrderings<String> get searchTerms => $state.composableBuilder(
+      column: $state.table.searchTerms,
+      builder: (column, joinBuilders) =>
+          ColumnOrderings(column, joinBuilders: joinBuilders));
 }
 
 class $DatabaseManager {

--- a/examples/migrations_example/lib/database.g.dart
+++ b/examples/migrations_example/lib/database.g.dart
@@ -985,15 +985,6 @@ class $$UsersTableTableManager extends RootTableManager<
         ));
 }
 
-typedef $$UsersTableProcessedTableManager = ProcessedTableManager<
-    _$Database,
-    $UsersTable,
-    User,
-    $$UsersTableFilterComposer,
-    $$UsersTableOrderingComposer,
-    $$UsersTableCreateCompanionBuilder,
-    $$UsersTableUpdateCompanionBuilder>;
-
 class $$UsersTableFilterComposer
     extends FilterComposer<_$Database, $UsersTable> {
   $$UsersTableFilterComposer(super.$state);
@@ -1123,15 +1114,6 @@ class $GroupsTableManager extends RootTableManager<
         ));
 }
 
-typedef $GroupsProcessedTableManager = ProcessedTableManager<
-    _$Database,
-    Groups,
-    Group,
-    $GroupsFilterComposer,
-    $GroupsOrderingComposer,
-    $GroupsCreateCompanionBuilder,
-    $GroupsUpdateCompanionBuilder>;
-
 class $GroupsFilterComposer extends FilterComposer<_$Database, Groups> {
   $GroupsFilterComposer(super.$state);
   ColumnFilters<int> get id => $state.composableBuilder(
@@ -1245,15 +1227,6 @@ class $NotesTableManager extends RootTableManager<
           ),
         ));
 }
-
-typedef $NotesProcessedTableManager = ProcessedTableManager<
-    _$Database,
-    Notes,
-    Note,
-    $NotesFilterComposer,
-    $NotesOrderingComposer,
-    $NotesCreateCompanionBuilder,
-    $NotesUpdateCompanionBuilder>;
 
 class $NotesFilterComposer extends FilterComposer<_$Database, Notes> {
   $NotesFilterComposer(super.$state);

--- a/examples/migrations_example/lib/database.g.dart
+++ b/examples/migrations_example/lib/database.g.dart
@@ -162,6 +162,15 @@ class User extends DataClass implements Insertable<User> {
         birthday: birthday.present ? birthday.value : this.birthday,
         nextUser: nextUser.present ? nextUser.value : this.nextUser,
       );
+  User copyWithCompanion(UsersCompanion data) {
+    return User(
+      id: data.id.present ? data.id.value : this.id,
+      name: data.name.present ? data.name.value : this.name,
+      birthday: data.birthday.present ? data.birthday.value : this.birthday,
+      nextUser: data.nextUser.present ? data.nextUser.value : this.nextUser,
+    );
+  }
+
   @override
   String toString() {
     return (StringBuffer('User(')
@@ -417,6 +426,15 @@ class Group extends DataClass implements Insertable<Group> {
         deleted: deleted.present ? deleted.value : this.deleted,
         owner: owner ?? this.owner,
       );
+  Group copyWithCompanion(GroupsCompanion data) {
+    return Group(
+      id: data.id.present ? data.id.value : this.id,
+      title: data.title.present ? data.title.value : this.title,
+      deleted: data.deleted.present ? data.deleted.value : this.deleted,
+      owner: data.owner.present ? data.owner.value : this.owner,
+    );
+  }
+
   @override
   String toString() {
     return (StringBuffer('Group(')
@@ -650,6 +668,15 @@ class Note extends DataClass implements Insertable<Note> {
         content: content ?? this.content,
         searchTerms: searchTerms ?? this.searchTerms,
       );
+  Note copyWithCompanion(NotesCompanion data) {
+    return Note(
+      title: data.title.present ? data.title.value : this.title,
+      content: data.content.present ? data.content.value : this.content,
+      searchTerms:
+          data.searchTerms.present ? data.searchTerms.value : this.searchTerms,
+    );
+  }
+
   @override
   String toString() {
     return (StringBuffer('Note(')
@@ -902,7 +929,7 @@ abstract class _$Database extends GeneratedDatabase {
       const DriftDatabaseOptions(storeDateTimeAsText: true);
 }
 
-typedef $$UsersTableInsertCompanionBuilder = UsersCompanion Function({
+typedef $$UsersTableCreateCompanionBuilder = UsersCompanion Function({
   Value<int> id,
   Value<String> name,
   Value<DateTime?> birthday,
@@ -921,8 +948,7 @@ class $$UsersTableTableManager extends RootTableManager<
     User,
     $$UsersTableFilterComposer,
     $$UsersTableOrderingComposer,
-    $$UsersTableProcessedTableManager,
-    $$UsersTableInsertCompanionBuilder,
+    $$UsersTableCreateCompanionBuilder,
     $$UsersTableUpdateCompanionBuilder> {
   $$UsersTableTableManager(_$Database db, $UsersTable table)
       : super(TableManagerState(
@@ -932,8 +958,7 @@ class $$UsersTableTableManager extends RootTableManager<
               $$UsersTableFilterComposer(ComposerState(db, table)),
           orderingComposer:
               $$UsersTableOrderingComposer(ComposerState(db, table)),
-          getChildManagerBuilder: (p) => $$UsersTableProcessedTableManager(p),
-          getUpdateCompanionBuilder: ({
+          updateCompanionCallback: ({
             Value<int> id = const Value.absent(),
             Value<String> name = const Value.absent(),
             Value<DateTime?> birthday = const Value.absent(),
@@ -945,7 +970,7 @@ class $$UsersTableTableManager extends RootTableManager<
             birthday: birthday,
             nextUser: nextUser,
           ),
-          getInsertCompanionBuilder: ({
+          createCompanionCallback: ({
             Value<int> id = const Value.absent(),
             Value<String> name = const Value.absent(),
             Value<DateTime?> birthday = const Value.absent(),
@@ -960,36 +985,21 @@ class $$UsersTableTableManager extends RootTableManager<
         ));
 }
 
-class $$UsersTableProcessedTableManager extends ProcessedTableManager<
+typedef $$UsersTableProcessedTableManager = ProcessedTableManager<
     _$Database,
     $UsersTable,
     User,
     $$UsersTableFilterComposer,
     $$UsersTableOrderingComposer,
-    $$UsersTableProcessedTableManager,
-    $$UsersTableInsertCompanionBuilder,
-    $$UsersTableUpdateCompanionBuilder> {
-  $$UsersTableProcessedTableManager(super.$state);
-}
+    $$UsersTableCreateCompanionBuilder,
+    $$UsersTableUpdateCompanionBuilder>;
 
 class $$UsersTableFilterComposer
     extends FilterComposer<_$Database, $UsersTable> {
   $$UsersTableFilterComposer(super.$state);
-  ColumnFilters<int> get id => $state.composableBuilder(
-      column: $state.table.id,
-      builder: (column, joinBuilders) =>
-          ColumnFilters(column, joinBuilders: joinBuilders));
-
-  ColumnFilters<String> get name => $state.composableBuilder(
-      column: $state.table.name,
-      builder: (column, joinBuilders) =>
-          ColumnFilters(column, joinBuilders: joinBuilders));
-
-  ColumnFilters<DateTime> get birthday => $state.composableBuilder(
-      column: $state.table.birthday,
-      builder: (column, joinBuilders) =>
-          ColumnFilters(column, joinBuilders: joinBuilders));
-
+  ColumnFilters<int> get id => ColumnFilters($state.table.id);
+  ColumnFilters<String> get name => ColumnFilters($state.table.name);
+  ColumnFilters<DateTime> get birthday => ColumnFilters($state.table.birthday);
   $$UsersTableFilterComposer get nextUser {
     final $$UsersTableFilterComposer composer = $state.composerBuilder(
         composer: this,
@@ -1019,21 +1029,10 @@ class $$UsersTableFilterComposer
 class $$UsersTableOrderingComposer
     extends OrderingComposer<_$Database, $UsersTable> {
   $$UsersTableOrderingComposer(super.$state);
-  ColumnOrderings<int> get id => $state.composableBuilder(
-      column: $state.table.id,
-      builder: (column, joinBuilders) =>
-          ColumnOrderings(column, joinBuilders: joinBuilders));
-
-  ColumnOrderings<String> get name => $state.composableBuilder(
-      column: $state.table.name,
-      builder: (column, joinBuilders) =>
-          ColumnOrderings(column, joinBuilders: joinBuilders));
-
-  ColumnOrderings<DateTime> get birthday => $state.composableBuilder(
-      column: $state.table.birthday,
-      builder: (column, joinBuilders) =>
-          ColumnOrderings(column, joinBuilders: joinBuilders));
-
+  ColumnOrderings<int> get id => ColumnOrderings($state.table.id);
+  ColumnOrderings<String> get name => ColumnOrderings($state.table.name);
+  ColumnOrderings<DateTime> get birthday =>
+      ColumnOrderings($state.table.birthday);
   $$UsersTableOrderingComposer get nextUser {
     final $$UsersTableOrderingComposer composer = $state.composerBuilder(
         composer: this,
@@ -1047,7 +1046,7 @@ class $$UsersTableOrderingComposer
   }
 }
 
-typedef $GroupsInsertCompanionBuilder = GroupsCompanion Function({
+typedef $GroupsCreateCompanionBuilder = GroupsCompanion Function({
   Value<int> id,
   required String title,
   Value<bool?> deleted,
@@ -1066,8 +1065,7 @@ class $GroupsTableManager extends RootTableManager<
     Group,
     $GroupsFilterComposer,
     $GroupsOrderingComposer,
-    $GroupsProcessedTableManager,
-    $GroupsInsertCompanionBuilder,
+    $GroupsCreateCompanionBuilder,
     $GroupsUpdateCompanionBuilder> {
   $GroupsTableManager(_$Database db, Groups table)
       : super(TableManagerState(
@@ -1075,8 +1073,7 @@ class $GroupsTableManager extends RootTableManager<
           table: table,
           filteringComposer: $GroupsFilterComposer(ComposerState(db, table)),
           orderingComposer: $GroupsOrderingComposer(ComposerState(db, table)),
-          getChildManagerBuilder: (p) => $GroupsProcessedTableManager(p),
-          getUpdateCompanionBuilder: ({
+          updateCompanionCallback: ({
             Value<int> id = const Value.absent(),
             Value<String> title = const Value.absent(),
             Value<bool?> deleted = const Value.absent(),
@@ -1088,7 +1085,7 @@ class $GroupsTableManager extends RootTableManager<
             deleted: deleted,
             owner: owner,
           ),
-          getInsertCompanionBuilder: ({
+          createCompanionCallback: ({
             Value<int> id = const Value.absent(),
             required String title,
             Value<bool?> deleted = const Value.absent(),
@@ -1103,35 +1100,20 @@ class $GroupsTableManager extends RootTableManager<
         ));
 }
 
-class $GroupsProcessedTableManager extends ProcessedTableManager<
+typedef $GroupsProcessedTableManager = ProcessedTableManager<
     _$Database,
     Groups,
     Group,
     $GroupsFilterComposer,
     $GroupsOrderingComposer,
-    $GroupsProcessedTableManager,
-    $GroupsInsertCompanionBuilder,
-    $GroupsUpdateCompanionBuilder> {
-  $GroupsProcessedTableManager(super.$state);
-}
+    $GroupsCreateCompanionBuilder,
+    $GroupsUpdateCompanionBuilder>;
 
 class $GroupsFilterComposer extends FilterComposer<_$Database, Groups> {
   $GroupsFilterComposer(super.$state);
-  ColumnFilters<int> get id => $state.composableBuilder(
-      column: $state.table.id,
-      builder: (column, joinBuilders) =>
-          ColumnFilters(column, joinBuilders: joinBuilders));
-
-  ColumnFilters<String> get title => $state.composableBuilder(
-      column: $state.table.title,
-      builder: (column, joinBuilders) =>
-          ColumnFilters(column, joinBuilders: joinBuilders));
-
-  ColumnFilters<bool> get deleted => $state.composableBuilder(
-      column: $state.table.deleted,
-      builder: (column, joinBuilders) =>
-          ColumnFilters(column, joinBuilders: joinBuilders));
-
+  ColumnFilters<int> get id => ColumnFilters($state.table.id);
+  ColumnFilters<String> get title => ColumnFilters($state.table.title);
+  ColumnFilters<bool> get deleted => ColumnFilters($state.table.deleted);
   $$UsersTableFilterComposer get owner {
     final $$UsersTableFilterComposer composer = $state.composerBuilder(
         composer: this,
@@ -1147,21 +1129,9 @@ class $GroupsFilterComposer extends FilterComposer<_$Database, Groups> {
 
 class $GroupsOrderingComposer extends OrderingComposer<_$Database, Groups> {
   $GroupsOrderingComposer(super.$state);
-  ColumnOrderings<int> get id => $state.composableBuilder(
-      column: $state.table.id,
-      builder: (column, joinBuilders) =>
-          ColumnOrderings(column, joinBuilders: joinBuilders));
-
-  ColumnOrderings<String> get title => $state.composableBuilder(
-      column: $state.table.title,
-      builder: (column, joinBuilders) =>
-          ColumnOrderings(column, joinBuilders: joinBuilders));
-
-  ColumnOrderings<bool> get deleted => $state.composableBuilder(
-      column: $state.table.deleted,
-      builder: (column, joinBuilders) =>
-          ColumnOrderings(column, joinBuilders: joinBuilders));
-
+  ColumnOrderings<int> get id => ColumnOrderings($state.table.id);
+  ColumnOrderings<String> get title => ColumnOrderings($state.table.title);
+  ColumnOrderings<bool> get deleted => ColumnOrderings($state.table.deleted);
   $$UsersTableOrderingComposer get owner {
     final $$UsersTableOrderingComposer composer = $state.composerBuilder(
         composer: this,
@@ -1175,7 +1145,7 @@ class $GroupsOrderingComposer extends OrderingComposer<_$Database, Groups> {
   }
 }
 
-typedef $NotesInsertCompanionBuilder = NotesCompanion Function({
+typedef $NotesCreateCompanionBuilder = NotesCompanion Function({
   required String title,
   required String content,
   required String searchTerms,
@@ -1194,8 +1164,7 @@ class $NotesTableManager extends RootTableManager<
     Note,
     $NotesFilterComposer,
     $NotesOrderingComposer,
-    $NotesProcessedTableManager,
-    $NotesInsertCompanionBuilder,
+    $NotesCreateCompanionBuilder,
     $NotesUpdateCompanionBuilder> {
   $NotesTableManager(_$Database db, Notes table)
       : super(TableManagerState(
@@ -1203,8 +1172,7 @@ class $NotesTableManager extends RootTableManager<
           table: table,
           filteringComposer: $NotesFilterComposer(ComposerState(db, table)),
           orderingComposer: $NotesOrderingComposer(ComposerState(db, table)),
-          getChildManagerBuilder: (p) => $NotesProcessedTableManager(p),
-          getUpdateCompanionBuilder: ({
+          updateCompanionCallback: ({
             Value<String> title = const Value.absent(),
             Value<String> content = const Value.absent(),
             Value<String> searchTerms = const Value.absent(),
@@ -1216,7 +1184,7 @@ class $NotesTableManager extends RootTableManager<
             searchTerms: searchTerms,
             rowid: rowid,
           ),
-          getInsertCompanionBuilder: ({
+          createCompanionCallback: ({
             required String title,
             required String content,
             required String searchTerms,
@@ -1231,52 +1199,29 @@ class $NotesTableManager extends RootTableManager<
         ));
 }
 
-class $NotesProcessedTableManager extends ProcessedTableManager<
+typedef $NotesProcessedTableManager = ProcessedTableManager<
     _$Database,
     Notes,
     Note,
     $NotesFilterComposer,
     $NotesOrderingComposer,
-    $NotesProcessedTableManager,
-    $NotesInsertCompanionBuilder,
-    $NotesUpdateCompanionBuilder> {
-  $NotesProcessedTableManager(super.$state);
-}
+    $NotesCreateCompanionBuilder,
+    $NotesUpdateCompanionBuilder>;
 
 class $NotesFilterComposer extends FilterComposer<_$Database, Notes> {
   $NotesFilterComposer(super.$state);
-  ColumnFilters<String> get title => $state.composableBuilder(
-      column: $state.table.title,
-      builder: (column, joinBuilders) =>
-          ColumnFilters(column, joinBuilders: joinBuilders));
-
-  ColumnFilters<String> get content => $state.composableBuilder(
-      column: $state.table.content,
-      builder: (column, joinBuilders) =>
-          ColumnFilters(column, joinBuilders: joinBuilders));
-
-  ColumnFilters<String> get searchTerms => $state.composableBuilder(
-      column: $state.table.searchTerms,
-      builder: (column, joinBuilders) =>
-          ColumnFilters(column, joinBuilders: joinBuilders));
+  ColumnFilters<String> get title => ColumnFilters($state.table.title);
+  ColumnFilters<String> get content => ColumnFilters($state.table.content);
+  ColumnFilters<String> get searchTerms =>
+      ColumnFilters($state.table.searchTerms);
 }
 
 class $NotesOrderingComposer extends OrderingComposer<_$Database, Notes> {
   $NotesOrderingComposer(super.$state);
-  ColumnOrderings<String> get title => $state.composableBuilder(
-      column: $state.table.title,
-      builder: (column, joinBuilders) =>
-          ColumnOrderings(column, joinBuilders: joinBuilders));
-
-  ColumnOrderings<String> get content => $state.composableBuilder(
-      column: $state.table.content,
-      builder: (column, joinBuilders) =>
-          ColumnOrderings(column, joinBuilders: joinBuilders));
-
-  ColumnOrderings<String> get searchTerms => $state.composableBuilder(
-      column: $state.table.searchTerms,
-      builder: (column, joinBuilders) =>
-          ColumnOrderings(column, joinBuilders: joinBuilders));
+  ColumnOrderings<String> get title => ColumnOrderings($state.table.title);
+  ColumnOrderings<String> get content => ColumnOrderings($state.table.content);
+  ColumnOrderings<String> get searchTerms =>
+      ColumnOrderings($state.table.searchTerms);
 }
 
 class $DatabaseManager {

--- a/examples/modular/lib/src/posts.drift.dart
+++ b/examples/modular/lib/src/posts.drift.dart
@@ -287,9 +287,16 @@ typedef $PostsProcessedTableManager = i0.ProcessedTableManager<
 class $PostsFilterComposer
     extends i0.FilterComposer<i0.GeneratedDatabase, i1.Posts> {
   $PostsFilterComposer(super.$state);
-  i0.ColumnFilters<int> get id => i0.ColumnFilters($state.table.id);
-  i0.ColumnFilters<String> get content =>
-      i0.ColumnFilters($state.table.content);
+  i0.ColumnFilters<int> get id => $state.composableBuilder(
+      column: $state.table.id,
+      builder: (column, joinBuilders) =>
+          i0.ColumnFilters(column, joinBuilders: joinBuilders));
+
+  i0.ColumnFilters<String> get content => $state.composableBuilder(
+      column: $state.table.content,
+      builder: (column, joinBuilders) =>
+          i0.ColumnFilters(column, joinBuilders: joinBuilders));
+
   i2.$UsersFilterComposer get author {
     final i2.$UsersFilterComposer composer = $state.composerBuilder(
         composer: this,
@@ -311,9 +318,16 @@ class $PostsFilterComposer
 class $PostsOrderingComposer
     extends i0.OrderingComposer<i0.GeneratedDatabase, i1.Posts> {
   $PostsOrderingComposer(super.$state);
-  i0.ColumnOrderings<int> get id => i0.ColumnOrderings($state.table.id);
-  i0.ColumnOrderings<String> get content =>
-      i0.ColumnOrderings($state.table.content);
+  i0.ColumnOrderings<int> get id => $state.composableBuilder(
+      column: $state.table.id,
+      builder: (column, joinBuilders) =>
+          i0.ColumnOrderings(column, joinBuilders: joinBuilders));
+
+  i0.ColumnOrderings<String> get content => $state.composableBuilder(
+      column: $state.table.content,
+      builder: (column, joinBuilders) =>
+          i0.ColumnOrderings(column, joinBuilders: joinBuilders));
+
   i2.$UsersOrderingComposer get author {
     final i2.$UsersOrderingComposer composer = $state.composerBuilder(
         composer: this,

--- a/examples/modular/lib/src/posts.drift.dart
+++ b/examples/modular/lib/src/posts.drift.dart
@@ -225,7 +225,7 @@ class PostsCompanion extends i0.UpdateCompanion<i1.Post> {
   }
 }
 
-typedef $PostsInsertCompanionBuilder = i1.PostsCompanion Function({
+typedef $PostsCreateCompanionBuilder = i1.PostsCompanion Function({
   i0.Value<int> id,
   required int author,
   i0.Value<String?> content,
@@ -242,8 +242,7 @@ class $PostsTableManager extends i0.RootTableManager<
     i1.Post,
     i1.$PostsFilterComposer,
     i1.$PostsOrderingComposer,
-    $PostsProcessedTableManager,
-    $PostsInsertCompanionBuilder,
+    $PostsCreateCompanionBuilder,
     $PostsUpdateCompanionBuilder> {
   $PostsTableManager(i0.GeneratedDatabase db, i1.Posts table)
       : super(i0.TableManagerState(
@@ -253,8 +252,7 @@ class $PostsTableManager extends i0.RootTableManager<
               i1.$PostsFilterComposer(i0.ComposerState(db, table)),
           orderingComposer:
               i1.$PostsOrderingComposer(i0.ComposerState(db, table)),
-          getChildManagerBuilder: (p) => $PostsProcessedTableManager(p),
-          getUpdateCompanionBuilder: ({
+          updateCompanionCallback: ({
             i0.Value<int> id = const i0.Value.absent(),
             i0.Value<int> author = const i0.Value.absent(),
             i0.Value<String?> content = const i0.Value.absent(),
@@ -264,7 +262,7 @@ class $PostsTableManager extends i0.RootTableManager<
             author: author,
             content: content,
           ),
-          getInsertCompanionBuilder: ({
+          createCompanionCallback: ({
             i0.Value<int> id = const i0.Value.absent(),
             required int author,
             i0.Value<String?> content = const i0.Value.absent(),
@@ -277,31 +275,21 @@ class $PostsTableManager extends i0.RootTableManager<
         ));
 }
 
-class $PostsProcessedTableManager extends i0.ProcessedTableManager<
+typedef $PostsProcessedTableManager = i0.ProcessedTableManager<
     i0.GeneratedDatabase,
     i1.Posts,
     i1.Post,
     i1.$PostsFilterComposer,
     i1.$PostsOrderingComposer,
-    $PostsProcessedTableManager,
-    $PostsInsertCompanionBuilder,
-    $PostsUpdateCompanionBuilder> {
-  $PostsProcessedTableManager(super.$state);
-}
+    $PostsCreateCompanionBuilder,
+    $PostsUpdateCompanionBuilder>;
 
 class $PostsFilterComposer
     extends i0.FilterComposer<i0.GeneratedDatabase, i1.Posts> {
   $PostsFilterComposer(super.$state);
-  i0.ColumnFilters<int> get id => $state.composableBuilder(
-      column: $state.table.id,
-      builder: (column, joinBuilders) =>
-          i0.ColumnFilters(column, joinBuilders: joinBuilders));
-
-  i0.ColumnFilters<String> get content => $state.composableBuilder(
-      column: $state.table.content,
-      builder: (column, joinBuilders) =>
-          i0.ColumnFilters(column, joinBuilders: joinBuilders));
-
+  i0.ColumnFilters<int> get id => i0.ColumnFilters($state.table.id);
+  i0.ColumnFilters<String> get content =>
+      i0.ColumnFilters($state.table.content);
   i2.$UsersFilterComposer get author {
     final i2.$UsersFilterComposer composer = $state.composerBuilder(
         composer: this,
@@ -323,16 +311,9 @@ class $PostsFilterComposer
 class $PostsOrderingComposer
     extends i0.OrderingComposer<i0.GeneratedDatabase, i1.Posts> {
   $PostsOrderingComposer(super.$state);
-  i0.ColumnOrderings<int> get id => $state.composableBuilder(
-      column: $state.table.id,
-      builder: (column, joinBuilders) =>
-          i0.ColumnOrderings(column, joinBuilders: joinBuilders));
-
-  i0.ColumnOrderings<String> get content => $state.composableBuilder(
-      column: $state.table.content,
-      builder: (column, joinBuilders) =>
-          i0.ColumnOrderings(column, joinBuilders: joinBuilders));
-
+  i0.ColumnOrderings<int> get id => i0.ColumnOrderings($state.table.id);
+  i0.ColumnOrderings<String> get content =>
+      i0.ColumnOrderings($state.table.content);
   i2.$UsersOrderingComposer get author {
     final i2.$UsersOrderingComposer composer = $state.composerBuilder(
         composer: this,
@@ -547,7 +528,7 @@ class LikesCompanion extends i0.UpdateCompanion<i1.Like> {
   }
 }
 
-typedef $LikesInsertCompanionBuilder = i1.LikesCompanion Function({
+typedef $LikesCreateCompanionBuilder = i1.LikesCompanion Function({
   required int post,
   required int likedBy,
   i0.Value<int> rowid,
@@ -564,8 +545,7 @@ class $LikesTableManager extends i0.RootTableManager<
     i1.Like,
     i1.$LikesFilterComposer,
     i1.$LikesOrderingComposer,
-    $LikesProcessedTableManager,
-    $LikesInsertCompanionBuilder,
+    $LikesCreateCompanionBuilder,
     $LikesUpdateCompanionBuilder> {
   $LikesTableManager(i0.GeneratedDatabase db, i1.Likes table)
       : super(i0.TableManagerState(
@@ -575,8 +555,7 @@ class $LikesTableManager extends i0.RootTableManager<
               i1.$LikesFilterComposer(i0.ComposerState(db, table)),
           orderingComposer:
               i1.$LikesOrderingComposer(i0.ComposerState(db, table)),
-          getChildManagerBuilder: (p) => $LikesProcessedTableManager(p),
-          getUpdateCompanionBuilder: ({
+          updateCompanionCallback: ({
             i0.Value<int> post = const i0.Value.absent(),
             i0.Value<int> likedBy = const i0.Value.absent(),
             i0.Value<int> rowid = const i0.Value.absent(),
@@ -586,7 +565,7 @@ class $LikesTableManager extends i0.RootTableManager<
             likedBy: likedBy,
             rowid: rowid,
           ),
-          getInsertCompanionBuilder: ({
+          createCompanionCallback: ({
             required int post,
             required int likedBy,
             i0.Value<int> rowid = const i0.Value.absent(),
@@ -599,17 +578,14 @@ class $LikesTableManager extends i0.RootTableManager<
         ));
 }
 
-class $LikesProcessedTableManager extends i0.ProcessedTableManager<
+typedef $LikesProcessedTableManager = i0.ProcessedTableManager<
     i0.GeneratedDatabase,
     i1.Likes,
     i1.Like,
     i1.$LikesFilterComposer,
     i1.$LikesOrderingComposer,
-    $LikesProcessedTableManager,
-    $LikesInsertCompanionBuilder,
-    $LikesUpdateCompanionBuilder> {
-  $LikesProcessedTableManager(super.$state);
-}
+    $LikesCreateCompanionBuilder,
+    $LikesUpdateCompanionBuilder>;
 
 class $LikesFilterComposer
     extends i0.FilterComposer<i0.GeneratedDatabase, i1.Likes> {

--- a/examples/modular/lib/src/posts.drift.dart
+++ b/examples/modular/lib/src/posts.drift.dart
@@ -275,15 +275,6 @@ class $PostsTableManager extends i0.RootTableManager<
         ));
 }
 
-typedef $PostsProcessedTableManager = i0.ProcessedTableManager<
-    i0.GeneratedDatabase,
-    i1.Posts,
-    i1.Post,
-    i1.$PostsFilterComposer,
-    i1.$PostsOrderingComposer,
-    $PostsCreateCompanionBuilder,
-    $PostsUpdateCompanionBuilder>;
-
 class $PostsFilterComposer
     extends i0.FilterComposer<i0.GeneratedDatabase, i1.Posts> {
   $PostsFilterComposer(super.$state);
@@ -591,15 +582,6 @@ class $LikesTableManager extends i0.RootTableManager<
           ),
         ));
 }
-
-typedef $LikesProcessedTableManager = i0.ProcessedTableManager<
-    i0.GeneratedDatabase,
-    i1.Likes,
-    i1.Like,
-    i1.$LikesFilterComposer,
-    i1.$LikesOrderingComposer,
-    $LikesCreateCompanionBuilder,
-    $LikesUpdateCompanionBuilder>;
 
 class $LikesFilterComposer
     extends i0.FilterComposer<i0.GeneratedDatabase, i1.Likes> {

--- a/examples/modular/lib/src/search.drift.dart
+++ b/examples/modular/lib/src/search.drift.dart
@@ -263,15 +263,6 @@ class $SearchInPostsTableManager extends i0.RootTableManager<
         ));
 }
 
-typedef $SearchInPostsProcessedTableManager = i0.ProcessedTableManager<
-    i0.GeneratedDatabase,
-    i1.SearchInPosts,
-    i1.SearchInPost,
-    i1.$SearchInPostsFilterComposer,
-    i1.$SearchInPostsOrderingComposer,
-    $SearchInPostsCreateCompanionBuilder,
-    $SearchInPostsUpdateCompanionBuilder>;
-
 class $SearchInPostsFilterComposer
     extends i0.FilterComposer<i0.GeneratedDatabase, i1.SearchInPosts> {
   $SearchInPostsFilterComposer(super.$state);

--- a/examples/modular/lib/src/search.drift.dart
+++ b/examples/modular/lib/src/search.drift.dart
@@ -275,18 +275,29 @@ typedef $SearchInPostsProcessedTableManager = i0.ProcessedTableManager<
 class $SearchInPostsFilterComposer
     extends i0.FilterComposer<i0.GeneratedDatabase, i1.SearchInPosts> {
   $SearchInPostsFilterComposer(super.$state);
-  i0.ColumnFilters<String> get author => i0.ColumnFilters($state.table.author);
-  i0.ColumnFilters<String> get content =>
-      i0.ColumnFilters($state.table.content);
+  i0.ColumnFilters<String> get author => $state.composableBuilder(
+      column: $state.table.author,
+      builder: (column, joinBuilders) =>
+          i0.ColumnFilters(column, joinBuilders: joinBuilders));
+
+  i0.ColumnFilters<String> get content => $state.composableBuilder(
+      column: $state.table.content,
+      builder: (column, joinBuilders) =>
+          i0.ColumnFilters(column, joinBuilders: joinBuilders));
 }
 
 class $SearchInPostsOrderingComposer
     extends i0.OrderingComposer<i0.GeneratedDatabase, i1.SearchInPosts> {
   $SearchInPostsOrderingComposer(super.$state);
-  i0.ColumnOrderings<String> get author =>
-      i0.ColumnOrderings($state.table.author);
-  i0.ColumnOrderings<String> get content =>
-      i0.ColumnOrderings($state.table.content);
+  i0.ColumnOrderings<String> get author => $state.composableBuilder(
+      column: $state.table.author,
+      builder: (column, joinBuilders) =>
+          i0.ColumnOrderings(column, joinBuilders: joinBuilders));
+
+  i0.ColumnOrderings<String> get content => $state.composableBuilder(
+      column: $state.table.content,
+      builder: (column, joinBuilders) =>
+          i0.ColumnOrderings(column, joinBuilders: joinBuilders));
 }
 
 i0.Trigger get postsInsert => i0.Trigger(

--- a/examples/modular/lib/src/search.drift.dart
+++ b/examples/modular/lib/src/search.drift.dart
@@ -211,7 +211,7 @@ class SearchInPostsCompanion extends i0.UpdateCompanion<i1.SearchInPost> {
   }
 }
 
-typedef $SearchInPostsInsertCompanionBuilder = i1.SearchInPostsCompanion
+typedef $SearchInPostsCreateCompanionBuilder = i1.SearchInPostsCompanion
     Function({
   required String author,
   required String content,
@@ -230,8 +230,7 @@ class $SearchInPostsTableManager extends i0.RootTableManager<
     i1.SearchInPost,
     i1.$SearchInPostsFilterComposer,
     i1.$SearchInPostsOrderingComposer,
-    $SearchInPostsProcessedTableManager,
-    $SearchInPostsInsertCompanionBuilder,
+    $SearchInPostsCreateCompanionBuilder,
     $SearchInPostsUpdateCompanionBuilder> {
   $SearchInPostsTableManager(i0.GeneratedDatabase db, i1.SearchInPosts table)
       : super(i0.TableManagerState(
@@ -241,8 +240,7 @@ class $SearchInPostsTableManager extends i0.RootTableManager<
               i1.$SearchInPostsFilterComposer(i0.ComposerState(db, table)),
           orderingComposer:
               i1.$SearchInPostsOrderingComposer(i0.ComposerState(db, table)),
-          getChildManagerBuilder: (p) => $SearchInPostsProcessedTableManager(p),
-          getUpdateCompanionBuilder: ({
+          updateCompanionCallback: ({
             i0.Value<String> author = const i0.Value.absent(),
             i0.Value<String> content = const i0.Value.absent(),
             i0.Value<int> rowid = const i0.Value.absent(),
@@ -252,7 +250,7 @@ class $SearchInPostsTableManager extends i0.RootTableManager<
             content: content,
             rowid: rowid,
           ),
-          getInsertCompanionBuilder: ({
+          createCompanionCallback: ({
             required String author,
             required String content,
             i0.Value<int> rowid = const i0.Value.absent(),
@@ -265,44 +263,30 @@ class $SearchInPostsTableManager extends i0.RootTableManager<
         ));
 }
 
-class $SearchInPostsProcessedTableManager extends i0.ProcessedTableManager<
+typedef $SearchInPostsProcessedTableManager = i0.ProcessedTableManager<
     i0.GeneratedDatabase,
     i1.SearchInPosts,
     i1.SearchInPost,
     i1.$SearchInPostsFilterComposer,
     i1.$SearchInPostsOrderingComposer,
-    $SearchInPostsProcessedTableManager,
-    $SearchInPostsInsertCompanionBuilder,
-    $SearchInPostsUpdateCompanionBuilder> {
-  $SearchInPostsProcessedTableManager(super.$state);
-}
+    $SearchInPostsCreateCompanionBuilder,
+    $SearchInPostsUpdateCompanionBuilder>;
 
 class $SearchInPostsFilterComposer
     extends i0.FilterComposer<i0.GeneratedDatabase, i1.SearchInPosts> {
   $SearchInPostsFilterComposer(super.$state);
-  i0.ColumnFilters<String> get author => $state.composableBuilder(
-      column: $state.table.author,
-      builder: (column, joinBuilders) =>
-          i0.ColumnFilters(column, joinBuilders: joinBuilders));
-
-  i0.ColumnFilters<String> get content => $state.composableBuilder(
-      column: $state.table.content,
-      builder: (column, joinBuilders) =>
-          i0.ColumnFilters(column, joinBuilders: joinBuilders));
+  i0.ColumnFilters<String> get author => i0.ColumnFilters($state.table.author);
+  i0.ColumnFilters<String> get content =>
+      i0.ColumnFilters($state.table.content);
 }
 
 class $SearchInPostsOrderingComposer
     extends i0.OrderingComposer<i0.GeneratedDatabase, i1.SearchInPosts> {
   $SearchInPostsOrderingComposer(super.$state);
-  i0.ColumnOrderings<String> get author => $state.composableBuilder(
-      column: $state.table.author,
-      builder: (column, joinBuilders) =>
-          i0.ColumnOrderings(column, joinBuilders: joinBuilders));
-
-  i0.ColumnOrderings<String> get content => $state.composableBuilder(
-      column: $state.table.content,
-      builder: (column, joinBuilders) =>
-          i0.ColumnOrderings(column, joinBuilders: joinBuilders));
+  i0.ColumnOrderings<String> get author =>
+      i0.ColumnOrderings($state.table.author);
+  i0.ColumnOrderings<String> get content =>
+      i0.ColumnOrderings($state.table.content);
 }
 
 i0.Trigger get postsInsert => i0.Trigger(

--- a/examples/modular/lib/src/users.drift.dart
+++ b/examples/modular/lib/src/users.drift.dart
@@ -327,7 +327,7 @@ class UsersCompanion extends i0.UpdateCompanion<i1.User> {
   }
 }
 
-typedef $UsersInsertCompanionBuilder = i1.UsersCompanion Function({
+typedef $UsersCreateCompanionBuilder = i1.UsersCompanion Function({
   i0.Value<int> id,
   required String name,
   i0.Value<String?> biography,
@@ -348,8 +348,7 @@ class $UsersTableManager extends i0.RootTableManager<
     i1.User,
     i1.$UsersFilterComposer,
     i1.$UsersOrderingComposer,
-    $UsersProcessedTableManager,
-    $UsersInsertCompanionBuilder,
+    $UsersCreateCompanionBuilder,
     $UsersUpdateCompanionBuilder> {
   $UsersTableManager(i0.GeneratedDatabase db, i1.Users table)
       : super(i0.TableManagerState(
@@ -359,8 +358,7 @@ class $UsersTableManager extends i0.RootTableManager<
               i1.$UsersFilterComposer(i0.ComposerState(db, table)),
           orderingComposer:
               i1.$UsersOrderingComposer(i0.ComposerState(db, table)),
-          getChildManagerBuilder: (p) => $UsersProcessedTableManager(p),
-          getUpdateCompanionBuilder: ({
+          updateCompanionCallback: ({
             i0.Value<int> id = const i0.Value.absent(),
             i0.Value<String> name = const i0.Value.absent(),
             i0.Value<String?> biography = const i0.Value.absent(),
@@ -374,7 +372,7 @@ class $UsersTableManager extends i0.RootTableManager<
             preferences: preferences,
             profilePicture: profilePicture,
           ),
-          getInsertCompanionBuilder: ({
+          createCompanionCallback: ({
             i0.Value<int> id = const i0.Value.absent(),
             required String name,
             i0.Value<String?> biography = const i0.Value.absent(),
@@ -391,77 +389,40 @@ class $UsersTableManager extends i0.RootTableManager<
         ));
 }
 
-class $UsersProcessedTableManager extends i0.ProcessedTableManager<
+typedef $UsersProcessedTableManager = i0.ProcessedTableManager<
     i0.GeneratedDatabase,
     i1.Users,
     i1.User,
     i1.$UsersFilterComposer,
     i1.$UsersOrderingComposer,
-    $UsersProcessedTableManager,
-    $UsersInsertCompanionBuilder,
-    $UsersUpdateCompanionBuilder> {
-  $UsersProcessedTableManager(super.$state);
-}
+    $UsersCreateCompanionBuilder,
+    $UsersUpdateCompanionBuilder>;
 
 class $UsersFilterComposer
     extends i0.FilterComposer<i0.GeneratedDatabase, i1.Users> {
   $UsersFilterComposer(super.$state);
-  i0.ColumnFilters<int> get id => $state.composableBuilder(
-      column: $state.table.id,
-      builder: (column, joinBuilders) =>
-          i0.ColumnFilters(column, joinBuilders: joinBuilders));
-
-  i0.ColumnFilters<String> get name => $state.composableBuilder(
-      column: $state.table.name,
-      builder: (column, joinBuilders) =>
-          i0.ColumnFilters(column, joinBuilders: joinBuilders));
-
-  i0.ColumnFilters<String> get biography => $state.composableBuilder(
-      column: $state.table.biography,
-      builder: (column, joinBuilders) =>
-          i0.ColumnFilters(column, joinBuilders: joinBuilders));
-
+  i0.ColumnFilters<int> get id => i0.ColumnFilters($state.table.id);
+  i0.ColumnFilters<String> get name => i0.ColumnFilters($state.table.name);
+  i0.ColumnFilters<String> get biography =>
+      i0.ColumnFilters($state.table.biography);
   i0.ColumnWithTypeConverterFilters<i2.Preferences?, i2.Preferences, String>
-      get preferences => $state.composableBuilder(
-          column: $state.table.preferences,
-          builder: (column, joinBuilders) => i0.ColumnWithTypeConverterFilters(
-              column,
-              joinBuilders: joinBuilders));
-
-  i0.ColumnFilters<i3.Uint8List> get profilePicture => $state.composableBuilder(
-      column: $state.table.profilePicture,
-      builder: (column, joinBuilders) =>
-          i0.ColumnFilters(column, joinBuilders: joinBuilders));
+      get preferences =>
+          i0.ColumnWithTypeConverterFilters($state.table.preferences);
+  i0.ColumnFilters<i3.Uint8List> get profilePicture =>
+      i0.ColumnFilters($state.table.profilePicture);
 }
 
 class $UsersOrderingComposer
     extends i0.OrderingComposer<i0.GeneratedDatabase, i1.Users> {
   $UsersOrderingComposer(super.$state);
-  i0.ColumnOrderings<int> get id => $state.composableBuilder(
-      column: $state.table.id,
-      builder: (column, joinBuilders) =>
-          i0.ColumnOrderings(column, joinBuilders: joinBuilders));
-
-  i0.ColumnOrderings<String> get name => $state.composableBuilder(
-      column: $state.table.name,
-      builder: (column, joinBuilders) =>
-          i0.ColumnOrderings(column, joinBuilders: joinBuilders));
-
-  i0.ColumnOrderings<String> get biography => $state.composableBuilder(
-      column: $state.table.biography,
-      builder: (column, joinBuilders) =>
-          i0.ColumnOrderings(column, joinBuilders: joinBuilders));
-
-  i0.ColumnOrderings<String> get preferences => $state.composableBuilder(
-      column: $state.table.preferences,
-      builder: (column, joinBuilders) =>
-          i0.ColumnOrderings(column, joinBuilders: joinBuilders));
-
+  i0.ColumnOrderings<int> get id => i0.ColumnOrderings($state.table.id);
+  i0.ColumnOrderings<String> get name => i0.ColumnOrderings($state.table.name);
+  i0.ColumnOrderings<String> get biography =>
+      i0.ColumnOrderings($state.table.biography);
+  i0.ColumnOrderings<String> get preferences =>
+      i0.ColumnOrderings($state.table.preferences);
   i0.ColumnOrderings<i3.Uint8List> get profilePicture =>
-      $state.composableBuilder(
-          column: $state.table.profilePicture,
-          builder: (column, joinBuilders) =>
-              i0.ColumnOrderings(column, joinBuilders: joinBuilders));
+      i0.ColumnOrderings($state.table.profilePicture);
 }
 
 i0.Index get usersName =>
@@ -668,7 +629,7 @@ class FollowsCompanion extends i0.UpdateCompanion<i1.Follow> {
   }
 }
 
-typedef $FollowsInsertCompanionBuilder = i1.FollowsCompanion Function({
+typedef $FollowsCreateCompanionBuilder = i1.FollowsCompanion Function({
   required int followed,
   required int follower,
   i0.Value<int> rowid,
@@ -685,8 +646,7 @@ class $FollowsTableManager extends i0.RootTableManager<
     i1.Follow,
     i1.$FollowsFilterComposer,
     i1.$FollowsOrderingComposer,
-    $FollowsProcessedTableManager,
-    $FollowsInsertCompanionBuilder,
+    $FollowsCreateCompanionBuilder,
     $FollowsUpdateCompanionBuilder> {
   $FollowsTableManager(i0.GeneratedDatabase db, i1.Follows table)
       : super(i0.TableManagerState(
@@ -696,8 +656,7 @@ class $FollowsTableManager extends i0.RootTableManager<
               i1.$FollowsFilterComposer(i0.ComposerState(db, table)),
           orderingComposer:
               i1.$FollowsOrderingComposer(i0.ComposerState(db, table)),
-          getChildManagerBuilder: (p) => $FollowsProcessedTableManager(p),
-          getUpdateCompanionBuilder: ({
+          updateCompanionCallback: ({
             i0.Value<int> followed = const i0.Value.absent(),
             i0.Value<int> follower = const i0.Value.absent(),
             i0.Value<int> rowid = const i0.Value.absent(),
@@ -707,7 +666,7 @@ class $FollowsTableManager extends i0.RootTableManager<
             follower: follower,
             rowid: rowid,
           ),
-          getInsertCompanionBuilder: ({
+          createCompanionCallback: ({
             required int followed,
             required int follower,
             i0.Value<int> rowid = const i0.Value.absent(),
@@ -720,17 +679,14 @@ class $FollowsTableManager extends i0.RootTableManager<
         ));
 }
 
-class $FollowsProcessedTableManager extends i0.ProcessedTableManager<
+typedef $FollowsProcessedTableManager = i0.ProcessedTableManager<
     i0.GeneratedDatabase,
     i1.Follows,
     i1.Follow,
     i1.$FollowsFilterComposer,
     i1.$FollowsOrderingComposer,
-    $FollowsProcessedTableManager,
-    $FollowsInsertCompanionBuilder,
-    $FollowsUpdateCompanionBuilder> {
-  $FollowsProcessedTableManager(super.$state);
-}
+    $FollowsCreateCompanionBuilder,
+    $FollowsUpdateCompanionBuilder>;
 
 class $FollowsFilterComposer
     extends i0.FilterComposer<i0.GeneratedDatabase, i1.Follows> {

--- a/examples/modular/lib/src/users.drift.dart
+++ b/examples/modular/lib/src/users.drift.dart
@@ -401,28 +401,62 @@ typedef $UsersProcessedTableManager = i0.ProcessedTableManager<
 class $UsersFilterComposer
     extends i0.FilterComposer<i0.GeneratedDatabase, i1.Users> {
   $UsersFilterComposer(super.$state);
-  i0.ColumnFilters<int> get id => i0.ColumnFilters($state.table.id);
-  i0.ColumnFilters<String> get name => i0.ColumnFilters($state.table.name);
-  i0.ColumnFilters<String> get biography =>
-      i0.ColumnFilters($state.table.biography);
+  i0.ColumnFilters<int> get id => $state.composableBuilder(
+      column: $state.table.id,
+      builder: (column, joinBuilders) =>
+          i0.ColumnFilters(column, joinBuilders: joinBuilders));
+
+  i0.ColumnFilters<String> get name => $state.composableBuilder(
+      column: $state.table.name,
+      builder: (column, joinBuilders) =>
+          i0.ColumnFilters(column, joinBuilders: joinBuilders));
+
+  i0.ColumnFilters<String> get biography => $state.composableBuilder(
+      column: $state.table.biography,
+      builder: (column, joinBuilders) =>
+          i0.ColumnFilters(column, joinBuilders: joinBuilders));
+
   i0.ColumnWithTypeConverterFilters<i2.Preferences?, i2.Preferences, String>
-      get preferences =>
-          i0.ColumnWithTypeConverterFilters($state.table.preferences);
-  i0.ColumnFilters<i3.Uint8List> get profilePicture =>
-      i0.ColumnFilters($state.table.profilePicture);
+      get preferences => $state.composableBuilder(
+          column: $state.table.preferences,
+          builder: (column, joinBuilders) => i0.ColumnWithTypeConverterFilters(
+              column,
+              joinBuilders: joinBuilders));
+
+  i0.ColumnFilters<i3.Uint8List> get profilePicture => $state.composableBuilder(
+      column: $state.table.profilePicture,
+      builder: (column, joinBuilders) =>
+          i0.ColumnFilters(column, joinBuilders: joinBuilders));
 }
 
 class $UsersOrderingComposer
     extends i0.OrderingComposer<i0.GeneratedDatabase, i1.Users> {
   $UsersOrderingComposer(super.$state);
-  i0.ColumnOrderings<int> get id => i0.ColumnOrderings($state.table.id);
-  i0.ColumnOrderings<String> get name => i0.ColumnOrderings($state.table.name);
-  i0.ColumnOrderings<String> get biography =>
-      i0.ColumnOrderings($state.table.biography);
-  i0.ColumnOrderings<String> get preferences =>
-      i0.ColumnOrderings($state.table.preferences);
+  i0.ColumnOrderings<int> get id => $state.composableBuilder(
+      column: $state.table.id,
+      builder: (column, joinBuilders) =>
+          i0.ColumnOrderings(column, joinBuilders: joinBuilders));
+
+  i0.ColumnOrderings<String> get name => $state.composableBuilder(
+      column: $state.table.name,
+      builder: (column, joinBuilders) =>
+          i0.ColumnOrderings(column, joinBuilders: joinBuilders));
+
+  i0.ColumnOrderings<String> get biography => $state.composableBuilder(
+      column: $state.table.biography,
+      builder: (column, joinBuilders) =>
+          i0.ColumnOrderings(column, joinBuilders: joinBuilders));
+
+  i0.ColumnOrderings<String> get preferences => $state.composableBuilder(
+      column: $state.table.preferences,
+      builder: (column, joinBuilders) =>
+          i0.ColumnOrderings(column, joinBuilders: joinBuilders));
+
   i0.ColumnOrderings<i3.Uint8List> get profilePicture =>
-      i0.ColumnOrderings($state.table.profilePicture);
+      $state.composableBuilder(
+          column: $state.table.profilePicture,
+          builder: (column, joinBuilders) =>
+              i0.ColumnOrderings(column, joinBuilders: joinBuilders));
 }
 
 i0.Index get usersName =>

--- a/examples/modular/lib/src/users.drift.dart
+++ b/examples/modular/lib/src/users.drift.dart
@@ -389,15 +389,6 @@ class $UsersTableManager extends i0.RootTableManager<
         ));
 }
 
-typedef $UsersProcessedTableManager = i0.ProcessedTableManager<
-    i0.GeneratedDatabase,
-    i1.Users,
-    i1.User,
-    i1.$UsersFilterComposer,
-    i1.$UsersOrderingComposer,
-    $UsersCreateCompanionBuilder,
-    $UsersUpdateCompanionBuilder>;
-
 class $UsersFilterComposer
     extends i0.FilterComposer<i0.GeneratedDatabase, i1.Users> {
   $UsersFilterComposer(super.$state);
@@ -712,15 +703,6 @@ class $FollowsTableManager extends i0.RootTableManager<
           ),
         ));
 }
-
-typedef $FollowsProcessedTableManager = i0.ProcessedTableManager<
-    i0.GeneratedDatabase,
-    i1.Follows,
-    i1.Follow,
-    i1.$FollowsFilterComposer,
-    i1.$FollowsOrderingComposer,
-    $FollowsCreateCompanionBuilder,
-    $FollowsUpdateCompanionBuilder>;
 
 class $FollowsFilterComposer
     extends i0.FilterComposer<i0.GeneratedDatabase, i1.Follows> {

--- a/examples/multi_package/server/lib/database.drift.dart
+++ b/examples/multi_package/server/lib/database.drift.dart
@@ -149,6 +149,14 @@ class ActiveSession extends i0.DataClass
         user: user ?? this.user,
         bearerToken: bearerToken ?? this.bearerToken,
       );
+  ActiveSession copyWithCompanion(i3.ActiveSessionsCompanion data) {
+    return ActiveSession(
+      user: data.user.present ? data.user.value : this.user,
+      bearerToken:
+          data.bearerToken.present ? data.bearerToken.value : this.bearerToken,
+    );
+  }
+
   @override
   String toString() {
     return (StringBuffer('ActiveSession(')
@@ -232,7 +240,7 @@ class ActiveSessionsCompanion extends i0.UpdateCompanion<i3.ActiveSession> {
   }
 }
 
-typedef $$ActiveSessionsTableInsertCompanionBuilder = i3.ActiveSessionsCompanion
+typedef $$ActiveSessionsTableCreateCompanionBuilder = i3.ActiveSessionsCompanion
     Function({
   required int user,
   required String bearerToken,
@@ -251,8 +259,7 @@ class $$ActiveSessionsTableTableManager extends i0.RootTableManager<
     i3.ActiveSession,
     i3.$$ActiveSessionsTableFilterComposer,
     i3.$$ActiveSessionsTableOrderingComposer,
-    $$ActiveSessionsTableProcessedTableManager,
-    $$ActiveSessionsTableInsertCompanionBuilder,
+    $$ActiveSessionsTableCreateCompanionBuilder,
     $$ActiveSessionsTableUpdateCompanionBuilder> {
   $$ActiveSessionsTableTableManager(
       i0.GeneratedDatabase db, i3.$ActiveSessionsTable table)
@@ -263,9 +270,7 @@ class $$ActiveSessionsTableTableManager extends i0.RootTableManager<
               .$$ActiveSessionsTableFilterComposer(i0.ComposerState(db, table)),
           orderingComposer: i3.$$ActiveSessionsTableOrderingComposer(
               i0.ComposerState(db, table)),
-          getChildManagerBuilder: (p) =>
-              $$ActiveSessionsTableProcessedTableManager(p),
-          getUpdateCompanionBuilder: ({
+          updateCompanionCallback: ({
             i0.Value<int> user = const i0.Value.absent(),
             i0.Value<String> bearerToken = const i0.Value.absent(),
             i0.Value<int> rowid = const i0.Value.absent(),
@@ -275,7 +280,7 @@ class $$ActiveSessionsTableTableManager extends i0.RootTableManager<
             bearerToken: bearerToken,
             rowid: rowid,
           ),
-          getInsertCompanionBuilder: ({
+          createCompanionCallback: ({
             required int user,
             required String bearerToken,
             i0.Value<int> rowid = const i0.Value.absent(),
@@ -288,27 +293,20 @@ class $$ActiveSessionsTableTableManager extends i0.RootTableManager<
         ));
 }
 
-class $$ActiveSessionsTableProcessedTableManager
-    extends i0.ProcessedTableManager<
-        i0.GeneratedDatabase,
-        i3.$ActiveSessionsTable,
-        i3.ActiveSession,
-        i3.$$ActiveSessionsTableFilterComposer,
-        i3.$$ActiveSessionsTableOrderingComposer,
-        $$ActiveSessionsTableProcessedTableManager,
-        $$ActiveSessionsTableInsertCompanionBuilder,
-        $$ActiveSessionsTableUpdateCompanionBuilder> {
-  $$ActiveSessionsTableProcessedTableManager(super.$state);
-}
+typedef $$ActiveSessionsTableProcessedTableManager = i0.ProcessedTableManager<
+    i0.GeneratedDatabase,
+    i3.$ActiveSessionsTable,
+    i3.ActiveSession,
+    i3.$$ActiveSessionsTableFilterComposer,
+    i3.$$ActiveSessionsTableOrderingComposer,
+    $$ActiveSessionsTableCreateCompanionBuilder,
+    $$ActiveSessionsTableUpdateCompanionBuilder>;
 
 class $$ActiveSessionsTableFilterComposer
     extends i0.FilterComposer<i0.GeneratedDatabase, i3.$ActiveSessionsTable> {
   $$ActiveSessionsTableFilterComposer(super.$state);
-  i0.ColumnFilters<String> get bearerToken => $state.composableBuilder(
-      column: $state.table.bearerToken,
-      builder: (column, joinBuilders) =>
-          i0.ColumnFilters(column, joinBuilders: joinBuilders));
-
+  i0.ColumnFilters<String> get bearerToken =>
+      i0.ColumnFilters($state.table.bearerToken);
   i1.$$UsersTableFilterComposer get user {
     final i1.$$UsersTableFilterComposer composer = $state.composerBuilder(
         composer: this,
@@ -330,11 +328,8 @@ class $$ActiveSessionsTableFilterComposer
 class $$ActiveSessionsTableOrderingComposer
     extends i0.OrderingComposer<i0.GeneratedDatabase, i3.$ActiveSessionsTable> {
   $$ActiveSessionsTableOrderingComposer(super.$state);
-  i0.ColumnOrderings<String> get bearerToken => $state.composableBuilder(
-      column: $state.table.bearerToken,
-      builder: (column, joinBuilders) =>
-          i0.ColumnOrderings(column, joinBuilders: joinBuilders));
-
+  i0.ColumnOrderings<String> get bearerToken =>
+      i0.ColumnOrderings($state.table.bearerToken);
   i1.$$UsersTableOrderingComposer get user {
     final i1.$$UsersTableOrderingComposer composer = $state.composerBuilder(
         composer: this,

--- a/examples/multi_package/server/lib/database.drift.dart
+++ b/examples/multi_package/server/lib/database.drift.dart
@@ -293,15 +293,6 @@ class $$ActiveSessionsTableTableManager extends i0.RootTableManager<
         ));
 }
 
-typedef $$ActiveSessionsTableProcessedTableManager = i0.ProcessedTableManager<
-    i0.GeneratedDatabase,
-    i3.$ActiveSessionsTable,
-    i3.ActiveSession,
-    i3.$$ActiveSessionsTableFilterComposer,
-    i3.$$ActiveSessionsTableOrderingComposer,
-    $$ActiveSessionsTableCreateCompanionBuilder,
-    $$ActiveSessionsTableUpdateCompanionBuilder>;
-
 class $$ActiveSessionsTableFilterComposer
     extends i0.FilterComposer<i0.GeneratedDatabase, i3.$ActiveSessionsTable> {
   $$ActiveSessionsTableFilterComposer(super.$state);

--- a/examples/multi_package/server/lib/database.drift.dart
+++ b/examples/multi_package/server/lib/database.drift.dart
@@ -305,8 +305,11 @@ typedef $$ActiveSessionsTableProcessedTableManager = i0.ProcessedTableManager<
 class $$ActiveSessionsTableFilterComposer
     extends i0.FilterComposer<i0.GeneratedDatabase, i3.$ActiveSessionsTable> {
   $$ActiveSessionsTableFilterComposer(super.$state);
-  i0.ColumnFilters<String> get bearerToken =>
-      i0.ColumnFilters($state.table.bearerToken);
+  i0.ColumnFilters<String> get bearerToken => $state.composableBuilder(
+      column: $state.table.bearerToken,
+      builder: (column, joinBuilders) =>
+          i0.ColumnFilters(column, joinBuilders: joinBuilders));
+
   i1.$$UsersTableFilterComposer get user {
     final i1.$$UsersTableFilterComposer composer = $state.composerBuilder(
         composer: this,
@@ -328,8 +331,11 @@ class $$ActiveSessionsTableFilterComposer
 class $$ActiveSessionsTableOrderingComposer
     extends i0.OrderingComposer<i0.GeneratedDatabase, i3.$ActiveSessionsTable> {
   $$ActiveSessionsTableOrderingComposer(super.$state);
-  i0.ColumnOrderings<String> get bearerToken =>
-      i0.ColumnOrderings($state.table.bearerToken);
+  i0.ColumnOrderings<String> get bearerToken => $state.composableBuilder(
+      column: $state.table.bearerToken,
+      builder: (column, joinBuilders) =>
+          i0.ColumnOrderings(column, joinBuilders: joinBuilders));
+
   i1.$$UsersTableOrderingComposer get user {
     final i1.$$UsersTableOrderingComposer composer = $state.composerBuilder(
         composer: this,

--- a/examples/multi_package/shared/lib/src/posts.drift.dart
+++ b/examples/multi_package/shared/lib/src/posts.drift.dart
@@ -267,8 +267,11 @@ typedef $PostsProcessedTableManager = i0.ProcessedTableManager<
 class $PostsFilterComposer
     extends i0.FilterComposer<i0.GeneratedDatabase, i1.Posts> {
   $PostsFilterComposer(super.$state);
-  i0.ColumnFilters<String> get content =>
-      i0.ColumnFilters($state.table.content);
+  i0.ColumnFilters<String> get content => $state.composableBuilder(
+      column: $state.table.content,
+      builder: (column, joinBuilders) =>
+          i0.ColumnFilters(column, joinBuilders: joinBuilders));
+
   i2.$$UsersTableFilterComposer get author {
     final i2.$$UsersTableFilterComposer composer = $state.composerBuilder(
         composer: this,
@@ -290,8 +293,11 @@ class $PostsFilterComposer
 class $PostsOrderingComposer
     extends i0.OrderingComposer<i0.GeneratedDatabase, i1.Posts> {
   $PostsOrderingComposer(super.$state);
-  i0.ColumnOrderings<String> get content =>
-      i0.ColumnOrderings($state.table.content);
+  i0.ColumnOrderings<String> get content => $state.composableBuilder(
+      column: $state.table.content,
+      builder: (column, joinBuilders) =>
+          i0.ColumnOrderings(column, joinBuilders: joinBuilders));
+
   i2.$$UsersTableOrderingComposer get author {
     final i2.$$UsersTableOrderingComposer composer = $state.composerBuilder(
         composer: this,

--- a/examples/multi_package/shared/lib/src/posts.drift.dart
+++ b/examples/multi_package/shared/lib/src/posts.drift.dart
@@ -255,15 +255,6 @@ class $PostsTableManager extends i0.RootTableManager<
         ));
 }
 
-typedef $PostsProcessedTableManager = i0.ProcessedTableManager<
-    i0.GeneratedDatabase,
-    i1.Posts,
-    i1.Post,
-    i1.$PostsFilterComposer,
-    i1.$PostsOrderingComposer,
-    $PostsCreateCompanionBuilder,
-    $PostsUpdateCompanionBuilder>;
-
 class $PostsFilterComposer
     extends i0.FilterComposer<i0.GeneratedDatabase, i1.Posts> {
   $PostsFilterComposer(super.$state);

--- a/examples/multi_package/shared/lib/src/posts.drift.dart
+++ b/examples/multi_package/shared/lib/src/posts.drift.dart
@@ -116,6 +116,13 @@ class Post extends i0.DataClass implements i0.Insertable<i1.Post> {
         author: author ?? this.author,
         content: content.present ? content.value : this.content,
       );
+  Post copyWithCompanion(i1.PostsCompanion data) {
+    return Post(
+      author: data.author.present ? data.author.value : this.author,
+      content: data.content.present ? data.content.value : this.content,
+    );
+  }
+
   @override
   String toString() {
     return (StringBuffer('Post(')
@@ -198,7 +205,7 @@ class PostsCompanion extends i0.UpdateCompanion<i1.Post> {
   }
 }
 
-typedef $PostsInsertCompanionBuilder = i1.PostsCompanion Function({
+typedef $PostsCreateCompanionBuilder = i1.PostsCompanion Function({
   required int author,
   i0.Value<String?> content,
   i0.Value<int> rowid,
@@ -215,8 +222,7 @@ class $PostsTableManager extends i0.RootTableManager<
     i1.Post,
     i1.$PostsFilterComposer,
     i1.$PostsOrderingComposer,
-    $PostsProcessedTableManager,
-    $PostsInsertCompanionBuilder,
+    $PostsCreateCompanionBuilder,
     $PostsUpdateCompanionBuilder> {
   $PostsTableManager(i0.GeneratedDatabase db, i1.Posts table)
       : super(i0.TableManagerState(
@@ -226,8 +232,7 @@ class $PostsTableManager extends i0.RootTableManager<
               i1.$PostsFilterComposer(i0.ComposerState(db, table)),
           orderingComposer:
               i1.$PostsOrderingComposer(i0.ComposerState(db, table)),
-          getChildManagerBuilder: (p) => $PostsProcessedTableManager(p),
-          getUpdateCompanionBuilder: ({
+          updateCompanionCallback: ({
             i0.Value<int> author = const i0.Value.absent(),
             i0.Value<String?> content = const i0.Value.absent(),
             i0.Value<int> rowid = const i0.Value.absent(),
@@ -237,7 +242,7 @@ class $PostsTableManager extends i0.RootTableManager<
             content: content,
             rowid: rowid,
           ),
-          getInsertCompanionBuilder: ({
+          createCompanionCallback: ({
             required int author,
             i0.Value<String?> content = const i0.Value.absent(),
             i0.Value<int> rowid = const i0.Value.absent(),
@@ -250,26 +255,20 @@ class $PostsTableManager extends i0.RootTableManager<
         ));
 }
 
-class $PostsProcessedTableManager extends i0.ProcessedTableManager<
+typedef $PostsProcessedTableManager = i0.ProcessedTableManager<
     i0.GeneratedDatabase,
     i1.Posts,
     i1.Post,
     i1.$PostsFilterComposer,
     i1.$PostsOrderingComposer,
-    $PostsProcessedTableManager,
-    $PostsInsertCompanionBuilder,
-    $PostsUpdateCompanionBuilder> {
-  $PostsProcessedTableManager(super.$state);
-}
+    $PostsCreateCompanionBuilder,
+    $PostsUpdateCompanionBuilder>;
 
 class $PostsFilterComposer
     extends i0.FilterComposer<i0.GeneratedDatabase, i1.Posts> {
   $PostsFilterComposer(super.$state);
-  i0.ColumnFilters<String> get content => $state.composableBuilder(
-      column: $state.table.content,
-      builder: (column, joinBuilders) =>
-          i0.ColumnFilters(column, joinBuilders: joinBuilders));
-
+  i0.ColumnFilters<String> get content =>
+      i0.ColumnFilters($state.table.content);
   i2.$$UsersTableFilterComposer get author {
     final i2.$$UsersTableFilterComposer composer = $state.composerBuilder(
         composer: this,
@@ -291,11 +290,8 @@ class $PostsFilterComposer
 class $PostsOrderingComposer
     extends i0.OrderingComposer<i0.GeneratedDatabase, i1.Posts> {
   $PostsOrderingComposer(super.$state);
-  i0.ColumnOrderings<String> get content => $state.composableBuilder(
-      column: $state.table.content,
-      builder: (column, joinBuilders) =>
-          i0.ColumnOrderings(column, joinBuilders: joinBuilders));
-
+  i0.ColumnOrderings<String> get content =>
+      i0.ColumnOrderings($state.table.content);
   i2.$$UsersTableOrderingComposer get author {
     final i2.$$UsersTableOrderingComposer composer = $state.composerBuilder(
         composer: this,

--- a/examples/multi_package/shared/lib/src/users.drift.dart
+++ b/examples/multi_package/shared/lib/src/users.drift.dart
@@ -236,13 +236,27 @@ typedef $$UsersTableProcessedTableManager = i0.ProcessedTableManager<
 class $$UsersTableFilterComposer
     extends i0.FilterComposer<i0.GeneratedDatabase, i1.$UsersTable> {
   $$UsersTableFilterComposer(super.$state);
-  i0.ColumnFilters<int> get id => i0.ColumnFilters($state.table.id);
-  i0.ColumnFilters<String> get name => i0.ColumnFilters($state.table.name);
+  i0.ColumnFilters<int> get id => $state.composableBuilder(
+      column: $state.table.id,
+      builder: (column, joinBuilders) =>
+          i0.ColumnFilters(column, joinBuilders: joinBuilders));
+
+  i0.ColumnFilters<String> get name => $state.composableBuilder(
+      column: $state.table.name,
+      builder: (column, joinBuilders) =>
+          i0.ColumnFilters(column, joinBuilders: joinBuilders));
 }
 
 class $$UsersTableOrderingComposer
     extends i0.OrderingComposer<i0.GeneratedDatabase, i1.$UsersTable> {
   $$UsersTableOrderingComposer(super.$state);
-  i0.ColumnOrderings<int> get id => i0.ColumnOrderings($state.table.id);
-  i0.ColumnOrderings<String> get name => i0.ColumnOrderings($state.table.name);
+  i0.ColumnOrderings<int> get id => $state.composableBuilder(
+      column: $state.table.id,
+      builder: (column, joinBuilders) =>
+          i0.ColumnOrderings(column, joinBuilders: joinBuilders));
+
+  i0.ColumnOrderings<String> get name => $state.composableBuilder(
+      column: $state.table.name,
+      builder: (column, joinBuilders) =>
+          i0.ColumnOrderings(column, joinBuilders: joinBuilders));
 }

--- a/examples/multi_package/shared/lib/src/users.drift.dart
+++ b/examples/multi_package/shared/lib/src/users.drift.dart
@@ -106,6 +106,13 @@ class User extends i0.DataClass implements i0.Insertable<i1.User> {
         id: id ?? this.id,
         name: name ?? this.name,
       );
+  User copyWithCompanion(i1.UsersCompanion data) {
+    return User(
+      id: data.id.present ? data.id.value : this.id,
+      name: data.name.present ? data.name.value : this.name,
+    );
+  }
+
   @override
   String toString() {
     return (StringBuffer('User(')
@@ -173,7 +180,7 @@ class UsersCompanion extends i0.UpdateCompanion<i1.User> {
   }
 }
 
-typedef $$UsersTableInsertCompanionBuilder = i1.UsersCompanion Function({
+typedef $$UsersTableCreateCompanionBuilder = i1.UsersCompanion Function({
   i0.Value<int> id,
   required String name,
 });
@@ -188,8 +195,7 @@ class $$UsersTableTableManager extends i0.RootTableManager<
     i1.User,
     i1.$$UsersTableFilterComposer,
     i1.$$UsersTableOrderingComposer,
-    $$UsersTableProcessedTableManager,
-    $$UsersTableInsertCompanionBuilder,
+    $$UsersTableCreateCompanionBuilder,
     $$UsersTableUpdateCompanionBuilder> {
   $$UsersTableTableManager(i0.GeneratedDatabase db, i1.$UsersTable table)
       : super(i0.TableManagerState(
@@ -199,8 +205,7 @@ class $$UsersTableTableManager extends i0.RootTableManager<
               i1.$$UsersTableFilterComposer(i0.ComposerState(db, table)),
           orderingComposer:
               i1.$$UsersTableOrderingComposer(i0.ComposerState(db, table)),
-          getChildManagerBuilder: (p) => $$UsersTableProcessedTableManager(p),
-          getUpdateCompanionBuilder: ({
+          updateCompanionCallback: ({
             i0.Value<int> id = const i0.Value.absent(),
             i0.Value<String> name = const i0.Value.absent(),
           }) =>
@@ -208,7 +213,7 @@ class $$UsersTableTableManager extends i0.RootTableManager<
             id: id,
             name: name,
           ),
-          getInsertCompanionBuilder: ({
+          createCompanionCallback: ({
             i0.Value<int> id = const i0.Value.absent(),
             required String name,
           }) =>
@@ -219,42 +224,25 @@ class $$UsersTableTableManager extends i0.RootTableManager<
         ));
 }
 
-class $$UsersTableProcessedTableManager extends i0.ProcessedTableManager<
+typedef $$UsersTableProcessedTableManager = i0.ProcessedTableManager<
     i0.GeneratedDatabase,
     i1.$UsersTable,
     i1.User,
     i1.$$UsersTableFilterComposer,
     i1.$$UsersTableOrderingComposer,
-    $$UsersTableProcessedTableManager,
-    $$UsersTableInsertCompanionBuilder,
-    $$UsersTableUpdateCompanionBuilder> {
-  $$UsersTableProcessedTableManager(super.$state);
-}
+    $$UsersTableCreateCompanionBuilder,
+    $$UsersTableUpdateCompanionBuilder>;
 
 class $$UsersTableFilterComposer
     extends i0.FilterComposer<i0.GeneratedDatabase, i1.$UsersTable> {
   $$UsersTableFilterComposer(super.$state);
-  i0.ColumnFilters<int> get id => $state.composableBuilder(
-      column: $state.table.id,
-      builder: (column, joinBuilders) =>
-          i0.ColumnFilters(column, joinBuilders: joinBuilders));
-
-  i0.ColumnFilters<String> get name => $state.composableBuilder(
-      column: $state.table.name,
-      builder: (column, joinBuilders) =>
-          i0.ColumnFilters(column, joinBuilders: joinBuilders));
+  i0.ColumnFilters<int> get id => i0.ColumnFilters($state.table.id);
+  i0.ColumnFilters<String> get name => i0.ColumnFilters($state.table.name);
 }
 
 class $$UsersTableOrderingComposer
     extends i0.OrderingComposer<i0.GeneratedDatabase, i1.$UsersTable> {
   $$UsersTableOrderingComposer(super.$state);
-  i0.ColumnOrderings<int> get id => $state.composableBuilder(
-      column: $state.table.id,
-      builder: (column, joinBuilders) =>
-          i0.ColumnOrderings(column, joinBuilders: joinBuilders));
-
-  i0.ColumnOrderings<String> get name => $state.composableBuilder(
-      column: $state.table.name,
-      builder: (column, joinBuilders) =>
-          i0.ColumnOrderings(column, joinBuilders: joinBuilders));
+  i0.ColumnOrderings<int> get id => i0.ColumnOrderings($state.table.id);
+  i0.ColumnOrderings<String> get name => i0.ColumnOrderings($state.table.name);
 }

--- a/examples/multi_package/shared/lib/src/users.drift.dart
+++ b/examples/multi_package/shared/lib/src/users.drift.dart
@@ -224,15 +224,6 @@ class $$UsersTableTableManager extends i0.RootTableManager<
         ));
 }
 
-typedef $$UsersTableProcessedTableManager = i0.ProcessedTableManager<
-    i0.GeneratedDatabase,
-    i1.$UsersTable,
-    i1.User,
-    i1.$$UsersTableFilterComposer,
-    i1.$$UsersTableOrderingComposer,
-    $$UsersTableCreateCompanionBuilder,
-    $$UsersTableUpdateCompanionBuilder>;
-
 class $$UsersTableFilterComposer
     extends i0.FilterComposer<i0.GeneratedDatabase, i1.$UsersTable> {
   $$UsersTableFilterComposer(super.$state);

--- a/examples/web_worker_example/lib/database.g.dart
+++ b/examples/web_worker_example/lib/database.g.dart
@@ -106,6 +106,13 @@ class Entry extends DataClass implements Insertable<Entry> {
         id: id ?? this.id,
         value: value ?? this.value,
       );
+  Entry copyWithCompanion(EntriesCompanion data) {
+    return Entry(
+      id: data.id.present ? data.id.value : this.id,
+      value: data.value.present ? data.value.value : this.value,
+    );
+  }
+
   @override
   String toString() {
     return (StringBuffer('Entry(')

--- a/examples/with_built_value/lib/tables.drift.dart
+++ b/examples/with_built_value/lib/tables.drift.dart
@@ -237,13 +237,27 @@ typedef $UsersProcessedTableManager = i0.ProcessedTableManager<
 class $UsersFilterComposer
     extends i0.FilterComposer<i0.GeneratedDatabase, i1.Users> {
   $UsersFilterComposer(super.$state);
-  i0.ColumnFilters<int> get id => i0.ColumnFilters($state.table.id);
-  i0.ColumnFilters<String> get name => i0.ColumnFilters($state.table.name);
+  i0.ColumnFilters<int> get id => $state.composableBuilder(
+      column: $state.table.id,
+      builder: (column, joinBuilders) =>
+          i0.ColumnFilters(column, joinBuilders: joinBuilders));
+
+  i0.ColumnFilters<String> get name => $state.composableBuilder(
+      column: $state.table.name,
+      builder: (column, joinBuilders) =>
+          i0.ColumnFilters(column, joinBuilders: joinBuilders));
 }
 
 class $UsersOrderingComposer
     extends i0.OrderingComposer<i0.GeneratedDatabase, i1.Users> {
   $UsersOrderingComposer(super.$state);
-  i0.ColumnOrderings<int> get id => i0.ColumnOrderings($state.table.id);
-  i0.ColumnOrderings<String> get name => i0.ColumnOrderings($state.table.name);
+  i0.ColumnOrderings<int> get id => $state.composableBuilder(
+      column: $state.table.id,
+      builder: (column, joinBuilders) =>
+          i0.ColumnOrderings(column, joinBuilders: joinBuilders));
+
+  i0.ColumnOrderings<String> get name => $state.composableBuilder(
+      column: $state.table.name,
+      builder: (column, joinBuilders) =>
+          i0.ColumnOrderings(column, joinBuilders: joinBuilders));
 }

--- a/examples/with_built_value/lib/tables.drift.dart
+++ b/examples/with_built_value/lib/tables.drift.dart
@@ -107,6 +107,13 @@ class User extends i0.DataClass implements i0.Insertable<i1.User> {
         id: id ?? this.id,
         name: name ?? this.name,
       );
+  User copyWithCompanion(i1.UsersCompanion data) {
+    return User(
+      id: data.id.present ? data.id.value : this.id,
+      name: data.name.present ? data.name.value : this.name,
+    );
+  }
+
   @override
   String toString() {
     return (StringBuffer('User(')
@@ -174,7 +181,7 @@ class UsersCompanion extends i0.UpdateCompanion<i1.User> {
   }
 }
 
-typedef $UsersInsertCompanionBuilder = i1.UsersCompanion Function({
+typedef $UsersCreateCompanionBuilder = i1.UsersCompanion Function({
   i0.Value<int> id,
   required String name,
 });
@@ -189,8 +196,7 @@ class $UsersTableManager extends i0.RootTableManager<
     i1.User,
     i1.$UsersFilterComposer,
     i1.$UsersOrderingComposer,
-    $UsersProcessedTableManager,
-    $UsersInsertCompanionBuilder,
+    $UsersCreateCompanionBuilder,
     $UsersUpdateCompanionBuilder> {
   $UsersTableManager(i0.GeneratedDatabase db, i1.Users table)
       : super(i0.TableManagerState(
@@ -200,8 +206,7 @@ class $UsersTableManager extends i0.RootTableManager<
               i1.$UsersFilterComposer(i0.ComposerState(db, table)),
           orderingComposer:
               i1.$UsersOrderingComposer(i0.ComposerState(db, table)),
-          getChildManagerBuilder: (p) => $UsersProcessedTableManager(p),
-          getUpdateCompanionBuilder: ({
+          updateCompanionCallback: ({
             i0.Value<int> id = const i0.Value.absent(),
             i0.Value<String> name = const i0.Value.absent(),
           }) =>
@@ -209,7 +214,7 @@ class $UsersTableManager extends i0.RootTableManager<
             id: id,
             name: name,
           ),
-          getInsertCompanionBuilder: ({
+          createCompanionCallback: ({
             i0.Value<int> id = const i0.Value.absent(),
             required String name,
           }) =>
@@ -220,42 +225,25 @@ class $UsersTableManager extends i0.RootTableManager<
         ));
 }
 
-class $UsersProcessedTableManager extends i0.ProcessedTableManager<
+typedef $UsersProcessedTableManager = i0.ProcessedTableManager<
     i0.GeneratedDatabase,
     i1.Users,
     i1.User,
     i1.$UsersFilterComposer,
     i1.$UsersOrderingComposer,
-    $UsersProcessedTableManager,
-    $UsersInsertCompanionBuilder,
-    $UsersUpdateCompanionBuilder> {
-  $UsersProcessedTableManager(super.$state);
-}
+    $UsersCreateCompanionBuilder,
+    $UsersUpdateCompanionBuilder>;
 
 class $UsersFilterComposer
     extends i0.FilterComposer<i0.GeneratedDatabase, i1.Users> {
   $UsersFilterComposer(super.$state);
-  i0.ColumnFilters<int> get id => $state.composableBuilder(
-      column: $state.table.id,
-      builder: (column, joinBuilders) =>
-          i0.ColumnFilters(column, joinBuilders: joinBuilders));
-
-  i0.ColumnFilters<String> get name => $state.composableBuilder(
-      column: $state.table.name,
-      builder: (column, joinBuilders) =>
-          i0.ColumnFilters(column, joinBuilders: joinBuilders));
+  i0.ColumnFilters<int> get id => i0.ColumnFilters($state.table.id);
+  i0.ColumnFilters<String> get name => i0.ColumnFilters($state.table.name);
 }
 
 class $UsersOrderingComposer
     extends i0.OrderingComposer<i0.GeneratedDatabase, i1.Users> {
   $UsersOrderingComposer(super.$state);
-  i0.ColumnOrderings<int> get id => $state.composableBuilder(
-      column: $state.table.id,
-      builder: (column, joinBuilders) =>
-          i0.ColumnOrderings(column, joinBuilders: joinBuilders));
-
-  i0.ColumnOrderings<String> get name => $state.composableBuilder(
-      column: $state.table.name,
-      builder: (column, joinBuilders) =>
-          i0.ColumnOrderings(column, joinBuilders: joinBuilders));
+  i0.ColumnOrderings<int> get id => i0.ColumnOrderings($state.table.id);
+  i0.ColumnOrderings<String> get name => i0.ColumnOrderings($state.table.name);
 }

--- a/examples/with_built_value/lib/tables.drift.dart
+++ b/examples/with_built_value/lib/tables.drift.dart
@@ -225,15 +225,6 @@ class $UsersTableManager extends i0.RootTableManager<
         ));
 }
 
-typedef $UsersProcessedTableManager = i0.ProcessedTableManager<
-    i0.GeneratedDatabase,
-    i1.Users,
-    i1.User,
-    i1.$UsersFilterComposer,
-    i1.$UsersOrderingComposer,
-    $UsersCreateCompanionBuilder,
-    $UsersUpdateCompanionBuilder>;
-
 class $UsersFilterComposer
     extends i0.FilterComposer<i0.GeneratedDatabase, i1.Users> {
   $UsersFilterComposer(super.$state);

--- a/extras/benchmarks/lib/src/moor/database.g.dart
+++ b/extras/benchmarks/lib/src/moor/database.g.dart
@@ -105,6 +105,13 @@ class KeyValue extends DataClass implements Insertable<KeyValue> {
         key: key ?? this.key,
         value: value ?? this.value,
       );
+  KeyValue copyWithCompanion(KeyValuesCompanion data) {
+    return KeyValue(
+      key: data.key.present ? data.key.value : this.key,
+      value: data.value.present ? data.value.value : this.value,
+    );
+  }
+
   @override
   String toString() {
     return (StringBuffer('KeyValue(')

--- a/extras/drift_postgres/example/main.g.dart
+++ b/extras/drift_postgres/example/main.g.dart
@@ -262,15 +262,29 @@ typedef $$UsersTableProcessedTableManager = ProcessedTableManager<
 class $$UsersTableFilterComposer
     extends FilterComposer<_$DriftPostgresDatabase, $UsersTable> {
   $$UsersTableFilterComposer(super.$state);
-  ColumnFilters<UuidValue> get id => ColumnFilters($state.table.id);
-  ColumnFilters<String> get name => ColumnFilters($state.table.name);
+  ColumnFilters<UuidValue> get id => $state.composableBuilder(
+      column: $state.table.id,
+      builder: (column, joinBuilders) =>
+          ColumnFilters(column, joinBuilders: joinBuilders));
+
+  ColumnFilters<String> get name => $state.composableBuilder(
+      column: $state.table.name,
+      builder: (column, joinBuilders) =>
+          ColumnFilters(column, joinBuilders: joinBuilders));
 }
 
 class $$UsersTableOrderingComposer
     extends OrderingComposer<_$DriftPostgresDatabase, $UsersTable> {
   $$UsersTableOrderingComposer(super.$state);
-  ColumnOrderings<UuidValue> get id => ColumnOrderings($state.table.id);
-  ColumnOrderings<String> get name => ColumnOrderings($state.table.name);
+  ColumnOrderings<UuidValue> get id => $state.composableBuilder(
+      column: $state.table.id,
+      builder: (column, joinBuilders) =>
+          ColumnOrderings(column, joinBuilders: joinBuilders));
+
+  ColumnOrderings<String> get name => $state.composableBuilder(
+      column: $state.table.name,
+      builder: (column, joinBuilders) =>
+          ColumnOrderings(column, joinBuilders: joinBuilders));
 }
 
 class $DriftPostgresDatabaseManager {

--- a/extras/drift_postgres/example/main.g.dart
+++ b/extras/drift_postgres/example/main.g.dart
@@ -250,15 +250,6 @@ class $$UsersTableTableManager extends RootTableManager<
         ));
 }
 
-typedef $$UsersTableProcessedTableManager = ProcessedTableManager<
-    _$DriftPostgresDatabase,
-    $UsersTable,
-    User,
-    $$UsersTableFilterComposer,
-    $$UsersTableOrderingComposer,
-    $$UsersTableCreateCompanionBuilder,
-    $$UsersTableUpdateCompanionBuilder>;
-
 class $$UsersTableFilterComposer
     extends FilterComposer<_$DriftPostgresDatabase, $UsersTable> {
   $$UsersTableFilterComposer(super.$state);

--- a/extras/drift_postgres/example/main.g.dart
+++ b/extras/drift_postgres/example/main.g.dart
@@ -103,6 +103,13 @@ class User extends DataClass implements Insertable<User> {
         id: id ?? this.id,
         name: name ?? this.name,
       );
+  User copyWithCompanion(UsersCompanion data) {
+    return User(
+      id: data.id.present ? data.id.value : this.id,
+      name: data.name.present ? data.name.value : this.name,
+    );
+  }
+
   @override
   String toString() {
     return (StringBuffer('User(')
@@ -193,7 +200,7 @@ abstract class _$DriftPostgresDatabase extends GeneratedDatabase {
   List<DatabaseSchemaEntity> get allSchemaEntities => [users];
 }
 
-typedef $$UsersTableInsertCompanionBuilder = UsersCompanion Function({
+typedef $$UsersTableCreateCompanionBuilder = UsersCompanion Function({
   Value<UuidValue> id,
   required String name,
   Value<int> rowid,
@@ -210,8 +217,7 @@ class $$UsersTableTableManager extends RootTableManager<
     User,
     $$UsersTableFilterComposer,
     $$UsersTableOrderingComposer,
-    $$UsersTableProcessedTableManager,
-    $$UsersTableInsertCompanionBuilder,
+    $$UsersTableCreateCompanionBuilder,
     $$UsersTableUpdateCompanionBuilder> {
   $$UsersTableTableManager(_$DriftPostgresDatabase db, $UsersTable table)
       : super(TableManagerState(
@@ -221,8 +227,7 @@ class $$UsersTableTableManager extends RootTableManager<
               $$UsersTableFilterComposer(ComposerState(db, table)),
           orderingComposer:
               $$UsersTableOrderingComposer(ComposerState(db, table)),
-          getChildManagerBuilder: (p) => $$UsersTableProcessedTableManager(p),
-          getUpdateCompanionBuilder: ({
+          updateCompanionCallback: ({
             Value<UuidValue> id = const Value.absent(),
             Value<String> name = const Value.absent(),
             Value<int> rowid = const Value.absent(),
@@ -232,7 +237,7 @@ class $$UsersTableTableManager extends RootTableManager<
             name: name,
             rowid: rowid,
           ),
-          getInsertCompanionBuilder: ({
+          createCompanionCallback: ({
             Value<UuidValue> id = const Value.absent(),
             required String name,
             Value<int> rowid = const Value.absent(),
@@ -245,44 +250,27 @@ class $$UsersTableTableManager extends RootTableManager<
         ));
 }
 
-class $$UsersTableProcessedTableManager extends ProcessedTableManager<
+typedef $$UsersTableProcessedTableManager = ProcessedTableManager<
     _$DriftPostgresDatabase,
     $UsersTable,
     User,
     $$UsersTableFilterComposer,
     $$UsersTableOrderingComposer,
-    $$UsersTableProcessedTableManager,
-    $$UsersTableInsertCompanionBuilder,
-    $$UsersTableUpdateCompanionBuilder> {
-  $$UsersTableProcessedTableManager(super.$state);
-}
+    $$UsersTableCreateCompanionBuilder,
+    $$UsersTableUpdateCompanionBuilder>;
 
 class $$UsersTableFilterComposer
     extends FilterComposer<_$DriftPostgresDatabase, $UsersTable> {
   $$UsersTableFilterComposer(super.$state);
-  ColumnFilters<UuidValue> get id => $state.composableBuilder(
-      column: $state.table.id,
-      builder: (column, joinBuilders) =>
-          ColumnFilters(column, joinBuilders: joinBuilders));
-
-  ColumnFilters<String> get name => $state.composableBuilder(
-      column: $state.table.name,
-      builder: (column, joinBuilders) =>
-          ColumnFilters(column, joinBuilders: joinBuilders));
+  ColumnFilters<UuidValue> get id => ColumnFilters($state.table.id);
+  ColumnFilters<String> get name => ColumnFilters($state.table.name);
 }
 
 class $$UsersTableOrderingComposer
     extends OrderingComposer<_$DriftPostgresDatabase, $UsersTable> {
   $$UsersTableOrderingComposer(super.$state);
-  ColumnOrderings<UuidValue> get id => $state.composableBuilder(
-      column: $state.table.id,
-      builder: (column, joinBuilders) =>
-          ColumnOrderings(column, joinBuilders: joinBuilders));
-
-  ColumnOrderings<String> get name => $state.composableBuilder(
-      column: $state.table.name,
-      builder: (column, joinBuilders) =>
-          ColumnOrderings(column, joinBuilders: joinBuilders));
+  ColumnOrderings<UuidValue> get id => ColumnOrderings($state.table.id);
+  ColumnOrderings<String> get name => ColumnOrderings($state.table.name);
 }
 
 class $DriftPostgresDatabaseManager {

--- a/extras/integration_tests/drift_testcases/lib/database/database.g.dart
+++ b/extras/integration_tests/drift_testcases/lib/database/database.g.dart
@@ -780,15 +780,6 @@ class $$UsersTableTableManager extends RootTableManager<
         ));
 }
 
-typedef $$UsersTableProcessedTableManager = ProcessedTableManager<
-    _$Database,
-    $UsersTable,
-    User,
-    $$UsersTableFilterComposer,
-    $$UsersTableOrderingComposer,
-    $$UsersTableCreateCompanionBuilder,
-    $$UsersTableUpdateCompanionBuilder>;
-
 class $$UsersTableFilterComposer
     extends FilterComposer<_$Database, $UsersTable> {
   $$UsersTableFilterComposer(super.$state);
@@ -906,15 +897,6 @@ class $$FriendshipsTableTableManager extends RootTableManager<
           ),
         ));
 }
-
-typedef $$FriendshipsTableProcessedTableManager = ProcessedTableManager<
-    _$Database,
-    $FriendshipsTable,
-    Friendship,
-    $$FriendshipsTableFilterComposer,
-    $$FriendshipsTableOrderingComposer,
-    $$FriendshipsTableCreateCompanionBuilder,
-    $$FriendshipsTableUpdateCompanionBuilder>;
 
 class $$FriendshipsTableFilterComposer
     extends FilterComposer<_$Database, $FriendshipsTable> {

--- a/extras/integration_tests/drift_testcases/lib/database/database.g.dart
+++ b/extras/integration_tests/drift_testcases/lib/database/database.g.dart
@@ -792,28 +792,61 @@ typedef $$UsersTableProcessedTableManager = ProcessedTableManager<
 class $$UsersTableFilterComposer
     extends FilterComposer<_$Database, $UsersTable> {
   $$UsersTableFilterComposer(super.$state);
-  ColumnFilters<int> get id => ColumnFilters($state.table.id);
-  ColumnFilters<String> get name => ColumnFilters($state.table.name);
-  ColumnFilters<DateTime> get birthDate =>
-      ColumnFilters($state.table.birthDate);
-  ColumnFilters<Uint8List> get profilePicture =>
-      ColumnFilters($state.table.profilePicture);
+  ColumnFilters<int> get id => $state.composableBuilder(
+      column: $state.table.id,
+      builder: (column, joinBuilders) =>
+          ColumnFilters(column, joinBuilders: joinBuilders));
+
+  ColumnFilters<String> get name => $state.composableBuilder(
+      column: $state.table.name,
+      builder: (column, joinBuilders) =>
+          ColumnFilters(column, joinBuilders: joinBuilders));
+
+  ColumnFilters<DateTime> get birthDate => $state.composableBuilder(
+      column: $state.table.birthDate,
+      builder: (column, joinBuilders) =>
+          ColumnFilters(column, joinBuilders: joinBuilders));
+
+  ColumnFilters<Uint8List> get profilePicture => $state.composableBuilder(
+      column: $state.table.profilePicture,
+      builder: (column, joinBuilders) =>
+          ColumnFilters(column, joinBuilders: joinBuilders));
+
   ColumnWithTypeConverterFilters<Preferences?, Preferences, String>
-      get preferences =>
-          ColumnWithTypeConverterFilters($state.table.preferences);
+      get preferences => $state.composableBuilder(
+          column: $state.table.preferences,
+          builder: (column, joinBuilders) => ColumnWithTypeConverterFilters(
+              column,
+              joinBuilders: joinBuilders));
 }
 
 class $$UsersTableOrderingComposer
     extends OrderingComposer<_$Database, $UsersTable> {
   $$UsersTableOrderingComposer(super.$state);
-  ColumnOrderings<int> get id => ColumnOrderings($state.table.id);
-  ColumnOrderings<String> get name => ColumnOrderings($state.table.name);
-  ColumnOrderings<DateTime> get birthDate =>
-      ColumnOrderings($state.table.birthDate);
-  ColumnOrderings<Uint8List> get profilePicture =>
-      ColumnOrderings($state.table.profilePicture);
-  ColumnOrderings<String> get preferences =>
-      ColumnOrderings($state.table.preferences);
+  ColumnOrderings<int> get id => $state.composableBuilder(
+      column: $state.table.id,
+      builder: (column, joinBuilders) =>
+          ColumnOrderings(column, joinBuilders: joinBuilders));
+
+  ColumnOrderings<String> get name => $state.composableBuilder(
+      column: $state.table.name,
+      builder: (column, joinBuilders) =>
+          ColumnOrderings(column, joinBuilders: joinBuilders));
+
+  ColumnOrderings<DateTime> get birthDate => $state.composableBuilder(
+      column: $state.table.birthDate,
+      builder: (column, joinBuilders) =>
+          ColumnOrderings(column, joinBuilders: joinBuilders));
+
+  ColumnOrderings<Uint8List> get profilePicture => $state.composableBuilder(
+      column: $state.table.profilePicture,
+      builder: (column, joinBuilders) =>
+          ColumnOrderings(column, joinBuilders: joinBuilders));
+
+  ColumnOrderings<String> get preferences => $state.composableBuilder(
+      column: $state.table.preferences,
+      builder: (column, joinBuilders) =>
+          ColumnOrderings(column, joinBuilders: joinBuilders));
 }
 
 typedef $$FriendshipsTableCreateCompanionBuilder = FriendshipsCompanion
@@ -886,20 +919,39 @@ typedef $$FriendshipsTableProcessedTableManager = ProcessedTableManager<
 class $$FriendshipsTableFilterComposer
     extends FilterComposer<_$Database, $FriendshipsTable> {
   $$FriendshipsTableFilterComposer(super.$state);
-  ColumnFilters<int> get firstUser => ColumnFilters($state.table.firstUser);
-  ColumnFilters<int> get secondUser => ColumnFilters($state.table.secondUser);
-  ColumnFilters<bool> get reallyGoodFriends =>
-      ColumnFilters($state.table.reallyGoodFriends);
+  ColumnFilters<int> get firstUser => $state.composableBuilder(
+      column: $state.table.firstUser,
+      builder: (column, joinBuilders) =>
+          ColumnFilters(column, joinBuilders: joinBuilders));
+
+  ColumnFilters<int> get secondUser => $state.composableBuilder(
+      column: $state.table.secondUser,
+      builder: (column, joinBuilders) =>
+          ColumnFilters(column, joinBuilders: joinBuilders));
+
+  ColumnFilters<bool> get reallyGoodFriends => $state.composableBuilder(
+      column: $state.table.reallyGoodFriends,
+      builder: (column, joinBuilders) =>
+          ColumnFilters(column, joinBuilders: joinBuilders));
 }
 
 class $$FriendshipsTableOrderingComposer
     extends OrderingComposer<_$Database, $FriendshipsTable> {
   $$FriendshipsTableOrderingComposer(super.$state);
-  ColumnOrderings<int> get firstUser => ColumnOrderings($state.table.firstUser);
-  ColumnOrderings<int> get secondUser =>
-      ColumnOrderings($state.table.secondUser);
-  ColumnOrderings<bool> get reallyGoodFriends =>
-      ColumnOrderings($state.table.reallyGoodFriends);
+  ColumnOrderings<int> get firstUser => $state.composableBuilder(
+      column: $state.table.firstUser,
+      builder: (column, joinBuilders) =>
+          ColumnOrderings(column, joinBuilders: joinBuilders));
+
+  ColumnOrderings<int> get secondUser => $state.composableBuilder(
+      column: $state.table.secondUser,
+      builder: (column, joinBuilders) =>
+          ColumnOrderings(column, joinBuilders: joinBuilders));
+
+  ColumnOrderings<bool> get reallyGoodFriends => $state.composableBuilder(
+      column: $state.table.reallyGoodFriends,
+      builder: (column, joinBuilders) =>
+          ColumnOrderings(column, joinBuilders: joinBuilders));
 }
 
 class $DatabaseManager {

--- a/extras/integration_tests/drift_testcases/lib/database/database.g.dart
+++ b/extras/integration_tests/drift_testcases/lib/database/database.g.dart
@@ -199,6 +199,19 @@ class User extends DataClass implements Insertable<User> {
             profilePicture.present ? profilePicture.value : this.profilePicture,
         preferences: preferences.present ? preferences.value : this.preferences,
       );
+  User copyWithCompanion(UsersCompanion data) {
+    return User(
+      id: data.id.present ? data.id.value : this.id,
+      name: data.name.present ? data.name.value : this.name,
+      birthDate: data.birthDate.present ? data.birthDate.value : this.birthDate,
+      profilePicture: data.profilePicture.present
+          ? data.profilePicture.value
+          : this.profilePicture,
+      preferences:
+          data.preferences.present ? data.preferences.value : this.preferences,
+    );
+  }
+
   @override
   String toString() {
     return (StringBuffer('User(')
@@ -457,6 +470,17 @@ class Friendship extends DataClass implements Insertable<Friendship> {
         secondUser: secondUser ?? this.secondUser,
         reallyGoodFriends: reallyGoodFriends ?? this.reallyGoodFriends,
       );
+  Friendship copyWithCompanion(FriendshipsCompanion data) {
+    return Friendship(
+      firstUser: data.firstUser.present ? data.firstUser.value : this.firstUser,
+      secondUser:
+          data.secondUser.present ? data.secondUser.value : this.secondUser,
+      reallyGoodFriends: data.reallyGoodFriends.present
+          ? data.reallyGoodFriends.value
+          : this.reallyGoodFriends,
+    );
+  }
+
   @override
   String toString() {
     return (StringBuffer('Friendship(')
@@ -694,7 +718,7 @@ abstract class _$Database extends GeneratedDatabase {
   List<DatabaseSchemaEntity> get allSchemaEntities => [users, friendships];
 }
 
-typedef $$UsersTableInsertCompanionBuilder = UsersCompanion Function({
+typedef $$UsersTableCreateCompanionBuilder = UsersCompanion Function({
   Value<int> id,
   required String name,
   required DateTime birthDate,
@@ -715,8 +739,7 @@ class $$UsersTableTableManager extends RootTableManager<
     User,
     $$UsersTableFilterComposer,
     $$UsersTableOrderingComposer,
-    $$UsersTableProcessedTableManager,
-    $$UsersTableInsertCompanionBuilder,
+    $$UsersTableCreateCompanionBuilder,
     $$UsersTableUpdateCompanionBuilder> {
   $$UsersTableTableManager(_$Database db, $UsersTable table)
       : super(TableManagerState(
@@ -726,8 +749,7 @@ class $$UsersTableTableManager extends RootTableManager<
               $$UsersTableFilterComposer(ComposerState(db, table)),
           orderingComposer:
               $$UsersTableOrderingComposer(ComposerState(db, table)),
-          getChildManagerBuilder: (p) => $$UsersTableProcessedTableManager(p),
-          getUpdateCompanionBuilder: ({
+          updateCompanionCallback: ({
             Value<int> id = const Value.absent(),
             Value<String> name = const Value.absent(),
             Value<DateTime> birthDate = const Value.absent(),
@@ -741,7 +763,7 @@ class $$UsersTableTableManager extends RootTableManager<
             profilePicture: profilePicture,
             preferences: preferences,
           ),
-          getInsertCompanionBuilder: ({
+          createCompanionCallback: ({
             Value<int> id = const Value.absent(),
             required String name,
             required DateTime birthDate,
@@ -758,79 +780,43 @@ class $$UsersTableTableManager extends RootTableManager<
         ));
 }
 
-class $$UsersTableProcessedTableManager extends ProcessedTableManager<
+typedef $$UsersTableProcessedTableManager = ProcessedTableManager<
     _$Database,
     $UsersTable,
     User,
     $$UsersTableFilterComposer,
     $$UsersTableOrderingComposer,
-    $$UsersTableProcessedTableManager,
-    $$UsersTableInsertCompanionBuilder,
-    $$UsersTableUpdateCompanionBuilder> {
-  $$UsersTableProcessedTableManager(super.$state);
-}
+    $$UsersTableCreateCompanionBuilder,
+    $$UsersTableUpdateCompanionBuilder>;
 
 class $$UsersTableFilterComposer
     extends FilterComposer<_$Database, $UsersTable> {
   $$UsersTableFilterComposer(super.$state);
-  ColumnFilters<int> get id => $state.composableBuilder(
-      column: $state.table.id,
-      builder: (column, joinBuilders) =>
-          ColumnFilters(column, joinBuilders: joinBuilders));
-
-  ColumnFilters<String> get name => $state.composableBuilder(
-      column: $state.table.name,
-      builder: (column, joinBuilders) =>
-          ColumnFilters(column, joinBuilders: joinBuilders));
-
-  ColumnFilters<DateTime> get birthDate => $state.composableBuilder(
-      column: $state.table.birthDate,
-      builder: (column, joinBuilders) =>
-          ColumnFilters(column, joinBuilders: joinBuilders));
-
-  ColumnFilters<Uint8List> get profilePicture => $state.composableBuilder(
-      column: $state.table.profilePicture,
-      builder: (column, joinBuilders) =>
-          ColumnFilters(column, joinBuilders: joinBuilders));
-
+  ColumnFilters<int> get id => ColumnFilters($state.table.id);
+  ColumnFilters<String> get name => ColumnFilters($state.table.name);
+  ColumnFilters<DateTime> get birthDate =>
+      ColumnFilters($state.table.birthDate);
+  ColumnFilters<Uint8List> get profilePicture =>
+      ColumnFilters($state.table.profilePicture);
   ColumnWithTypeConverterFilters<Preferences?, Preferences, String>
-      get preferences => $state.composableBuilder(
-          column: $state.table.preferences,
-          builder: (column, joinBuilders) => ColumnWithTypeConverterFilters(
-              column,
-              joinBuilders: joinBuilders));
+      get preferences =>
+          ColumnWithTypeConverterFilters($state.table.preferences);
 }
 
 class $$UsersTableOrderingComposer
     extends OrderingComposer<_$Database, $UsersTable> {
   $$UsersTableOrderingComposer(super.$state);
-  ColumnOrderings<int> get id => $state.composableBuilder(
-      column: $state.table.id,
-      builder: (column, joinBuilders) =>
-          ColumnOrderings(column, joinBuilders: joinBuilders));
-
-  ColumnOrderings<String> get name => $state.composableBuilder(
-      column: $state.table.name,
-      builder: (column, joinBuilders) =>
-          ColumnOrderings(column, joinBuilders: joinBuilders));
-
-  ColumnOrderings<DateTime> get birthDate => $state.composableBuilder(
-      column: $state.table.birthDate,
-      builder: (column, joinBuilders) =>
-          ColumnOrderings(column, joinBuilders: joinBuilders));
-
-  ColumnOrderings<Uint8List> get profilePicture => $state.composableBuilder(
-      column: $state.table.profilePicture,
-      builder: (column, joinBuilders) =>
-          ColumnOrderings(column, joinBuilders: joinBuilders));
-
-  ColumnOrderings<String> get preferences => $state.composableBuilder(
-      column: $state.table.preferences,
-      builder: (column, joinBuilders) =>
-          ColumnOrderings(column, joinBuilders: joinBuilders));
+  ColumnOrderings<int> get id => ColumnOrderings($state.table.id);
+  ColumnOrderings<String> get name => ColumnOrderings($state.table.name);
+  ColumnOrderings<DateTime> get birthDate =>
+      ColumnOrderings($state.table.birthDate);
+  ColumnOrderings<Uint8List> get profilePicture =>
+      ColumnOrderings($state.table.profilePicture);
+  ColumnOrderings<String> get preferences =>
+      ColumnOrderings($state.table.preferences);
 }
 
-typedef $$FriendshipsTableInsertCompanionBuilder = FriendshipsCompanion
+typedef $$FriendshipsTableCreateCompanionBuilder = FriendshipsCompanion
     Function({
   required int firstUser,
   required int secondUser,
@@ -851,8 +837,7 @@ class $$FriendshipsTableTableManager extends RootTableManager<
     Friendship,
     $$FriendshipsTableFilterComposer,
     $$FriendshipsTableOrderingComposer,
-    $$FriendshipsTableProcessedTableManager,
-    $$FriendshipsTableInsertCompanionBuilder,
+    $$FriendshipsTableCreateCompanionBuilder,
     $$FriendshipsTableUpdateCompanionBuilder> {
   $$FriendshipsTableTableManager(_$Database db, $FriendshipsTable table)
       : super(TableManagerState(
@@ -862,9 +847,7 @@ class $$FriendshipsTableTableManager extends RootTableManager<
               $$FriendshipsTableFilterComposer(ComposerState(db, table)),
           orderingComposer:
               $$FriendshipsTableOrderingComposer(ComposerState(db, table)),
-          getChildManagerBuilder: (p) =>
-              $$FriendshipsTableProcessedTableManager(p),
-          getUpdateCompanionBuilder: ({
+          updateCompanionCallback: ({
             Value<int> firstUser = const Value.absent(),
             Value<int> secondUser = const Value.absent(),
             Value<bool> reallyGoodFriends = const Value.absent(),
@@ -876,7 +859,7 @@ class $$FriendshipsTableTableManager extends RootTableManager<
             reallyGoodFriends: reallyGoodFriends,
             rowid: rowid,
           ),
-          getInsertCompanionBuilder: ({
+          createCompanionCallback: ({
             required int firstUser,
             required int secondUser,
             Value<bool> reallyGoodFriends = const Value.absent(),
@@ -891,54 +874,32 @@ class $$FriendshipsTableTableManager extends RootTableManager<
         ));
 }
 
-class $$FriendshipsTableProcessedTableManager extends ProcessedTableManager<
+typedef $$FriendshipsTableProcessedTableManager = ProcessedTableManager<
     _$Database,
     $FriendshipsTable,
     Friendship,
     $$FriendshipsTableFilterComposer,
     $$FriendshipsTableOrderingComposer,
-    $$FriendshipsTableProcessedTableManager,
-    $$FriendshipsTableInsertCompanionBuilder,
-    $$FriendshipsTableUpdateCompanionBuilder> {
-  $$FriendshipsTableProcessedTableManager(super.$state);
-}
+    $$FriendshipsTableCreateCompanionBuilder,
+    $$FriendshipsTableUpdateCompanionBuilder>;
 
 class $$FriendshipsTableFilterComposer
     extends FilterComposer<_$Database, $FriendshipsTable> {
   $$FriendshipsTableFilterComposer(super.$state);
-  ColumnFilters<int> get firstUser => $state.composableBuilder(
-      column: $state.table.firstUser,
-      builder: (column, joinBuilders) =>
-          ColumnFilters(column, joinBuilders: joinBuilders));
-
-  ColumnFilters<int> get secondUser => $state.composableBuilder(
-      column: $state.table.secondUser,
-      builder: (column, joinBuilders) =>
-          ColumnFilters(column, joinBuilders: joinBuilders));
-
-  ColumnFilters<bool> get reallyGoodFriends => $state.composableBuilder(
-      column: $state.table.reallyGoodFriends,
-      builder: (column, joinBuilders) =>
-          ColumnFilters(column, joinBuilders: joinBuilders));
+  ColumnFilters<int> get firstUser => ColumnFilters($state.table.firstUser);
+  ColumnFilters<int> get secondUser => ColumnFilters($state.table.secondUser);
+  ColumnFilters<bool> get reallyGoodFriends =>
+      ColumnFilters($state.table.reallyGoodFriends);
 }
 
 class $$FriendshipsTableOrderingComposer
     extends OrderingComposer<_$Database, $FriendshipsTable> {
   $$FriendshipsTableOrderingComposer(super.$state);
-  ColumnOrderings<int> get firstUser => $state.composableBuilder(
-      column: $state.table.firstUser,
-      builder: (column, joinBuilders) =>
-          ColumnOrderings(column, joinBuilders: joinBuilders));
-
-  ColumnOrderings<int> get secondUser => $state.composableBuilder(
-      column: $state.table.secondUser,
-      builder: (column, joinBuilders) =>
-          ColumnOrderings(column, joinBuilders: joinBuilders));
-
-  ColumnOrderings<bool> get reallyGoodFriends => $state.composableBuilder(
-      column: $state.table.reallyGoodFriends,
-      builder: (column, joinBuilders) =>
-          ColumnOrderings(column, joinBuilders: joinBuilders));
+  ColumnOrderings<int> get firstUser => ColumnOrderings($state.table.firstUser);
+  ColumnOrderings<int> get secondUser =>
+      ColumnOrderings($state.table.secondUser);
+  ColumnOrderings<bool> get reallyGoodFriends =>
+      ColumnOrderings($state.table.reallyGoodFriends);
 }
 
 class $DatabaseManager {

--- a/extras/integration_tests/legacy_web/test/saves_after_migration_regression_test.g.dart
+++ b/extras/integration_tests/legacy_web/test/saves_after_migration_regression_test.g.dart
@@ -86,6 +86,12 @@ class Foo extends DataClass implements Insertable<Foo> {
   Foo copyWith({int? id}) => Foo(
         id: id ?? this.id,
       );
+  Foo copyWithCompanion(FoosCompanion data) {
+    return Foo(
+      id: data.id.present ? data.id.value : this.id,
+    );
+  }
+
   @override
   String toString() {
     return (StringBuffer('Foo(')
@@ -224,6 +230,12 @@ class Bar extends DataClass implements Insertable<Bar> {
   Bar copyWith({int? id}) => Bar(
         id: id ?? this.id,
       );
+  Bar copyWithCompanion(BarsCompanion data) {
+    return Bar(
+      id: data.id.present ? data.id.value : this.id,
+    );
+  }
+
   @override
   String toString() {
     return (StringBuffer('Bar(')

--- a/extras/integration_tests/web_wasm/lib/src/database.g.dart
+++ b/extras/integration_tests/web_wasm/lib/src/database.g.dart
@@ -250,15 +250,29 @@ typedef $$TestTableTableProcessedTableManager = ProcessedTableManager<
 class $$TestTableTableFilterComposer
     extends FilterComposer<_$TestDatabase, $TestTableTable> {
   $$TestTableTableFilterComposer(super.$state);
-  ColumnFilters<int> get id => ColumnFilters($state.table.id);
-  ColumnFilters<String> get content => ColumnFilters($state.table.content);
+  ColumnFilters<int> get id => $state.composableBuilder(
+      column: $state.table.id,
+      builder: (column, joinBuilders) =>
+          ColumnFilters(column, joinBuilders: joinBuilders));
+
+  ColumnFilters<String> get content => $state.composableBuilder(
+      column: $state.table.content,
+      builder: (column, joinBuilders) =>
+          ColumnFilters(column, joinBuilders: joinBuilders));
 }
 
 class $$TestTableTableOrderingComposer
     extends OrderingComposer<_$TestDatabase, $TestTableTable> {
   $$TestTableTableOrderingComposer(super.$state);
-  ColumnOrderings<int> get id => ColumnOrderings($state.table.id);
-  ColumnOrderings<String> get content => ColumnOrderings($state.table.content);
+  ColumnOrderings<int> get id => $state.composableBuilder(
+      column: $state.table.id,
+      builder: (column, joinBuilders) =>
+          ColumnOrderings(column, joinBuilders: joinBuilders));
+
+  ColumnOrderings<String> get content => $state.composableBuilder(
+      column: $state.table.content,
+      builder: (column, joinBuilders) =>
+          ColumnOrderings(column, joinBuilders: joinBuilders));
 }
 
 class $TestDatabaseManager {

--- a/extras/integration_tests/web_wasm/lib/src/database.g.dart
+++ b/extras/integration_tests/web_wasm/lib/src/database.g.dart
@@ -107,6 +107,13 @@ class TestTableData extends DataClass implements Insertable<TestTableData> {
         id: id ?? this.id,
         content: content ?? this.content,
       );
+  TestTableData copyWithCompanion(TestTableCompanion data) {
+    return TestTableData(
+      id: data.id.present ? data.id.value : this.id,
+      content: data.content.present ? data.content.value : this.content,
+    );
+  }
+
   @override
   String toString() {
     return (StringBuffer('TestTableData(')
@@ -187,7 +194,7 @@ abstract class _$TestDatabase extends GeneratedDatabase {
   List<DatabaseSchemaEntity> get allSchemaEntities => [testTable];
 }
 
-typedef $$TestTableTableInsertCompanionBuilder = TestTableCompanion Function({
+typedef $$TestTableTableCreateCompanionBuilder = TestTableCompanion Function({
   Value<int> id,
   required String content,
 });
@@ -202,8 +209,7 @@ class $$TestTableTableTableManager extends RootTableManager<
     TestTableData,
     $$TestTableTableFilterComposer,
     $$TestTableTableOrderingComposer,
-    $$TestTableTableProcessedTableManager,
-    $$TestTableTableInsertCompanionBuilder,
+    $$TestTableTableCreateCompanionBuilder,
     $$TestTableTableUpdateCompanionBuilder> {
   $$TestTableTableTableManager(_$TestDatabase db, $TestTableTable table)
       : super(TableManagerState(
@@ -213,9 +219,7 @@ class $$TestTableTableTableManager extends RootTableManager<
               $$TestTableTableFilterComposer(ComposerState(db, table)),
           orderingComposer:
               $$TestTableTableOrderingComposer(ComposerState(db, table)),
-          getChildManagerBuilder: (p) =>
-              $$TestTableTableProcessedTableManager(p),
-          getUpdateCompanionBuilder: ({
+          updateCompanionCallback: ({
             Value<int> id = const Value.absent(),
             Value<String> content = const Value.absent(),
           }) =>
@@ -223,7 +227,7 @@ class $$TestTableTableTableManager extends RootTableManager<
             id: id,
             content: content,
           ),
-          getInsertCompanionBuilder: ({
+          createCompanionCallback: ({
             Value<int> id = const Value.absent(),
             required String content,
           }) =>
@@ -234,44 +238,27 @@ class $$TestTableTableTableManager extends RootTableManager<
         ));
 }
 
-class $$TestTableTableProcessedTableManager extends ProcessedTableManager<
+typedef $$TestTableTableProcessedTableManager = ProcessedTableManager<
     _$TestDatabase,
     $TestTableTable,
     TestTableData,
     $$TestTableTableFilterComposer,
     $$TestTableTableOrderingComposer,
-    $$TestTableTableProcessedTableManager,
-    $$TestTableTableInsertCompanionBuilder,
-    $$TestTableTableUpdateCompanionBuilder> {
-  $$TestTableTableProcessedTableManager(super.$state);
-}
+    $$TestTableTableCreateCompanionBuilder,
+    $$TestTableTableUpdateCompanionBuilder>;
 
 class $$TestTableTableFilterComposer
     extends FilterComposer<_$TestDatabase, $TestTableTable> {
   $$TestTableTableFilterComposer(super.$state);
-  ColumnFilters<int> get id => $state.composableBuilder(
-      column: $state.table.id,
-      builder: (column, joinBuilders) =>
-          ColumnFilters(column, joinBuilders: joinBuilders));
-
-  ColumnFilters<String> get content => $state.composableBuilder(
-      column: $state.table.content,
-      builder: (column, joinBuilders) =>
-          ColumnFilters(column, joinBuilders: joinBuilders));
+  ColumnFilters<int> get id => ColumnFilters($state.table.id);
+  ColumnFilters<String> get content => ColumnFilters($state.table.content);
 }
 
 class $$TestTableTableOrderingComposer
     extends OrderingComposer<_$TestDatabase, $TestTableTable> {
   $$TestTableTableOrderingComposer(super.$state);
-  ColumnOrderings<int> get id => $state.composableBuilder(
-      column: $state.table.id,
-      builder: (column, joinBuilders) =>
-          ColumnOrderings(column, joinBuilders: joinBuilders));
-
-  ColumnOrderings<String> get content => $state.composableBuilder(
-      column: $state.table.content,
-      builder: (column, joinBuilders) =>
-          ColumnOrderings(column, joinBuilders: joinBuilders));
+  ColumnOrderings<int> get id => ColumnOrderings($state.table.id);
+  ColumnOrderings<String> get content => ColumnOrderings($state.table.content);
 }
 
 class $TestDatabaseManager {

--- a/extras/integration_tests/web_wasm/lib/src/database.g.dart
+++ b/extras/integration_tests/web_wasm/lib/src/database.g.dart
@@ -238,15 +238,6 @@ class $$TestTableTableTableManager extends RootTableManager<
         ));
 }
 
-typedef $$TestTableTableProcessedTableManager = ProcessedTableManager<
-    _$TestDatabase,
-    $TestTableTable,
-    TestTableData,
-    $$TestTableTableFilterComposer,
-    $$TestTableTableOrderingComposer,
-    $$TestTableTableCreateCompanionBuilder,
-    $$TestTableTableUpdateCompanionBuilder>;
-
 class $$TestTableTableFilterComposer
     extends FilterComposer<_$TestDatabase, $TestTableTable> {
   $$TestTableTableFilterComposer(super.$state);


### PR DESCRIPTION
This PR does the following:

* Cherry Pick the Flutter CI fixes from the `drift_flutter` branch
* Add a option for combining successive filter calls with an OR instead of a hardcoded AND.
* Rename Generics in the Manager API to more descriptive names (`$Table` instead of `T`)
* Make Manager classes non-const for now
* Rename some fields on `ManagerState`
* Remove unnecessary code from Manager API (`_getChildManagerBuilder`)
* Add distinct option for some queries

I will create the next PR once this is merged.

NOTE: I "fixed" a "bug" and then reverted it. 
Lmk if I should go back and undo the commits so we should have a cleaner git history.

I want to make this as painless for you as possible.
The next feature (references) will introduce another level of complexity and I don't want to be the only person with a strong understanding of it.  

I'll be documenting the next PR very clearly.
I'm looking for constructive criticism if you ever have any for me.