### PR TITLE
feat: Read References

### DIFF
--- a/docs/lib/snippets/_shared/todo_tables.drift.dart
+++ b/docs/lib/snippets/_shared/todo_tables.drift.dart
@@ -335,7 +335,9 @@ class $$TodoItemsTableTableManager extends i0.RootTableManager<
     i1.$$TodoItemsTableFilterComposer,
     i1.$$TodoItemsTableOrderingComposer,
     $$TodoItemsTableCreateCompanionBuilder,
-    $$TodoItemsTableUpdateCompanionBuilder> {
+    $$TodoItemsTableUpdateCompanionBuilder,
+    $$TodoItemsTableWithReferences,
+    i1.TodoItem> {
   $$TodoItemsTableTableManager(
       i0.GeneratedDatabase db, i1.$TodoItemsTable table)
       : super(i0.TableManagerState(
@@ -345,6 +347,8 @@ class $$TodoItemsTableTableManager extends i0.RootTableManager<
               i1.$$TodoItemsTableFilterComposer(i0.ComposerState(db, table)),
           orderingComposer:
               i1.$$TodoItemsTableOrderingComposer(i0.ComposerState(db, table)),
+          dataclassMapper: (p0) async =>
+              p0.map((e) => $$TodoItemsTableWithReferences(db, e)).toList(),
           updateCompanionCallback: ({
             i0.Value<int> id = const i0.Value.absent(),
             i0.Value<String> title = const i0.Value.absent(),
@@ -375,6 +379,17 @@ class $$TodoItemsTableTableManager extends i0.RootTableManager<
           ),
         ));
 }
+
+typedef $$TodoItemsTableProcessedTableManager = i0.ProcessedTableManager<
+    i0.GeneratedDatabase,
+    i1.$TodoItemsTable,
+    i1.TodoItem,
+    i1.$$TodoItemsTableFilterComposer,
+    i1.$$TodoItemsTableOrderingComposer,
+    $$TodoItemsTableCreateCompanionBuilder,
+    $$TodoItemsTableUpdateCompanionBuilder,
+    $$TodoItemsTableWithReferences,
+    i1.TodoItem>;
 
 class $$TodoItemsTableFilterComposer
     extends i0.FilterComposer<i0.GeneratedDatabase, i1.$TodoItemsTable> {
@@ -457,6 +472,13 @@ class $$TodoItemsTableOrderingComposer
                     parentComposers)));
     return composer;
   }
+}
+
+class $$TodoItemsTableWithReferences {
+  // ignore: unused_field
+  final i0.GeneratedDatabase _db;
+  final i1.TodoItem i1TodoItem;
+  $$TodoItemsTableWithReferences(this._db, this.i1TodoItem);
 }
 
 class $CategoriesTable extends i2.Categories
@@ -655,7 +677,9 @@ class $$CategoriesTableTableManager extends i0.RootTableManager<
     i1.$$CategoriesTableFilterComposer,
     i1.$$CategoriesTableOrderingComposer,
     $$CategoriesTableCreateCompanionBuilder,
-    $$CategoriesTableUpdateCompanionBuilder> {
+    $$CategoriesTableUpdateCompanionBuilder,
+    $$CategoriesTableWithReferences,
+    i1.Category> {
   $$CategoriesTableTableManager(
       i0.GeneratedDatabase db, i1.$CategoriesTable table)
       : super(i0.TableManagerState(
@@ -665,6 +689,8 @@ class $$CategoriesTableTableManager extends i0.RootTableManager<
               i1.$$CategoriesTableFilterComposer(i0.ComposerState(db, table)),
           orderingComposer:
               i1.$$CategoriesTableOrderingComposer(i0.ComposerState(db, table)),
+          dataclassMapper: (p0) async =>
+              p0.map((e) => $$CategoriesTableWithReferences(db, e)).toList(),
           updateCompanionCallback: ({
             i0.Value<int> id = const i0.Value.absent(),
             i0.Value<String> name = const i0.Value.absent(),
@@ -683,6 +709,17 @@ class $$CategoriesTableTableManager extends i0.RootTableManager<
           ),
         ));
 }
+
+typedef $$CategoriesTableProcessedTableManager = i0.ProcessedTableManager<
+    i0.GeneratedDatabase,
+    i1.$CategoriesTable,
+    i1.Category,
+    i1.$$CategoriesTableFilterComposer,
+    i1.$$CategoriesTableOrderingComposer,
+    $$CategoriesTableCreateCompanionBuilder,
+    $$CategoriesTableUpdateCompanionBuilder,
+    $$CategoriesTableWithReferences,
+    i1.Category>;
 
 class $$CategoriesTableFilterComposer
     extends i0.FilterComposer<i0.GeneratedDatabase, i1.$CategoriesTable> {
@@ -710,6 +747,13 @@ class $$CategoriesTableOrderingComposer
       column: $state.table.name,
       builder: (column, joinBuilders) =>
           i0.ColumnOrderings(column, joinBuilders: joinBuilders));
+}
+
+class $$CategoriesTableWithReferences {
+  // ignore: unused_field
+  final i0.GeneratedDatabase _db;
+  final i1.Category i1Category;
+  $$CategoriesTableWithReferences(this._db, this.i1Category);
 }
 
 class $UsersTable extends i2.Users with i0.TableInfo<$UsersTable, i1.User> {
@@ -908,7 +952,9 @@ class $$UsersTableTableManager extends i0.RootTableManager<
     i1.$$UsersTableFilterComposer,
     i1.$$UsersTableOrderingComposer,
     $$UsersTableCreateCompanionBuilder,
-    $$UsersTableUpdateCompanionBuilder> {
+    $$UsersTableUpdateCompanionBuilder,
+    $$UsersTableWithReferences,
+    i1.User> {
   $$UsersTableTableManager(i0.GeneratedDatabase db, i1.$UsersTable table)
       : super(i0.TableManagerState(
           db: db,
@@ -917,6 +963,8 @@ class $$UsersTableTableManager extends i0.RootTableManager<
               i1.$$UsersTableFilterComposer(i0.ComposerState(db, table)),
           orderingComposer:
               i1.$$UsersTableOrderingComposer(i0.ComposerState(db, table)),
+          dataclassMapper: (p0) async =>
+              p0.map((e) => $$UsersTableWithReferences(db, e)).toList(),
           updateCompanionCallback: ({
             i0.Value<int> id = const i0.Value.absent(),
             i0.Value<DateTime> birthDate = const i0.Value.absent(),
@@ -935,6 +983,17 @@ class $$UsersTableTableManager extends i0.RootTableManager<
           ),
         ));
 }
+
+typedef $$UsersTableProcessedTableManager = i0.ProcessedTableManager<
+    i0.GeneratedDatabase,
+    i1.$UsersTable,
+    i1.User,
+    i1.$$UsersTableFilterComposer,
+    i1.$$UsersTableOrderingComposer,
+    $$UsersTableCreateCompanionBuilder,
+    $$UsersTableUpdateCompanionBuilder,
+    $$UsersTableWithReferences,
+    i1.User>;
 
 class $$UsersTableFilterComposer
     extends i0.FilterComposer<i0.GeneratedDatabase, i1.$UsersTable> {
@@ -962,4 +1021,11 @@ class $$UsersTableOrderingComposer
       column: $state.table.birthDate,
       builder: (column, joinBuilders) =>
           i0.ColumnOrderings(column, joinBuilders: joinBuilders));
+}
+
+class $$UsersTableWithReferences {
+  // ignore: unused_field
+  final i0.GeneratedDatabase _db;
+  final i1.User i1User;
+  $$UsersTableWithReferences(this._db, this.i1User);
 }

--- a/docs/lib/snippets/_shared/todo_tables.drift.dart
+++ b/docs/lib/snippets/_shared/todo_tables.drift.dart
@@ -336,7 +336,7 @@ class $$TodoItemsTableTableManager extends i0.RootTableManager<
     i1.$$TodoItemsTableOrderingComposer,
     $$TodoItemsTableCreateCompanionBuilder,
     $$TodoItemsTableUpdateCompanionBuilder,
-    $$TodoItemsTableWithReferences,
+    (i1.TodoItem, $$TodoItemsTableWithReferences),
     i1.TodoItem> {
   $$TodoItemsTableTableManager(
       i0.GeneratedDatabase db, i1.$TodoItemsTable table)
@@ -347,8 +347,9 @@ class $$TodoItemsTableTableManager extends i0.RootTableManager<
               i1.$$TodoItemsTableFilterComposer(i0.ComposerState(db, table)),
           orderingComposer:
               i1.$$TodoItemsTableOrderingComposer(i0.ComposerState(db, table)),
-          withReferenceMapper: (p0) =>
-              p0.map((e) => $$TodoItemsTableWithReferences(db, e)).toList(),
+          withReferenceMapper: (p0) => p0
+              .map((e) => (e, $$TodoItemsTableWithReferences(db, e)))
+              .toList(),
           updateCompanionCallback: ({
             i0.Value<int> id = const i0.Value.absent(),
             i0.Value<String> title = const i0.Value.absent(),
@@ -388,7 +389,7 @@ typedef $$TodoItemsTableProcessedTableManager = i0.ProcessedTableManager<
     i1.$$TodoItemsTableOrderingComposer,
     $$TodoItemsTableCreateCompanionBuilder,
     $$TodoItemsTableUpdateCompanionBuilder,
-    $$TodoItemsTableWithReferences,
+    (i1.TodoItem, $$TodoItemsTableWithReferences),
     i1.TodoItem>;
 
 class $$TodoItemsTableFilterComposer
@@ -477,8 +478,8 @@ class $$TodoItemsTableOrderingComposer
 class $$TodoItemsTableWithReferences {
   // ignore: unused_field
   final i0.GeneratedDatabase _db;
-  final i1.TodoItem i1TodoItem;
-  $$TodoItemsTableWithReferences(this._db, this.i1TodoItem);
+  final i1.TodoItem _item;
+  $$TodoItemsTableWithReferences(this._db, this._item);
 }
 
 class $CategoriesTable extends i2.Categories
@@ -678,7 +679,7 @@ class $$CategoriesTableTableManager extends i0.RootTableManager<
     i1.$$CategoriesTableOrderingComposer,
     $$CategoriesTableCreateCompanionBuilder,
     $$CategoriesTableUpdateCompanionBuilder,
-    $$CategoriesTableWithReferences,
+    (i1.Category, $$CategoriesTableWithReferences),
     i1.Category> {
   $$CategoriesTableTableManager(
       i0.GeneratedDatabase db, i1.$CategoriesTable table)
@@ -689,8 +690,9 @@ class $$CategoriesTableTableManager extends i0.RootTableManager<
               i1.$$CategoriesTableFilterComposer(i0.ComposerState(db, table)),
           orderingComposer:
               i1.$$CategoriesTableOrderingComposer(i0.ComposerState(db, table)),
-          withReferenceMapper: (p0) =>
-              p0.map((e) => $$CategoriesTableWithReferences(db, e)).toList(),
+          withReferenceMapper: (p0) => p0
+              .map((e) => (e, $$CategoriesTableWithReferences(db, e)))
+              .toList(),
           updateCompanionCallback: ({
             i0.Value<int> id = const i0.Value.absent(),
             i0.Value<String> name = const i0.Value.absent(),
@@ -718,7 +720,7 @@ typedef $$CategoriesTableProcessedTableManager = i0.ProcessedTableManager<
     i1.$$CategoriesTableOrderingComposer,
     $$CategoriesTableCreateCompanionBuilder,
     $$CategoriesTableUpdateCompanionBuilder,
-    $$CategoriesTableWithReferences,
+    (i1.Category, $$CategoriesTableWithReferences),
     i1.Category>;
 
 class $$CategoriesTableFilterComposer
@@ -752,8 +754,8 @@ class $$CategoriesTableOrderingComposer
 class $$CategoriesTableWithReferences {
   // ignore: unused_field
   final i0.GeneratedDatabase _db;
-  final i1.Category i1Category;
-  $$CategoriesTableWithReferences(this._db, this.i1Category);
+  final i1.Category _item;
+  $$CategoriesTableWithReferences(this._db, this._item);
 }
 
 class $UsersTable extends i2.Users with i0.TableInfo<$UsersTable, i1.User> {
@@ -953,7 +955,7 @@ class $$UsersTableTableManager extends i0.RootTableManager<
     i1.$$UsersTableOrderingComposer,
     $$UsersTableCreateCompanionBuilder,
     $$UsersTableUpdateCompanionBuilder,
-    $$UsersTableWithReferences,
+    (i1.User, $$UsersTableWithReferences),
     i1.User> {
   $$UsersTableTableManager(i0.GeneratedDatabase db, i1.$UsersTable table)
       : super(i0.TableManagerState(
@@ -964,7 +966,7 @@ class $$UsersTableTableManager extends i0.RootTableManager<
           orderingComposer:
               i1.$$UsersTableOrderingComposer(i0.ComposerState(db, table)),
           withReferenceMapper: (p0) =>
-              p0.map((e) => $$UsersTableWithReferences(db, e)).toList(),
+              p0.map((e) => (e, $$UsersTableWithReferences(db, e))).toList(),
           updateCompanionCallback: ({
             i0.Value<int> id = const i0.Value.absent(),
             i0.Value<DateTime> birthDate = const i0.Value.absent(),
@@ -992,7 +994,7 @@ typedef $$UsersTableProcessedTableManager = i0.ProcessedTableManager<
     i1.$$UsersTableOrderingComposer,
     $$UsersTableCreateCompanionBuilder,
     $$UsersTableUpdateCompanionBuilder,
-    $$UsersTableWithReferences,
+    (i1.User, $$UsersTableWithReferences),
     i1.User>;
 
 class $$UsersTableFilterComposer
@@ -1026,6 +1028,6 @@ class $$UsersTableOrderingComposer
 class $$UsersTableWithReferences {
   // ignore: unused_field
   final i0.GeneratedDatabase _db;
-  final i1.User i1User;
-  $$UsersTableWithReferences(this._db, this.i1User);
+  final i1.User _item;
+  $$UsersTableWithReferences(this._db, this._item);
 }

--- a/docs/lib/snippets/_shared/todo_tables.drift.dart
+++ b/docs/lib/snippets/_shared/todo_tables.drift.dart
@@ -478,6 +478,7 @@ class $$TodoItemsTableOrderingComposer
 class $$TodoItemsTableWithReferences {
   // ignore: unused_field
   final i0.GeneratedDatabase _db;
+  // ignore: unused_field
   final i1.TodoItem _item;
   $$TodoItemsTableWithReferences(this._db, this._item);
 }
@@ -754,6 +755,7 @@ class $$CategoriesTableOrderingComposer
 class $$CategoriesTableWithReferences {
   // ignore: unused_field
   final i0.GeneratedDatabase _db;
+  // ignore: unused_field
   final i1.Category _item;
   $$CategoriesTableWithReferences(this._db, this._item);
 }
@@ -1028,6 +1030,7 @@ class $$UsersTableOrderingComposer
 class $$UsersTableWithReferences {
   // ignore: unused_field
   final i0.GeneratedDatabase _db;
+  // ignore: unused_field
   final i1.User _item;
   $$UsersTableWithReferences(this._db, this._item);
 }

--- a/docs/lib/snippets/_shared/todo_tables.drift.dart
+++ b/docs/lib/snippets/_shared/todo_tables.drift.dart
@@ -347,7 +347,7 @@ class $$TodoItemsTableTableManager extends i0.RootTableManager<
               i1.$$TodoItemsTableFilterComposer(i0.ComposerState(db, table)),
           orderingComposer:
               i1.$$TodoItemsTableOrderingComposer(i0.ComposerState(db, table)),
-          dataclassMapper: (p0) async =>
+          withReferenceMapper: (p0) =>
               p0.map((e) => $$TodoItemsTableWithReferences(db, e)).toList(),
           updateCompanionCallback: ({
             i0.Value<int> id = const i0.Value.absent(),
@@ -689,7 +689,7 @@ class $$CategoriesTableTableManager extends i0.RootTableManager<
               i1.$$CategoriesTableFilterComposer(i0.ComposerState(db, table)),
           orderingComposer:
               i1.$$CategoriesTableOrderingComposer(i0.ComposerState(db, table)),
-          dataclassMapper: (p0) async =>
+          withReferenceMapper: (p0) =>
               p0.map((e) => $$CategoriesTableWithReferences(db, e)).toList(),
           updateCompanionCallback: ({
             i0.Value<int> id = const i0.Value.absent(),
@@ -963,7 +963,7 @@ class $$UsersTableTableManager extends i0.RootTableManager<
               i1.$$UsersTableFilterComposer(i0.ComposerState(db, table)),
           orderingComposer:
               i1.$$UsersTableOrderingComposer(i0.ComposerState(db, table)),
-          dataclassMapper: (p0) async =>
+          withReferenceMapper: (p0) =>
               p0.map((e) => $$UsersTableWithReferences(db, e)).toList(),
           updateCompanionCallback: ({
             i0.Value<int> id = const i0.Value.absent(),

--- a/docs/lib/snippets/_shared/todo_tables.drift.dart
+++ b/docs/lib/snippets/_shared/todo_tables.drift.dart
@@ -328,70 +328,6 @@ typedef $$TodoItemsTableUpdateCompanionBuilder = i1.TodoItemsCompanion
   i0.Value<DateTime?> dueDate,
 });
 
-class $$TodoItemsTableTableManager extends i0.RootTableManager<
-    i0.GeneratedDatabase,
-    i1.$TodoItemsTable,
-    i1.TodoItem,
-    i1.$$TodoItemsTableFilterComposer,
-    i1.$$TodoItemsTableOrderingComposer,
-    $$TodoItemsTableCreateCompanionBuilder,
-    $$TodoItemsTableUpdateCompanionBuilder,
-    (i1.TodoItem, $$TodoItemsTableWithReferences),
-    i1.TodoItem> {
-  $$TodoItemsTableTableManager(
-      i0.GeneratedDatabase db, i1.$TodoItemsTable table)
-      : super(i0.TableManagerState(
-          db: db,
-          table: table,
-          filteringComposer:
-              i1.$$TodoItemsTableFilterComposer(i0.ComposerState(db, table)),
-          orderingComposer:
-              i1.$$TodoItemsTableOrderingComposer(i0.ComposerState(db, table)),
-          withReferenceMapper: (p0) => p0
-              .map((e) => (e, $$TodoItemsTableWithReferences(db, e)))
-              .toList(),
-          updateCompanionCallback: ({
-            i0.Value<int> id = const i0.Value.absent(),
-            i0.Value<String> title = const i0.Value.absent(),
-            i0.Value<String> content = const i0.Value.absent(),
-            i0.Value<int?> category = const i0.Value.absent(),
-            i0.Value<DateTime?> dueDate = const i0.Value.absent(),
-          }) =>
-              i1.TodoItemsCompanion(
-            id: id,
-            title: title,
-            content: content,
-            category: category,
-            dueDate: dueDate,
-          ),
-          createCompanionCallback: ({
-            i0.Value<int> id = const i0.Value.absent(),
-            required String title,
-            required String content,
-            i0.Value<int?> category = const i0.Value.absent(),
-            i0.Value<DateTime?> dueDate = const i0.Value.absent(),
-          }) =>
-              i1.TodoItemsCompanion.insert(
-            id: id,
-            title: title,
-            content: content,
-            category: category,
-            dueDate: dueDate,
-          ),
-        ));
-}
-
-typedef $$TodoItemsTableProcessedTableManager = i0.ProcessedTableManager<
-    i0.GeneratedDatabase,
-    i1.$TodoItemsTable,
-    i1.TodoItem,
-    i1.$$TodoItemsTableFilterComposer,
-    i1.$$TodoItemsTableOrderingComposer,
-    $$TodoItemsTableCreateCompanionBuilder,
-    $$TodoItemsTableUpdateCompanionBuilder,
-    (i1.TodoItem, $$TodoItemsTableWithReferences),
-    i1.TodoItem>;
-
 class $$TodoItemsTableFilterComposer
     extends i0.FilterComposer<i0.GeneratedDatabase, i1.$TodoItemsTable> {
   $$TodoItemsTableFilterComposer(super.$state);
@@ -475,13 +411,68 @@ class $$TodoItemsTableOrderingComposer
   }
 }
 
-class $$TodoItemsTableWithReferences {
-  // ignore: unused_field
-  final i0.GeneratedDatabase _db;
-  // ignore: unused_field
-  final i1.TodoItem _item;
-  $$TodoItemsTableWithReferences(this._db, this._item);
+class $$TodoItemsTableTableManager extends i0.RootTableManager<
+    i0.GeneratedDatabase,
+    i1.$TodoItemsTable,
+    i1.TodoItem,
+    i1.$$TodoItemsTableFilterComposer,
+    i1.$$TodoItemsTableOrderingComposer,
+    $$TodoItemsTableCreateCompanionBuilder,
+    $$TodoItemsTableUpdateCompanionBuilder,
+    (i1.TodoItem, i0.BaseWithReferences<i0.GeneratedDatabase, i1.TodoItem>),
+    i1.TodoItem> {
+  $$TodoItemsTableTableManager(
+      i0.GeneratedDatabase db, i1.$TodoItemsTable table)
+      : super(i0.TableManagerState(
+          db: db,
+          table: table,
+          filteringComposer:
+              i1.$$TodoItemsTableFilterComposer(i0.ComposerState(db, table)),
+          orderingComposer:
+              i1.$$TodoItemsTableOrderingComposer(i0.ComposerState(db, table)),
+          withReferenceMapper: (p0) =>
+              p0.map((e) => (e, i0.BaseWithReferences(db, e))).toList(),
+          updateCompanionCallback: ({
+            i0.Value<int> id = const i0.Value.absent(),
+            i0.Value<String> title = const i0.Value.absent(),
+            i0.Value<String> content = const i0.Value.absent(),
+            i0.Value<int?> category = const i0.Value.absent(),
+            i0.Value<DateTime?> dueDate = const i0.Value.absent(),
+          }) =>
+              i1.TodoItemsCompanion(
+            id: id,
+            title: title,
+            content: content,
+            category: category,
+            dueDate: dueDate,
+          ),
+          createCompanionCallback: ({
+            i0.Value<int> id = const i0.Value.absent(),
+            required String title,
+            required String content,
+            i0.Value<int?> category = const i0.Value.absent(),
+            i0.Value<DateTime?> dueDate = const i0.Value.absent(),
+          }) =>
+              i1.TodoItemsCompanion.insert(
+            id: id,
+            title: title,
+            content: content,
+            category: category,
+            dueDate: dueDate,
+          ),
+        ));
 }
+
+typedef $$TodoItemsTableProcessedTableManager = i0.ProcessedTableManager<
+    i0.GeneratedDatabase,
+    i1.$TodoItemsTable,
+    i1.TodoItem,
+    i1.$$TodoItemsTableFilterComposer,
+    i1.$$TodoItemsTableOrderingComposer,
+    $$TodoItemsTableCreateCompanionBuilder,
+    $$TodoItemsTableUpdateCompanionBuilder,
+    (i1.TodoItem, i0.BaseWithReferences<i0.GeneratedDatabase, i1.TodoItem>),
+    i1.TodoItem>;
 
 class $CategoriesTable extends i2.Categories
     with i0.TableInfo<$CategoriesTable, i1.Category> {
@@ -672,58 +663,6 @@ typedef $$CategoriesTableUpdateCompanionBuilder = i1.CategoriesCompanion
   i0.Value<String> name,
 });
 
-class $$CategoriesTableTableManager extends i0.RootTableManager<
-    i0.GeneratedDatabase,
-    i1.$CategoriesTable,
-    i1.Category,
-    i1.$$CategoriesTableFilterComposer,
-    i1.$$CategoriesTableOrderingComposer,
-    $$CategoriesTableCreateCompanionBuilder,
-    $$CategoriesTableUpdateCompanionBuilder,
-    (i1.Category, $$CategoriesTableWithReferences),
-    i1.Category> {
-  $$CategoriesTableTableManager(
-      i0.GeneratedDatabase db, i1.$CategoriesTable table)
-      : super(i0.TableManagerState(
-          db: db,
-          table: table,
-          filteringComposer:
-              i1.$$CategoriesTableFilterComposer(i0.ComposerState(db, table)),
-          orderingComposer:
-              i1.$$CategoriesTableOrderingComposer(i0.ComposerState(db, table)),
-          withReferenceMapper: (p0) => p0
-              .map((e) => (e, $$CategoriesTableWithReferences(db, e)))
-              .toList(),
-          updateCompanionCallback: ({
-            i0.Value<int> id = const i0.Value.absent(),
-            i0.Value<String> name = const i0.Value.absent(),
-          }) =>
-              i1.CategoriesCompanion(
-            id: id,
-            name: name,
-          ),
-          createCompanionCallback: ({
-            i0.Value<int> id = const i0.Value.absent(),
-            required String name,
-          }) =>
-              i1.CategoriesCompanion.insert(
-            id: id,
-            name: name,
-          ),
-        ));
-}
-
-typedef $$CategoriesTableProcessedTableManager = i0.ProcessedTableManager<
-    i0.GeneratedDatabase,
-    i1.$CategoriesTable,
-    i1.Category,
-    i1.$$CategoriesTableFilterComposer,
-    i1.$$CategoriesTableOrderingComposer,
-    $$CategoriesTableCreateCompanionBuilder,
-    $$CategoriesTableUpdateCompanionBuilder,
-    (i1.Category, $$CategoriesTableWithReferences),
-    i1.Category>;
-
 class $$CategoriesTableFilterComposer
     extends i0.FilterComposer<i0.GeneratedDatabase, i1.$CategoriesTable> {
   $$CategoriesTableFilterComposer(super.$state);
@@ -752,13 +691,56 @@ class $$CategoriesTableOrderingComposer
           i0.ColumnOrderings(column, joinBuilders: joinBuilders));
 }
 
-class $$CategoriesTableWithReferences {
-  // ignore: unused_field
-  final i0.GeneratedDatabase _db;
-  // ignore: unused_field
-  final i1.Category _item;
-  $$CategoriesTableWithReferences(this._db, this._item);
+class $$CategoriesTableTableManager extends i0.RootTableManager<
+    i0.GeneratedDatabase,
+    i1.$CategoriesTable,
+    i1.Category,
+    i1.$$CategoriesTableFilterComposer,
+    i1.$$CategoriesTableOrderingComposer,
+    $$CategoriesTableCreateCompanionBuilder,
+    $$CategoriesTableUpdateCompanionBuilder,
+    (i1.Category, i0.BaseWithReferences<i0.GeneratedDatabase, i1.Category>),
+    i1.Category> {
+  $$CategoriesTableTableManager(
+      i0.GeneratedDatabase db, i1.$CategoriesTable table)
+      : super(i0.TableManagerState(
+          db: db,
+          table: table,
+          filteringComposer:
+              i1.$$CategoriesTableFilterComposer(i0.ComposerState(db, table)),
+          orderingComposer:
+              i1.$$CategoriesTableOrderingComposer(i0.ComposerState(db, table)),
+          withReferenceMapper: (p0) =>
+              p0.map((e) => (e, i0.BaseWithReferences(db, e))).toList(),
+          updateCompanionCallback: ({
+            i0.Value<int> id = const i0.Value.absent(),
+            i0.Value<String> name = const i0.Value.absent(),
+          }) =>
+              i1.CategoriesCompanion(
+            id: id,
+            name: name,
+          ),
+          createCompanionCallback: ({
+            i0.Value<int> id = const i0.Value.absent(),
+            required String name,
+          }) =>
+              i1.CategoriesCompanion.insert(
+            id: id,
+            name: name,
+          ),
+        ));
 }
+
+typedef $$CategoriesTableProcessedTableManager = i0.ProcessedTableManager<
+    i0.GeneratedDatabase,
+    i1.$CategoriesTable,
+    i1.Category,
+    i1.$$CategoriesTableFilterComposer,
+    i1.$$CategoriesTableOrderingComposer,
+    $$CategoriesTableCreateCompanionBuilder,
+    $$CategoriesTableUpdateCompanionBuilder,
+    (i1.Category, i0.BaseWithReferences<i0.GeneratedDatabase, i1.Category>),
+    i1.Category>;
 
 class $UsersTable extends i2.Users with i0.TableInfo<$UsersTable, i1.User> {
   @override
@@ -949,56 +931,6 @@ typedef $$UsersTableUpdateCompanionBuilder = i1.UsersCompanion Function({
   i0.Value<DateTime> birthDate,
 });
 
-class $$UsersTableTableManager extends i0.RootTableManager<
-    i0.GeneratedDatabase,
-    i1.$UsersTable,
-    i1.User,
-    i1.$$UsersTableFilterComposer,
-    i1.$$UsersTableOrderingComposer,
-    $$UsersTableCreateCompanionBuilder,
-    $$UsersTableUpdateCompanionBuilder,
-    (i1.User, $$UsersTableWithReferences),
-    i1.User> {
-  $$UsersTableTableManager(i0.GeneratedDatabase db, i1.$UsersTable table)
-      : super(i0.TableManagerState(
-          db: db,
-          table: table,
-          filteringComposer:
-              i1.$$UsersTableFilterComposer(i0.ComposerState(db, table)),
-          orderingComposer:
-              i1.$$UsersTableOrderingComposer(i0.ComposerState(db, table)),
-          withReferenceMapper: (p0) =>
-              p0.map((e) => (e, $$UsersTableWithReferences(db, e))).toList(),
-          updateCompanionCallback: ({
-            i0.Value<int> id = const i0.Value.absent(),
-            i0.Value<DateTime> birthDate = const i0.Value.absent(),
-          }) =>
-              i1.UsersCompanion(
-            id: id,
-            birthDate: birthDate,
-          ),
-          createCompanionCallback: ({
-            i0.Value<int> id = const i0.Value.absent(),
-            required DateTime birthDate,
-          }) =>
-              i1.UsersCompanion.insert(
-            id: id,
-            birthDate: birthDate,
-          ),
-        ));
-}
-
-typedef $$UsersTableProcessedTableManager = i0.ProcessedTableManager<
-    i0.GeneratedDatabase,
-    i1.$UsersTable,
-    i1.User,
-    i1.$$UsersTableFilterComposer,
-    i1.$$UsersTableOrderingComposer,
-    $$UsersTableCreateCompanionBuilder,
-    $$UsersTableUpdateCompanionBuilder,
-    (i1.User, $$UsersTableWithReferences),
-    i1.User>;
-
 class $$UsersTableFilterComposer
     extends i0.FilterComposer<i0.GeneratedDatabase, i1.$UsersTable> {
   $$UsersTableFilterComposer(super.$state);
@@ -1027,10 +959,52 @@ class $$UsersTableOrderingComposer
           i0.ColumnOrderings(column, joinBuilders: joinBuilders));
 }
 
-class $$UsersTableWithReferences {
-  // ignore: unused_field
-  final i0.GeneratedDatabase _db;
-  // ignore: unused_field
-  final i1.User _item;
-  $$UsersTableWithReferences(this._db, this._item);
+class $$UsersTableTableManager extends i0.RootTableManager<
+    i0.GeneratedDatabase,
+    i1.$UsersTable,
+    i1.User,
+    i1.$$UsersTableFilterComposer,
+    i1.$$UsersTableOrderingComposer,
+    $$UsersTableCreateCompanionBuilder,
+    $$UsersTableUpdateCompanionBuilder,
+    (i1.User, i0.BaseWithReferences<i0.GeneratedDatabase, i1.User>),
+    i1.User> {
+  $$UsersTableTableManager(i0.GeneratedDatabase db, i1.$UsersTable table)
+      : super(i0.TableManagerState(
+          db: db,
+          table: table,
+          filteringComposer:
+              i1.$$UsersTableFilterComposer(i0.ComposerState(db, table)),
+          orderingComposer:
+              i1.$$UsersTableOrderingComposer(i0.ComposerState(db, table)),
+          withReferenceMapper: (p0) =>
+              p0.map((e) => (e, i0.BaseWithReferences(db, e))).toList(),
+          updateCompanionCallback: ({
+            i0.Value<int> id = const i0.Value.absent(),
+            i0.Value<DateTime> birthDate = const i0.Value.absent(),
+          }) =>
+              i1.UsersCompanion(
+            id: id,
+            birthDate: birthDate,
+          ),
+          createCompanionCallback: ({
+            i0.Value<int> id = const i0.Value.absent(),
+            required DateTime birthDate,
+          }) =>
+              i1.UsersCompanion.insert(
+            id: id,
+            birthDate: birthDate,
+          ),
+        ));
 }
+
+typedef $$UsersTableProcessedTableManager = i0.ProcessedTableManager<
+    i0.GeneratedDatabase,
+    i1.$UsersTable,
+    i1.User,
+    i1.$$UsersTableFilterComposer,
+    i1.$$UsersTableOrderingComposer,
+    $$UsersTableCreateCompanionBuilder,
+    $$UsersTableUpdateCompanionBuilder,
+    (i1.User, i0.BaseWithReferences<i0.GeneratedDatabase, i1.User>),
+    i1.User>;

--- a/docs/lib/snippets/dart_api/manager.dart
+++ b/docs/lib/snippets/dart_api/manager.dart
@@ -212,33 +212,33 @@ extension ManagerExamples on AppDatabase {
 
   Future managerWithRefs() async {
 // #docregion manager_with_refs
-    final todoWithCategory = await managers.todoItems
+    final (todos, todoRefs) = await managers.todoItems
         .filter((f) => f.id(1))
         .withReferences()
         .getSingle();
-    final category = await todoWithCategory.category?.getSingle();
+    final category = await todoRefs.category?.getSingle();
 
     // You could also do nested references, even with a filter
     // Here we will get the category of this todo item, with all the todo items in that category
-    final categoryWithTodos =
-        await todoWithCategory.category?.withReferences().getSingle();
-    // And now we can get all the todo items in that category
-    final allTodoInCategory = await categoryWithTodos?.todoItemsRefs.get();
-    // We could even filter it, so here is all the todo items in that category with a title of "Title"
-    final allTodoInCategoryWithTitle = await categoryWithTodos?.todoItemsRefs
-        .filter((f) => f.title("Title"))
-        .get();
+    if (todoRefs.category != null) {
+      final (_, categoryRefs) =
+          await todoRefs.category!.withReferences().getSingle();
+      // And now we can get all the todo items in that category
+      final allTodoInCategory = await categoryRefs.todoItemsRefs.get();
+      // We could even filter it, so here is all the todo items in that category with a title of "Title"
+      final allTodoInCategoryWithTitle = await categoryRefs.todoItemsRefs
+          .filter((f) => f.title("Title"))
+          .get();
+    }
 // #enddocregion manager_with_refs
   }
 
   Future managerWithRefsNPlus1() async {
 // #docregion manager_with_refs_n_plus_1
     // Get all users with their referenced groups
-    final usersWithReferences = await managers.users.withReferences().get();
-    for (var i in usersWithReferences) {
-      final user = i.user;
+    for (final (user, refs) in await managers.users.withReferences().get()) {
       final administeredGroups =
-          await i.administeredGroups.get(); // Will run many queries
+          await refs.administeredGroups.get(); // Will run many queries
     }
 // #enddocregion manager_with_refs_n_plus_1
   }

--- a/docs/lib/snippets/dart_api/manager.dart
+++ b/docs/lib/snippets/dart_api/manager.dart
@@ -1,4 +1,4 @@
-// ignore_for_file: invalid_use_of_internal_member
+// ignore_for_file: invalid_use_of_internal_member, unused_local_variable
 
 import 'package:drift/drift.dart';
 
@@ -44,8 +44,8 @@ class AppDatabase extends _$AppDatabase {
 }
 
 extension ManagerExamples on AppDatabase {
-  // #docregion manager_create
   Future<void> createTodoItem() async {
+    // #docregion manager_create
     // Create a new item
     await managers.todoItems
         .create((o) => o(title: 'Title', content: 'Content'));
@@ -63,11 +63,11 @@ extension ManagerExamples on AppDatabase {
         o(title: 'Title 2', content: 'Content 2'),
       ],
     );
+    // #enddocregion manager_create
   }
-  // #enddocregion manager_create
 
-  // #docregion manager_update
   Future<void> updateTodoItems() async {
+    // #docregion manager_update
     // Update all items
     await managers.todoItems.update((o) => o(content: Value('New Content')));
 
@@ -75,11 +75,11 @@ extension ManagerExamples on AppDatabase {
     await managers.todoItems
         .filter((f) => f.id.isIn([1, 2, 3]))
         .update((o) => o(content: Value('New Content')));
+    // #enddocregion manager_update
   }
-  // #enddocregion manager_update
 
-  // #docregion manager_replace
   Future<void> replaceTodoItems() async {
+    // #docregion manager_replace
     // Replace a single item
     var obj = await managers.todoItems.filter((o) => o.id(1)).getSingle();
     obj = obj.copyWith(content: 'New Content');
@@ -90,21 +90,21 @@ extension ManagerExamples on AppDatabase {
         await managers.todoItems.filter((o) => o.id.isIn([1, 2, 3])).get();
     objs = objs.map((o) => o.copyWith(content: 'New Content')).toList();
     await managers.todoItems.bulkReplace(objs);
+    // #enddocregion manager_replace
   }
-  // #enddocregion manager_replace
 
-  // #docregion manager_delete
   Future<void> deleteTodoItems() async {
+    // #docregion manager_delete
     // Delete all items
     await managers.todoItems.delete();
 
     // Delete a single item
     await managers.todoItems.filter((f) => f.id(5)).delete();
+    // #enddocregion manager_delete
   }
-  // #enddocregion manager_delete
 
-  // #docregion manager_select
   Future<void> selectTodoItems() async {
+    // #docregion manager_select
     // Get all items
     managers.todoItems.get();
 
@@ -113,11 +113,11 @@ extension ManagerExamples on AppDatabase {
 
     // To get a single item, apply a filter and call `getSingle`
     await managers.todoItems.filter((f) => f.id(1)).getSingle();
+    // #enddocregion manager_select
   }
-  // #enddocregion manager_select
 
-  // #docregion manager_filter
   Future<void> filterTodoItems() async {
+    // #docregion manager_filter
     // All items with a title of "Title"
     managers.todoItems.filter((f) => f.title("Title"));
 
@@ -126,52 +126,52 @@ extension ManagerExamples on AppDatabase {
 
     // All items with a title of "Title" or content that is not null
     managers.todoItems.filter((f) => f.title("Title") | f.content.not.isNull());
+    // #enddocregion manager_filter
   }
-  // #enddocregion manager_filter
 
-  // #docregion manager_type_specific_filter
   Future filterWithType() async {
+    // #docregion manager_type_specific_filter
     // Filter all items created since 7 days ago
     managers.todoItems.filter(
         (f) => f.createdAt.isAfter(DateTime.now().subtract(Duration(days: 7))));
 
     // Filter all items with a title that starts with "Title"
     managers.todoItems.filter((f) => f.title.startsWith('Title'));
-  }
 // #enddocregion manager_type_specific_filter
+  }
 
-// #docregion manager_ordering
   Future orderWithType() async {
+// #docregion manager_ordering
     // Order all items by their creation date in ascending order
     managers.todoItems.orderBy((o) => o.createdAt.asc());
 
     // Order all items by their title in ascending order and then by their content in ascending order
     managers.todoItems.orderBy((o) => o.title.asc() & o.content.asc());
-  }
 // #enddocregion manager_ordering
+  }
 
-// #docregion manager_count
   Future count() async {
+// #docregion manager_count
     // Count all items
     await managers.todoItems.count();
 
     // Count all items with a title of "Title"
     await managers.todoItems.filter((f) => f.title("Title")).count();
-  }
 // #enddocregion manager_count
+  }
 
-// #docregion manager_exists
   Future exists() async {
+// #docregion manager_exists
     // Check if any items exist
     await managers.todoItems.exists();
 
     // Check if any items with a title of "Title" exist
     await managers.todoItems.filter((f) => f.title("Title")).exists();
-  }
 // #enddocregion manager_exists
+  }
 
-// #docregion manager_filter_forward_references
   Future relationalFilter() async {
+// #docregion manager_filter_forward_references
     // Get all items with a category description of "School"
     managers.todoItems.filter((f) => f.category.description("School"));
 
@@ -182,11 +182,11 @@ extension ManagerExamples on AppDatabase {
           (f) => f.title("Title") | f.category.description("School"),
         )
         .exists();
-  }
 // #enddocregion manager_filter_forward_references
+  }
 
-// #docregion manager_filter_back_references
   Future reverseRelationalFilter() async {
+// #docregion manager_filter_back_references
     // Get the category that has a todo item with an id of 1
     managers.todoCategory.filter((f) => f.todoItemsRefs((f) => f.id(1)));
 
@@ -195,11 +195,11 @@ extension ManagerExamples on AppDatabase {
     managers.todoCategory.filter(
       (f) => f.description("School") | f.todoItemsRefs((f) => f.id(1)),
     );
-  }
 // #enddocregion manager_filter_back_references
+  }
 
-// #docregion manager_filter_custom_back_references
   Future reverseNamedRelationalFilter() async {
+// #docregion manager_filter_custom_back_references
     // Get all users who are administrators of a group with a name containing "Business"
     // or who own a group with an id of 1, 2, 4, or 5
     managers.users.filter(
@@ -207,8 +207,41 @@ extension ManagerExamples on AppDatabase {
           f.administeredGroups((f) => f.name.contains("Business")) |
           f.ownedGroups((f) => f.id.isIn([1, 2, 4, 5])),
     );
-  }
 // #enddocregion manager_filter_custom_back_references
+  }
+
+  Future managerWithRefs() async {
+// #docregion manager_with_refs
+    final todoWithCategory = await managers.todoItems
+        .filter((f) => f.id(1))
+        .withReferences()
+        .getSingle();
+    final category = await todoWithCategory.category?.getSingle();
+
+    // You could also do nested references, even with a filter
+    // Here we will get the category of this todo item, with all the todo items in that category
+    final categoryWithTodos =
+        await todoWithCategory.category?.withReferences().getSingle();
+    // And now we can get all the todo items in that category
+    final allTodoInCategory = await categoryWithTodos?.todoItemsRefs.get();
+    // We could even filter it, so here is all the todo items in that category with a title of "Title"
+    final allTodoInCategoryWithTitle = await categoryWithTodos?.todoItemsRefs
+        .filter((f) => f.title("Title"))
+        .get();
+// #enddocregion manager_with_refs
+  }
+
+  Future managerWithRefsNPlus1() async {
+// #docregion manager_with_refs_n_plus_1
+    // Get all users with their referenced groups
+    final usersWithReferences = await managers.users.withReferences().get();
+    for (var i in usersWithReferences) {
+      final user = i.user;
+      final administeredGroups =
+          await i.administeredGroups.get(); // Will run many queries
+    }
+// #enddocregion manager_with_refs_n_plus_1
+  }
 }
 
 // #docregion manager_filter_extensions

--- a/docs/lib/snippets/modular/custom_types/drift_table.drift.dart
+++ b/docs/lib/snippets/modular/custom_types/drift_table.drift.dart
@@ -263,7 +263,7 @@ class $PeriodicRemindersTableManager extends i0.RootTableManager<
               i1.$PeriodicRemindersFilterComposer(i0.ComposerState(db, table)),
           orderingComposer: i1
               .$PeriodicRemindersOrderingComposer(i0.ComposerState(db, table)),
-          dataclassMapper: (p0) async =>
+          withReferenceMapper: (p0) =>
               p0.map((e) => $PeriodicRemindersWithReferences(db, e)).toList(),
           updateCompanionCallback: ({
             i0.Value<int> id = const i0.Value.absent(),

--- a/docs/lib/snippets/modular/custom_types/drift_table.drift.dart
+++ b/docs/lib/snippets/modular/custom_types/drift_table.drift.dart
@@ -251,7 +251,9 @@ class $PeriodicRemindersTableManager extends i0.RootTableManager<
     i1.$PeriodicRemindersFilterComposer,
     i1.$PeriodicRemindersOrderingComposer,
     $PeriodicRemindersCreateCompanionBuilder,
-    $PeriodicRemindersUpdateCompanionBuilder> {
+    $PeriodicRemindersUpdateCompanionBuilder,
+    $PeriodicRemindersWithReferences,
+    i1.PeriodicReminder> {
   $PeriodicRemindersTableManager(
       i0.GeneratedDatabase db, i1.PeriodicReminders table)
       : super(i0.TableManagerState(
@@ -261,6 +263,8 @@ class $PeriodicRemindersTableManager extends i0.RootTableManager<
               i1.$PeriodicRemindersFilterComposer(i0.ComposerState(db, table)),
           orderingComposer: i1
               .$PeriodicRemindersOrderingComposer(i0.ComposerState(db, table)),
+          dataclassMapper: (p0) async =>
+              p0.map((e) => $PeriodicRemindersWithReferences(db, e)).toList(),
           updateCompanionCallback: ({
             i0.Value<int> id = const i0.Value.absent(),
             i0.Value<Duration> frequency = const i0.Value.absent(),
@@ -283,6 +287,17 @@ class $PeriodicRemindersTableManager extends i0.RootTableManager<
           ),
         ));
 }
+
+typedef $PeriodicRemindersProcessedTableManager = i0.ProcessedTableManager<
+    i0.GeneratedDatabase,
+    i1.PeriodicReminders,
+    i1.PeriodicReminder,
+    i1.$PeriodicRemindersFilterComposer,
+    i1.$PeriodicRemindersOrderingComposer,
+    $PeriodicRemindersCreateCompanionBuilder,
+    $PeriodicRemindersUpdateCompanionBuilder,
+    $PeriodicRemindersWithReferences,
+    i1.PeriodicReminder>;
 
 class $PeriodicRemindersFilterComposer
     extends i0.FilterComposer<i0.GeneratedDatabase, i1.PeriodicReminders> {
@@ -320,4 +335,11 @@ class $PeriodicRemindersOrderingComposer
       column: $state.table.reminder,
       builder: (column, joinBuilders) =>
           i0.ColumnOrderings(column, joinBuilders: joinBuilders));
+}
+
+class $PeriodicRemindersWithReferences {
+  // ignore: unused_field
+  final i0.GeneratedDatabase _db;
+  final i1.PeriodicReminder i1PeriodicReminder;
+  $PeriodicRemindersWithReferences(this._db, this.i1PeriodicReminder);
 }

--- a/docs/lib/snippets/modular/custom_types/drift_table.drift.dart
+++ b/docs/lib/snippets/modular/custom_types/drift_table.drift.dart
@@ -244,62 +244,6 @@ typedef $PeriodicRemindersUpdateCompanionBuilder = i1.PeriodicRemindersCompanion
   i0.Value<String> reminder,
 });
 
-class $PeriodicRemindersTableManager extends i0.RootTableManager<
-    i0.GeneratedDatabase,
-    i1.PeriodicReminders,
-    i1.PeriodicReminder,
-    i1.$PeriodicRemindersFilterComposer,
-    i1.$PeriodicRemindersOrderingComposer,
-    $PeriodicRemindersCreateCompanionBuilder,
-    $PeriodicRemindersUpdateCompanionBuilder,
-    (i1.PeriodicReminder, $PeriodicRemindersWithReferences),
-    i1.PeriodicReminder> {
-  $PeriodicRemindersTableManager(
-      i0.GeneratedDatabase db, i1.PeriodicReminders table)
-      : super(i0.TableManagerState(
-          db: db,
-          table: table,
-          filteringComposer:
-              i1.$PeriodicRemindersFilterComposer(i0.ComposerState(db, table)),
-          orderingComposer: i1
-              .$PeriodicRemindersOrderingComposer(i0.ComposerState(db, table)),
-          withReferenceMapper: (p0) => p0
-              .map((e) => (e, $PeriodicRemindersWithReferences(db, e)))
-              .toList(),
-          updateCompanionCallback: ({
-            i0.Value<int> id = const i0.Value.absent(),
-            i0.Value<Duration> frequency = const i0.Value.absent(),
-            i0.Value<String> reminder = const i0.Value.absent(),
-          }) =>
-              i1.PeriodicRemindersCompanion(
-            id: id,
-            frequency: frequency,
-            reminder: reminder,
-          ),
-          createCompanionCallback: ({
-            i0.Value<int> id = const i0.Value.absent(),
-            required Duration frequency,
-            required String reminder,
-          }) =>
-              i1.PeriodicRemindersCompanion.insert(
-            id: id,
-            frequency: frequency,
-            reminder: reminder,
-          ),
-        ));
-}
-
-typedef $PeriodicRemindersProcessedTableManager = i0.ProcessedTableManager<
-    i0.GeneratedDatabase,
-    i1.PeriodicReminders,
-    i1.PeriodicReminder,
-    i1.$PeriodicRemindersFilterComposer,
-    i1.$PeriodicRemindersOrderingComposer,
-    $PeriodicRemindersCreateCompanionBuilder,
-    $PeriodicRemindersUpdateCompanionBuilder,
-    (i1.PeriodicReminder, $PeriodicRemindersWithReferences),
-    i1.PeriodicReminder>;
-
 class $PeriodicRemindersFilterComposer
     extends i0.FilterComposer<i0.GeneratedDatabase, i1.PeriodicReminders> {
   $PeriodicRemindersFilterComposer(super.$state);
@@ -338,10 +282,63 @@ class $PeriodicRemindersOrderingComposer
           i0.ColumnOrderings(column, joinBuilders: joinBuilders));
 }
 
-class $PeriodicRemindersWithReferences {
-  // ignore: unused_field
-  final i0.GeneratedDatabase _db;
-  // ignore: unused_field
-  final i1.PeriodicReminder _item;
-  $PeriodicRemindersWithReferences(this._db, this._item);
+class $PeriodicRemindersTableManager extends i0.RootTableManager<
+    i0.GeneratedDatabase,
+    i1.PeriodicReminders,
+    i1.PeriodicReminder,
+    i1.$PeriodicRemindersFilterComposer,
+    i1.$PeriodicRemindersOrderingComposer,
+    $PeriodicRemindersCreateCompanionBuilder,
+    $PeriodicRemindersUpdateCompanionBuilder,
+    (
+      i1.PeriodicReminder,
+      i0.BaseWithReferences<i0.GeneratedDatabase, i1.PeriodicReminder>
+    ),
+    i1.PeriodicReminder> {
+  $PeriodicRemindersTableManager(
+      i0.GeneratedDatabase db, i1.PeriodicReminders table)
+      : super(i0.TableManagerState(
+          db: db,
+          table: table,
+          filteringComposer:
+              i1.$PeriodicRemindersFilterComposer(i0.ComposerState(db, table)),
+          orderingComposer: i1
+              .$PeriodicRemindersOrderingComposer(i0.ComposerState(db, table)),
+          withReferenceMapper: (p0) =>
+              p0.map((e) => (e, i0.BaseWithReferences(db, e))).toList(),
+          updateCompanionCallback: ({
+            i0.Value<int> id = const i0.Value.absent(),
+            i0.Value<Duration> frequency = const i0.Value.absent(),
+            i0.Value<String> reminder = const i0.Value.absent(),
+          }) =>
+              i1.PeriodicRemindersCompanion(
+            id: id,
+            frequency: frequency,
+            reminder: reminder,
+          ),
+          createCompanionCallback: ({
+            i0.Value<int> id = const i0.Value.absent(),
+            required Duration frequency,
+            required String reminder,
+          }) =>
+              i1.PeriodicRemindersCompanion.insert(
+            id: id,
+            frequency: frequency,
+            reminder: reminder,
+          ),
+        ));
 }
+
+typedef $PeriodicRemindersProcessedTableManager = i0.ProcessedTableManager<
+    i0.GeneratedDatabase,
+    i1.PeriodicReminders,
+    i1.PeriodicReminder,
+    i1.$PeriodicRemindersFilterComposer,
+    i1.$PeriodicRemindersOrderingComposer,
+    $PeriodicRemindersCreateCompanionBuilder,
+    $PeriodicRemindersUpdateCompanionBuilder,
+    (
+      i1.PeriodicReminder,
+      i0.BaseWithReferences<i0.GeneratedDatabase, i1.PeriodicReminder>
+    ),
+    i1.PeriodicReminder>;

--- a/docs/lib/snippets/modular/custom_types/drift_table.drift.dart
+++ b/docs/lib/snippets/modular/custom_types/drift_table.drift.dart
@@ -252,7 +252,7 @@ class $PeriodicRemindersTableManager extends i0.RootTableManager<
     i1.$PeriodicRemindersOrderingComposer,
     $PeriodicRemindersCreateCompanionBuilder,
     $PeriodicRemindersUpdateCompanionBuilder,
-    $PeriodicRemindersWithReferences,
+    (i1.PeriodicReminder, $PeriodicRemindersWithReferences),
     i1.PeriodicReminder> {
   $PeriodicRemindersTableManager(
       i0.GeneratedDatabase db, i1.PeriodicReminders table)
@@ -263,8 +263,9 @@ class $PeriodicRemindersTableManager extends i0.RootTableManager<
               i1.$PeriodicRemindersFilterComposer(i0.ComposerState(db, table)),
           orderingComposer: i1
               .$PeriodicRemindersOrderingComposer(i0.ComposerState(db, table)),
-          withReferenceMapper: (p0) =>
-              p0.map((e) => $PeriodicRemindersWithReferences(db, e)).toList(),
+          withReferenceMapper: (p0) => p0
+              .map((e) => (e, $PeriodicRemindersWithReferences(db, e)))
+              .toList(),
           updateCompanionCallback: ({
             i0.Value<int> id = const i0.Value.absent(),
             i0.Value<Duration> frequency = const i0.Value.absent(),
@@ -296,7 +297,7 @@ typedef $PeriodicRemindersProcessedTableManager = i0.ProcessedTableManager<
     i1.$PeriodicRemindersOrderingComposer,
     $PeriodicRemindersCreateCompanionBuilder,
     $PeriodicRemindersUpdateCompanionBuilder,
-    $PeriodicRemindersWithReferences,
+    (i1.PeriodicReminder, $PeriodicRemindersWithReferences),
     i1.PeriodicReminder>;
 
 class $PeriodicRemindersFilterComposer
@@ -340,6 +341,6 @@ class $PeriodicRemindersOrderingComposer
 class $PeriodicRemindersWithReferences {
   // ignore: unused_field
   final i0.GeneratedDatabase _db;
-  final i1.PeriodicReminder i1PeriodicReminder;
-  $PeriodicRemindersWithReferences(this._db, this.i1PeriodicReminder);
+  final i1.PeriodicReminder _item;
+  $PeriodicRemindersWithReferences(this._db, this._item);
 }

--- a/docs/lib/snippets/modular/custom_types/drift_table.drift.dart
+++ b/docs/lib/snippets/modular/custom_types/drift_table.drift.dart
@@ -341,6 +341,7 @@ class $PeriodicRemindersOrderingComposer
 class $PeriodicRemindersWithReferences {
   // ignore: unused_field
   final i0.GeneratedDatabase _db;
+  // ignore: unused_field
   final i1.PeriodicReminder _item;
   $PeriodicRemindersWithReferences(this._db, this._item);
 }

--- a/docs/lib/snippets/modular/custom_types/table.drift.dart
+++ b/docs/lib/snippets/modular/custom_types/table.drift.dart
@@ -242,63 +242,6 @@ typedef $$PeriodicRemindersTableUpdateCompanionBuilder
   i0.Value<String> reminder,
 });
 
-class $$PeriodicRemindersTableTableManager extends i0.RootTableManager<
-    i0.GeneratedDatabase,
-    i1.$PeriodicRemindersTable,
-    i1.PeriodicReminder,
-    i1.$$PeriodicRemindersTableFilterComposer,
-    i1.$$PeriodicRemindersTableOrderingComposer,
-    $$PeriodicRemindersTableCreateCompanionBuilder,
-    $$PeriodicRemindersTableUpdateCompanionBuilder,
-    (i1.PeriodicReminder, $$PeriodicRemindersTableWithReferences),
-    i1.PeriodicReminder> {
-  $$PeriodicRemindersTableTableManager(
-      i0.GeneratedDatabase db, i1.$PeriodicRemindersTable table)
-      : super(i0.TableManagerState(
-          db: db,
-          table: table,
-          filteringComposer: i1.$$PeriodicRemindersTableFilterComposer(
-              i0.ComposerState(db, table)),
-          orderingComposer: i1.$$PeriodicRemindersTableOrderingComposer(
-              i0.ComposerState(db, table)),
-          withReferenceMapper: (p0) => p0
-              .map((e) => (e, $$PeriodicRemindersTableWithReferences(db, e)))
-              .toList(),
-          updateCompanionCallback: ({
-            i0.Value<int> id = const i0.Value.absent(),
-            i0.Value<Duration> frequency = const i0.Value.absent(),
-            i0.Value<String> reminder = const i0.Value.absent(),
-          }) =>
-              i1.PeriodicRemindersCompanion(
-            id: id,
-            frequency: frequency,
-            reminder: reminder,
-          ),
-          createCompanionCallback: ({
-            i0.Value<int> id = const i0.Value.absent(),
-            i0.Value<Duration> frequency = const i0.Value.absent(),
-            required String reminder,
-          }) =>
-              i1.PeriodicRemindersCompanion.insert(
-            id: id,
-            frequency: frequency,
-            reminder: reminder,
-          ),
-        ));
-}
-
-typedef $$PeriodicRemindersTableProcessedTableManager
-    = i0.ProcessedTableManager<
-        i0.GeneratedDatabase,
-        i1.$PeriodicRemindersTable,
-        i1.PeriodicReminder,
-        i1.$$PeriodicRemindersTableFilterComposer,
-        i1.$$PeriodicRemindersTableOrderingComposer,
-        $$PeriodicRemindersTableCreateCompanionBuilder,
-        $$PeriodicRemindersTableUpdateCompanionBuilder,
-        (i1.PeriodicReminder, $$PeriodicRemindersTableWithReferences),
-        i1.PeriodicReminder>;
-
 class $$PeriodicRemindersTableFilterComposer extends i0
     .FilterComposer<i0.GeneratedDatabase, i1.$PeriodicRemindersTable> {
   $$PeriodicRemindersTableFilterComposer(super.$state);
@@ -337,10 +280,64 @@ class $$PeriodicRemindersTableOrderingComposer extends i0
           i0.ColumnOrderings(column, joinBuilders: joinBuilders));
 }
 
-class $$PeriodicRemindersTableWithReferences {
-  // ignore: unused_field
-  final i0.GeneratedDatabase _db;
-  // ignore: unused_field
-  final i1.PeriodicReminder _item;
-  $$PeriodicRemindersTableWithReferences(this._db, this._item);
+class $$PeriodicRemindersTableTableManager extends i0.RootTableManager<
+    i0.GeneratedDatabase,
+    i1.$PeriodicRemindersTable,
+    i1.PeriodicReminder,
+    i1.$$PeriodicRemindersTableFilterComposer,
+    i1.$$PeriodicRemindersTableOrderingComposer,
+    $$PeriodicRemindersTableCreateCompanionBuilder,
+    $$PeriodicRemindersTableUpdateCompanionBuilder,
+    (
+      i1.PeriodicReminder,
+      i0.BaseWithReferences<i0.GeneratedDatabase, i1.PeriodicReminder>
+    ),
+    i1.PeriodicReminder> {
+  $$PeriodicRemindersTableTableManager(
+      i0.GeneratedDatabase db, i1.$PeriodicRemindersTable table)
+      : super(i0.TableManagerState(
+          db: db,
+          table: table,
+          filteringComposer: i1.$$PeriodicRemindersTableFilterComposer(
+              i0.ComposerState(db, table)),
+          orderingComposer: i1.$$PeriodicRemindersTableOrderingComposer(
+              i0.ComposerState(db, table)),
+          withReferenceMapper: (p0) =>
+              p0.map((e) => (e, i0.BaseWithReferences(db, e))).toList(),
+          updateCompanionCallback: ({
+            i0.Value<int> id = const i0.Value.absent(),
+            i0.Value<Duration> frequency = const i0.Value.absent(),
+            i0.Value<String> reminder = const i0.Value.absent(),
+          }) =>
+              i1.PeriodicRemindersCompanion(
+            id: id,
+            frequency: frequency,
+            reminder: reminder,
+          ),
+          createCompanionCallback: ({
+            i0.Value<int> id = const i0.Value.absent(),
+            i0.Value<Duration> frequency = const i0.Value.absent(),
+            required String reminder,
+          }) =>
+              i1.PeriodicRemindersCompanion.insert(
+            id: id,
+            frequency: frequency,
+            reminder: reminder,
+          ),
+        ));
 }
+
+typedef $$PeriodicRemindersTableProcessedTableManager
+    = i0.ProcessedTableManager<
+        i0.GeneratedDatabase,
+        i1.$PeriodicRemindersTable,
+        i1.PeriodicReminder,
+        i1.$$PeriodicRemindersTableFilterComposer,
+        i1.$$PeriodicRemindersTableOrderingComposer,
+        $$PeriodicRemindersTableCreateCompanionBuilder,
+        $$PeriodicRemindersTableUpdateCompanionBuilder,
+        (
+          i1.PeriodicReminder,
+          i0.BaseWithReferences<i0.GeneratedDatabase, i1.PeriodicReminder>
+        ),
+        i1.PeriodicReminder>;

--- a/docs/lib/snippets/modular/custom_types/table.drift.dart
+++ b/docs/lib/snippets/modular/custom_types/table.drift.dart
@@ -261,7 +261,7 @@ class $$PeriodicRemindersTableTableManager extends i0.RootTableManager<
               i0.ComposerState(db, table)),
           orderingComposer: i1.$$PeriodicRemindersTableOrderingComposer(
               i0.ComposerState(db, table)),
-          dataclassMapper: (p0) async => p0
+          withReferenceMapper: (p0) => p0
               .map((e) => $$PeriodicRemindersTableWithReferences(db, e))
               .toList(),
           updateCompanionCallback: ({

--- a/docs/lib/snippets/modular/custom_types/table.drift.dart
+++ b/docs/lib/snippets/modular/custom_types/table.drift.dart
@@ -249,7 +249,9 @@ class $$PeriodicRemindersTableTableManager extends i0.RootTableManager<
     i1.$$PeriodicRemindersTableFilterComposer,
     i1.$$PeriodicRemindersTableOrderingComposer,
     $$PeriodicRemindersTableCreateCompanionBuilder,
-    $$PeriodicRemindersTableUpdateCompanionBuilder> {
+    $$PeriodicRemindersTableUpdateCompanionBuilder,
+    $$PeriodicRemindersTableWithReferences,
+    i1.PeriodicReminder> {
   $$PeriodicRemindersTableTableManager(
       i0.GeneratedDatabase db, i1.$PeriodicRemindersTable table)
       : super(i0.TableManagerState(
@@ -259,6 +261,9 @@ class $$PeriodicRemindersTableTableManager extends i0.RootTableManager<
               i0.ComposerState(db, table)),
           orderingComposer: i1.$$PeriodicRemindersTableOrderingComposer(
               i0.ComposerState(db, table)),
+          dataclassMapper: (p0) async => p0
+              .map((e) => $$PeriodicRemindersTableWithReferences(db, e))
+              .toList(),
           updateCompanionCallback: ({
             i0.Value<int> id = const i0.Value.absent(),
             i0.Value<Duration> frequency = const i0.Value.absent(),
@@ -281,6 +286,18 @@ class $$PeriodicRemindersTableTableManager extends i0.RootTableManager<
           ),
         ));
 }
+
+typedef $$PeriodicRemindersTableProcessedTableManager
+    = i0.ProcessedTableManager<
+        i0.GeneratedDatabase,
+        i1.$PeriodicRemindersTable,
+        i1.PeriodicReminder,
+        i1.$$PeriodicRemindersTableFilterComposer,
+        i1.$$PeriodicRemindersTableOrderingComposer,
+        $$PeriodicRemindersTableCreateCompanionBuilder,
+        $$PeriodicRemindersTableUpdateCompanionBuilder,
+        $$PeriodicRemindersTableWithReferences,
+        i1.PeriodicReminder>;
 
 class $$PeriodicRemindersTableFilterComposer extends i0
     .FilterComposer<i0.GeneratedDatabase, i1.$PeriodicRemindersTable> {
@@ -318,4 +335,11 @@ class $$PeriodicRemindersTableOrderingComposer extends i0
       column: $state.table.reminder,
       builder: (column, joinBuilders) =>
           i0.ColumnOrderings(column, joinBuilders: joinBuilders));
+}
+
+class $$PeriodicRemindersTableWithReferences {
+  // ignore: unused_field
+  final i0.GeneratedDatabase _db;
+  final i1.PeriodicReminder i1PeriodicReminder;
+  $$PeriodicRemindersTableWithReferences(this._db, this.i1PeriodicReminder);
 }

--- a/docs/lib/snippets/modular/custom_types/table.drift.dart
+++ b/docs/lib/snippets/modular/custom_types/table.drift.dart
@@ -250,7 +250,7 @@ class $$PeriodicRemindersTableTableManager extends i0.RootTableManager<
     i1.$$PeriodicRemindersTableOrderingComposer,
     $$PeriodicRemindersTableCreateCompanionBuilder,
     $$PeriodicRemindersTableUpdateCompanionBuilder,
-    $$PeriodicRemindersTableWithReferences,
+    (i1.PeriodicReminder, $$PeriodicRemindersTableWithReferences),
     i1.PeriodicReminder> {
   $$PeriodicRemindersTableTableManager(
       i0.GeneratedDatabase db, i1.$PeriodicRemindersTable table)
@@ -262,7 +262,7 @@ class $$PeriodicRemindersTableTableManager extends i0.RootTableManager<
           orderingComposer: i1.$$PeriodicRemindersTableOrderingComposer(
               i0.ComposerState(db, table)),
           withReferenceMapper: (p0) => p0
-              .map((e) => $$PeriodicRemindersTableWithReferences(db, e))
+              .map((e) => (e, $$PeriodicRemindersTableWithReferences(db, e)))
               .toList(),
           updateCompanionCallback: ({
             i0.Value<int> id = const i0.Value.absent(),
@@ -296,7 +296,7 @@ typedef $$PeriodicRemindersTableProcessedTableManager
         i1.$$PeriodicRemindersTableOrderingComposer,
         $$PeriodicRemindersTableCreateCompanionBuilder,
         $$PeriodicRemindersTableUpdateCompanionBuilder,
-        $$PeriodicRemindersTableWithReferences,
+        (i1.PeriodicReminder, $$PeriodicRemindersTableWithReferences),
         i1.PeriodicReminder>;
 
 class $$PeriodicRemindersTableFilterComposer extends i0
@@ -340,6 +340,6 @@ class $$PeriodicRemindersTableOrderingComposer extends i0
 class $$PeriodicRemindersTableWithReferences {
   // ignore: unused_field
   final i0.GeneratedDatabase _db;
-  final i1.PeriodicReminder i1PeriodicReminder;
-  $$PeriodicRemindersTableWithReferences(this._db, this.i1PeriodicReminder);
+  final i1.PeriodicReminder _item;
+  $$PeriodicRemindersTableWithReferences(this._db, this._item);
 }

--- a/docs/lib/snippets/modular/custom_types/table.drift.dart
+++ b/docs/lib/snippets/modular/custom_types/table.drift.dart
@@ -340,6 +340,7 @@ class $$PeriodicRemindersTableOrderingComposer extends i0
 class $$PeriodicRemindersTableWithReferences {
   // ignore: unused_field
   final i0.GeneratedDatabase _db;
+  // ignore: unused_field
   final i1.PeriodicReminder _item;
   $$PeriodicRemindersTableWithReferences(this._db, this._item);
 }

--- a/docs/lib/snippets/modular/drift/example.drift.dart
+++ b/docs/lib/snippets/modular/drift/example.drift.dart
@@ -414,6 +414,7 @@ class $TodosOrderingComposer
 class $TodosWithReferences {
   // ignore: unused_field
   final i0.GeneratedDatabase _db;
+  // ignore: unused_field
   final i1.Todo _item;
   $TodosWithReferences(this._db, this._item);
 }
@@ -693,6 +694,7 @@ class $CategoriesOrderingComposer
 class $CategoriesWithReferences {
   // ignore: unused_field
   final i0.GeneratedDatabase _db;
+  // ignore: unused_field
   final i1.Category _item;
   $CategoriesWithReferences(this._db, this._item);
 }

--- a/docs/lib/snippets/modular/drift/example.drift.dart
+++ b/docs/lib/snippets/modular/drift/example.drift.dart
@@ -281,64 +281,6 @@ typedef $TodosUpdateCompanionBuilder = i1.TodosCompanion Function({
   i0.Value<int?> category,
 });
 
-class $TodosTableManager extends i0.RootTableManager<
-    i0.GeneratedDatabase,
-    i1.Todos,
-    i1.Todo,
-    i1.$TodosFilterComposer,
-    i1.$TodosOrderingComposer,
-    $TodosCreateCompanionBuilder,
-    $TodosUpdateCompanionBuilder,
-    (i1.Todo, $TodosWithReferences),
-    i1.Todo> {
-  $TodosTableManager(i0.GeneratedDatabase db, i1.Todos table)
-      : super(i0.TableManagerState(
-          db: db,
-          table: table,
-          filteringComposer:
-              i1.$TodosFilterComposer(i0.ComposerState(db, table)),
-          orderingComposer:
-              i1.$TodosOrderingComposer(i0.ComposerState(db, table)),
-          withReferenceMapper: (p0) =>
-              p0.map((e) => (e, $TodosWithReferences(db, e))).toList(),
-          updateCompanionCallback: ({
-            i0.Value<int> id = const i0.Value.absent(),
-            i0.Value<String> title = const i0.Value.absent(),
-            i0.Value<String> content = const i0.Value.absent(),
-            i0.Value<int?> category = const i0.Value.absent(),
-          }) =>
-              i1.TodosCompanion(
-            id: id,
-            title: title,
-            content: content,
-            category: category,
-          ),
-          createCompanionCallback: ({
-            i0.Value<int> id = const i0.Value.absent(),
-            required String title,
-            required String content,
-            i0.Value<int?> category = const i0.Value.absent(),
-          }) =>
-              i1.TodosCompanion.insert(
-            id: id,
-            title: title,
-            content: content,
-            category: category,
-          ),
-        ));
-}
-
-typedef $TodosProcessedTableManager = i0.ProcessedTableManager<
-    i0.GeneratedDatabase,
-    i1.Todos,
-    i1.Todo,
-    i1.$TodosFilterComposer,
-    i1.$TodosOrderingComposer,
-    $TodosCreateCompanionBuilder,
-    $TodosUpdateCompanionBuilder,
-    (i1.Todo, $TodosWithReferences),
-    i1.Todo>;
-
 class $TodosFilterComposer
     extends i0.FilterComposer<i0.GeneratedDatabase, i1.Todos> {
   $TodosFilterComposer(super.$state);
@@ -411,13 +353,63 @@ class $TodosOrderingComposer
   }
 }
 
-class $TodosWithReferences {
-  // ignore: unused_field
-  final i0.GeneratedDatabase _db;
-  // ignore: unused_field
-  final i1.Todo _item;
-  $TodosWithReferences(this._db, this._item);
+class $TodosTableManager extends i0.RootTableManager<
+    i0.GeneratedDatabase,
+    i1.Todos,
+    i1.Todo,
+    i1.$TodosFilterComposer,
+    i1.$TodosOrderingComposer,
+    $TodosCreateCompanionBuilder,
+    $TodosUpdateCompanionBuilder,
+    (i1.Todo, i0.BaseWithReferences<i0.GeneratedDatabase, i1.Todo>),
+    i1.Todo> {
+  $TodosTableManager(i0.GeneratedDatabase db, i1.Todos table)
+      : super(i0.TableManagerState(
+          db: db,
+          table: table,
+          filteringComposer:
+              i1.$TodosFilterComposer(i0.ComposerState(db, table)),
+          orderingComposer:
+              i1.$TodosOrderingComposer(i0.ComposerState(db, table)),
+          withReferenceMapper: (p0) =>
+              p0.map((e) => (e, i0.BaseWithReferences(db, e))).toList(),
+          updateCompanionCallback: ({
+            i0.Value<int> id = const i0.Value.absent(),
+            i0.Value<String> title = const i0.Value.absent(),
+            i0.Value<String> content = const i0.Value.absent(),
+            i0.Value<int?> category = const i0.Value.absent(),
+          }) =>
+              i1.TodosCompanion(
+            id: id,
+            title: title,
+            content: content,
+            category: category,
+          ),
+          createCompanionCallback: ({
+            i0.Value<int> id = const i0.Value.absent(),
+            required String title,
+            required String content,
+            i0.Value<int?> category = const i0.Value.absent(),
+          }) =>
+              i1.TodosCompanion.insert(
+            id: id,
+            title: title,
+            content: content,
+            category: category,
+          ),
+        ));
 }
+
+typedef $TodosProcessedTableManager = i0.ProcessedTableManager<
+    i0.GeneratedDatabase,
+    i1.Todos,
+    i1.Todo,
+    i1.$TodosFilterComposer,
+    i1.$TodosOrderingComposer,
+    $TodosCreateCompanionBuilder,
+    $TodosUpdateCompanionBuilder,
+    (i1.Todo, i0.BaseWithReferences<i0.GeneratedDatabase, i1.Todo>),
+    i1.Todo>;
 
 class Categories extends i0.Table with i0.TableInfo<Categories, i1.Category> {
   @override
@@ -613,56 +605,6 @@ typedef $CategoriesUpdateCompanionBuilder = i1.CategoriesCompanion Function({
   i0.Value<String> description,
 });
 
-class $CategoriesTableManager extends i0.RootTableManager<
-    i0.GeneratedDatabase,
-    i1.Categories,
-    i1.Category,
-    i1.$CategoriesFilterComposer,
-    i1.$CategoriesOrderingComposer,
-    $CategoriesCreateCompanionBuilder,
-    $CategoriesUpdateCompanionBuilder,
-    (i1.Category, $CategoriesWithReferences),
-    i1.Category> {
-  $CategoriesTableManager(i0.GeneratedDatabase db, i1.Categories table)
-      : super(i0.TableManagerState(
-          db: db,
-          table: table,
-          filteringComposer:
-              i1.$CategoriesFilterComposer(i0.ComposerState(db, table)),
-          orderingComposer:
-              i1.$CategoriesOrderingComposer(i0.ComposerState(db, table)),
-          withReferenceMapper: (p0) =>
-              p0.map((e) => (e, $CategoriesWithReferences(db, e))).toList(),
-          updateCompanionCallback: ({
-            i0.Value<int> id = const i0.Value.absent(),
-            i0.Value<String> description = const i0.Value.absent(),
-          }) =>
-              i1.CategoriesCompanion(
-            id: id,
-            description: description,
-          ),
-          createCompanionCallback: ({
-            i0.Value<int> id = const i0.Value.absent(),
-            required String description,
-          }) =>
-              i1.CategoriesCompanion.insert(
-            id: id,
-            description: description,
-          ),
-        ));
-}
-
-typedef $CategoriesProcessedTableManager = i0.ProcessedTableManager<
-    i0.GeneratedDatabase,
-    i1.Categories,
-    i1.Category,
-    i1.$CategoriesFilterComposer,
-    i1.$CategoriesOrderingComposer,
-    $CategoriesCreateCompanionBuilder,
-    $CategoriesUpdateCompanionBuilder,
-    (i1.Category, $CategoriesWithReferences),
-    i1.Category>;
-
 class $CategoriesFilterComposer
     extends i0.FilterComposer<i0.GeneratedDatabase, i1.Categories> {
   $CategoriesFilterComposer(super.$state);
@@ -691,13 +633,55 @@ class $CategoriesOrderingComposer
           i0.ColumnOrderings(column, joinBuilders: joinBuilders));
 }
 
-class $CategoriesWithReferences {
-  // ignore: unused_field
-  final i0.GeneratedDatabase _db;
-  // ignore: unused_field
-  final i1.Category _item;
-  $CategoriesWithReferences(this._db, this._item);
+class $CategoriesTableManager extends i0.RootTableManager<
+    i0.GeneratedDatabase,
+    i1.Categories,
+    i1.Category,
+    i1.$CategoriesFilterComposer,
+    i1.$CategoriesOrderingComposer,
+    $CategoriesCreateCompanionBuilder,
+    $CategoriesUpdateCompanionBuilder,
+    (i1.Category, i0.BaseWithReferences<i0.GeneratedDatabase, i1.Category>),
+    i1.Category> {
+  $CategoriesTableManager(i0.GeneratedDatabase db, i1.Categories table)
+      : super(i0.TableManagerState(
+          db: db,
+          table: table,
+          filteringComposer:
+              i1.$CategoriesFilterComposer(i0.ComposerState(db, table)),
+          orderingComposer:
+              i1.$CategoriesOrderingComposer(i0.ComposerState(db, table)),
+          withReferenceMapper: (p0) =>
+              p0.map((e) => (e, i0.BaseWithReferences(db, e))).toList(),
+          updateCompanionCallback: ({
+            i0.Value<int> id = const i0.Value.absent(),
+            i0.Value<String> description = const i0.Value.absent(),
+          }) =>
+              i1.CategoriesCompanion(
+            id: id,
+            description: description,
+          ),
+          createCompanionCallback: ({
+            i0.Value<int> id = const i0.Value.absent(),
+            required String description,
+          }) =>
+              i1.CategoriesCompanion.insert(
+            id: id,
+            description: description,
+          ),
+        ));
 }
+
+typedef $CategoriesProcessedTableManager = i0.ProcessedTableManager<
+    i0.GeneratedDatabase,
+    i1.Categories,
+    i1.Category,
+    i1.$CategoriesFilterComposer,
+    i1.$CategoriesOrderingComposer,
+    $CategoriesCreateCompanionBuilder,
+    $CategoriesUpdateCompanionBuilder,
+    (i1.Category, i0.BaseWithReferences<i0.GeneratedDatabase, i1.Category>),
+    i1.Category>;
 
 class ExampleDrift extends i2.ModularAccessor {
   ExampleDrift(i0.GeneratedDatabase db) : super(db);

--- a/docs/lib/snippets/modular/drift/example.drift.dart
+++ b/docs/lib/snippets/modular/drift/example.drift.dart
@@ -299,7 +299,7 @@ class $TodosTableManager extends i0.RootTableManager<
               i1.$TodosFilterComposer(i0.ComposerState(db, table)),
           orderingComposer:
               i1.$TodosOrderingComposer(i0.ComposerState(db, table)),
-          dataclassMapper: (p0) async =>
+          withReferenceMapper: (p0) =>
               p0.map((e) => $TodosWithReferences(db, e)).toList(),
           updateCompanionCallback: ({
             i0.Value<int> id = const i0.Value.absent(),
@@ -630,7 +630,7 @@ class $CategoriesTableManager extends i0.RootTableManager<
               i1.$CategoriesFilterComposer(i0.ComposerState(db, table)),
           orderingComposer:
               i1.$CategoriesOrderingComposer(i0.ComposerState(db, table)),
-          dataclassMapper: (p0) async =>
+          withReferenceMapper: (p0) =>
               p0.map((e) => $CategoriesWithReferences(db, e)).toList(),
           updateCompanionCallback: ({
             i0.Value<int> id = const i0.Value.absent(),

--- a/docs/lib/snippets/modular/drift/example.drift.dart
+++ b/docs/lib/snippets/modular/drift/example.drift.dart
@@ -288,7 +288,9 @@ class $TodosTableManager extends i0.RootTableManager<
     i1.$TodosFilterComposer,
     i1.$TodosOrderingComposer,
     $TodosCreateCompanionBuilder,
-    $TodosUpdateCompanionBuilder> {
+    $TodosUpdateCompanionBuilder,
+    $TodosWithReferences,
+    i1.Todo> {
   $TodosTableManager(i0.GeneratedDatabase db, i1.Todos table)
       : super(i0.TableManagerState(
           db: db,
@@ -297,6 +299,8 @@ class $TodosTableManager extends i0.RootTableManager<
               i1.$TodosFilterComposer(i0.ComposerState(db, table)),
           orderingComposer:
               i1.$TodosOrderingComposer(i0.ComposerState(db, table)),
+          dataclassMapper: (p0) async =>
+              p0.map((e) => $TodosWithReferences(db, e)).toList(),
           updateCompanionCallback: ({
             i0.Value<int> id = const i0.Value.absent(),
             i0.Value<String> title = const i0.Value.absent(),
@@ -323,6 +327,17 @@ class $TodosTableManager extends i0.RootTableManager<
           ),
         ));
 }
+
+typedef $TodosProcessedTableManager = i0.ProcessedTableManager<
+    i0.GeneratedDatabase,
+    i1.Todos,
+    i1.Todo,
+    i1.$TodosFilterComposer,
+    i1.$TodosOrderingComposer,
+    $TodosCreateCompanionBuilder,
+    $TodosUpdateCompanionBuilder,
+    $TodosWithReferences,
+    i1.Todo>;
 
 class $TodosFilterComposer
     extends i0.FilterComposer<i0.GeneratedDatabase, i1.Todos> {
@@ -394,6 +409,13 @@ class $TodosOrderingComposer
                 parentComposers)));
     return composer;
   }
+}
+
+class $TodosWithReferences {
+  // ignore: unused_field
+  final i0.GeneratedDatabase _db;
+  final i1.Todo i1Todo;
+  $TodosWithReferences(this._db, this.i1Todo);
 }
 
 class Categories extends i0.Table with i0.TableInfo<Categories, i1.Category> {
@@ -597,7 +619,9 @@ class $CategoriesTableManager extends i0.RootTableManager<
     i1.$CategoriesFilterComposer,
     i1.$CategoriesOrderingComposer,
     $CategoriesCreateCompanionBuilder,
-    $CategoriesUpdateCompanionBuilder> {
+    $CategoriesUpdateCompanionBuilder,
+    $CategoriesWithReferences,
+    i1.Category> {
   $CategoriesTableManager(i0.GeneratedDatabase db, i1.Categories table)
       : super(i0.TableManagerState(
           db: db,
@@ -606,6 +630,8 @@ class $CategoriesTableManager extends i0.RootTableManager<
               i1.$CategoriesFilterComposer(i0.ComposerState(db, table)),
           orderingComposer:
               i1.$CategoriesOrderingComposer(i0.ComposerState(db, table)),
+          dataclassMapper: (p0) async =>
+              p0.map((e) => $CategoriesWithReferences(db, e)).toList(),
           updateCompanionCallback: ({
             i0.Value<int> id = const i0.Value.absent(),
             i0.Value<String> description = const i0.Value.absent(),
@@ -624,6 +650,17 @@ class $CategoriesTableManager extends i0.RootTableManager<
           ),
         ));
 }
+
+typedef $CategoriesProcessedTableManager = i0.ProcessedTableManager<
+    i0.GeneratedDatabase,
+    i1.Categories,
+    i1.Category,
+    i1.$CategoriesFilterComposer,
+    i1.$CategoriesOrderingComposer,
+    $CategoriesCreateCompanionBuilder,
+    $CategoriesUpdateCompanionBuilder,
+    $CategoriesWithReferences,
+    i1.Category>;
 
 class $CategoriesFilterComposer
     extends i0.FilterComposer<i0.GeneratedDatabase, i1.Categories> {
@@ -651,6 +688,13 @@ class $CategoriesOrderingComposer
       column: $state.table.description,
       builder: (column, joinBuilders) =>
           i0.ColumnOrderings(column, joinBuilders: joinBuilders));
+}
+
+class $CategoriesWithReferences {
+  // ignore: unused_field
+  final i0.GeneratedDatabase _db;
+  final i1.Category i1Category;
+  $CategoriesWithReferences(this._db, this.i1Category);
 }
 
 class ExampleDrift extends i2.ModularAccessor {

--- a/docs/lib/snippets/modular/drift/example.drift.dart
+++ b/docs/lib/snippets/modular/drift/example.drift.dart
@@ -289,7 +289,7 @@ class $TodosTableManager extends i0.RootTableManager<
     i1.$TodosOrderingComposer,
     $TodosCreateCompanionBuilder,
     $TodosUpdateCompanionBuilder,
-    $TodosWithReferences,
+    (i1.Todo, $TodosWithReferences),
     i1.Todo> {
   $TodosTableManager(i0.GeneratedDatabase db, i1.Todos table)
       : super(i0.TableManagerState(
@@ -300,7 +300,7 @@ class $TodosTableManager extends i0.RootTableManager<
           orderingComposer:
               i1.$TodosOrderingComposer(i0.ComposerState(db, table)),
           withReferenceMapper: (p0) =>
-              p0.map((e) => $TodosWithReferences(db, e)).toList(),
+              p0.map((e) => (e, $TodosWithReferences(db, e))).toList(),
           updateCompanionCallback: ({
             i0.Value<int> id = const i0.Value.absent(),
             i0.Value<String> title = const i0.Value.absent(),
@@ -336,7 +336,7 @@ typedef $TodosProcessedTableManager = i0.ProcessedTableManager<
     i1.$TodosOrderingComposer,
     $TodosCreateCompanionBuilder,
     $TodosUpdateCompanionBuilder,
-    $TodosWithReferences,
+    (i1.Todo, $TodosWithReferences),
     i1.Todo>;
 
 class $TodosFilterComposer
@@ -414,8 +414,8 @@ class $TodosOrderingComposer
 class $TodosWithReferences {
   // ignore: unused_field
   final i0.GeneratedDatabase _db;
-  final i1.Todo i1Todo;
-  $TodosWithReferences(this._db, this.i1Todo);
+  final i1.Todo _item;
+  $TodosWithReferences(this._db, this._item);
 }
 
 class Categories extends i0.Table with i0.TableInfo<Categories, i1.Category> {
@@ -620,7 +620,7 @@ class $CategoriesTableManager extends i0.RootTableManager<
     i1.$CategoriesOrderingComposer,
     $CategoriesCreateCompanionBuilder,
     $CategoriesUpdateCompanionBuilder,
-    $CategoriesWithReferences,
+    (i1.Category, $CategoriesWithReferences),
     i1.Category> {
   $CategoriesTableManager(i0.GeneratedDatabase db, i1.Categories table)
       : super(i0.TableManagerState(
@@ -631,7 +631,7 @@ class $CategoriesTableManager extends i0.RootTableManager<
           orderingComposer:
               i1.$CategoriesOrderingComposer(i0.ComposerState(db, table)),
           withReferenceMapper: (p0) =>
-              p0.map((e) => $CategoriesWithReferences(db, e)).toList(),
+              p0.map((e) => (e, $CategoriesWithReferences(db, e))).toList(),
           updateCompanionCallback: ({
             i0.Value<int> id = const i0.Value.absent(),
             i0.Value<String> description = const i0.Value.absent(),
@@ -659,7 +659,7 @@ typedef $CategoriesProcessedTableManager = i0.ProcessedTableManager<
     i1.$CategoriesOrderingComposer,
     $CategoriesCreateCompanionBuilder,
     $CategoriesUpdateCompanionBuilder,
-    $CategoriesWithReferences,
+    (i1.Category, $CategoriesWithReferences),
     i1.Category>;
 
 class $CategoriesFilterComposer
@@ -693,8 +693,8 @@ class $CategoriesOrderingComposer
 class $CategoriesWithReferences {
   // ignore: unused_field
   final i0.GeneratedDatabase _db;
-  final i1.Category i1Category;
-  $CategoriesWithReferences(this._db, this.i1Category);
+  final i1.Category _item;
+  $CategoriesWithReferences(this._db, this._item);
 }
 
 class ExampleDrift extends i2.ModularAccessor {

--- a/docs/lib/snippets/modular/drift/with_existing.drift.dart
+++ b/docs/lib/snippets/modular/drift/with_existing.drift.dart
@@ -146,7 +146,7 @@ class $UsersTableManager extends i0.RootTableManager<
               i2.$UsersFilterComposer(i0.ComposerState(db, table)),
           orderingComposer:
               i2.$UsersOrderingComposer(i0.ComposerState(db, table)),
-          dataclassMapper: (p0) async =>
+          withReferenceMapper: (p0) =>
               p0.map((e) => $UsersWithReferences(db, e)).toList(),
           updateCompanionCallback: ({
             i0.Value<int> id = const i0.Value.absent(),
@@ -440,7 +440,7 @@ class $FriendsTableManager extends i0.RootTableManager<
               i2.$FriendsFilterComposer(i0.ComposerState(db, table)),
           orderingComposer:
               i2.$FriendsOrderingComposer(i0.ComposerState(db, table)),
-          dataclassMapper: (p0) async =>
+          withReferenceMapper: (p0) =>
               p0.map((e) => $FriendsWithReferences(db, e)).toList(),
           updateCompanionCallback: ({
             i0.Value<int> userA = const i0.Value.absent(),

--- a/docs/lib/snippets/modular/drift/with_existing.drift.dart
+++ b/docs/lib/snippets/modular/drift/with_existing.drift.dart
@@ -128,56 +128,6 @@ typedef $UsersUpdateCompanionBuilder = i2.UsersCompanion Function({
   i0.Value<String> name,
 });
 
-class $UsersTableManager extends i0.RootTableManager<
-    i0.GeneratedDatabase,
-    i2.Users,
-    i1.User,
-    i2.$UsersFilterComposer,
-    i2.$UsersOrderingComposer,
-    $UsersCreateCompanionBuilder,
-    $UsersUpdateCompanionBuilder,
-    (i1.User, $UsersWithReferences),
-    i1.User> {
-  $UsersTableManager(i0.GeneratedDatabase db, i2.Users table)
-      : super(i0.TableManagerState(
-          db: db,
-          table: table,
-          filteringComposer:
-              i2.$UsersFilterComposer(i0.ComposerState(db, table)),
-          orderingComposer:
-              i2.$UsersOrderingComposer(i0.ComposerState(db, table)),
-          withReferenceMapper: (p0) =>
-              p0.map((e) => (e, $UsersWithReferences(db, e))).toList(),
-          updateCompanionCallback: ({
-            i0.Value<int> id = const i0.Value.absent(),
-            i0.Value<String> name = const i0.Value.absent(),
-          }) =>
-              i2.UsersCompanion(
-            id: id,
-            name: name,
-          ),
-          createCompanionCallback: ({
-            i0.Value<int> id = const i0.Value.absent(),
-            required String name,
-          }) =>
-              i2.UsersCompanion.insert(
-            id: id,
-            name: name,
-          ),
-        ));
-}
-
-typedef $UsersProcessedTableManager = i0.ProcessedTableManager<
-    i0.GeneratedDatabase,
-    i2.Users,
-    i1.User,
-    i2.$UsersFilterComposer,
-    i2.$UsersOrderingComposer,
-    $UsersCreateCompanionBuilder,
-    $UsersUpdateCompanionBuilder,
-    (i1.User, $UsersWithReferences),
-    i1.User>;
-
 class $UsersFilterComposer
     extends i0.FilterComposer<i0.GeneratedDatabase, i2.Users> {
   $UsersFilterComposer(super.$state);
@@ -206,13 +156,55 @@ class $UsersOrderingComposer
           i0.ColumnOrderings(column, joinBuilders: joinBuilders));
 }
 
-class $UsersWithReferences {
-  // ignore: unused_field
-  final i0.GeneratedDatabase _db;
-  // ignore: unused_field
-  final i1.User _item;
-  $UsersWithReferences(this._db, this._item);
+class $UsersTableManager extends i0.RootTableManager<
+    i0.GeneratedDatabase,
+    i2.Users,
+    i1.User,
+    i2.$UsersFilterComposer,
+    i2.$UsersOrderingComposer,
+    $UsersCreateCompanionBuilder,
+    $UsersUpdateCompanionBuilder,
+    (i1.User, i0.BaseWithReferences<i0.GeneratedDatabase, i1.User>),
+    i1.User> {
+  $UsersTableManager(i0.GeneratedDatabase db, i2.Users table)
+      : super(i0.TableManagerState(
+          db: db,
+          table: table,
+          filteringComposer:
+              i2.$UsersFilterComposer(i0.ComposerState(db, table)),
+          orderingComposer:
+              i2.$UsersOrderingComposer(i0.ComposerState(db, table)),
+          withReferenceMapper: (p0) =>
+              p0.map((e) => (e, i0.BaseWithReferences(db, e))).toList(),
+          updateCompanionCallback: ({
+            i0.Value<int> id = const i0.Value.absent(),
+            i0.Value<String> name = const i0.Value.absent(),
+          }) =>
+              i2.UsersCompanion(
+            id: id,
+            name: name,
+          ),
+          createCompanionCallback: ({
+            i0.Value<int> id = const i0.Value.absent(),
+            required String name,
+          }) =>
+              i2.UsersCompanion.insert(
+            id: id,
+            name: name,
+          ),
+        ));
 }
+
+typedef $UsersProcessedTableManager = i0.ProcessedTableManager<
+    i0.GeneratedDatabase,
+    i2.Users,
+    i1.User,
+    i2.$UsersFilterComposer,
+    i2.$UsersOrderingComposer,
+    $UsersCreateCompanionBuilder,
+    $UsersUpdateCompanionBuilder,
+    (i1.User, i0.BaseWithReferences<i0.GeneratedDatabase, i1.User>),
+    i1.User>;
 
 class Friends extends i0.Table with i0.TableInfo<Friends, i2.Friend> {
   @override
@@ -423,60 +415,6 @@ typedef $FriendsUpdateCompanionBuilder = i2.FriendsCompanion Function({
   i0.Value<int> rowid,
 });
 
-class $FriendsTableManager extends i0.RootTableManager<
-    i0.GeneratedDatabase,
-    i2.Friends,
-    i2.Friend,
-    i2.$FriendsFilterComposer,
-    i2.$FriendsOrderingComposer,
-    $FriendsCreateCompanionBuilder,
-    $FriendsUpdateCompanionBuilder,
-    (i2.Friend, $FriendsWithReferences),
-    i2.Friend> {
-  $FriendsTableManager(i0.GeneratedDatabase db, i2.Friends table)
-      : super(i0.TableManagerState(
-          db: db,
-          table: table,
-          filteringComposer:
-              i2.$FriendsFilterComposer(i0.ComposerState(db, table)),
-          orderingComposer:
-              i2.$FriendsOrderingComposer(i0.ComposerState(db, table)),
-          withReferenceMapper: (p0) =>
-              p0.map((e) => (e, $FriendsWithReferences(db, e))).toList(),
-          updateCompanionCallback: ({
-            i0.Value<int> userA = const i0.Value.absent(),
-            i0.Value<int> userB = const i0.Value.absent(),
-            i0.Value<int> rowid = const i0.Value.absent(),
-          }) =>
-              i2.FriendsCompanion(
-            userA: userA,
-            userB: userB,
-            rowid: rowid,
-          ),
-          createCompanionCallback: ({
-            required int userA,
-            required int userB,
-            i0.Value<int> rowid = const i0.Value.absent(),
-          }) =>
-              i2.FriendsCompanion.insert(
-            userA: userA,
-            userB: userB,
-            rowid: rowid,
-          ),
-        ));
-}
-
-typedef $FriendsProcessedTableManager = i0.ProcessedTableManager<
-    i0.GeneratedDatabase,
-    i2.Friends,
-    i2.Friend,
-    i2.$FriendsFilterComposer,
-    i2.$FriendsOrderingComposer,
-    $FriendsCreateCompanionBuilder,
-    $FriendsUpdateCompanionBuilder,
-    (i2.Friend, $FriendsWithReferences),
-    i2.Friend>;
-
 class $FriendsFilterComposer
     extends i0.FilterComposer<i0.GeneratedDatabase, i2.Friends> {
   $FriendsFilterComposer(super.$state);
@@ -553,13 +491,59 @@ class $FriendsOrderingComposer
   }
 }
 
-class $FriendsWithReferences {
-  // ignore: unused_field
-  final i0.GeneratedDatabase _db;
-  // ignore: unused_field
-  final i2.Friend _item;
-  $FriendsWithReferences(this._db, this._item);
+class $FriendsTableManager extends i0.RootTableManager<
+    i0.GeneratedDatabase,
+    i2.Friends,
+    i2.Friend,
+    i2.$FriendsFilterComposer,
+    i2.$FriendsOrderingComposer,
+    $FriendsCreateCompanionBuilder,
+    $FriendsUpdateCompanionBuilder,
+    (i2.Friend, i0.BaseWithReferences<i0.GeneratedDatabase, i2.Friend>),
+    i2.Friend> {
+  $FriendsTableManager(i0.GeneratedDatabase db, i2.Friends table)
+      : super(i0.TableManagerState(
+          db: db,
+          table: table,
+          filteringComposer:
+              i2.$FriendsFilterComposer(i0.ComposerState(db, table)),
+          orderingComposer:
+              i2.$FriendsOrderingComposer(i0.ComposerState(db, table)),
+          withReferenceMapper: (p0) =>
+              p0.map((e) => (e, i0.BaseWithReferences(db, e))).toList(),
+          updateCompanionCallback: ({
+            i0.Value<int> userA = const i0.Value.absent(),
+            i0.Value<int> userB = const i0.Value.absent(),
+            i0.Value<int> rowid = const i0.Value.absent(),
+          }) =>
+              i2.FriendsCompanion(
+            userA: userA,
+            userB: userB,
+            rowid: rowid,
+          ),
+          createCompanionCallback: ({
+            required int userA,
+            required int userB,
+            i0.Value<int> rowid = const i0.Value.absent(),
+          }) =>
+              i2.FriendsCompanion.insert(
+            userA: userA,
+            userB: userB,
+            rowid: rowid,
+          ),
+        ));
 }
+
+typedef $FriendsProcessedTableManager = i0.ProcessedTableManager<
+    i0.GeneratedDatabase,
+    i2.Friends,
+    i2.Friend,
+    i2.$FriendsFilterComposer,
+    i2.$FriendsOrderingComposer,
+    $FriendsCreateCompanionBuilder,
+    $FriendsUpdateCompanionBuilder,
+    (i2.Friend, i0.BaseWithReferences<i0.GeneratedDatabase, i2.Friend>),
+    i2.Friend>;
 
 class WithExistingDrift extends i3.ModularAccessor {
   WithExistingDrift(i0.GeneratedDatabase db) : super(db);

--- a/docs/lib/snippets/modular/drift/with_existing.drift.dart
+++ b/docs/lib/snippets/modular/drift/with_existing.drift.dart
@@ -135,7 +135,9 @@ class $UsersTableManager extends i0.RootTableManager<
     i2.$UsersFilterComposer,
     i2.$UsersOrderingComposer,
     $UsersCreateCompanionBuilder,
-    $UsersUpdateCompanionBuilder> {
+    $UsersUpdateCompanionBuilder,
+    $UsersWithReferences,
+    i1.User> {
   $UsersTableManager(i0.GeneratedDatabase db, i2.Users table)
       : super(i0.TableManagerState(
           db: db,
@@ -144,6 +146,8 @@ class $UsersTableManager extends i0.RootTableManager<
               i2.$UsersFilterComposer(i0.ComposerState(db, table)),
           orderingComposer:
               i2.$UsersOrderingComposer(i0.ComposerState(db, table)),
+          dataclassMapper: (p0) async =>
+              p0.map((e) => $UsersWithReferences(db, e)).toList(),
           updateCompanionCallback: ({
             i0.Value<int> id = const i0.Value.absent(),
             i0.Value<String> name = const i0.Value.absent(),
@@ -162,6 +166,17 @@ class $UsersTableManager extends i0.RootTableManager<
           ),
         ));
 }
+
+typedef $UsersProcessedTableManager = i0.ProcessedTableManager<
+    i0.GeneratedDatabase,
+    i2.Users,
+    i1.User,
+    i2.$UsersFilterComposer,
+    i2.$UsersOrderingComposer,
+    $UsersCreateCompanionBuilder,
+    $UsersUpdateCompanionBuilder,
+    $UsersWithReferences,
+    i1.User>;
 
 class $UsersFilterComposer
     extends i0.FilterComposer<i0.GeneratedDatabase, i2.Users> {
@@ -189,6 +204,13 @@ class $UsersOrderingComposer
       column: $state.table.name,
       builder: (column, joinBuilders) =>
           i0.ColumnOrderings(column, joinBuilders: joinBuilders));
+}
+
+class $UsersWithReferences {
+  // ignore: unused_field
+  final i0.GeneratedDatabase _db;
+  final i1.User i1User;
+  $UsersWithReferences(this._db, this.i1User);
 }
 
 class Friends extends i0.Table with i0.TableInfo<Friends, i2.Friend> {
@@ -407,7 +429,9 @@ class $FriendsTableManager extends i0.RootTableManager<
     i2.$FriendsFilterComposer,
     i2.$FriendsOrderingComposer,
     $FriendsCreateCompanionBuilder,
-    $FriendsUpdateCompanionBuilder> {
+    $FriendsUpdateCompanionBuilder,
+    $FriendsWithReferences,
+    i2.Friend> {
   $FriendsTableManager(i0.GeneratedDatabase db, i2.Friends table)
       : super(i0.TableManagerState(
           db: db,
@@ -416,6 +440,8 @@ class $FriendsTableManager extends i0.RootTableManager<
               i2.$FriendsFilterComposer(i0.ComposerState(db, table)),
           orderingComposer:
               i2.$FriendsOrderingComposer(i0.ComposerState(db, table)),
+          dataclassMapper: (p0) async =>
+              p0.map((e) => $FriendsWithReferences(db, e)).toList(),
           updateCompanionCallback: ({
             i0.Value<int> userA = const i0.Value.absent(),
             i0.Value<int> userB = const i0.Value.absent(),
@@ -438,6 +464,17 @@ class $FriendsTableManager extends i0.RootTableManager<
           ),
         ));
 }
+
+typedef $FriendsProcessedTableManager = i0.ProcessedTableManager<
+    i0.GeneratedDatabase,
+    i2.Friends,
+    i2.Friend,
+    i2.$FriendsFilterComposer,
+    i2.$FriendsOrderingComposer,
+    $FriendsCreateCompanionBuilder,
+    $FriendsUpdateCompanionBuilder,
+    $FriendsWithReferences,
+    i2.Friend>;
 
 class $FriendsFilterComposer
     extends i0.FilterComposer<i0.GeneratedDatabase, i2.Friends> {
@@ -513,6 +550,13 @@ class $FriendsOrderingComposer
                 parentComposers)));
     return composer;
   }
+}
+
+class $FriendsWithReferences {
+  // ignore: unused_field
+  final i0.GeneratedDatabase _db;
+  final i2.Friend i2Friend;
+  $FriendsWithReferences(this._db, this.i2Friend);
 }
 
 class WithExistingDrift extends i3.ModularAccessor {

--- a/docs/lib/snippets/modular/drift/with_existing.drift.dart
+++ b/docs/lib/snippets/modular/drift/with_existing.drift.dart
@@ -209,6 +209,7 @@ class $UsersOrderingComposer
 class $UsersWithReferences {
   // ignore: unused_field
   final i0.GeneratedDatabase _db;
+  // ignore: unused_field
   final i1.User _item;
   $UsersWithReferences(this._db, this._item);
 }
@@ -555,6 +556,7 @@ class $FriendsOrderingComposer
 class $FriendsWithReferences {
   // ignore: unused_field
   final i0.GeneratedDatabase _db;
+  // ignore: unused_field
   final i2.Friend _item;
   $FriendsWithReferences(this._db, this._item);
 }

--- a/docs/lib/snippets/modular/drift/with_existing.drift.dart
+++ b/docs/lib/snippets/modular/drift/with_existing.drift.dart
@@ -136,7 +136,7 @@ class $UsersTableManager extends i0.RootTableManager<
     i2.$UsersOrderingComposer,
     $UsersCreateCompanionBuilder,
     $UsersUpdateCompanionBuilder,
-    $UsersWithReferences,
+    (i1.User, $UsersWithReferences),
     i1.User> {
   $UsersTableManager(i0.GeneratedDatabase db, i2.Users table)
       : super(i0.TableManagerState(
@@ -147,7 +147,7 @@ class $UsersTableManager extends i0.RootTableManager<
           orderingComposer:
               i2.$UsersOrderingComposer(i0.ComposerState(db, table)),
           withReferenceMapper: (p0) =>
-              p0.map((e) => $UsersWithReferences(db, e)).toList(),
+              p0.map((e) => (e, $UsersWithReferences(db, e))).toList(),
           updateCompanionCallback: ({
             i0.Value<int> id = const i0.Value.absent(),
             i0.Value<String> name = const i0.Value.absent(),
@@ -175,7 +175,7 @@ typedef $UsersProcessedTableManager = i0.ProcessedTableManager<
     i2.$UsersOrderingComposer,
     $UsersCreateCompanionBuilder,
     $UsersUpdateCompanionBuilder,
-    $UsersWithReferences,
+    (i1.User, $UsersWithReferences),
     i1.User>;
 
 class $UsersFilterComposer
@@ -209,8 +209,8 @@ class $UsersOrderingComposer
 class $UsersWithReferences {
   // ignore: unused_field
   final i0.GeneratedDatabase _db;
-  final i1.User i1User;
-  $UsersWithReferences(this._db, this.i1User);
+  final i1.User _item;
+  $UsersWithReferences(this._db, this._item);
 }
 
 class Friends extends i0.Table with i0.TableInfo<Friends, i2.Friend> {
@@ -430,7 +430,7 @@ class $FriendsTableManager extends i0.RootTableManager<
     i2.$FriendsOrderingComposer,
     $FriendsCreateCompanionBuilder,
     $FriendsUpdateCompanionBuilder,
-    $FriendsWithReferences,
+    (i2.Friend, $FriendsWithReferences),
     i2.Friend> {
   $FriendsTableManager(i0.GeneratedDatabase db, i2.Friends table)
       : super(i0.TableManagerState(
@@ -441,7 +441,7 @@ class $FriendsTableManager extends i0.RootTableManager<
           orderingComposer:
               i2.$FriendsOrderingComposer(i0.ComposerState(db, table)),
           withReferenceMapper: (p0) =>
-              p0.map((e) => $FriendsWithReferences(db, e)).toList(),
+              p0.map((e) => (e, $FriendsWithReferences(db, e))).toList(),
           updateCompanionCallback: ({
             i0.Value<int> userA = const i0.Value.absent(),
             i0.Value<int> userB = const i0.Value.absent(),
@@ -473,7 +473,7 @@ typedef $FriendsProcessedTableManager = i0.ProcessedTableManager<
     i2.$FriendsOrderingComposer,
     $FriendsCreateCompanionBuilder,
     $FriendsUpdateCompanionBuilder,
-    $FriendsWithReferences,
+    (i2.Friend, $FriendsWithReferences),
     i2.Friend>;
 
 class $FriendsFilterComposer
@@ -555,8 +555,8 @@ class $FriendsOrderingComposer
 class $FriendsWithReferences {
   // ignore: unused_field
   final i0.GeneratedDatabase _db;
-  final i2.Friend i2Friend;
-  $FriendsWithReferences(this._db, this.i2Friend);
+  final i2.Friend _item;
+  $FriendsWithReferences(this._db, this._item);
 }
 
 class WithExistingDrift extends i3.ModularAccessor {

--- a/docs/lib/snippets/modular/many_to_many/json.drift.dart
+++ b/docs/lib/snippets/modular/many_to_many/json.drift.dart
@@ -316,6 +316,7 @@ class $$ShoppingCartsTableOrderingComposer
 class $$ShoppingCartsTableWithReferences {
   // ignore: unused_field
   final i0.GeneratedDatabase _db;
+  // ignore: unused_field
   final i2.ShoppingCart _item;
   $$ShoppingCartsTableWithReferences(this._db, this._item);
 }

--- a/docs/lib/snippets/modular/many_to_many/json.drift.dart
+++ b/docs/lib/snippets/modular/many_to_many/json.drift.dart
@@ -237,7 +237,9 @@ class $$ShoppingCartsTableTableManager extends i0.RootTableManager<
     i2.$$ShoppingCartsTableFilterComposer,
     i2.$$ShoppingCartsTableOrderingComposer,
     $$ShoppingCartsTableCreateCompanionBuilder,
-    $$ShoppingCartsTableUpdateCompanionBuilder> {
+    $$ShoppingCartsTableUpdateCompanionBuilder,
+    $$ShoppingCartsTableWithReferences,
+    i2.ShoppingCart> {
   $$ShoppingCartsTableTableManager(
       i0.GeneratedDatabase db, i2.$ShoppingCartsTable table)
       : super(i0.TableManagerState(
@@ -247,6 +249,8 @@ class $$ShoppingCartsTableTableManager extends i0.RootTableManager<
               .$$ShoppingCartsTableFilterComposer(i0.ComposerState(db, table)),
           orderingComposer: i2.$$ShoppingCartsTableOrderingComposer(
               i0.ComposerState(db, table)),
+          dataclassMapper: (p0) async =>
+              p0.map((e) => $$ShoppingCartsTableWithReferences(db, e)).toList(),
           updateCompanionCallback: ({
             i0.Value<int> id = const i0.Value.absent(),
             i0.Value<i3.ShoppingCartEntries> entries = const i0.Value.absent(),
@@ -265,6 +269,17 @@ class $$ShoppingCartsTableTableManager extends i0.RootTableManager<
           ),
         ));
 }
+
+typedef $$ShoppingCartsTableProcessedTableManager = i0.ProcessedTableManager<
+    i0.GeneratedDatabase,
+    i2.$ShoppingCartsTable,
+    i2.ShoppingCart,
+    i2.$$ShoppingCartsTableFilterComposer,
+    i2.$$ShoppingCartsTableOrderingComposer,
+    $$ShoppingCartsTableCreateCompanionBuilder,
+    $$ShoppingCartsTableUpdateCompanionBuilder,
+    $$ShoppingCartsTableWithReferences,
+    i2.ShoppingCart>;
 
 class $$ShoppingCartsTableFilterComposer
     extends i0.FilterComposer<i0.GeneratedDatabase, i2.$ShoppingCartsTable> {
@@ -295,4 +310,11 @@ class $$ShoppingCartsTableOrderingComposer
       column: $state.table.entries,
       builder: (column, joinBuilders) =>
           i0.ColumnOrderings(column, joinBuilders: joinBuilders));
+}
+
+class $$ShoppingCartsTableWithReferences {
+  // ignore: unused_field
+  final i0.GeneratedDatabase _db;
+  final i2.ShoppingCart i2ShoppingCart;
+  $$ShoppingCartsTableWithReferences(this._db, this.i2ShoppingCart);
 }

--- a/docs/lib/snippets/modular/many_to_many/json.drift.dart
+++ b/docs/lib/snippets/modular/many_to_many/json.drift.dart
@@ -230,58 +230,6 @@ typedef $$ShoppingCartsTableUpdateCompanionBuilder = i2.ShoppingCartsCompanion
   i0.Value<i3.ShoppingCartEntries> entries,
 });
 
-class $$ShoppingCartsTableTableManager extends i0.RootTableManager<
-    i0.GeneratedDatabase,
-    i2.$ShoppingCartsTable,
-    i2.ShoppingCart,
-    i2.$$ShoppingCartsTableFilterComposer,
-    i2.$$ShoppingCartsTableOrderingComposer,
-    $$ShoppingCartsTableCreateCompanionBuilder,
-    $$ShoppingCartsTableUpdateCompanionBuilder,
-    (i2.ShoppingCart, $$ShoppingCartsTableWithReferences),
-    i2.ShoppingCart> {
-  $$ShoppingCartsTableTableManager(
-      i0.GeneratedDatabase db, i2.$ShoppingCartsTable table)
-      : super(i0.TableManagerState(
-          db: db,
-          table: table,
-          filteringComposer: i2
-              .$$ShoppingCartsTableFilterComposer(i0.ComposerState(db, table)),
-          orderingComposer: i2.$$ShoppingCartsTableOrderingComposer(
-              i0.ComposerState(db, table)),
-          withReferenceMapper: (p0) => p0
-              .map((e) => (e, $$ShoppingCartsTableWithReferences(db, e)))
-              .toList(),
-          updateCompanionCallback: ({
-            i0.Value<int> id = const i0.Value.absent(),
-            i0.Value<i3.ShoppingCartEntries> entries = const i0.Value.absent(),
-          }) =>
-              i2.ShoppingCartsCompanion(
-            id: id,
-            entries: entries,
-          ),
-          createCompanionCallback: ({
-            i0.Value<int> id = const i0.Value.absent(),
-            required i3.ShoppingCartEntries entries,
-          }) =>
-              i2.ShoppingCartsCompanion.insert(
-            id: id,
-            entries: entries,
-          ),
-        ));
-}
-
-typedef $$ShoppingCartsTableProcessedTableManager = i0.ProcessedTableManager<
-    i0.GeneratedDatabase,
-    i2.$ShoppingCartsTable,
-    i2.ShoppingCart,
-    i2.$$ShoppingCartsTableFilterComposer,
-    i2.$$ShoppingCartsTableOrderingComposer,
-    $$ShoppingCartsTableCreateCompanionBuilder,
-    $$ShoppingCartsTableUpdateCompanionBuilder,
-    (i2.ShoppingCart, $$ShoppingCartsTableWithReferences),
-    i2.ShoppingCart>;
-
 class $$ShoppingCartsTableFilterComposer
     extends i0.FilterComposer<i0.GeneratedDatabase, i2.$ShoppingCartsTable> {
   $$ShoppingCartsTableFilterComposer(super.$state);
@@ -313,10 +261,59 @@ class $$ShoppingCartsTableOrderingComposer
           i0.ColumnOrderings(column, joinBuilders: joinBuilders));
 }
 
-class $$ShoppingCartsTableWithReferences {
-  // ignore: unused_field
-  final i0.GeneratedDatabase _db;
-  // ignore: unused_field
-  final i2.ShoppingCart _item;
-  $$ShoppingCartsTableWithReferences(this._db, this._item);
+class $$ShoppingCartsTableTableManager extends i0.RootTableManager<
+    i0.GeneratedDatabase,
+    i2.$ShoppingCartsTable,
+    i2.ShoppingCart,
+    i2.$$ShoppingCartsTableFilterComposer,
+    i2.$$ShoppingCartsTableOrderingComposer,
+    $$ShoppingCartsTableCreateCompanionBuilder,
+    $$ShoppingCartsTableUpdateCompanionBuilder,
+    (
+      i2.ShoppingCart,
+      i0.BaseWithReferences<i0.GeneratedDatabase, i2.ShoppingCart>
+    ),
+    i2.ShoppingCart> {
+  $$ShoppingCartsTableTableManager(
+      i0.GeneratedDatabase db, i2.$ShoppingCartsTable table)
+      : super(i0.TableManagerState(
+          db: db,
+          table: table,
+          filteringComposer: i2
+              .$$ShoppingCartsTableFilterComposer(i0.ComposerState(db, table)),
+          orderingComposer: i2.$$ShoppingCartsTableOrderingComposer(
+              i0.ComposerState(db, table)),
+          withReferenceMapper: (p0) =>
+              p0.map((e) => (e, i0.BaseWithReferences(db, e))).toList(),
+          updateCompanionCallback: ({
+            i0.Value<int> id = const i0.Value.absent(),
+            i0.Value<i3.ShoppingCartEntries> entries = const i0.Value.absent(),
+          }) =>
+              i2.ShoppingCartsCompanion(
+            id: id,
+            entries: entries,
+          ),
+          createCompanionCallback: ({
+            i0.Value<int> id = const i0.Value.absent(),
+            required i3.ShoppingCartEntries entries,
+          }) =>
+              i2.ShoppingCartsCompanion.insert(
+            id: id,
+            entries: entries,
+          ),
+        ));
 }
+
+typedef $$ShoppingCartsTableProcessedTableManager = i0.ProcessedTableManager<
+    i0.GeneratedDatabase,
+    i2.$ShoppingCartsTable,
+    i2.ShoppingCart,
+    i2.$$ShoppingCartsTableFilterComposer,
+    i2.$$ShoppingCartsTableOrderingComposer,
+    $$ShoppingCartsTableCreateCompanionBuilder,
+    $$ShoppingCartsTableUpdateCompanionBuilder,
+    (
+      i2.ShoppingCart,
+      i0.BaseWithReferences<i0.GeneratedDatabase, i2.ShoppingCart>
+    ),
+    i2.ShoppingCart>;

--- a/docs/lib/snippets/modular/many_to_many/json.drift.dart
+++ b/docs/lib/snippets/modular/many_to_many/json.drift.dart
@@ -238,7 +238,7 @@ class $$ShoppingCartsTableTableManager extends i0.RootTableManager<
     i2.$$ShoppingCartsTableOrderingComposer,
     $$ShoppingCartsTableCreateCompanionBuilder,
     $$ShoppingCartsTableUpdateCompanionBuilder,
-    $$ShoppingCartsTableWithReferences,
+    (i2.ShoppingCart, $$ShoppingCartsTableWithReferences),
     i2.ShoppingCart> {
   $$ShoppingCartsTableTableManager(
       i0.GeneratedDatabase db, i2.$ShoppingCartsTable table)
@@ -249,8 +249,9 @@ class $$ShoppingCartsTableTableManager extends i0.RootTableManager<
               .$$ShoppingCartsTableFilterComposer(i0.ComposerState(db, table)),
           orderingComposer: i2.$$ShoppingCartsTableOrderingComposer(
               i0.ComposerState(db, table)),
-          withReferenceMapper: (p0) =>
-              p0.map((e) => $$ShoppingCartsTableWithReferences(db, e)).toList(),
+          withReferenceMapper: (p0) => p0
+              .map((e) => (e, $$ShoppingCartsTableWithReferences(db, e)))
+              .toList(),
           updateCompanionCallback: ({
             i0.Value<int> id = const i0.Value.absent(),
             i0.Value<i3.ShoppingCartEntries> entries = const i0.Value.absent(),
@@ -278,7 +279,7 @@ typedef $$ShoppingCartsTableProcessedTableManager = i0.ProcessedTableManager<
     i2.$$ShoppingCartsTableOrderingComposer,
     $$ShoppingCartsTableCreateCompanionBuilder,
     $$ShoppingCartsTableUpdateCompanionBuilder,
-    $$ShoppingCartsTableWithReferences,
+    (i2.ShoppingCart, $$ShoppingCartsTableWithReferences),
     i2.ShoppingCart>;
 
 class $$ShoppingCartsTableFilterComposer
@@ -315,6 +316,6 @@ class $$ShoppingCartsTableOrderingComposer
 class $$ShoppingCartsTableWithReferences {
   // ignore: unused_field
   final i0.GeneratedDatabase _db;
-  final i2.ShoppingCart i2ShoppingCart;
-  $$ShoppingCartsTableWithReferences(this._db, this.i2ShoppingCart);
+  final i2.ShoppingCart _item;
+  $$ShoppingCartsTableWithReferences(this._db, this._item);
 }

--- a/docs/lib/snippets/modular/many_to_many/json.drift.dart
+++ b/docs/lib/snippets/modular/many_to_many/json.drift.dart
@@ -249,7 +249,7 @@ class $$ShoppingCartsTableTableManager extends i0.RootTableManager<
               .$$ShoppingCartsTableFilterComposer(i0.ComposerState(db, table)),
           orderingComposer: i2.$$ShoppingCartsTableOrderingComposer(
               i0.ComposerState(db, table)),
-          dataclassMapper: (p0) async =>
+          withReferenceMapper: (p0) =>
               p0.map((e) => $$ShoppingCartsTableWithReferences(db, e)).toList(),
           updateCompanionCallback: ({
             i0.Value<int> id = const i0.Value.absent(),

--- a/docs/lib/snippets/modular/many_to_many/relational.drift.dart
+++ b/docs/lib/snippets/modular/many_to_many/relational.drift.dart
@@ -210,7 +210,7 @@ class $$ShoppingCartsTableTableManager extends i0.RootTableManager<
               .$$ShoppingCartsTableFilterComposer(i0.ComposerState(db, table)),
           orderingComposer: i2.$$ShoppingCartsTableOrderingComposer(
               i0.ComposerState(db, table)),
-          dataclassMapper: (p0) async =>
+          withReferenceMapper: (p0) =>
               p0.map((e) => $$ShoppingCartsTableWithReferences(db, e)).toList(),
           updateCompanionCallback: ({
             i0.Value<int> id = const i0.Value.absent(),
@@ -503,7 +503,7 @@ class $$ShoppingCartEntriesTableTableManager extends i0.RootTableManager<
               i0.ComposerState(db, table)),
           orderingComposer: i2.$$ShoppingCartEntriesTableOrderingComposer(
               i0.ComposerState(db, table)),
-          dataclassMapper: (p0) async => p0
+          withReferenceMapper: (p0) => p0
               .map((e) => $$ShoppingCartEntriesTableWithReferences(db, e))
               .toList(),
           updateCompanionCallback: ({

--- a/docs/lib/snippets/modular/many_to_many/relational.drift.dart
+++ b/docs/lib/snippets/modular/many_to_many/relational.drift.dart
@@ -198,7 +198,9 @@ class $$ShoppingCartsTableTableManager extends i0.RootTableManager<
     i2.$$ShoppingCartsTableFilterComposer,
     i2.$$ShoppingCartsTableOrderingComposer,
     $$ShoppingCartsTableCreateCompanionBuilder,
-    $$ShoppingCartsTableUpdateCompanionBuilder> {
+    $$ShoppingCartsTableUpdateCompanionBuilder,
+    $$ShoppingCartsTableWithReferences,
+    i2.ShoppingCart> {
   $$ShoppingCartsTableTableManager(
       i0.GeneratedDatabase db, i2.$ShoppingCartsTable table)
       : super(i0.TableManagerState(
@@ -208,6 +210,8 @@ class $$ShoppingCartsTableTableManager extends i0.RootTableManager<
               .$$ShoppingCartsTableFilterComposer(i0.ComposerState(db, table)),
           orderingComposer: i2.$$ShoppingCartsTableOrderingComposer(
               i0.ComposerState(db, table)),
+          dataclassMapper: (p0) async =>
+              p0.map((e) => $$ShoppingCartsTableWithReferences(db, e)).toList(),
           updateCompanionCallback: ({
             i0.Value<int> id = const i0.Value.absent(),
           }) =>
@@ -222,6 +226,17 @@ class $$ShoppingCartsTableTableManager extends i0.RootTableManager<
           ),
         ));
 }
+
+typedef $$ShoppingCartsTableProcessedTableManager = i0.ProcessedTableManager<
+    i0.GeneratedDatabase,
+    i2.$ShoppingCartsTable,
+    i2.ShoppingCart,
+    i2.$$ShoppingCartsTableFilterComposer,
+    i2.$$ShoppingCartsTableOrderingComposer,
+    $$ShoppingCartsTableCreateCompanionBuilder,
+    $$ShoppingCartsTableUpdateCompanionBuilder,
+    $$ShoppingCartsTableWithReferences,
+    i2.ShoppingCart>;
 
 class $$ShoppingCartsTableFilterComposer
     extends i0.FilterComposer<i0.GeneratedDatabase, i2.$ShoppingCartsTable> {
@@ -239,6 +254,13 @@ class $$ShoppingCartsTableOrderingComposer
       column: $state.table.id,
       builder: (column, joinBuilders) =>
           i0.ColumnOrderings(column, joinBuilders: joinBuilders));
+}
+
+class $$ShoppingCartsTableWithReferences {
+  // ignore: unused_field
+  final i0.GeneratedDatabase _db;
+  final i2.ShoppingCart i2ShoppingCart;
+  $$ShoppingCartsTableWithReferences(this._db, this.i2ShoppingCart);
 }
 
 class $ShoppingCartEntriesTable extends i3.ShoppingCartEntries
@@ -469,7 +491,9 @@ class $$ShoppingCartEntriesTableTableManager extends i0.RootTableManager<
     i2.$$ShoppingCartEntriesTableFilterComposer,
     i2.$$ShoppingCartEntriesTableOrderingComposer,
     $$ShoppingCartEntriesTableCreateCompanionBuilder,
-    $$ShoppingCartEntriesTableUpdateCompanionBuilder> {
+    $$ShoppingCartEntriesTableUpdateCompanionBuilder,
+    $$ShoppingCartEntriesTableWithReferences,
+    i2.ShoppingCartEntry> {
   $$ShoppingCartEntriesTableTableManager(
       i0.GeneratedDatabase db, i2.$ShoppingCartEntriesTable table)
       : super(i0.TableManagerState(
@@ -479,6 +503,9 @@ class $$ShoppingCartEntriesTableTableManager extends i0.RootTableManager<
               i0.ComposerState(db, table)),
           orderingComposer: i2.$$ShoppingCartEntriesTableOrderingComposer(
               i0.ComposerState(db, table)),
+          dataclassMapper: (p0) async => p0
+              .map((e) => $$ShoppingCartEntriesTableWithReferences(db, e))
+              .toList(),
           updateCompanionCallback: ({
             i0.Value<int> shoppingCart = const i0.Value.absent(),
             i0.Value<int> item = const i0.Value.absent(),
@@ -501,6 +528,18 @@ class $$ShoppingCartEntriesTableTableManager extends i0.RootTableManager<
           ),
         ));
 }
+
+typedef $$ShoppingCartEntriesTableProcessedTableManager
+    = i0.ProcessedTableManager<
+        i0.GeneratedDatabase,
+        i2.$ShoppingCartEntriesTable,
+        i2.ShoppingCartEntry,
+        i2.$$ShoppingCartEntriesTableFilterComposer,
+        i2.$$ShoppingCartEntriesTableOrderingComposer,
+        $$ShoppingCartEntriesTableCreateCompanionBuilder,
+        $$ShoppingCartEntriesTableUpdateCompanionBuilder,
+        $$ShoppingCartEntriesTableWithReferences,
+        i2.ShoppingCartEntry>;
 
 class $$ShoppingCartEntriesTableFilterComposer extends i0
     .FilterComposer<i0.GeneratedDatabase, i2.$ShoppingCartEntriesTable> {
@@ -582,4 +621,11 @@ class $$ShoppingCartEntriesTableOrderingComposer extends i0
                     parentComposers)));
     return composer;
   }
+}
+
+class $$ShoppingCartEntriesTableWithReferences {
+  // ignore: unused_field
+  final i0.GeneratedDatabase _db;
+  final i2.ShoppingCartEntry i2ShoppingCartEntry;
+  $$ShoppingCartEntriesTableWithReferences(this._db, this.i2ShoppingCartEntry);
 }

--- a/docs/lib/snippets/modular/many_to_many/relational.drift.dart
+++ b/docs/lib/snippets/modular/many_to_many/relational.drift.dart
@@ -199,7 +199,7 @@ class $$ShoppingCartsTableTableManager extends i0.RootTableManager<
     i2.$$ShoppingCartsTableOrderingComposer,
     $$ShoppingCartsTableCreateCompanionBuilder,
     $$ShoppingCartsTableUpdateCompanionBuilder,
-    $$ShoppingCartsTableWithReferences,
+    (i2.ShoppingCart, $$ShoppingCartsTableWithReferences),
     i2.ShoppingCart> {
   $$ShoppingCartsTableTableManager(
       i0.GeneratedDatabase db, i2.$ShoppingCartsTable table)
@@ -210,8 +210,9 @@ class $$ShoppingCartsTableTableManager extends i0.RootTableManager<
               .$$ShoppingCartsTableFilterComposer(i0.ComposerState(db, table)),
           orderingComposer: i2.$$ShoppingCartsTableOrderingComposer(
               i0.ComposerState(db, table)),
-          withReferenceMapper: (p0) =>
-              p0.map((e) => $$ShoppingCartsTableWithReferences(db, e)).toList(),
+          withReferenceMapper: (p0) => p0
+              .map((e) => (e, $$ShoppingCartsTableWithReferences(db, e)))
+              .toList(),
           updateCompanionCallback: ({
             i0.Value<int> id = const i0.Value.absent(),
           }) =>
@@ -235,7 +236,7 @@ typedef $$ShoppingCartsTableProcessedTableManager = i0.ProcessedTableManager<
     i2.$$ShoppingCartsTableOrderingComposer,
     $$ShoppingCartsTableCreateCompanionBuilder,
     $$ShoppingCartsTableUpdateCompanionBuilder,
-    $$ShoppingCartsTableWithReferences,
+    (i2.ShoppingCart, $$ShoppingCartsTableWithReferences),
     i2.ShoppingCart>;
 
 class $$ShoppingCartsTableFilterComposer
@@ -259,8 +260,8 @@ class $$ShoppingCartsTableOrderingComposer
 class $$ShoppingCartsTableWithReferences {
   // ignore: unused_field
   final i0.GeneratedDatabase _db;
-  final i2.ShoppingCart i2ShoppingCart;
-  $$ShoppingCartsTableWithReferences(this._db, this.i2ShoppingCart);
+  final i2.ShoppingCart _item;
+  $$ShoppingCartsTableWithReferences(this._db, this._item);
 }
 
 class $ShoppingCartEntriesTable extends i3.ShoppingCartEntries
@@ -492,7 +493,7 @@ class $$ShoppingCartEntriesTableTableManager extends i0.RootTableManager<
     i2.$$ShoppingCartEntriesTableOrderingComposer,
     $$ShoppingCartEntriesTableCreateCompanionBuilder,
     $$ShoppingCartEntriesTableUpdateCompanionBuilder,
-    $$ShoppingCartEntriesTableWithReferences,
+    (i2.ShoppingCartEntry, $$ShoppingCartEntriesTableWithReferences),
     i2.ShoppingCartEntry> {
   $$ShoppingCartEntriesTableTableManager(
       i0.GeneratedDatabase db, i2.$ShoppingCartEntriesTable table)
@@ -504,7 +505,7 @@ class $$ShoppingCartEntriesTableTableManager extends i0.RootTableManager<
           orderingComposer: i2.$$ShoppingCartEntriesTableOrderingComposer(
               i0.ComposerState(db, table)),
           withReferenceMapper: (p0) => p0
-              .map((e) => $$ShoppingCartEntriesTableWithReferences(db, e))
+              .map((e) => (e, $$ShoppingCartEntriesTableWithReferences(db, e)))
               .toList(),
           updateCompanionCallback: ({
             i0.Value<int> shoppingCart = const i0.Value.absent(),
@@ -538,7 +539,7 @@ typedef $$ShoppingCartEntriesTableProcessedTableManager
         i2.$$ShoppingCartEntriesTableOrderingComposer,
         $$ShoppingCartEntriesTableCreateCompanionBuilder,
         $$ShoppingCartEntriesTableUpdateCompanionBuilder,
-        $$ShoppingCartEntriesTableWithReferences,
+        (i2.ShoppingCartEntry, $$ShoppingCartEntriesTableWithReferences),
         i2.ShoppingCartEntry>;
 
 class $$ShoppingCartEntriesTableFilterComposer extends i0
@@ -626,6 +627,6 @@ class $$ShoppingCartEntriesTableOrderingComposer extends i0
 class $$ShoppingCartEntriesTableWithReferences {
   // ignore: unused_field
   final i0.GeneratedDatabase _db;
-  final i2.ShoppingCartEntry i2ShoppingCartEntry;
-  $$ShoppingCartEntriesTableWithReferences(this._db, this.i2ShoppingCartEntry);
+  final i2.ShoppingCartEntry _item;
+  $$ShoppingCartEntriesTableWithReferences(this._db, this._item);
 }

--- a/docs/lib/snippets/modular/many_to_many/relational.drift.dart
+++ b/docs/lib/snippets/modular/many_to_many/relational.drift.dart
@@ -191,6 +191,24 @@ typedef $$ShoppingCartsTableUpdateCompanionBuilder = i2.ShoppingCartsCompanion
   i0.Value<int> id,
 });
 
+class $$ShoppingCartsTableFilterComposer
+    extends i0.FilterComposer<i0.GeneratedDatabase, i2.$ShoppingCartsTable> {
+  $$ShoppingCartsTableFilterComposer(super.$state);
+  i0.ColumnFilters<int> get id => $state.composableBuilder(
+      column: $state.table.id,
+      builder: (column, joinBuilders) =>
+          i0.ColumnFilters(column, joinBuilders: joinBuilders));
+}
+
+class $$ShoppingCartsTableOrderingComposer
+    extends i0.OrderingComposer<i0.GeneratedDatabase, i2.$ShoppingCartsTable> {
+  $$ShoppingCartsTableOrderingComposer(super.$state);
+  i0.ColumnOrderings<int> get id => $state.composableBuilder(
+      column: $state.table.id,
+      builder: (column, joinBuilders) =>
+          i0.ColumnOrderings(column, joinBuilders: joinBuilders));
+}
+
 class $$ShoppingCartsTableTableManager extends i0.RootTableManager<
     i0.GeneratedDatabase,
     i2.$ShoppingCartsTable,
@@ -199,7 +217,10 @@ class $$ShoppingCartsTableTableManager extends i0.RootTableManager<
     i2.$$ShoppingCartsTableOrderingComposer,
     $$ShoppingCartsTableCreateCompanionBuilder,
     $$ShoppingCartsTableUpdateCompanionBuilder,
-    (i2.ShoppingCart, $$ShoppingCartsTableWithReferences),
+    (
+      i2.ShoppingCart,
+      i0.BaseWithReferences<i0.GeneratedDatabase, i2.ShoppingCart>
+    ),
     i2.ShoppingCart> {
   $$ShoppingCartsTableTableManager(
       i0.GeneratedDatabase db, i2.$ShoppingCartsTable table)
@@ -210,9 +231,8 @@ class $$ShoppingCartsTableTableManager extends i0.RootTableManager<
               .$$ShoppingCartsTableFilterComposer(i0.ComposerState(db, table)),
           orderingComposer: i2.$$ShoppingCartsTableOrderingComposer(
               i0.ComposerState(db, table)),
-          withReferenceMapper: (p0) => p0
-              .map((e) => (e, $$ShoppingCartsTableWithReferences(db, e)))
-              .toList(),
+          withReferenceMapper: (p0) =>
+              p0.map((e) => (e, i0.BaseWithReferences(db, e))).toList(),
           updateCompanionCallback: ({
             i0.Value<int> id = const i0.Value.absent(),
           }) =>
@@ -236,34 +256,11 @@ typedef $$ShoppingCartsTableProcessedTableManager = i0.ProcessedTableManager<
     i2.$$ShoppingCartsTableOrderingComposer,
     $$ShoppingCartsTableCreateCompanionBuilder,
     $$ShoppingCartsTableUpdateCompanionBuilder,
-    (i2.ShoppingCart, $$ShoppingCartsTableWithReferences),
+    (
+      i2.ShoppingCart,
+      i0.BaseWithReferences<i0.GeneratedDatabase, i2.ShoppingCart>
+    ),
     i2.ShoppingCart>;
-
-class $$ShoppingCartsTableFilterComposer
-    extends i0.FilterComposer<i0.GeneratedDatabase, i2.$ShoppingCartsTable> {
-  $$ShoppingCartsTableFilterComposer(super.$state);
-  i0.ColumnFilters<int> get id => $state.composableBuilder(
-      column: $state.table.id,
-      builder: (column, joinBuilders) =>
-          i0.ColumnFilters(column, joinBuilders: joinBuilders));
-}
-
-class $$ShoppingCartsTableOrderingComposer
-    extends i0.OrderingComposer<i0.GeneratedDatabase, i2.$ShoppingCartsTable> {
-  $$ShoppingCartsTableOrderingComposer(super.$state);
-  i0.ColumnOrderings<int> get id => $state.composableBuilder(
-      column: $state.table.id,
-      builder: (column, joinBuilders) =>
-          i0.ColumnOrderings(column, joinBuilders: joinBuilders));
-}
-
-class $$ShoppingCartsTableWithReferences {
-  // ignore: unused_field
-  final i0.GeneratedDatabase _db;
-  // ignore: unused_field
-  final i2.ShoppingCart _item;
-  $$ShoppingCartsTableWithReferences(this._db, this._item);
-}
 
 class $ShoppingCartEntriesTable extends i3.ShoppingCartEntries
     with i0.TableInfo<$ShoppingCartEntriesTable, i2.ShoppingCartEntry> {
@@ -486,63 +483,6 @@ typedef $$ShoppingCartEntriesTableUpdateCompanionBuilder
   i0.Value<int> rowid,
 });
 
-class $$ShoppingCartEntriesTableTableManager extends i0.RootTableManager<
-    i0.GeneratedDatabase,
-    i2.$ShoppingCartEntriesTable,
-    i2.ShoppingCartEntry,
-    i2.$$ShoppingCartEntriesTableFilterComposer,
-    i2.$$ShoppingCartEntriesTableOrderingComposer,
-    $$ShoppingCartEntriesTableCreateCompanionBuilder,
-    $$ShoppingCartEntriesTableUpdateCompanionBuilder,
-    (i2.ShoppingCartEntry, $$ShoppingCartEntriesTableWithReferences),
-    i2.ShoppingCartEntry> {
-  $$ShoppingCartEntriesTableTableManager(
-      i0.GeneratedDatabase db, i2.$ShoppingCartEntriesTable table)
-      : super(i0.TableManagerState(
-          db: db,
-          table: table,
-          filteringComposer: i2.$$ShoppingCartEntriesTableFilterComposer(
-              i0.ComposerState(db, table)),
-          orderingComposer: i2.$$ShoppingCartEntriesTableOrderingComposer(
-              i0.ComposerState(db, table)),
-          withReferenceMapper: (p0) => p0
-              .map((e) => (e, $$ShoppingCartEntriesTableWithReferences(db, e)))
-              .toList(),
-          updateCompanionCallback: ({
-            i0.Value<int> shoppingCart = const i0.Value.absent(),
-            i0.Value<int> item = const i0.Value.absent(),
-            i0.Value<int> rowid = const i0.Value.absent(),
-          }) =>
-              i2.ShoppingCartEntriesCompanion(
-            shoppingCart: shoppingCart,
-            item: item,
-            rowid: rowid,
-          ),
-          createCompanionCallback: ({
-            required int shoppingCart,
-            required int item,
-            i0.Value<int> rowid = const i0.Value.absent(),
-          }) =>
-              i2.ShoppingCartEntriesCompanion.insert(
-            shoppingCart: shoppingCart,
-            item: item,
-            rowid: rowid,
-          ),
-        ));
-}
-
-typedef $$ShoppingCartEntriesTableProcessedTableManager
-    = i0.ProcessedTableManager<
-        i0.GeneratedDatabase,
-        i2.$ShoppingCartEntriesTable,
-        i2.ShoppingCartEntry,
-        i2.$$ShoppingCartEntriesTableFilterComposer,
-        i2.$$ShoppingCartEntriesTableOrderingComposer,
-        $$ShoppingCartEntriesTableCreateCompanionBuilder,
-        $$ShoppingCartEntriesTableUpdateCompanionBuilder,
-        (i2.ShoppingCartEntry, $$ShoppingCartEntriesTableWithReferences),
-        i2.ShoppingCartEntry>;
-
 class $$ShoppingCartEntriesTableFilterComposer extends i0
     .FilterComposer<i0.GeneratedDatabase, i2.$ShoppingCartEntriesTable> {
   $$ShoppingCartEntriesTableFilterComposer(super.$state);
@@ -625,10 +565,64 @@ class $$ShoppingCartEntriesTableOrderingComposer extends i0
   }
 }
 
-class $$ShoppingCartEntriesTableWithReferences {
-  // ignore: unused_field
-  final i0.GeneratedDatabase _db;
-  // ignore: unused_field
-  final i2.ShoppingCartEntry _item;
-  $$ShoppingCartEntriesTableWithReferences(this._db, this._item);
+class $$ShoppingCartEntriesTableTableManager extends i0.RootTableManager<
+    i0.GeneratedDatabase,
+    i2.$ShoppingCartEntriesTable,
+    i2.ShoppingCartEntry,
+    i2.$$ShoppingCartEntriesTableFilterComposer,
+    i2.$$ShoppingCartEntriesTableOrderingComposer,
+    $$ShoppingCartEntriesTableCreateCompanionBuilder,
+    $$ShoppingCartEntriesTableUpdateCompanionBuilder,
+    (
+      i2.ShoppingCartEntry,
+      i0.BaseWithReferences<i0.GeneratedDatabase, i2.ShoppingCartEntry>
+    ),
+    i2.ShoppingCartEntry> {
+  $$ShoppingCartEntriesTableTableManager(
+      i0.GeneratedDatabase db, i2.$ShoppingCartEntriesTable table)
+      : super(i0.TableManagerState(
+          db: db,
+          table: table,
+          filteringComposer: i2.$$ShoppingCartEntriesTableFilterComposer(
+              i0.ComposerState(db, table)),
+          orderingComposer: i2.$$ShoppingCartEntriesTableOrderingComposer(
+              i0.ComposerState(db, table)),
+          withReferenceMapper: (p0) =>
+              p0.map((e) => (e, i0.BaseWithReferences(db, e))).toList(),
+          updateCompanionCallback: ({
+            i0.Value<int> shoppingCart = const i0.Value.absent(),
+            i0.Value<int> item = const i0.Value.absent(),
+            i0.Value<int> rowid = const i0.Value.absent(),
+          }) =>
+              i2.ShoppingCartEntriesCompanion(
+            shoppingCart: shoppingCart,
+            item: item,
+            rowid: rowid,
+          ),
+          createCompanionCallback: ({
+            required int shoppingCart,
+            required int item,
+            i0.Value<int> rowid = const i0.Value.absent(),
+          }) =>
+              i2.ShoppingCartEntriesCompanion.insert(
+            shoppingCart: shoppingCart,
+            item: item,
+            rowid: rowid,
+          ),
+        ));
 }
+
+typedef $$ShoppingCartEntriesTableProcessedTableManager
+    = i0.ProcessedTableManager<
+        i0.GeneratedDatabase,
+        i2.$ShoppingCartEntriesTable,
+        i2.ShoppingCartEntry,
+        i2.$$ShoppingCartEntriesTableFilterComposer,
+        i2.$$ShoppingCartEntriesTableOrderingComposer,
+        $$ShoppingCartEntriesTableCreateCompanionBuilder,
+        $$ShoppingCartEntriesTableUpdateCompanionBuilder,
+        (
+          i2.ShoppingCartEntry,
+          i0.BaseWithReferences<i0.GeneratedDatabase, i2.ShoppingCartEntry>
+        ),
+        i2.ShoppingCartEntry>;

--- a/docs/lib/snippets/modular/many_to_many/relational.drift.dart
+++ b/docs/lib/snippets/modular/many_to_many/relational.drift.dart
@@ -260,6 +260,7 @@ class $$ShoppingCartsTableOrderingComposer
 class $$ShoppingCartsTableWithReferences {
   // ignore: unused_field
   final i0.GeneratedDatabase _db;
+  // ignore: unused_field
   final i2.ShoppingCart _item;
   $$ShoppingCartsTableWithReferences(this._db, this._item);
 }
@@ -627,6 +628,7 @@ class $$ShoppingCartEntriesTableOrderingComposer extends i0
 class $$ShoppingCartEntriesTableWithReferences {
   // ignore: unused_field
   final i0.GeneratedDatabase _db;
+  // ignore: unused_field
   final i2.ShoppingCartEntry _item;
   $$ShoppingCartEntriesTableWithReferences(this._db, this._item);
 }

--- a/docs/lib/snippets/modular/many_to_many/shared.drift.dart
+++ b/docs/lib/snippets/modular/many_to_many/shared.drift.dart
@@ -338,6 +338,7 @@ class $$BuyableItemsTableOrderingComposer
 class $$BuyableItemsTableWithReferences {
   // ignore: unused_field
   final i0.GeneratedDatabase _db;
+  // ignore: unused_field
   final i1.BuyableItem _item;
   $$BuyableItemsTableWithReferences(this._db, this._item);
 }

--- a/docs/lib/snippets/modular/many_to_many/shared.drift.dart
+++ b/docs/lib/snippets/modular/many_to_many/shared.drift.dart
@@ -241,62 +241,6 @@ typedef $$BuyableItemsTableUpdateCompanionBuilder = i1.BuyableItemsCompanion
   i0.Value<int> price,
 });
 
-class $$BuyableItemsTableTableManager extends i0.RootTableManager<
-    i0.GeneratedDatabase,
-    i1.$BuyableItemsTable,
-    i1.BuyableItem,
-    i1.$$BuyableItemsTableFilterComposer,
-    i1.$$BuyableItemsTableOrderingComposer,
-    $$BuyableItemsTableCreateCompanionBuilder,
-    $$BuyableItemsTableUpdateCompanionBuilder,
-    (i1.BuyableItem, $$BuyableItemsTableWithReferences),
-    i1.BuyableItem> {
-  $$BuyableItemsTableTableManager(
-      i0.GeneratedDatabase db, i1.$BuyableItemsTable table)
-      : super(i0.TableManagerState(
-          db: db,
-          table: table,
-          filteringComposer:
-              i1.$$BuyableItemsTableFilterComposer(i0.ComposerState(db, table)),
-          orderingComposer: i1
-              .$$BuyableItemsTableOrderingComposer(i0.ComposerState(db, table)),
-          withReferenceMapper: (p0) => p0
-              .map((e) => (e, $$BuyableItemsTableWithReferences(db, e)))
-              .toList(),
-          updateCompanionCallback: ({
-            i0.Value<int> id = const i0.Value.absent(),
-            i0.Value<String> description = const i0.Value.absent(),
-            i0.Value<int> price = const i0.Value.absent(),
-          }) =>
-              i1.BuyableItemsCompanion(
-            id: id,
-            description: description,
-            price: price,
-          ),
-          createCompanionCallback: ({
-            i0.Value<int> id = const i0.Value.absent(),
-            required String description,
-            required int price,
-          }) =>
-              i1.BuyableItemsCompanion.insert(
-            id: id,
-            description: description,
-            price: price,
-          ),
-        ));
-}
-
-typedef $$BuyableItemsTableProcessedTableManager = i0.ProcessedTableManager<
-    i0.GeneratedDatabase,
-    i1.$BuyableItemsTable,
-    i1.BuyableItem,
-    i1.$$BuyableItemsTableFilterComposer,
-    i1.$$BuyableItemsTableOrderingComposer,
-    $$BuyableItemsTableCreateCompanionBuilder,
-    $$BuyableItemsTableUpdateCompanionBuilder,
-    (i1.BuyableItem, $$BuyableItemsTableWithReferences),
-    i1.BuyableItem>;
-
 class $$BuyableItemsTableFilterComposer
     extends i0.FilterComposer<i0.GeneratedDatabase, i1.$BuyableItemsTable> {
   $$BuyableItemsTableFilterComposer(super.$state);
@@ -335,10 +279,63 @@ class $$BuyableItemsTableOrderingComposer
           i0.ColumnOrderings(column, joinBuilders: joinBuilders));
 }
 
-class $$BuyableItemsTableWithReferences {
-  // ignore: unused_field
-  final i0.GeneratedDatabase _db;
-  // ignore: unused_field
-  final i1.BuyableItem _item;
-  $$BuyableItemsTableWithReferences(this._db, this._item);
+class $$BuyableItemsTableTableManager extends i0.RootTableManager<
+    i0.GeneratedDatabase,
+    i1.$BuyableItemsTable,
+    i1.BuyableItem,
+    i1.$$BuyableItemsTableFilterComposer,
+    i1.$$BuyableItemsTableOrderingComposer,
+    $$BuyableItemsTableCreateCompanionBuilder,
+    $$BuyableItemsTableUpdateCompanionBuilder,
+    (
+      i1.BuyableItem,
+      i0.BaseWithReferences<i0.GeneratedDatabase, i1.BuyableItem>
+    ),
+    i1.BuyableItem> {
+  $$BuyableItemsTableTableManager(
+      i0.GeneratedDatabase db, i1.$BuyableItemsTable table)
+      : super(i0.TableManagerState(
+          db: db,
+          table: table,
+          filteringComposer:
+              i1.$$BuyableItemsTableFilterComposer(i0.ComposerState(db, table)),
+          orderingComposer: i1
+              .$$BuyableItemsTableOrderingComposer(i0.ComposerState(db, table)),
+          withReferenceMapper: (p0) =>
+              p0.map((e) => (e, i0.BaseWithReferences(db, e))).toList(),
+          updateCompanionCallback: ({
+            i0.Value<int> id = const i0.Value.absent(),
+            i0.Value<String> description = const i0.Value.absent(),
+            i0.Value<int> price = const i0.Value.absent(),
+          }) =>
+              i1.BuyableItemsCompanion(
+            id: id,
+            description: description,
+            price: price,
+          ),
+          createCompanionCallback: ({
+            i0.Value<int> id = const i0.Value.absent(),
+            required String description,
+            required int price,
+          }) =>
+              i1.BuyableItemsCompanion.insert(
+            id: id,
+            description: description,
+            price: price,
+          ),
+        ));
 }
+
+typedef $$BuyableItemsTableProcessedTableManager = i0.ProcessedTableManager<
+    i0.GeneratedDatabase,
+    i1.$BuyableItemsTable,
+    i1.BuyableItem,
+    i1.$$BuyableItemsTableFilterComposer,
+    i1.$$BuyableItemsTableOrderingComposer,
+    $$BuyableItemsTableCreateCompanionBuilder,
+    $$BuyableItemsTableUpdateCompanionBuilder,
+    (
+      i1.BuyableItem,
+      i0.BaseWithReferences<i0.GeneratedDatabase, i1.BuyableItem>
+    ),
+    i1.BuyableItem>;

--- a/docs/lib/snippets/modular/many_to_many/shared.drift.dart
+++ b/docs/lib/snippets/modular/many_to_many/shared.drift.dart
@@ -249,7 +249,7 @@ class $$BuyableItemsTableTableManager extends i0.RootTableManager<
     i1.$$BuyableItemsTableOrderingComposer,
     $$BuyableItemsTableCreateCompanionBuilder,
     $$BuyableItemsTableUpdateCompanionBuilder,
-    $$BuyableItemsTableWithReferences,
+    (i1.BuyableItem, $$BuyableItemsTableWithReferences),
     i1.BuyableItem> {
   $$BuyableItemsTableTableManager(
       i0.GeneratedDatabase db, i1.$BuyableItemsTable table)
@@ -260,8 +260,9 @@ class $$BuyableItemsTableTableManager extends i0.RootTableManager<
               i1.$$BuyableItemsTableFilterComposer(i0.ComposerState(db, table)),
           orderingComposer: i1
               .$$BuyableItemsTableOrderingComposer(i0.ComposerState(db, table)),
-          withReferenceMapper: (p0) =>
-              p0.map((e) => $$BuyableItemsTableWithReferences(db, e)).toList(),
+          withReferenceMapper: (p0) => p0
+              .map((e) => (e, $$BuyableItemsTableWithReferences(db, e)))
+              .toList(),
           updateCompanionCallback: ({
             i0.Value<int> id = const i0.Value.absent(),
             i0.Value<String> description = const i0.Value.absent(),
@@ -293,7 +294,7 @@ typedef $$BuyableItemsTableProcessedTableManager = i0.ProcessedTableManager<
     i1.$$BuyableItemsTableOrderingComposer,
     $$BuyableItemsTableCreateCompanionBuilder,
     $$BuyableItemsTableUpdateCompanionBuilder,
-    $$BuyableItemsTableWithReferences,
+    (i1.BuyableItem, $$BuyableItemsTableWithReferences),
     i1.BuyableItem>;
 
 class $$BuyableItemsTableFilterComposer
@@ -337,6 +338,6 @@ class $$BuyableItemsTableOrderingComposer
 class $$BuyableItemsTableWithReferences {
   // ignore: unused_field
   final i0.GeneratedDatabase _db;
-  final i1.BuyableItem i1BuyableItem;
-  $$BuyableItemsTableWithReferences(this._db, this.i1BuyableItem);
+  final i1.BuyableItem _item;
+  $$BuyableItemsTableWithReferences(this._db, this._item);
 }

--- a/docs/lib/snippets/modular/many_to_many/shared.drift.dart
+++ b/docs/lib/snippets/modular/many_to_many/shared.drift.dart
@@ -248,7 +248,9 @@ class $$BuyableItemsTableTableManager extends i0.RootTableManager<
     i1.$$BuyableItemsTableFilterComposer,
     i1.$$BuyableItemsTableOrderingComposer,
     $$BuyableItemsTableCreateCompanionBuilder,
-    $$BuyableItemsTableUpdateCompanionBuilder> {
+    $$BuyableItemsTableUpdateCompanionBuilder,
+    $$BuyableItemsTableWithReferences,
+    i1.BuyableItem> {
   $$BuyableItemsTableTableManager(
       i0.GeneratedDatabase db, i1.$BuyableItemsTable table)
       : super(i0.TableManagerState(
@@ -258,6 +260,8 @@ class $$BuyableItemsTableTableManager extends i0.RootTableManager<
               i1.$$BuyableItemsTableFilterComposer(i0.ComposerState(db, table)),
           orderingComposer: i1
               .$$BuyableItemsTableOrderingComposer(i0.ComposerState(db, table)),
+          dataclassMapper: (p0) async =>
+              p0.map((e) => $$BuyableItemsTableWithReferences(db, e)).toList(),
           updateCompanionCallback: ({
             i0.Value<int> id = const i0.Value.absent(),
             i0.Value<String> description = const i0.Value.absent(),
@@ -280,6 +284,17 @@ class $$BuyableItemsTableTableManager extends i0.RootTableManager<
           ),
         ));
 }
+
+typedef $$BuyableItemsTableProcessedTableManager = i0.ProcessedTableManager<
+    i0.GeneratedDatabase,
+    i1.$BuyableItemsTable,
+    i1.BuyableItem,
+    i1.$$BuyableItemsTableFilterComposer,
+    i1.$$BuyableItemsTableOrderingComposer,
+    $$BuyableItemsTableCreateCompanionBuilder,
+    $$BuyableItemsTableUpdateCompanionBuilder,
+    $$BuyableItemsTableWithReferences,
+    i1.BuyableItem>;
 
 class $$BuyableItemsTableFilterComposer
     extends i0.FilterComposer<i0.GeneratedDatabase, i1.$BuyableItemsTable> {
@@ -317,4 +332,11 @@ class $$BuyableItemsTableOrderingComposer
       column: $state.table.price,
       builder: (column, joinBuilders) =>
           i0.ColumnOrderings(column, joinBuilders: joinBuilders));
+}
+
+class $$BuyableItemsTableWithReferences {
+  // ignore: unused_field
+  final i0.GeneratedDatabase _db;
+  final i1.BuyableItem i1BuyableItem;
+  $$BuyableItemsTableWithReferences(this._db, this.i1BuyableItem);
 }

--- a/docs/lib/snippets/modular/many_to_many/shared.drift.dart
+++ b/docs/lib/snippets/modular/many_to_many/shared.drift.dart
@@ -260,7 +260,7 @@ class $$BuyableItemsTableTableManager extends i0.RootTableManager<
               i1.$$BuyableItemsTableFilterComposer(i0.ComposerState(db, table)),
           orderingComposer: i1
               .$$BuyableItemsTableOrderingComposer(i0.ComposerState(db, table)),
-          dataclassMapper: (p0) async =>
+          withReferenceMapper: (p0) =>
               p0.map((e) => $$BuyableItemsTableWithReferences(db, e)).toList(),
           updateCompanionCallback: ({
             i0.Value<int> id = const i0.Value.absent(),

--- a/docs/lib/snippets/modular/upserts.drift.dart
+++ b/docs/lib/snippets/modular/upserts.drift.dart
@@ -290,6 +290,7 @@ class $$WordsTableOrderingComposer
 class $$WordsTableWithReferences {
   // ignore: unused_field
   final i0.GeneratedDatabase _db;
+  // ignore: unused_field
   final i1.Word _item;
   $$WordsTableWithReferences(this._db, this._item);
 }
@@ -687,6 +688,7 @@ class $$MatchResultsTableOrderingComposer
 class $$MatchResultsTableWithReferences {
   // ignore: unused_field
   final i0.GeneratedDatabase _db;
+  // ignore: unused_field
   final i1.MatchResult _item;
   $$MatchResultsTableWithReferences(this._db, this._item);
 }

--- a/docs/lib/snippets/modular/upserts.drift.dart
+++ b/docs/lib/snippets/modular/upserts.drift.dart
@@ -223,7 +223,7 @@ class $$WordsTableTableManager extends i0.RootTableManager<
               i1.$$WordsTableFilterComposer(i0.ComposerState(db, table)),
           orderingComposer:
               i1.$$WordsTableOrderingComposer(i0.ComposerState(db, table)),
-          dataclassMapper: (p0) async =>
+          withReferenceMapper: (p0) =>
               p0.map((e) => $$WordsTableWithReferences(db, e)).toList(),
           updateCompanionCallback: ({
             i0.Value<String> word = const i0.Value.absent(),
@@ -595,7 +595,7 @@ class $$MatchResultsTableTableManager extends i0.RootTableManager<
               i1.$$MatchResultsTableFilterComposer(i0.ComposerState(db, table)),
           orderingComposer: i1
               .$$MatchResultsTableOrderingComposer(i0.ComposerState(db, table)),
-          dataclassMapper: (p0) async =>
+          withReferenceMapper: (p0) =>
               p0.map((e) => $$MatchResultsTableWithReferences(db, e)).toList(),
           updateCompanionCallback: ({
             i0.Value<int> id = const i0.Value.absent(),

--- a/docs/lib/snippets/modular/upserts.drift.dart
+++ b/docs/lib/snippets/modular/upserts.drift.dart
@@ -213,7 +213,7 @@ class $$WordsTableTableManager extends i0.RootTableManager<
     i1.$$WordsTableOrderingComposer,
     $$WordsTableCreateCompanionBuilder,
     $$WordsTableUpdateCompanionBuilder,
-    $$WordsTableWithReferences,
+    (i1.Word, $$WordsTableWithReferences),
     i1.Word> {
   $$WordsTableTableManager(i0.GeneratedDatabase db, i1.$WordsTable table)
       : super(i0.TableManagerState(
@@ -224,7 +224,7 @@ class $$WordsTableTableManager extends i0.RootTableManager<
           orderingComposer:
               i1.$$WordsTableOrderingComposer(i0.ComposerState(db, table)),
           withReferenceMapper: (p0) =>
-              p0.map((e) => $$WordsTableWithReferences(db, e)).toList(),
+              p0.map((e) => (e, $$WordsTableWithReferences(db, e))).toList(),
           updateCompanionCallback: ({
             i0.Value<String> word = const i0.Value.absent(),
             i0.Value<int> usages = const i0.Value.absent(),
@@ -256,7 +256,7 @@ typedef $$WordsTableProcessedTableManager = i0.ProcessedTableManager<
     i1.$$WordsTableOrderingComposer,
     $$WordsTableCreateCompanionBuilder,
     $$WordsTableUpdateCompanionBuilder,
-    $$WordsTableWithReferences,
+    (i1.Word, $$WordsTableWithReferences),
     i1.Word>;
 
 class $$WordsTableFilterComposer
@@ -290,8 +290,8 @@ class $$WordsTableOrderingComposer
 class $$WordsTableWithReferences {
   // ignore: unused_field
   final i0.GeneratedDatabase _db;
-  final i1.Word i1Word;
-  $$WordsTableWithReferences(this._db, this.i1Word);
+  final i1.Word _item;
+  $$WordsTableWithReferences(this._db, this._item);
 }
 
 class $MatchResultsTable extends i2.MatchResults
@@ -584,7 +584,7 @@ class $$MatchResultsTableTableManager extends i0.RootTableManager<
     i1.$$MatchResultsTableOrderingComposer,
     $$MatchResultsTableCreateCompanionBuilder,
     $$MatchResultsTableUpdateCompanionBuilder,
-    $$MatchResultsTableWithReferences,
+    (i1.MatchResult, $$MatchResultsTableWithReferences),
     i1.MatchResult> {
   $$MatchResultsTableTableManager(
       i0.GeneratedDatabase db, i1.$MatchResultsTable table)
@@ -595,8 +595,9 @@ class $$MatchResultsTableTableManager extends i0.RootTableManager<
               i1.$$MatchResultsTableFilterComposer(i0.ComposerState(db, table)),
           orderingComposer: i1
               .$$MatchResultsTableOrderingComposer(i0.ComposerState(db, table)),
-          withReferenceMapper: (p0) =>
-              p0.map((e) => $$MatchResultsTableWithReferences(db, e)).toList(),
+          withReferenceMapper: (p0) => p0
+              .map((e) => (e, $$MatchResultsTableWithReferences(db, e)))
+              .toList(),
           updateCompanionCallback: ({
             i0.Value<int> id = const i0.Value.absent(),
             i0.Value<String> teamA = const i0.Value.absent(),
@@ -632,7 +633,7 @@ typedef $$MatchResultsTableProcessedTableManager = i0.ProcessedTableManager<
     i1.$$MatchResultsTableOrderingComposer,
     $$MatchResultsTableCreateCompanionBuilder,
     $$MatchResultsTableUpdateCompanionBuilder,
-    $$MatchResultsTableWithReferences,
+    (i1.MatchResult, $$MatchResultsTableWithReferences),
     i1.MatchResult>;
 
 class $$MatchResultsTableFilterComposer
@@ -686,6 +687,6 @@ class $$MatchResultsTableOrderingComposer
 class $$MatchResultsTableWithReferences {
   // ignore: unused_field
   final i0.GeneratedDatabase _db;
-  final i1.MatchResult i1MatchResult;
-  $$MatchResultsTableWithReferences(this._db, this.i1MatchResult);
+  final i1.MatchResult _item;
+  $$MatchResultsTableWithReferences(this._db, this._item);
 }

--- a/docs/lib/snippets/modular/upserts.drift.dart
+++ b/docs/lib/snippets/modular/upserts.drift.dart
@@ -205,6 +205,34 @@ typedef $$WordsTableUpdateCompanionBuilder = i1.WordsCompanion Function({
   i0.Value<int> rowid,
 });
 
+class $$WordsTableFilterComposer
+    extends i0.FilterComposer<i0.GeneratedDatabase, i1.$WordsTable> {
+  $$WordsTableFilterComposer(super.$state);
+  i0.ColumnFilters<String> get word => $state.composableBuilder(
+      column: $state.table.word,
+      builder: (column, joinBuilders) =>
+          i0.ColumnFilters(column, joinBuilders: joinBuilders));
+
+  i0.ColumnFilters<int> get usages => $state.composableBuilder(
+      column: $state.table.usages,
+      builder: (column, joinBuilders) =>
+          i0.ColumnFilters(column, joinBuilders: joinBuilders));
+}
+
+class $$WordsTableOrderingComposer
+    extends i0.OrderingComposer<i0.GeneratedDatabase, i1.$WordsTable> {
+  $$WordsTableOrderingComposer(super.$state);
+  i0.ColumnOrderings<String> get word => $state.composableBuilder(
+      column: $state.table.word,
+      builder: (column, joinBuilders) =>
+          i0.ColumnOrderings(column, joinBuilders: joinBuilders));
+
+  i0.ColumnOrderings<int> get usages => $state.composableBuilder(
+      column: $state.table.usages,
+      builder: (column, joinBuilders) =>
+          i0.ColumnOrderings(column, joinBuilders: joinBuilders));
+}
+
 class $$WordsTableTableManager extends i0.RootTableManager<
     i0.GeneratedDatabase,
     i1.$WordsTable,
@@ -213,7 +241,7 @@ class $$WordsTableTableManager extends i0.RootTableManager<
     i1.$$WordsTableOrderingComposer,
     $$WordsTableCreateCompanionBuilder,
     $$WordsTableUpdateCompanionBuilder,
-    (i1.Word, $$WordsTableWithReferences),
+    (i1.Word, i0.BaseWithReferences<i0.GeneratedDatabase, i1.Word>),
     i1.Word> {
   $$WordsTableTableManager(i0.GeneratedDatabase db, i1.$WordsTable table)
       : super(i0.TableManagerState(
@@ -224,7 +252,7 @@ class $$WordsTableTableManager extends i0.RootTableManager<
           orderingComposer:
               i1.$$WordsTableOrderingComposer(i0.ComposerState(db, table)),
           withReferenceMapper: (p0) =>
-              p0.map((e) => (e, $$WordsTableWithReferences(db, e))).toList(),
+              p0.map((e) => (e, i0.BaseWithReferences(db, e))).toList(),
           updateCompanionCallback: ({
             i0.Value<String> word = const i0.Value.absent(),
             i0.Value<int> usages = const i0.Value.absent(),
@@ -256,44 +284,8 @@ typedef $$WordsTableProcessedTableManager = i0.ProcessedTableManager<
     i1.$$WordsTableOrderingComposer,
     $$WordsTableCreateCompanionBuilder,
     $$WordsTableUpdateCompanionBuilder,
-    (i1.Word, $$WordsTableWithReferences),
+    (i1.Word, i0.BaseWithReferences<i0.GeneratedDatabase, i1.Word>),
     i1.Word>;
-
-class $$WordsTableFilterComposer
-    extends i0.FilterComposer<i0.GeneratedDatabase, i1.$WordsTable> {
-  $$WordsTableFilterComposer(super.$state);
-  i0.ColumnFilters<String> get word => $state.composableBuilder(
-      column: $state.table.word,
-      builder: (column, joinBuilders) =>
-          i0.ColumnFilters(column, joinBuilders: joinBuilders));
-
-  i0.ColumnFilters<int> get usages => $state.composableBuilder(
-      column: $state.table.usages,
-      builder: (column, joinBuilders) =>
-          i0.ColumnFilters(column, joinBuilders: joinBuilders));
-}
-
-class $$WordsTableOrderingComposer
-    extends i0.OrderingComposer<i0.GeneratedDatabase, i1.$WordsTable> {
-  $$WordsTableOrderingComposer(super.$state);
-  i0.ColumnOrderings<String> get word => $state.composableBuilder(
-      column: $state.table.word,
-      builder: (column, joinBuilders) =>
-          i0.ColumnOrderings(column, joinBuilders: joinBuilders));
-
-  i0.ColumnOrderings<int> get usages => $state.composableBuilder(
-      column: $state.table.usages,
-      builder: (column, joinBuilders) =>
-          i0.ColumnOrderings(column, joinBuilders: joinBuilders));
-}
-
-class $$WordsTableWithReferences {
-  // ignore: unused_field
-  final i0.GeneratedDatabase _db;
-  // ignore: unused_field
-  final i1.Word _item;
-  $$WordsTableWithReferences(this._db, this._item);
-}
 
 class $MatchResultsTable extends i2.MatchResults
     with i0.TableInfo<$MatchResultsTable, i1.MatchResult> {
@@ -577,66 +569,6 @@ typedef $$MatchResultsTableUpdateCompanionBuilder = i1.MatchResultsCompanion
   i0.Value<bool> teamAWon,
 });
 
-class $$MatchResultsTableTableManager extends i0.RootTableManager<
-    i0.GeneratedDatabase,
-    i1.$MatchResultsTable,
-    i1.MatchResult,
-    i1.$$MatchResultsTableFilterComposer,
-    i1.$$MatchResultsTableOrderingComposer,
-    $$MatchResultsTableCreateCompanionBuilder,
-    $$MatchResultsTableUpdateCompanionBuilder,
-    (i1.MatchResult, $$MatchResultsTableWithReferences),
-    i1.MatchResult> {
-  $$MatchResultsTableTableManager(
-      i0.GeneratedDatabase db, i1.$MatchResultsTable table)
-      : super(i0.TableManagerState(
-          db: db,
-          table: table,
-          filteringComposer:
-              i1.$$MatchResultsTableFilterComposer(i0.ComposerState(db, table)),
-          orderingComposer: i1
-              .$$MatchResultsTableOrderingComposer(i0.ComposerState(db, table)),
-          withReferenceMapper: (p0) => p0
-              .map((e) => (e, $$MatchResultsTableWithReferences(db, e)))
-              .toList(),
-          updateCompanionCallback: ({
-            i0.Value<int> id = const i0.Value.absent(),
-            i0.Value<String> teamA = const i0.Value.absent(),
-            i0.Value<String> teamB = const i0.Value.absent(),
-            i0.Value<bool> teamAWon = const i0.Value.absent(),
-          }) =>
-              i1.MatchResultsCompanion(
-            id: id,
-            teamA: teamA,
-            teamB: teamB,
-            teamAWon: teamAWon,
-          ),
-          createCompanionCallback: ({
-            i0.Value<int> id = const i0.Value.absent(),
-            required String teamA,
-            required String teamB,
-            required bool teamAWon,
-          }) =>
-              i1.MatchResultsCompanion.insert(
-            id: id,
-            teamA: teamA,
-            teamB: teamB,
-            teamAWon: teamAWon,
-          ),
-        ));
-}
-
-typedef $$MatchResultsTableProcessedTableManager = i0.ProcessedTableManager<
-    i0.GeneratedDatabase,
-    i1.$MatchResultsTable,
-    i1.MatchResult,
-    i1.$$MatchResultsTableFilterComposer,
-    i1.$$MatchResultsTableOrderingComposer,
-    $$MatchResultsTableCreateCompanionBuilder,
-    $$MatchResultsTableUpdateCompanionBuilder,
-    (i1.MatchResult, $$MatchResultsTableWithReferences),
-    i1.MatchResult>;
-
 class $$MatchResultsTableFilterComposer
     extends i0.FilterComposer<i0.GeneratedDatabase, i1.$MatchResultsTable> {
   $$MatchResultsTableFilterComposer(super.$state);
@@ -685,10 +617,67 @@ class $$MatchResultsTableOrderingComposer
           i0.ColumnOrderings(column, joinBuilders: joinBuilders));
 }
 
-class $$MatchResultsTableWithReferences {
-  // ignore: unused_field
-  final i0.GeneratedDatabase _db;
-  // ignore: unused_field
-  final i1.MatchResult _item;
-  $$MatchResultsTableWithReferences(this._db, this._item);
+class $$MatchResultsTableTableManager extends i0.RootTableManager<
+    i0.GeneratedDatabase,
+    i1.$MatchResultsTable,
+    i1.MatchResult,
+    i1.$$MatchResultsTableFilterComposer,
+    i1.$$MatchResultsTableOrderingComposer,
+    $$MatchResultsTableCreateCompanionBuilder,
+    $$MatchResultsTableUpdateCompanionBuilder,
+    (
+      i1.MatchResult,
+      i0.BaseWithReferences<i0.GeneratedDatabase, i1.MatchResult>
+    ),
+    i1.MatchResult> {
+  $$MatchResultsTableTableManager(
+      i0.GeneratedDatabase db, i1.$MatchResultsTable table)
+      : super(i0.TableManagerState(
+          db: db,
+          table: table,
+          filteringComposer:
+              i1.$$MatchResultsTableFilterComposer(i0.ComposerState(db, table)),
+          orderingComposer: i1
+              .$$MatchResultsTableOrderingComposer(i0.ComposerState(db, table)),
+          withReferenceMapper: (p0) =>
+              p0.map((e) => (e, i0.BaseWithReferences(db, e))).toList(),
+          updateCompanionCallback: ({
+            i0.Value<int> id = const i0.Value.absent(),
+            i0.Value<String> teamA = const i0.Value.absent(),
+            i0.Value<String> teamB = const i0.Value.absent(),
+            i0.Value<bool> teamAWon = const i0.Value.absent(),
+          }) =>
+              i1.MatchResultsCompanion(
+            id: id,
+            teamA: teamA,
+            teamB: teamB,
+            teamAWon: teamAWon,
+          ),
+          createCompanionCallback: ({
+            i0.Value<int> id = const i0.Value.absent(),
+            required String teamA,
+            required String teamB,
+            required bool teamAWon,
+          }) =>
+              i1.MatchResultsCompanion.insert(
+            id: id,
+            teamA: teamA,
+            teamB: teamB,
+            teamAWon: teamAWon,
+          ),
+        ));
 }
+
+typedef $$MatchResultsTableProcessedTableManager = i0.ProcessedTableManager<
+    i0.GeneratedDatabase,
+    i1.$MatchResultsTable,
+    i1.MatchResult,
+    i1.$$MatchResultsTableFilterComposer,
+    i1.$$MatchResultsTableOrderingComposer,
+    $$MatchResultsTableCreateCompanionBuilder,
+    $$MatchResultsTableUpdateCompanionBuilder,
+    (
+      i1.MatchResult,
+      i0.BaseWithReferences<i0.GeneratedDatabase, i1.MatchResult>
+    ),
+    i1.MatchResult>;

--- a/docs/lib/snippets/modular/upserts.drift.dart
+++ b/docs/lib/snippets/modular/upserts.drift.dart
@@ -212,7 +212,9 @@ class $$WordsTableTableManager extends i0.RootTableManager<
     i1.$$WordsTableFilterComposer,
     i1.$$WordsTableOrderingComposer,
     $$WordsTableCreateCompanionBuilder,
-    $$WordsTableUpdateCompanionBuilder> {
+    $$WordsTableUpdateCompanionBuilder,
+    $$WordsTableWithReferences,
+    i1.Word> {
   $$WordsTableTableManager(i0.GeneratedDatabase db, i1.$WordsTable table)
       : super(i0.TableManagerState(
           db: db,
@@ -221,6 +223,8 @@ class $$WordsTableTableManager extends i0.RootTableManager<
               i1.$$WordsTableFilterComposer(i0.ComposerState(db, table)),
           orderingComposer:
               i1.$$WordsTableOrderingComposer(i0.ComposerState(db, table)),
+          dataclassMapper: (p0) async =>
+              p0.map((e) => $$WordsTableWithReferences(db, e)).toList(),
           updateCompanionCallback: ({
             i0.Value<String> word = const i0.Value.absent(),
             i0.Value<int> usages = const i0.Value.absent(),
@@ -243,6 +247,17 @@ class $$WordsTableTableManager extends i0.RootTableManager<
           ),
         ));
 }
+
+typedef $$WordsTableProcessedTableManager = i0.ProcessedTableManager<
+    i0.GeneratedDatabase,
+    i1.$WordsTable,
+    i1.Word,
+    i1.$$WordsTableFilterComposer,
+    i1.$$WordsTableOrderingComposer,
+    $$WordsTableCreateCompanionBuilder,
+    $$WordsTableUpdateCompanionBuilder,
+    $$WordsTableWithReferences,
+    i1.Word>;
 
 class $$WordsTableFilterComposer
     extends i0.FilterComposer<i0.GeneratedDatabase, i1.$WordsTable> {
@@ -270,6 +285,13 @@ class $$WordsTableOrderingComposer
       column: $state.table.usages,
       builder: (column, joinBuilders) =>
           i0.ColumnOrderings(column, joinBuilders: joinBuilders));
+}
+
+class $$WordsTableWithReferences {
+  // ignore: unused_field
+  final i0.GeneratedDatabase _db;
+  final i1.Word i1Word;
+  $$WordsTableWithReferences(this._db, this.i1Word);
 }
 
 class $MatchResultsTable extends i2.MatchResults
@@ -561,7 +583,9 @@ class $$MatchResultsTableTableManager extends i0.RootTableManager<
     i1.$$MatchResultsTableFilterComposer,
     i1.$$MatchResultsTableOrderingComposer,
     $$MatchResultsTableCreateCompanionBuilder,
-    $$MatchResultsTableUpdateCompanionBuilder> {
+    $$MatchResultsTableUpdateCompanionBuilder,
+    $$MatchResultsTableWithReferences,
+    i1.MatchResult> {
   $$MatchResultsTableTableManager(
       i0.GeneratedDatabase db, i1.$MatchResultsTable table)
       : super(i0.TableManagerState(
@@ -571,6 +595,8 @@ class $$MatchResultsTableTableManager extends i0.RootTableManager<
               i1.$$MatchResultsTableFilterComposer(i0.ComposerState(db, table)),
           orderingComposer: i1
               .$$MatchResultsTableOrderingComposer(i0.ComposerState(db, table)),
+          dataclassMapper: (p0) async =>
+              p0.map((e) => $$MatchResultsTableWithReferences(db, e)).toList(),
           updateCompanionCallback: ({
             i0.Value<int> id = const i0.Value.absent(),
             i0.Value<String> teamA = const i0.Value.absent(),
@@ -597,6 +623,17 @@ class $$MatchResultsTableTableManager extends i0.RootTableManager<
           ),
         ));
 }
+
+typedef $$MatchResultsTableProcessedTableManager = i0.ProcessedTableManager<
+    i0.GeneratedDatabase,
+    i1.$MatchResultsTable,
+    i1.MatchResult,
+    i1.$$MatchResultsTableFilterComposer,
+    i1.$$MatchResultsTableOrderingComposer,
+    $$MatchResultsTableCreateCompanionBuilder,
+    $$MatchResultsTableUpdateCompanionBuilder,
+    $$MatchResultsTableWithReferences,
+    i1.MatchResult>;
 
 class $$MatchResultsTableFilterComposer
     extends i0.FilterComposer<i0.GeneratedDatabase, i1.$MatchResultsTable> {
@@ -644,4 +681,11 @@ class $$MatchResultsTableOrderingComposer
       column: $state.table.teamAWon,
       builder: (column, joinBuilders) =>
           i0.ColumnOrderings(column, joinBuilders: joinBuilders));
+}
+
+class $$MatchResultsTableWithReferences {
+  // ignore: unused_field
+  final i0.GeneratedDatabase _db;
+  final i1.MatchResult i1MatchResult;
+  $$MatchResultsTableWithReferences(this._db, this.i1MatchResult);
 }

--- a/docs/pages/docs/Dart API/manager.md
+++ b/docs/pages/docs/Dart API/manager.md
@@ -38,6 +38,25 @@ Type specific filters for `int`, `double`, `Int64`, `DateTime` and `String` are 
 
 {% include "blocks/snippet" snippets = snippets name = 'manager_type_specific_filter' %}
 
+### Reading references
+It's quite common that when looking up a single row, you also want to read related rows from other tables.  
+
+The `withReferences` method can be used to read references from multiple tables.
+It return the row along with prepared managers which have the correct filters applied.
+
+Foe example, if you wanted to read a `TodoItem`, and automatically read the `Category` that it belongs to, you could do the following:
+
+{% include "blocks/snippet" snippets = snippets name = 'manager_with_refs' %}
+
+
+{% block "blocks/alert" title="N+1 Performance" color="warning" %}
+Beware of creating too many queries when using `withReferences`.
+If you were to query all `TodoItems` and then read the `Category` for each item, you could potentially create a large number of queries.  
+
+{% include "blocks/snippet" snippets = snippets name = 'manager_with_refs_n_plus_1' %}
+
+If there were 1000 `TodoItems`, you would create 1001 queries, which would grind your application to a halt. Future versions of drift will include a way to mitigate this issue.
+{% endblock %}
 
 ### Filtering across tables
 You can filter across references to other tables by using the generated reference filters. You can nest these as deep as you'd like and the manager will take care of adding the aliased joins behind the scenes.

--- a/drift/example/main.g.dart
+++ b/drift/example/main.g.dart
@@ -820,6 +820,7 @@ class $$TodoCategoriesTableOrderingComposer
 class $$TodoCategoriesTableWithReferences {
   // ignore: unused_field
   final _$Database _db;
+  // ignore: unused_field
   final TodoCategory _item;
   $$TodoCategoriesTableWithReferences(this._db, this._item);
 
@@ -977,6 +978,7 @@ class $$TodoItemsTableOrderingComposer
 class $$TodoItemsTableWithReferences {
   // ignore: unused_field
   final _$Database _db;
+  // ignore: unused_field
   final TodoItem _item;
   $$TodoItemsTableWithReferences(this._db, this._item);
 

--- a/drift/example/main.g.dart
+++ b/drift/example/main.g.dart
@@ -743,7 +743,7 @@ class $$TodoCategoriesTableTableManager extends RootTableManager<
               $$TodoCategoriesTableFilterComposer(ComposerState(db, table)),
           orderingComposer:
               $$TodoCategoriesTableOrderingComposer(ComposerState(db, table)),
-          dataclassMapper: (p0) async => p0
+          withReferenceMapper: (p0) => p0
               .map((e) => $$TodoCategoriesTableWithReferences(db, e))
               .toList(),
           updateCompanionCallback: ({
@@ -860,7 +860,7 @@ class $$TodoItemsTableTableManager extends RootTableManager<
               $$TodoItemsTableFilterComposer(ComposerState(db, table)),
           orderingComposer:
               $$TodoItemsTableOrderingComposer(ComposerState(db, table)),
-          dataclassMapper: (p0) async =>
+          withReferenceMapper: (p0) =>
               p0.map((e) => $$TodoItemsTableWithReferences(db, e)).toList(),
           updateCompanionCallback: ({
             Value<int> id = const Value.absent(),

--- a/drift/example/main.g.dart
+++ b/drift/example/main.g.dart
@@ -725,6 +725,57 @@ typedef $$TodoCategoriesTableUpdateCompanionBuilder = TodoCategoriesCompanion
   Value<String> name,
 });
 
+class $$TodoCategoriesTableFilterComposer
+    extends FilterComposer<_$Database, $TodoCategoriesTable> {
+  $$TodoCategoriesTableFilterComposer(super.$state);
+  ColumnFilters<int> get id => $state.composableBuilder(
+      column: $state.table.id,
+      builder: (column, joinBuilders) =>
+          ColumnFilters(column, joinBuilders: joinBuilders));
+
+  ColumnFilters<String> get name => $state.composableBuilder(
+      column: $state.table.name,
+      builder: (column, joinBuilders) =>
+          ColumnFilters(column, joinBuilders: joinBuilders));
+
+  ComposableFilter todoItemsRefs(
+      ComposableFilter Function($$TodoItemsTableFilterComposer f) f) {
+    final $$TodoItemsTableFilterComposer composer = $state.composerBuilder(
+        composer: this,
+        getCurrentColumn: (t) => t.id,
+        referencedTable: $state.db.todoItems,
+        getReferencedColumn: (t) => t.categoryId,
+        builder: (joinBuilder, parentComposers) =>
+            $$TodoItemsTableFilterComposer(ComposerState(
+                $state.db, $state.db.todoItems, joinBuilder, parentComposers)));
+    return f(composer);
+  }
+}
+
+class $$TodoCategoriesTableOrderingComposer
+    extends OrderingComposer<_$Database, $TodoCategoriesTable> {
+  $$TodoCategoriesTableOrderingComposer(super.$state);
+  ColumnOrderings<int> get id => $state.composableBuilder(
+      column: $state.table.id,
+      builder: (column, joinBuilders) =>
+          ColumnOrderings(column, joinBuilders: joinBuilders));
+
+  ColumnOrderings<String> get name => $state.composableBuilder(
+      column: $state.table.name,
+      builder: (column, joinBuilders) =>
+          ColumnOrderings(column, joinBuilders: joinBuilders));
+}
+
+class $$TodoCategoriesTableWithReferences
+    extends BaseWithReferences<_$Database, TodoCategory> {
+  $$TodoCategoriesTableWithReferences(super.$_db, super.$_item);
+
+  $$TodoItemsTableProcessedTableManager get todoItemsRefs {
+    return $$TodoItemsTableTableManager($_db, $_db.todoItems)
+        .filter((f) => f.categoryId.id($_item.id));
+  }
+}
+
 class $$TodoCategoriesTableTableManager extends RootTableManager<
     _$Database,
     $TodoCategoriesTable,
@@ -775,61 +826,6 @@ typedef $$TodoCategoriesTableProcessedTableManager = ProcessedTableManager<
     $$TodoCategoriesTableUpdateCompanionBuilder,
     (TodoCategory, $$TodoCategoriesTableWithReferences),
     TodoCategory>;
-
-class $$TodoCategoriesTableFilterComposer
-    extends FilterComposer<_$Database, $TodoCategoriesTable> {
-  $$TodoCategoriesTableFilterComposer(super.$state);
-  ColumnFilters<int> get id => $state.composableBuilder(
-      column: $state.table.id,
-      builder: (column, joinBuilders) =>
-          ColumnFilters(column, joinBuilders: joinBuilders));
-
-  ColumnFilters<String> get name => $state.composableBuilder(
-      column: $state.table.name,
-      builder: (column, joinBuilders) =>
-          ColumnFilters(column, joinBuilders: joinBuilders));
-
-  ComposableFilter todoItemsRefs(
-      ComposableFilter Function($$TodoItemsTableFilterComposer f) f) {
-    final $$TodoItemsTableFilterComposer composer = $state.composerBuilder(
-        composer: this,
-        getCurrentColumn: (t) => t.id,
-        referencedTable: $state.db.todoItems,
-        getReferencedColumn: (t) => t.categoryId,
-        builder: (joinBuilder, parentComposers) =>
-            $$TodoItemsTableFilterComposer(ComposerState(
-                $state.db, $state.db.todoItems, joinBuilder, parentComposers)));
-    return f(composer);
-  }
-}
-
-class $$TodoCategoriesTableOrderingComposer
-    extends OrderingComposer<_$Database, $TodoCategoriesTable> {
-  $$TodoCategoriesTableOrderingComposer(super.$state);
-  ColumnOrderings<int> get id => $state.composableBuilder(
-      column: $state.table.id,
-      builder: (column, joinBuilders) =>
-          ColumnOrderings(column, joinBuilders: joinBuilders));
-
-  ColumnOrderings<String> get name => $state.composableBuilder(
-      column: $state.table.name,
-      builder: (column, joinBuilders) =>
-          ColumnOrderings(column, joinBuilders: joinBuilders));
-}
-
-class $$TodoCategoriesTableWithReferences {
-  // ignore: unused_field
-  final _$Database _db;
-  // ignore: unused_field
-  final TodoCategory _item;
-  $$TodoCategoriesTableWithReferences(this._db, this._item);
-
-  $$TodoItemsTableProcessedTableManager get todoItemsRefs {
-    return $$TodoItemsTableTableManager(_db, _db.todoItems)
-        .filter((f) => f.categoryId.id(_item.id));
-  }
-}
-
 typedef $$TodoItemsTableCreateCompanionBuilder = TodoItemsCompanion Function({
   Value<int> id,
   required String title,
@@ -842,65 +838,6 @@ typedef $$TodoItemsTableUpdateCompanionBuilder = TodoItemsCompanion Function({
   Value<String?> content,
   Value<int> categoryId,
 });
-
-class $$TodoItemsTableTableManager extends RootTableManager<
-    _$Database,
-    $TodoItemsTable,
-    TodoItem,
-    $$TodoItemsTableFilterComposer,
-    $$TodoItemsTableOrderingComposer,
-    $$TodoItemsTableCreateCompanionBuilder,
-    $$TodoItemsTableUpdateCompanionBuilder,
-    (TodoItem, $$TodoItemsTableWithReferences),
-    TodoItem> {
-  $$TodoItemsTableTableManager(_$Database db, $TodoItemsTable table)
-      : super(TableManagerState(
-          db: db,
-          table: table,
-          filteringComposer:
-              $$TodoItemsTableFilterComposer(ComposerState(db, table)),
-          orderingComposer:
-              $$TodoItemsTableOrderingComposer(ComposerState(db, table)),
-          withReferenceMapper: (p0) => p0
-              .map((e) => (e, $$TodoItemsTableWithReferences(db, e)))
-              .toList(),
-          updateCompanionCallback: ({
-            Value<int> id = const Value.absent(),
-            Value<String> title = const Value.absent(),
-            Value<String?> content = const Value.absent(),
-            Value<int> categoryId = const Value.absent(),
-          }) =>
-              TodoItemsCompanion(
-            id: id,
-            title: title,
-            content: content,
-            categoryId: categoryId,
-          ),
-          createCompanionCallback: ({
-            Value<int> id = const Value.absent(),
-            required String title,
-            Value<String?> content = const Value.absent(),
-            required int categoryId,
-          }) =>
-              TodoItemsCompanion.insert(
-            id: id,
-            title: title,
-            content: content,
-            categoryId: categoryId,
-          ),
-        ));
-}
-
-typedef $$TodoItemsTableProcessedTableManager = ProcessedTableManager<
-    _$Database,
-    $TodoItemsTable,
-    TodoItem,
-    $$TodoItemsTableFilterComposer,
-    $$TodoItemsTableOrderingComposer,
-    $$TodoItemsTableCreateCompanionBuilder,
-    $$TodoItemsTableUpdateCompanionBuilder,
-    (TodoItem, $$TodoItemsTableWithReferences),
-    TodoItem>;
 
 class $$TodoItemsTableFilterComposer
     extends FilterComposer<_$Database, $TodoItemsTable> {
@@ -975,19 +912,75 @@ class $$TodoItemsTableOrderingComposer
   }
 }
 
-class $$TodoItemsTableWithReferences {
-  // ignore: unused_field
-  final _$Database _db;
-  // ignore: unused_field
-  final TodoItem _item;
-  $$TodoItemsTableWithReferences(this._db, this._item);
+class $$TodoItemsTableWithReferences
+    extends BaseWithReferences<_$Database, TodoItem> {
+  $$TodoItemsTableWithReferences(super.$_db, super.$_item);
 
   $$TodoCategoriesTableProcessedTableManager? get categoryId {
-    if (_item.categoryId == null) return null;
-    return $$TodoCategoriesTableTableManager(_db, _db.todoCategories)
-        .filter((f) => f.id(_item.categoryId!));
+    if ($_item.categoryId == null) return null;
+    return $$TodoCategoriesTableTableManager($_db, $_db.todoCategories)
+        .filter((f) => f.id($_item.categoryId!));
   }
 }
+
+class $$TodoItemsTableTableManager extends RootTableManager<
+    _$Database,
+    $TodoItemsTable,
+    TodoItem,
+    $$TodoItemsTableFilterComposer,
+    $$TodoItemsTableOrderingComposer,
+    $$TodoItemsTableCreateCompanionBuilder,
+    $$TodoItemsTableUpdateCompanionBuilder,
+    (TodoItem, $$TodoItemsTableWithReferences),
+    TodoItem> {
+  $$TodoItemsTableTableManager(_$Database db, $TodoItemsTable table)
+      : super(TableManagerState(
+          db: db,
+          table: table,
+          filteringComposer:
+              $$TodoItemsTableFilterComposer(ComposerState(db, table)),
+          orderingComposer:
+              $$TodoItemsTableOrderingComposer(ComposerState(db, table)),
+          withReferenceMapper: (p0) => p0
+              .map((e) => (e, $$TodoItemsTableWithReferences(db, e)))
+              .toList(),
+          updateCompanionCallback: ({
+            Value<int> id = const Value.absent(),
+            Value<String> title = const Value.absent(),
+            Value<String?> content = const Value.absent(),
+            Value<int> categoryId = const Value.absent(),
+          }) =>
+              TodoItemsCompanion(
+            id: id,
+            title: title,
+            content: content,
+            categoryId: categoryId,
+          ),
+          createCompanionCallback: ({
+            Value<int> id = const Value.absent(),
+            required String title,
+            Value<String?> content = const Value.absent(),
+            required int categoryId,
+          }) =>
+              TodoItemsCompanion.insert(
+            id: id,
+            title: title,
+            content: content,
+            categoryId: categoryId,
+          ),
+        ));
+}
+
+typedef $$TodoItemsTableProcessedTableManager = ProcessedTableManager<
+    _$Database,
+    $TodoItemsTable,
+    TodoItem,
+    $$TodoItemsTableFilterComposer,
+    $$TodoItemsTableOrderingComposer,
+    $$TodoItemsTableCreateCompanionBuilder,
+    $$TodoItemsTableUpdateCompanionBuilder,
+    (TodoItem, $$TodoItemsTableWithReferences),
+    TodoItem>;
 
 class $DatabaseManager {
   final _$Database _db;

--- a/drift/example/main.g.dart
+++ b/drift/example/main.g.dart
@@ -733,7 +733,7 @@ class $$TodoCategoriesTableTableManager extends RootTableManager<
     $$TodoCategoriesTableOrderingComposer,
     $$TodoCategoriesTableCreateCompanionBuilder,
     $$TodoCategoriesTableUpdateCompanionBuilder,
-    $$TodoCategoriesTableWithReferences,
+    (TodoCategory, $$TodoCategoriesTableWithReferences),
     TodoCategory> {
   $$TodoCategoriesTableTableManager(_$Database db, $TodoCategoriesTable table)
       : super(TableManagerState(
@@ -744,7 +744,7 @@ class $$TodoCategoriesTableTableManager extends RootTableManager<
           orderingComposer:
               $$TodoCategoriesTableOrderingComposer(ComposerState(db, table)),
           withReferenceMapper: (p0) => p0
-              .map((e) => $$TodoCategoriesTableWithReferences(db, e))
+              .map((e) => (e, $$TodoCategoriesTableWithReferences(db, e)))
               .toList(),
           updateCompanionCallback: ({
             Value<int> id = const Value.absent(),
@@ -773,7 +773,7 @@ typedef $$TodoCategoriesTableProcessedTableManager = ProcessedTableManager<
     $$TodoCategoriesTableOrderingComposer,
     $$TodoCategoriesTableCreateCompanionBuilder,
     $$TodoCategoriesTableUpdateCompanionBuilder,
-    $$TodoCategoriesTableWithReferences,
+    (TodoCategory, $$TodoCategoriesTableWithReferences),
     TodoCategory>;
 
 class $$TodoCategoriesTableFilterComposer
@@ -820,12 +820,12 @@ class $$TodoCategoriesTableOrderingComposer
 class $$TodoCategoriesTableWithReferences {
   // ignore: unused_field
   final _$Database _db;
-  final TodoCategory todoCategory;
-  $$TodoCategoriesTableWithReferences(this._db, this.todoCategory);
+  final TodoCategory _item;
+  $$TodoCategoriesTableWithReferences(this._db, this._item);
 
   $$TodoItemsTableProcessedTableManager get todoItemsRefs {
     return $$TodoItemsTableTableManager(_db, _db.todoItems)
-        .filter((f) => f.categoryId.id(todoCategory.id));
+        .filter((f) => f.categoryId.id(_item.id));
   }
 }
 
@@ -850,7 +850,7 @@ class $$TodoItemsTableTableManager extends RootTableManager<
     $$TodoItemsTableOrderingComposer,
     $$TodoItemsTableCreateCompanionBuilder,
     $$TodoItemsTableUpdateCompanionBuilder,
-    $$TodoItemsTableWithReferences,
+    (TodoItem, $$TodoItemsTableWithReferences),
     TodoItem> {
   $$TodoItemsTableTableManager(_$Database db, $TodoItemsTable table)
       : super(TableManagerState(
@@ -860,8 +860,9 @@ class $$TodoItemsTableTableManager extends RootTableManager<
               $$TodoItemsTableFilterComposer(ComposerState(db, table)),
           orderingComposer:
               $$TodoItemsTableOrderingComposer(ComposerState(db, table)),
-          withReferenceMapper: (p0) =>
-              p0.map((e) => $$TodoItemsTableWithReferences(db, e)).toList(),
+          withReferenceMapper: (p0) => p0
+              .map((e) => (e, $$TodoItemsTableWithReferences(db, e)))
+              .toList(),
           updateCompanionCallback: ({
             Value<int> id = const Value.absent(),
             Value<String> title = const Value.absent(),
@@ -897,7 +898,7 @@ typedef $$TodoItemsTableProcessedTableManager = ProcessedTableManager<
     $$TodoItemsTableOrderingComposer,
     $$TodoItemsTableCreateCompanionBuilder,
     $$TodoItemsTableUpdateCompanionBuilder,
-    $$TodoItemsTableWithReferences,
+    (TodoItem, $$TodoItemsTableWithReferences),
     TodoItem>;
 
 class $$TodoItemsTableFilterComposer
@@ -976,13 +977,13 @@ class $$TodoItemsTableOrderingComposer
 class $$TodoItemsTableWithReferences {
   // ignore: unused_field
   final _$Database _db;
-  final TodoItem todoItem;
-  $$TodoItemsTableWithReferences(this._db, this.todoItem);
+  final TodoItem _item;
+  $$TodoItemsTableWithReferences(this._db, this._item);
 
   $$TodoCategoriesTableProcessedTableManager? get categoryId {
-    if (todoItem.categoryId == null) return null;
+    if (_item.categoryId == null) return null;
     return $$TodoCategoriesTableTableManager(_db, _db.todoCategories)
-        .filter((f) => f.id(todoItem.categoryId!));
+        .filter((f) => f.id(_item.categoryId!));
   }
 }
 

--- a/drift/example/main.g.dart
+++ b/drift/example/main.g.dart
@@ -732,7 +732,9 @@ class $$TodoCategoriesTableTableManager extends RootTableManager<
     $$TodoCategoriesTableFilterComposer,
     $$TodoCategoriesTableOrderingComposer,
     $$TodoCategoriesTableCreateCompanionBuilder,
-    $$TodoCategoriesTableUpdateCompanionBuilder> {
+    $$TodoCategoriesTableUpdateCompanionBuilder,
+    $$TodoCategoriesTableWithReferences,
+    TodoCategory> {
   $$TodoCategoriesTableTableManager(_$Database db, $TodoCategoriesTable table)
       : super(TableManagerState(
           db: db,
@@ -741,6 +743,9 @@ class $$TodoCategoriesTableTableManager extends RootTableManager<
               $$TodoCategoriesTableFilterComposer(ComposerState(db, table)),
           orderingComposer:
               $$TodoCategoriesTableOrderingComposer(ComposerState(db, table)),
+          dataclassMapper: (p0) async => p0
+              .map((e) => $$TodoCategoriesTableWithReferences(db, e))
+              .toList(),
           updateCompanionCallback: ({
             Value<int> id = const Value.absent(),
             Value<String> name = const Value.absent(),
@@ -759,6 +764,17 @@ class $$TodoCategoriesTableTableManager extends RootTableManager<
           ),
         ));
 }
+
+typedef $$TodoCategoriesTableProcessedTableManager = ProcessedTableManager<
+    _$Database,
+    $TodoCategoriesTable,
+    TodoCategory,
+    $$TodoCategoriesTableFilterComposer,
+    $$TodoCategoriesTableOrderingComposer,
+    $$TodoCategoriesTableCreateCompanionBuilder,
+    $$TodoCategoriesTableUpdateCompanionBuilder,
+    $$TodoCategoriesTableWithReferences,
+    TodoCategory>;
 
 class $$TodoCategoriesTableFilterComposer
     extends FilterComposer<_$Database, $TodoCategoriesTable> {
@@ -801,6 +817,18 @@ class $$TodoCategoriesTableOrderingComposer
           ColumnOrderings(column, joinBuilders: joinBuilders));
 }
 
+class $$TodoCategoriesTableWithReferences {
+  // ignore: unused_field
+  final _$Database _db;
+  final TodoCategory todoCategory;
+  $$TodoCategoriesTableWithReferences(this._db, this.todoCategory);
+
+  $$TodoItemsTableProcessedTableManager get todoItemsRefs {
+    return $$TodoItemsTableTableManager(_db, _db.todoItems)
+        .filter((f) => f.categoryId.id(todoCategory.id));
+  }
+}
+
 typedef $$TodoItemsTableCreateCompanionBuilder = TodoItemsCompanion Function({
   Value<int> id,
   required String title,
@@ -821,7 +849,9 @@ class $$TodoItemsTableTableManager extends RootTableManager<
     $$TodoItemsTableFilterComposer,
     $$TodoItemsTableOrderingComposer,
     $$TodoItemsTableCreateCompanionBuilder,
-    $$TodoItemsTableUpdateCompanionBuilder> {
+    $$TodoItemsTableUpdateCompanionBuilder,
+    $$TodoItemsTableWithReferences,
+    TodoItem> {
   $$TodoItemsTableTableManager(_$Database db, $TodoItemsTable table)
       : super(TableManagerState(
           db: db,
@@ -830,6 +860,8 @@ class $$TodoItemsTableTableManager extends RootTableManager<
               $$TodoItemsTableFilterComposer(ComposerState(db, table)),
           orderingComposer:
               $$TodoItemsTableOrderingComposer(ComposerState(db, table)),
+          dataclassMapper: (p0) async =>
+              p0.map((e) => $$TodoItemsTableWithReferences(db, e)).toList(),
           updateCompanionCallback: ({
             Value<int> id = const Value.absent(),
             Value<String> title = const Value.absent(),
@@ -856,6 +888,17 @@ class $$TodoItemsTableTableManager extends RootTableManager<
           ),
         ));
 }
+
+typedef $$TodoItemsTableProcessedTableManager = ProcessedTableManager<
+    _$Database,
+    $TodoItemsTable,
+    TodoItem,
+    $$TodoItemsTableFilterComposer,
+    $$TodoItemsTableOrderingComposer,
+    $$TodoItemsTableCreateCompanionBuilder,
+    $$TodoItemsTableUpdateCompanionBuilder,
+    $$TodoItemsTableWithReferences,
+    TodoItem>;
 
 class $$TodoItemsTableFilterComposer
     extends FilterComposer<_$Database, $TodoItemsTable> {
@@ -927,6 +970,19 @@ class $$TodoItemsTableOrderingComposer
                 $$TodoCategoriesTableOrderingComposer(ComposerState($state.db,
                     $state.db.todoCategories, joinBuilder, parentComposers)));
     return composer;
+  }
+}
+
+class $$TodoItemsTableWithReferences {
+  // ignore: unused_field
+  final _$Database _db;
+  final TodoItem todoItem;
+  $$TodoItemsTableWithReferences(this._db, this.todoItem);
+
+  $$TodoCategoriesTableProcessedTableManager? get categoryId {
+    if (todoItem.categoryId == null) return null;
+    return $$TodoCategoriesTableTableManager(_db, _db.todoCategories)
+        .filter((f) => f.id(todoItem.categoryId!));
   }
 }
 

--- a/drift/lib/src/runtime/manager/manager.dart
+++ b/drift/lib/src/runtime/manager/manager.dart
@@ -85,8 +85,7 @@ class TableManagerState<
   /// This function is used to ensure that the correct dataclass type is returned by the manager.
   /// When `withReferences` is called on a manager, and its `$ActiveDataclass` changes to `$DataclassWithReferences`, this function will do the actual conversion
   /// Every return from the manager should map its results using this function before returning.
-  Future<List<$ActiveDataclass>> toActiveDataclass(
-      List<$Dataclass> items) async {
+  List<$ActiveDataclass> toActiveDataclass(List<$Dataclass> items) {
     if ($DataclassWithReferences == $ActiveDataclass) {
       return _withReferenceMapper(items) as List<$ActiveDataclass>;
     } else {

--- a/drift/lib/src/runtime/manager/manager.dart
+++ b/drift/lib/src/runtime/manager/manager.dart
@@ -87,7 +87,7 @@ class TableManagerState<
   Future<List<$ActiveDataclass>> applyDataclassMapper(
       List<$Dataclass> items) async {
     if ($MappedDataclass == $ActiveDataclass) {
-      return await _dataclassMapper(items) as List<$ActiveDataclass>;
+      return _dataclassMapper(items) as List<$ActiveDataclass>;
     } else {
       return items as List<$ActiveDataclass>;
     }
@@ -814,5 +814,5 @@ class _JoinedResult<T extends Table, DT> extends _StatementType<T, DT> {
 }
 
 /// A function for asynchronously wrapping a [$Dataclass] into a [$MappedDataclass]
-typedef DataclassMapper<$Dataclass, $MappedDataclass>
-    = Future<List<$MappedDataclass>> Function(List<$Dataclass>);
+typedef DataclassMapper<$Dataclass, $MappedDataclass> = List<$MappedDataclass>
+    Function(List<$Dataclass>);

--- a/drift/lib/src/runtime/manager/manager.dart
+++ b/drift/lib/src/runtime/manager/manager.dart
@@ -813,3 +813,17 @@ class _JoinedResult<T extends Table, DT> extends _StatementType<T, DT> {
 
   const _JoinedResult(this.statement);
 }
+
+/// Base class for the "WithReferece" classes that
+class BaseWithReferences<$Database extends GeneratedDatabase, $Dataclass> {
+  /// The database instance
+  // ignore: non_constant_identifier_names
+  final $Database $_db;
+
+  /// The dataclass these references are for
+  // ignore: non_constant_identifier_names
+  final $Dataclass $_item;
+
+  /// Create a [BaseWithReferences] class
+  BaseWithReferences(this.$_db, this.$_item);
+}

--- a/drift/test/database/data_class_test.dart
+++ b/drift/test/database/data_class_test.dart
@@ -39,7 +39,7 @@ void main() {
         id: RowId(13),
         title: 'Title',
         content: 'Content',
-        category: 3,
+        category: RowId(3),
         targetDate: DateTime.now(),
       );
       expect(

--- a/drift/test/database/statements/join_test.dart
+++ b/drift/test/database/statements/join_test.dart
@@ -85,7 +85,7 @@ void main() {
           title: 'title',
           content: 'content',
           targetDate: date,
-          category: 3,
+          category: RowId(3),
           status: TodoStatus.workInProgress,
         ));
 

--- a/drift/test/database/statements/select_test.dart
+++ b/drift/test/database/statements/select_test.dart
@@ -19,7 +19,7 @@ const _todoEntry = TodoEntry(
   id: RowId(10),
   title: 'A todo title',
   content: 'Content',
-  category: 3,
+  category: RowId(3),
 );
 
 void main() {

--- a/drift/test/database/statements/update_test.dart
+++ b/drift/test/database/statements/update_test.dart
@@ -24,7 +24,7 @@ void main() {
     test('for entire table', () async {
       await db.update(db.todosTable).write(const TodosTableCompanion(
             title: Value('Updated title'),
-            category: Value(3),
+            category: Value(RowId(3)),
           ));
 
       verify(executor.runUpdate(

--- a/drift/test/extensions/geopoly_integration_test.g.dart
+++ b/drift/test/extensions/geopoly_integration_test.g.dart
@@ -252,7 +252,9 @@ class $GeopolyTestTableManager extends RootTableManager<
     $GeopolyTestFilterComposer,
     $GeopolyTestOrderingComposer,
     $GeopolyTestCreateCompanionBuilder,
-    $GeopolyTestUpdateCompanionBuilder> {
+    $GeopolyTestUpdateCompanionBuilder,
+    $GeopolyTestWithReferences,
+    GeopolyTestData> {
   $GeopolyTestTableManager(_$_GeopolyTestDatabase db, GeopolyTest table)
       : super(TableManagerState(
           db: db,
@@ -261,6 +263,8 @@ class $GeopolyTestTableManager extends RootTableManager<
               $GeopolyTestFilterComposer(ComposerState(db, table)),
           orderingComposer:
               $GeopolyTestOrderingComposer(ComposerState(db, table)),
+          dataclassMapper: (p0) async =>
+              p0.map((e) => $GeopolyTestWithReferences(db, e)).toList(),
           updateCompanionCallback: ({
             Value<GeopolyPolygon?> shape = const Value.absent(),
             Value<DriftAny?> a = const Value.absent(),
@@ -283,6 +287,17 @@ class $GeopolyTestTableManager extends RootTableManager<
           ),
         ));
 }
+
+typedef $GeopolyTestProcessedTableManager = ProcessedTableManager<
+    _$_GeopolyTestDatabase,
+    GeopolyTest,
+    GeopolyTestData,
+    $GeopolyTestFilterComposer,
+    $GeopolyTestOrderingComposer,
+    $GeopolyTestCreateCompanionBuilder,
+    $GeopolyTestUpdateCompanionBuilder,
+    $GeopolyTestWithReferences,
+    GeopolyTestData>;
 
 class $GeopolyTestFilterComposer
     extends FilterComposer<_$_GeopolyTestDatabase, GeopolyTest> {
@@ -310,6 +325,13 @@ class $GeopolyTestOrderingComposer
       column: $state.table.a,
       builder: (column, joinBuilders) =>
           ColumnOrderings(column, joinBuilders: joinBuilders));
+}
+
+class $GeopolyTestWithReferences {
+  // ignore: unused_field
+  final _$_GeopolyTestDatabase _db;
+  final GeopolyTestData geopolyTestData;
+  $GeopolyTestWithReferences(this._db, this.geopolyTestData);
 }
 
 class $_GeopolyTestDatabaseManager {

--- a/drift/test/extensions/geopoly_integration_test.g.dart
+++ b/drift/test/extensions/geopoly_integration_test.g.dart
@@ -253,7 +253,7 @@ class $GeopolyTestTableManager extends RootTableManager<
     $GeopolyTestOrderingComposer,
     $GeopolyTestCreateCompanionBuilder,
     $GeopolyTestUpdateCompanionBuilder,
-    $GeopolyTestWithReferences,
+    (GeopolyTestData, $GeopolyTestWithReferences),
     GeopolyTestData> {
   $GeopolyTestTableManager(_$_GeopolyTestDatabase db, GeopolyTest table)
       : super(TableManagerState(
@@ -264,7 +264,7 @@ class $GeopolyTestTableManager extends RootTableManager<
           orderingComposer:
               $GeopolyTestOrderingComposer(ComposerState(db, table)),
           withReferenceMapper: (p0) =>
-              p0.map((e) => $GeopolyTestWithReferences(db, e)).toList(),
+              p0.map((e) => (e, $GeopolyTestWithReferences(db, e))).toList(),
           updateCompanionCallback: ({
             Value<GeopolyPolygon?> shape = const Value.absent(),
             Value<DriftAny?> a = const Value.absent(),
@@ -296,7 +296,7 @@ typedef $GeopolyTestProcessedTableManager = ProcessedTableManager<
     $GeopolyTestOrderingComposer,
     $GeopolyTestCreateCompanionBuilder,
     $GeopolyTestUpdateCompanionBuilder,
-    $GeopolyTestWithReferences,
+    (GeopolyTestData, $GeopolyTestWithReferences),
     GeopolyTestData>;
 
 class $GeopolyTestFilterComposer
@@ -330,8 +330,8 @@ class $GeopolyTestOrderingComposer
 class $GeopolyTestWithReferences {
   // ignore: unused_field
   final _$_GeopolyTestDatabase _db;
-  final GeopolyTestData geopolyTestData;
-  $GeopolyTestWithReferences(this._db, this.geopolyTestData);
+  final GeopolyTestData _item;
+  $GeopolyTestWithReferences(this._db, this._item);
 }
 
 class $_GeopolyTestDatabaseManager {

--- a/drift/test/extensions/geopoly_integration_test.g.dart
+++ b/drift/test/extensions/geopoly_integration_test.g.dart
@@ -245,6 +245,34 @@ typedef $GeopolyTestUpdateCompanionBuilder = GeopolyTestCompanion Function({
   Value<int> rowid,
 });
 
+class $GeopolyTestFilterComposer
+    extends FilterComposer<_$_GeopolyTestDatabase, GeopolyTest> {
+  $GeopolyTestFilterComposer(super.$state);
+  ColumnFilters<GeopolyPolygon> get shape => $state.composableBuilder(
+      column: $state.table.shape,
+      builder: (column, joinBuilders) =>
+          ColumnFilters(column, joinBuilders: joinBuilders));
+
+  ColumnFilters<DriftAny> get a => $state.composableBuilder(
+      column: $state.table.a,
+      builder: (column, joinBuilders) =>
+          ColumnFilters(column, joinBuilders: joinBuilders));
+}
+
+class $GeopolyTestOrderingComposer
+    extends OrderingComposer<_$_GeopolyTestDatabase, GeopolyTest> {
+  $GeopolyTestOrderingComposer(super.$state);
+  ColumnOrderings<GeopolyPolygon> get shape => $state.composableBuilder(
+      column: $state.table.shape,
+      builder: (column, joinBuilders) =>
+          ColumnOrderings(column, joinBuilders: joinBuilders));
+
+  ColumnOrderings<DriftAny> get a => $state.composableBuilder(
+      column: $state.table.a,
+      builder: (column, joinBuilders) =>
+          ColumnOrderings(column, joinBuilders: joinBuilders));
+}
+
 class $GeopolyTestTableManager extends RootTableManager<
     _$_GeopolyTestDatabase,
     GeopolyTest,
@@ -253,7 +281,10 @@ class $GeopolyTestTableManager extends RootTableManager<
     $GeopolyTestOrderingComposer,
     $GeopolyTestCreateCompanionBuilder,
     $GeopolyTestUpdateCompanionBuilder,
-    (GeopolyTestData, $GeopolyTestWithReferences),
+    (
+      GeopolyTestData,
+      BaseWithReferences<_$_GeopolyTestDatabase, GeopolyTestData>
+    ),
     GeopolyTestData> {
   $GeopolyTestTableManager(_$_GeopolyTestDatabase db, GeopolyTest table)
       : super(TableManagerState(
@@ -264,7 +295,7 @@ class $GeopolyTestTableManager extends RootTableManager<
           orderingComposer:
               $GeopolyTestOrderingComposer(ComposerState(db, table)),
           withReferenceMapper: (p0) =>
-              p0.map((e) => (e, $GeopolyTestWithReferences(db, e))).toList(),
+              p0.map((e) => (e, BaseWithReferences(db, e))).toList(),
           updateCompanionCallback: ({
             Value<GeopolyPolygon?> shape = const Value.absent(),
             Value<DriftAny?> a = const Value.absent(),
@@ -296,44 +327,11 @@ typedef $GeopolyTestProcessedTableManager = ProcessedTableManager<
     $GeopolyTestOrderingComposer,
     $GeopolyTestCreateCompanionBuilder,
     $GeopolyTestUpdateCompanionBuilder,
-    (GeopolyTestData, $GeopolyTestWithReferences),
+    (
+      GeopolyTestData,
+      BaseWithReferences<_$_GeopolyTestDatabase, GeopolyTestData>
+    ),
     GeopolyTestData>;
-
-class $GeopolyTestFilterComposer
-    extends FilterComposer<_$_GeopolyTestDatabase, GeopolyTest> {
-  $GeopolyTestFilterComposer(super.$state);
-  ColumnFilters<GeopolyPolygon> get shape => $state.composableBuilder(
-      column: $state.table.shape,
-      builder: (column, joinBuilders) =>
-          ColumnFilters(column, joinBuilders: joinBuilders));
-
-  ColumnFilters<DriftAny> get a => $state.composableBuilder(
-      column: $state.table.a,
-      builder: (column, joinBuilders) =>
-          ColumnFilters(column, joinBuilders: joinBuilders));
-}
-
-class $GeopolyTestOrderingComposer
-    extends OrderingComposer<_$_GeopolyTestDatabase, GeopolyTest> {
-  $GeopolyTestOrderingComposer(super.$state);
-  ColumnOrderings<GeopolyPolygon> get shape => $state.composableBuilder(
-      column: $state.table.shape,
-      builder: (column, joinBuilders) =>
-          ColumnOrderings(column, joinBuilders: joinBuilders));
-
-  ColumnOrderings<DriftAny> get a => $state.composableBuilder(
-      column: $state.table.a,
-      builder: (column, joinBuilders) =>
-          ColumnOrderings(column, joinBuilders: joinBuilders));
-}
-
-class $GeopolyTestWithReferences {
-  // ignore: unused_field
-  final _$_GeopolyTestDatabase _db;
-  // ignore: unused_field
-  final GeopolyTestData _item;
-  $GeopolyTestWithReferences(this._db, this._item);
-}
 
 class $_GeopolyTestDatabaseManager {
   final _$_GeopolyTestDatabase _db;

--- a/drift/test/extensions/geopoly_integration_test.g.dart
+++ b/drift/test/extensions/geopoly_integration_test.g.dart
@@ -263,7 +263,7 @@ class $GeopolyTestTableManager extends RootTableManager<
               $GeopolyTestFilterComposer(ComposerState(db, table)),
           orderingComposer:
               $GeopolyTestOrderingComposer(ComposerState(db, table)),
-          dataclassMapper: (p0) async =>
+          withReferenceMapper: (p0) =>
               p0.map((e) => $GeopolyTestWithReferences(db, e)).toList(),
           updateCompanionCallback: ({
             Value<GeopolyPolygon?> shape = const Value.absent(),

--- a/drift/test/extensions/geopoly_integration_test.g.dart
+++ b/drift/test/extensions/geopoly_integration_test.g.dart
@@ -330,6 +330,7 @@ class $GeopolyTestOrderingComposer
 class $GeopolyTestWithReferences {
   // ignore: unused_field
   final _$_GeopolyTestDatabase _db;
+  // ignore: unused_field
   final GeopolyTestData _item;
   $GeopolyTestWithReferences(this._db, this._item);
 }

--- a/drift/test/extensions/json1_integration_test.dart
+++ b/drift/test/extensions/json1_integration_test.dart
@@ -85,12 +85,12 @@ void main() {
             TodosTableCompanion.insert(
                 title: Value('first title'),
                 content: 'entry in category',
-                category: Value(1)),
+                category: Value(RowId(1))),
             TodosTableCompanion.insert(content: 'not in category'),
             TodosTableCompanion.insert(
                 title: Value('second title'),
                 content: 'another in category',
-                category: Value(1))
+                category: Value(RowId(1)))
           ]);
       });
     });

--- a/drift/test/generated/custom_tables.g.dart
+++ b/drift/test/generated/custom_tables.g.dart
@@ -2039,7 +2039,7 @@ class $NoIdsTableManager extends RootTableManager<
     $NoIdsOrderingComposer,
     $NoIdsCreateCompanionBuilder,
     $NoIdsUpdateCompanionBuilder,
-    $NoIdsWithReferences,
+    (NoIdRow, $NoIdsWithReferences),
     NoIdRow> {
   $NoIdsTableManager(_$CustomTablesDb db, NoIds table)
       : super(TableManagerState(
@@ -2048,7 +2048,7 @@ class $NoIdsTableManager extends RootTableManager<
           filteringComposer: $NoIdsFilterComposer(ComposerState(db, table)),
           orderingComposer: $NoIdsOrderingComposer(ComposerState(db, table)),
           withReferenceMapper: (p0) =>
-              p0.map((e) => $NoIdsWithReferences(db, e)).toList(),
+              p0.map((e) => (e, $NoIdsWithReferences(db, e))).toList(),
           updateCompanionCallback: ({
             Value<Uint8List> payload = const Value.absent(),
           }) =>
@@ -2072,7 +2072,7 @@ typedef $NoIdsProcessedTableManager = ProcessedTableManager<
     $NoIdsOrderingComposer,
     $NoIdsCreateCompanionBuilder,
     $NoIdsUpdateCompanionBuilder,
-    $NoIdsWithReferences,
+    (NoIdRow, $NoIdsWithReferences),
     NoIdRow>;
 
 class $NoIdsFilterComposer extends FilterComposer<_$CustomTablesDb, NoIds> {
@@ -2094,8 +2094,8 @@ class $NoIdsOrderingComposer extends OrderingComposer<_$CustomTablesDb, NoIds> {
 class $NoIdsWithReferences {
   // ignore: unused_field
   final _$CustomTablesDb _db;
-  final NoIdRow noIdRow;
-  $NoIdsWithReferences(this._db, this.noIdRow);
+  final NoIdRow _item;
+  $NoIdsWithReferences(this._db, this._item);
 }
 
 typedef $WithDefaultsCreateCompanionBuilder = WithDefaultsCompanion Function({
@@ -2117,7 +2117,7 @@ class $WithDefaultsTableManager extends RootTableManager<
     $WithDefaultsOrderingComposer,
     $WithDefaultsCreateCompanionBuilder,
     $WithDefaultsUpdateCompanionBuilder,
-    $WithDefaultsWithReferences,
+    (WithDefault, $WithDefaultsWithReferences),
     WithDefault> {
   $WithDefaultsTableManager(_$CustomTablesDb db, WithDefaults table)
       : super(TableManagerState(
@@ -2128,7 +2128,7 @@ class $WithDefaultsTableManager extends RootTableManager<
           orderingComposer:
               $WithDefaultsOrderingComposer(ComposerState(db, table)),
           withReferenceMapper: (p0) =>
-              p0.map((e) => $WithDefaultsWithReferences(db, e)).toList(),
+              p0.map((e) => (e, $WithDefaultsWithReferences(db, e))).toList(),
           updateCompanionCallback: ({
             Value<String?> a = const Value.absent(),
             Value<int?> b = const Value.absent(),
@@ -2160,7 +2160,7 @@ typedef $WithDefaultsProcessedTableManager = ProcessedTableManager<
     $WithDefaultsOrderingComposer,
     $WithDefaultsCreateCompanionBuilder,
     $WithDefaultsUpdateCompanionBuilder,
-    $WithDefaultsWithReferences,
+    (WithDefault, $WithDefaultsWithReferences),
     WithDefault>;
 
 class $WithDefaultsFilterComposer
@@ -2194,8 +2194,8 @@ class $WithDefaultsOrderingComposer
 class $WithDefaultsWithReferences {
   // ignore: unused_field
   final _$CustomTablesDb _db;
-  final WithDefault withDefault;
-  $WithDefaultsWithReferences(this._db, this.withDefault);
+  final WithDefault _item;
+  $WithDefaultsWithReferences(this._db, this._item);
 }
 
 typedef $WithConstraintsCreateCompanionBuilder = WithConstraintsCompanion
@@ -2221,7 +2221,7 @@ class $WithConstraintsTableManager extends RootTableManager<
     $WithConstraintsOrderingComposer,
     $WithConstraintsCreateCompanionBuilder,
     $WithConstraintsUpdateCompanionBuilder,
-    $WithConstraintsWithReferences,
+    (WithConstraint, $WithConstraintsWithReferences),
     WithConstraint> {
   $WithConstraintsTableManager(_$CustomTablesDb db, WithConstraints table)
       : super(TableManagerState(
@@ -2231,8 +2231,9 @@ class $WithConstraintsTableManager extends RootTableManager<
               $WithConstraintsFilterComposer(ComposerState(db, table)),
           orderingComposer:
               $WithConstraintsOrderingComposer(ComposerState(db, table)),
-          withReferenceMapper: (p0) =>
-              p0.map((e) => $WithConstraintsWithReferences(db, e)).toList(),
+          withReferenceMapper: (p0) => p0
+              .map((e) => (e, $WithConstraintsWithReferences(db, e)))
+              .toList(),
           updateCompanionCallback: ({
             Value<String?> a = const Value.absent(),
             Value<int> b = const Value.absent(),
@@ -2268,7 +2269,7 @@ typedef $WithConstraintsProcessedTableManager = ProcessedTableManager<
     $WithConstraintsOrderingComposer,
     $WithConstraintsCreateCompanionBuilder,
     $WithConstraintsUpdateCompanionBuilder,
-    $WithConstraintsWithReferences,
+    (WithConstraint, $WithConstraintsWithReferences),
     WithConstraint>;
 
 class $WithConstraintsFilterComposer
@@ -2312,8 +2313,8 @@ class $WithConstraintsOrderingComposer
 class $WithConstraintsWithReferences {
   // ignore: unused_field
   final _$CustomTablesDb _db;
-  final WithConstraint withConstraint;
-  $WithConstraintsWithReferences(this._db, this.withConstraint);
+  final WithConstraint _item;
+  $WithConstraintsWithReferences(this._db, this._item);
 }
 
 typedef $ConfigTableCreateCompanionBuilder = ConfigCompanion Function({
@@ -2339,7 +2340,7 @@ class $ConfigTableTableManager extends RootTableManager<
     $ConfigTableOrderingComposer,
     $ConfigTableCreateCompanionBuilder,
     $ConfigTableUpdateCompanionBuilder,
-    $ConfigTableWithReferences,
+    (Config, $ConfigTableWithReferences),
     Config> {
   $ConfigTableTableManager(_$CustomTablesDb db, ConfigTable table)
       : super(TableManagerState(
@@ -2350,7 +2351,7 @@ class $ConfigTableTableManager extends RootTableManager<
           orderingComposer:
               $ConfigTableOrderingComposer(ComposerState(db, table)),
           withReferenceMapper: (p0) =>
-              p0.map((e) => $ConfigTableWithReferences(db, e)).toList(),
+              p0.map((e) => (e, $ConfigTableWithReferences(db, e))).toList(),
           updateCompanionCallback: ({
             Value<String> configKey = const Value.absent(),
             Value<DriftAny?> configValue = const Value.absent(),
@@ -2390,7 +2391,7 @@ typedef $ConfigTableProcessedTableManager = ProcessedTableManager<
     $ConfigTableOrderingComposer,
     $ConfigTableCreateCompanionBuilder,
     $ConfigTableUpdateCompanionBuilder,
-    $ConfigTableWithReferences,
+    (Config, $ConfigTableWithReferences),
     Config>;
 
 class $ConfigTableFilterComposer
@@ -2448,8 +2449,8 @@ class $ConfigTableOrderingComposer
 class $ConfigTableWithReferences {
   // ignore: unused_field
   final _$CustomTablesDb _db;
-  final Config config;
-  $ConfigTableWithReferences(this._db, this.config);
+  final Config _item;
+  $ConfigTableWithReferences(this._db, this._item);
 }
 
 typedef $MytableCreateCompanionBuilder = MytableCompanion Function({
@@ -2473,7 +2474,7 @@ class $MytableTableManager extends RootTableManager<
     $MytableOrderingComposer,
     $MytableCreateCompanionBuilder,
     $MytableUpdateCompanionBuilder,
-    $MytableWithReferences,
+    (MytableData, $MytableWithReferences),
     MytableData> {
   $MytableTableManager(_$CustomTablesDb db, Mytable table)
       : super(TableManagerState(
@@ -2482,7 +2483,7 @@ class $MytableTableManager extends RootTableManager<
           filteringComposer: $MytableFilterComposer(ComposerState(db, table)),
           orderingComposer: $MytableOrderingComposer(ComposerState(db, table)),
           withReferenceMapper: (p0) =>
-              p0.map((e) => $MytableWithReferences(db, e)).toList(),
+              p0.map((e) => (e, $MytableWithReferences(db, e))).toList(),
           updateCompanionCallback: ({
             Value<int> someid = const Value.absent(),
             Value<String?> sometext = const Value.absent(),
@@ -2518,7 +2519,7 @@ typedef $MytableProcessedTableManager = ProcessedTableManager<
     $MytableOrderingComposer,
     $MytableCreateCompanionBuilder,
     $MytableUpdateCompanionBuilder,
-    $MytableWithReferences,
+    (MytableData, $MytableWithReferences),
     MytableData>;
 
 class $MytableFilterComposer extends FilterComposer<_$CustomTablesDb, Mytable> {
@@ -2571,8 +2572,8 @@ class $MytableOrderingComposer
 class $MytableWithReferences {
   // ignore: unused_field
   final _$CustomTablesDb _db;
-  final MytableData mytableData;
-  $MytableWithReferences(this._db, this.mytableData);
+  final MytableData _item;
+  $MytableWithReferences(this._db, this._item);
 }
 
 typedef $EmailCreateCompanionBuilder = EmailCompanion Function({
@@ -2596,7 +2597,7 @@ class $EmailTableManager extends RootTableManager<
     $EmailOrderingComposer,
     $EmailCreateCompanionBuilder,
     $EmailUpdateCompanionBuilder,
-    $EmailWithReferences,
+    (EMail, $EmailWithReferences),
     EMail> {
   $EmailTableManager(_$CustomTablesDb db, Email table)
       : super(TableManagerState(
@@ -2605,7 +2606,7 @@ class $EmailTableManager extends RootTableManager<
           filteringComposer: $EmailFilterComposer(ComposerState(db, table)),
           orderingComposer: $EmailOrderingComposer(ComposerState(db, table)),
           withReferenceMapper: (p0) =>
-              p0.map((e) => $EmailWithReferences(db, e)).toList(),
+              p0.map((e) => (e, $EmailWithReferences(db, e))).toList(),
           updateCompanionCallback: ({
             Value<String> sender = const Value.absent(),
             Value<String> title = const Value.absent(),
@@ -2641,7 +2642,7 @@ typedef $EmailProcessedTableManager = ProcessedTableManager<
     $EmailOrderingComposer,
     $EmailCreateCompanionBuilder,
     $EmailUpdateCompanionBuilder,
-    $EmailWithReferences,
+    (EMail, $EmailWithReferences),
     EMail>;
 
 class $EmailFilterComposer extends FilterComposer<_$CustomTablesDb, Email> {
@@ -2683,8 +2684,8 @@ class $EmailOrderingComposer extends OrderingComposer<_$CustomTablesDb, Email> {
 class $EmailWithReferences {
   // ignore: unused_field
   final _$CustomTablesDb _db;
-  final EMail eMail;
-  $EmailWithReferences(this._db, this.eMail);
+  final EMail _item;
+  $EmailWithReferences(this._db, this._item);
 }
 
 typedef $WeirdTableCreateCompanionBuilder = WeirdTableCompanion Function({
@@ -2706,7 +2707,7 @@ class $WeirdTableTableManager extends RootTableManager<
     $WeirdTableOrderingComposer,
     $WeirdTableCreateCompanionBuilder,
     $WeirdTableUpdateCompanionBuilder,
-    $WeirdTableWithReferences,
+    (WeirdData, $WeirdTableWithReferences),
     WeirdData> {
   $WeirdTableTableManager(_$CustomTablesDb db, WeirdTable table)
       : super(TableManagerState(
@@ -2717,7 +2718,7 @@ class $WeirdTableTableManager extends RootTableManager<
           orderingComposer:
               $WeirdTableOrderingComposer(ComposerState(db, table)),
           withReferenceMapper: (p0) =>
-              p0.map((e) => $WeirdTableWithReferences(db, e)).toList(),
+              p0.map((e) => (e, $WeirdTableWithReferences(db, e))).toList(),
           updateCompanionCallback: ({
             Value<int> sqlClass = const Value.absent(),
             Value<String> textColumn = const Value.absent(),
@@ -2749,7 +2750,7 @@ typedef $WeirdTableProcessedTableManager = ProcessedTableManager<
     $WeirdTableOrderingComposer,
     $WeirdTableCreateCompanionBuilder,
     $WeirdTableUpdateCompanionBuilder,
-    $WeirdTableWithReferences,
+    (WeirdData, $WeirdTableWithReferences),
     WeirdData>;
 
 class $WeirdTableFilterComposer
@@ -2783,8 +2784,8 @@ class $WeirdTableOrderingComposer
 class $WeirdTableWithReferences {
   // ignore: unused_field
   final _$CustomTablesDb _db;
-  final WeirdData weirdData;
-  $WeirdTableWithReferences(this._db, this.weirdData);
+  final WeirdData _item;
+  $WeirdTableWithReferences(this._db, this._item);
 }
 
 class $CustomTablesDbManager {

--- a/drift/test/generated/custom_tables.g.dart
+++ b/drift/test/generated/custom_tables.g.dart
@@ -2038,13 +2038,17 @@ class $NoIdsTableManager extends RootTableManager<
     $NoIdsFilterComposer,
     $NoIdsOrderingComposer,
     $NoIdsCreateCompanionBuilder,
-    $NoIdsUpdateCompanionBuilder> {
+    $NoIdsUpdateCompanionBuilder,
+    $NoIdsWithReferences,
+    NoIdRow> {
   $NoIdsTableManager(_$CustomTablesDb db, NoIds table)
       : super(TableManagerState(
           db: db,
           table: table,
           filteringComposer: $NoIdsFilterComposer(ComposerState(db, table)),
           orderingComposer: $NoIdsOrderingComposer(ComposerState(db, table)),
+          dataclassMapper: (p0) async =>
+              p0.map((e) => $NoIdsWithReferences(db, e)).toList(),
           updateCompanionCallback: ({
             Value<Uint8List> payload = const Value.absent(),
           }) =>
@@ -2060,6 +2064,17 @@ class $NoIdsTableManager extends RootTableManager<
         ));
 }
 
+typedef $NoIdsProcessedTableManager = ProcessedTableManager<
+    _$CustomTablesDb,
+    NoIds,
+    NoIdRow,
+    $NoIdsFilterComposer,
+    $NoIdsOrderingComposer,
+    $NoIdsCreateCompanionBuilder,
+    $NoIdsUpdateCompanionBuilder,
+    $NoIdsWithReferences,
+    NoIdRow>;
+
 class $NoIdsFilterComposer extends FilterComposer<_$CustomTablesDb, NoIds> {
   $NoIdsFilterComposer(super.$state);
   ColumnFilters<Uint8List> get payload => $state.composableBuilder(
@@ -2074,6 +2089,13 @@ class $NoIdsOrderingComposer extends OrderingComposer<_$CustomTablesDb, NoIds> {
       column: $state.table.payload,
       builder: (column, joinBuilders) =>
           ColumnOrderings(column, joinBuilders: joinBuilders));
+}
+
+class $NoIdsWithReferences {
+  // ignore: unused_field
+  final _$CustomTablesDb _db;
+  final NoIdRow noIdRow;
+  $NoIdsWithReferences(this._db, this.noIdRow);
 }
 
 typedef $WithDefaultsCreateCompanionBuilder = WithDefaultsCompanion Function({
@@ -2094,7 +2116,9 @@ class $WithDefaultsTableManager extends RootTableManager<
     $WithDefaultsFilterComposer,
     $WithDefaultsOrderingComposer,
     $WithDefaultsCreateCompanionBuilder,
-    $WithDefaultsUpdateCompanionBuilder> {
+    $WithDefaultsUpdateCompanionBuilder,
+    $WithDefaultsWithReferences,
+    WithDefault> {
   $WithDefaultsTableManager(_$CustomTablesDb db, WithDefaults table)
       : super(TableManagerState(
           db: db,
@@ -2103,6 +2127,8 @@ class $WithDefaultsTableManager extends RootTableManager<
               $WithDefaultsFilterComposer(ComposerState(db, table)),
           orderingComposer:
               $WithDefaultsOrderingComposer(ComposerState(db, table)),
+          dataclassMapper: (p0) async =>
+              p0.map((e) => $WithDefaultsWithReferences(db, e)).toList(),
           updateCompanionCallback: ({
             Value<String?> a = const Value.absent(),
             Value<int?> b = const Value.absent(),
@@ -2125,6 +2151,17 @@ class $WithDefaultsTableManager extends RootTableManager<
           ),
         ));
 }
+
+typedef $WithDefaultsProcessedTableManager = ProcessedTableManager<
+    _$CustomTablesDb,
+    WithDefaults,
+    WithDefault,
+    $WithDefaultsFilterComposer,
+    $WithDefaultsOrderingComposer,
+    $WithDefaultsCreateCompanionBuilder,
+    $WithDefaultsUpdateCompanionBuilder,
+    $WithDefaultsWithReferences,
+    WithDefault>;
 
 class $WithDefaultsFilterComposer
     extends FilterComposer<_$CustomTablesDb, WithDefaults> {
@@ -2154,6 +2191,13 @@ class $WithDefaultsOrderingComposer
           ColumnOrderings(column, joinBuilders: joinBuilders));
 }
 
+class $WithDefaultsWithReferences {
+  // ignore: unused_field
+  final _$CustomTablesDb _db;
+  final WithDefault withDefault;
+  $WithDefaultsWithReferences(this._db, this.withDefault);
+}
+
 typedef $WithConstraintsCreateCompanionBuilder = WithConstraintsCompanion
     Function({
   Value<String?> a,
@@ -2176,7 +2220,9 @@ class $WithConstraintsTableManager extends RootTableManager<
     $WithConstraintsFilterComposer,
     $WithConstraintsOrderingComposer,
     $WithConstraintsCreateCompanionBuilder,
-    $WithConstraintsUpdateCompanionBuilder> {
+    $WithConstraintsUpdateCompanionBuilder,
+    $WithConstraintsWithReferences,
+    WithConstraint> {
   $WithConstraintsTableManager(_$CustomTablesDb db, WithConstraints table)
       : super(TableManagerState(
           db: db,
@@ -2185,6 +2231,8 @@ class $WithConstraintsTableManager extends RootTableManager<
               $WithConstraintsFilterComposer(ComposerState(db, table)),
           orderingComposer:
               $WithConstraintsOrderingComposer(ComposerState(db, table)),
+          dataclassMapper: (p0) async =>
+              p0.map((e) => $WithConstraintsWithReferences(db, e)).toList(),
           updateCompanionCallback: ({
             Value<String?> a = const Value.absent(),
             Value<int> b = const Value.absent(),
@@ -2211,6 +2259,17 @@ class $WithConstraintsTableManager extends RootTableManager<
           ),
         ));
 }
+
+typedef $WithConstraintsProcessedTableManager = ProcessedTableManager<
+    _$CustomTablesDb,
+    WithConstraints,
+    WithConstraint,
+    $WithConstraintsFilterComposer,
+    $WithConstraintsOrderingComposer,
+    $WithConstraintsCreateCompanionBuilder,
+    $WithConstraintsUpdateCompanionBuilder,
+    $WithConstraintsWithReferences,
+    WithConstraint>;
 
 class $WithConstraintsFilterComposer
     extends FilterComposer<_$CustomTablesDb, WithConstraints> {
@@ -2250,6 +2309,13 @@ class $WithConstraintsOrderingComposer
           ColumnOrderings(column, joinBuilders: joinBuilders));
 }
 
+class $WithConstraintsWithReferences {
+  // ignore: unused_field
+  final _$CustomTablesDb _db;
+  final WithConstraint withConstraint;
+  $WithConstraintsWithReferences(this._db, this.withConstraint);
+}
+
 typedef $ConfigTableCreateCompanionBuilder = ConfigCompanion Function({
   required String configKey,
   Value<DriftAny?> configValue,
@@ -2272,7 +2338,9 @@ class $ConfigTableTableManager extends RootTableManager<
     $ConfigTableFilterComposer,
     $ConfigTableOrderingComposer,
     $ConfigTableCreateCompanionBuilder,
-    $ConfigTableUpdateCompanionBuilder> {
+    $ConfigTableUpdateCompanionBuilder,
+    $ConfigTableWithReferences,
+    Config> {
   $ConfigTableTableManager(_$CustomTablesDb db, ConfigTable table)
       : super(TableManagerState(
           db: db,
@@ -2281,6 +2349,8 @@ class $ConfigTableTableManager extends RootTableManager<
               $ConfigTableFilterComposer(ComposerState(db, table)),
           orderingComposer:
               $ConfigTableOrderingComposer(ComposerState(db, table)),
+          dataclassMapper: (p0) async =>
+              p0.map((e) => $ConfigTableWithReferences(db, e)).toList(),
           updateCompanionCallback: ({
             Value<String> configKey = const Value.absent(),
             Value<DriftAny?> configValue = const Value.absent(),
@@ -2311,6 +2381,17 @@ class $ConfigTableTableManager extends RootTableManager<
           ),
         ));
 }
+
+typedef $ConfigTableProcessedTableManager = ProcessedTableManager<
+    _$CustomTablesDb,
+    ConfigTable,
+    Config,
+    $ConfigTableFilterComposer,
+    $ConfigTableOrderingComposer,
+    $ConfigTableCreateCompanionBuilder,
+    $ConfigTableUpdateCompanionBuilder,
+    $ConfigTableWithReferences,
+    Config>;
 
 class $ConfigTableFilterComposer
     extends FilterComposer<_$CustomTablesDb, ConfigTable> {
@@ -2364,6 +2445,13 @@ class $ConfigTableOrderingComposer
           ColumnOrderings(column, joinBuilders: joinBuilders));
 }
 
+class $ConfigTableWithReferences {
+  // ignore: unused_field
+  final _$CustomTablesDb _db;
+  final Config config;
+  $ConfigTableWithReferences(this._db, this.config);
+}
+
 typedef $MytableCreateCompanionBuilder = MytableCompanion Function({
   Value<int> someid,
   Value<String?> sometext,
@@ -2384,13 +2472,17 @@ class $MytableTableManager extends RootTableManager<
     $MytableFilterComposer,
     $MytableOrderingComposer,
     $MytableCreateCompanionBuilder,
-    $MytableUpdateCompanionBuilder> {
+    $MytableUpdateCompanionBuilder,
+    $MytableWithReferences,
+    MytableData> {
   $MytableTableManager(_$CustomTablesDb db, Mytable table)
       : super(TableManagerState(
           db: db,
           table: table,
           filteringComposer: $MytableFilterComposer(ComposerState(db, table)),
           orderingComposer: $MytableOrderingComposer(ComposerState(db, table)),
+          dataclassMapper: (p0) async =>
+              p0.map((e) => $MytableWithReferences(db, e)).toList(),
           updateCompanionCallback: ({
             Value<int> someid = const Value.absent(),
             Value<String?> sometext = const Value.absent(),
@@ -2417,6 +2509,17 @@ class $MytableTableManager extends RootTableManager<
           ),
         ));
 }
+
+typedef $MytableProcessedTableManager = ProcessedTableManager<
+    _$CustomTablesDb,
+    Mytable,
+    MytableData,
+    $MytableFilterComposer,
+    $MytableOrderingComposer,
+    $MytableCreateCompanionBuilder,
+    $MytableUpdateCompanionBuilder,
+    $MytableWithReferences,
+    MytableData>;
 
 class $MytableFilterComposer extends FilterComposer<_$CustomTablesDb, Mytable> {
   $MytableFilterComposer(super.$state);
@@ -2465,6 +2568,13 @@ class $MytableOrderingComposer
           ColumnOrderings(column, joinBuilders: joinBuilders));
 }
 
+class $MytableWithReferences {
+  // ignore: unused_field
+  final _$CustomTablesDb _db;
+  final MytableData mytableData;
+  $MytableWithReferences(this._db, this.mytableData);
+}
+
 typedef $EmailCreateCompanionBuilder = EmailCompanion Function({
   required String sender,
   required String title,
@@ -2485,13 +2595,17 @@ class $EmailTableManager extends RootTableManager<
     $EmailFilterComposer,
     $EmailOrderingComposer,
     $EmailCreateCompanionBuilder,
-    $EmailUpdateCompanionBuilder> {
+    $EmailUpdateCompanionBuilder,
+    $EmailWithReferences,
+    EMail> {
   $EmailTableManager(_$CustomTablesDb db, Email table)
       : super(TableManagerState(
           db: db,
           table: table,
           filteringComposer: $EmailFilterComposer(ComposerState(db, table)),
           orderingComposer: $EmailOrderingComposer(ComposerState(db, table)),
+          dataclassMapper: (p0) async =>
+              p0.map((e) => $EmailWithReferences(db, e)).toList(),
           updateCompanionCallback: ({
             Value<String> sender = const Value.absent(),
             Value<String> title = const Value.absent(),
@@ -2518,6 +2632,17 @@ class $EmailTableManager extends RootTableManager<
           ),
         ));
 }
+
+typedef $EmailProcessedTableManager = ProcessedTableManager<
+    _$CustomTablesDb,
+    Email,
+    EMail,
+    $EmailFilterComposer,
+    $EmailOrderingComposer,
+    $EmailCreateCompanionBuilder,
+    $EmailUpdateCompanionBuilder,
+    $EmailWithReferences,
+    EMail>;
 
 class $EmailFilterComposer extends FilterComposer<_$CustomTablesDb, Email> {
   $EmailFilterComposer(super.$state);
@@ -2555,6 +2680,13 @@ class $EmailOrderingComposer extends OrderingComposer<_$CustomTablesDb, Email> {
           ColumnOrderings(column, joinBuilders: joinBuilders));
 }
 
+class $EmailWithReferences {
+  // ignore: unused_field
+  final _$CustomTablesDb _db;
+  final EMail eMail;
+  $EmailWithReferences(this._db, this.eMail);
+}
+
 typedef $WeirdTableCreateCompanionBuilder = WeirdTableCompanion Function({
   required int sqlClass,
   required String textColumn,
@@ -2573,7 +2705,9 @@ class $WeirdTableTableManager extends RootTableManager<
     $WeirdTableFilterComposer,
     $WeirdTableOrderingComposer,
     $WeirdTableCreateCompanionBuilder,
-    $WeirdTableUpdateCompanionBuilder> {
+    $WeirdTableUpdateCompanionBuilder,
+    $WeirdTableWithReferences,
+    WeirdData> {
   $WeirdTableTableManager(_$CustomTablesDb db, WeirdTable table)
       : super(TableManagerState(
           db: db,
@@ -2582,6 +2716,8 @@ class $WeirdTableTableManager extends RootTableManager<
               $WeirdTableFilterComposer(ComposerState(db, table)),
           orderingComposer:
               $WeirdTableOrderingComposer(ComposerState(db, table)),
+          dataclassMapper: (p0) async =>
+              p0.map((e) => $WeirdTableWithReferences(db, e)).toList(),
           updateCompanionCallback: ({
             Value<int> sqlClass = const Value.absent(),
             Value<String> textColumn = const Value.absent(),
@@ -2604,6 +2740,17 @@ class $WeirdTableTableManager extends RootTableManager<
           ),
         ));
 }
+
+typedef $WeirdTableProcessedTableManager = ProcessedTableManager<
+    _$CustomTablesDb,
+    WeirdTable,
+    WeirdData,
+    $WeirdTableFilterComposer,
+    $WeirdTableOrderingComposer,
+    $WeirdTableCreateCompanionBuilder,
+    $WeirdTableUpdateCompanionBuilder,
+    $WeirdTableWithReferences,
+    WeirdData>;
 
 class $WeirdTableFilterComposer
     extends FilterComposer<_$CustomTablesDb, WeirdTable> {
@@ -2631,6 +2778,13 @@ class $WeirdTableOrderingComposer
       column: $state.table.textColumn,
       builder: (column, joinBuilders) =>
           ColumnOrderings(column, joinBuilders: joinBuilders));
+}
+
+class $WeirdTableWithReferences {
+  // ignore: unused_field
+  final _$CustomTablesDb _db;
+  final WeirdData weirdData;
+  $WeirdTableWithReferences(this._db, this.weirdData);
 }
 
 class $CustomTablesDbManager {

--- a/drift/test/generated/custom_tables.g.dart
+++ b/drift/test/generated/custom_tables.g.dart
@@ -2094,6 +2094,7 @@ class $NoIdsOrderingComposer extends OrderingComposer<_$CustomTablesDb, NoIds> {
 class $NoIdsWithReferences {
   // ignore: unused_field
   final _$CustomTablesDb _db;
+  // ignore: unused_field
   final NoIdRow _item;
   $NoIdsWithReferences(this._db, this._item);
 }
@@ -2194,6 +2195,7 @@ class $WithDefaultsOrderingComposer
 class $WithDefaultsWithReferences {
   // ignore: unused_field
   final _$CustomTablesDb _db;
+  // ignore: unused_field
   final WithDefault _item;
   $WithDefaultsWithReferences(this._db, this._item);
 }
@@ -2313,6 +2315,7 @@ class $WithConstraintsOrderingComposer
 class $WithConstraintsWithReferences {
   // ignore: unused_field
   final _$CustomTablesDb _db;
+  // ignore: unused_field
   final WithConstraint _item;
   $WithConstraintsWithReferences(this._db, this._item);
 }
@@ -2449,6 +2452,7 @@ class $ConfigTableOrderingComposer
 class $ConfigTableWithReferences {
   // ignore: unused_field
   final _$CustomTablesDb _db;
+  // ignore: unused_field
   final Config _item;
   $ConfigTableWithReferences(this._db, this._item);
 }
@@ -2572,6 +2576,7 @@ class $MytableOrderingComposer
 class $MytableWithReferences {
   // ignore: unused_field
   final _$CustomTablesDb _db;
+  // ignore: unused_field
   final MytableData _item;
   $MytableWithReferences(this._db, this._item);
 }
@@ -2684,6 +2689,7 @@ class $EmailOrderingComposer extends OrderingComposer<_$CustomTablesDb, Email> {
 class $EmailWithReferences {
   // ignore: unused_field
   final _$CustomTablesDb _db;
+  // ignore: unused_field
   final EMail _item;
   $EmailWithReferences(this._db, this._item);
 }
@@ -2784,6 +2790,7 @@ class $WeirdTableOrderingComposer
 class $WeirdTableWithReferences {
   // ignore: unused_field
   final _$CustomTablesDb _db;
+  // ignore: unused_field
   final WeirdData _item;
   $WeirdTableWithReferences(this._db, this._item);
 }

--- a/drift/test/generated/custom_tables.g.dart
+++ b/drift/test/generated/custom_tables.g.dart
@@ -2047,7 +2047,7 @@ class $NoIdsTableManager extends RootTableManager<
           table: table,
           filteringComposer: $NoIdsFilterComposer(ComposerState(db, table)),
           orderingComposer: $NoIdsOrderingComposer(ComposerState(db, table)),
-          dataclassMapper: (p0) async =>
+          withReferenceMapper: (p0) =>
               p0.map((e) => $NoIdsWithReferences(db, e)).toList(),
           updateCompanionCallback: ({
             Value<Uint8List> payload = const Value.absent(),
@@ -2127,7 +2127,7 @@ class $WithDefaultsTableManager extends RootTableManager<
               $WithDefaultsFilterComposer(ComposerState(db, table)),
           orderingComposer:
               $WithDefaultsOrderingComposer(ComposerState(db, table)),
-          dataclassMapper: (p0) async =>
+          withReferenceMapper: (p0) =>
               p0.map((e) => $WithDefaultsWithReferences(db, e)).toList(),
           updateCompanionCallback: ({
             Value<String?> a = const Value.absent(),
@@ -2231,7 +2231,7 @@ class $WithConstraintsTableManager extends RootTableManager<
               $WithConstraintsFilterComposer(ComposerState(db, table)),
           orderingComposer:
               $WithConstraintsOrderingComposer(ComposerState(db, table)),
-          dataclassMapper: (p0) async =>
+          withReferenceMapper: (p0) =>
               p0.map((e) => $WithConstraintsWithReferences(db, e)).toList(),
           updateCompanionCallback: ({
             Value<String?> a = const Value.absent(),
@@ -2349,7 +2349,7 @@ class $ConfigTableTableManager extends RootTableManager<
               $ConfigTableFilterComposer(ComposerState(db, table)),
           orderingComposer:
               $ConfigTableOrderingComposer(ComposerState(db, table)),
-          dataclassMapper: (p0) async =>
+          withReferenceMapper: (p0) =>
               p0.map((e) => $ConfigTableWithReferences(db, e)).toList(),
           updateCompanionCallback: ({
             Value<String> configKey = const Value.absent(),
@@ -2481,7 +2481,7 @@ class $MytableTableManager extends RootTableManager<
           table: table,
           filteringComposer: $MytableFilterComposer(ComposerState(db, table)),
           orderingComposer: $MytableOrderingComposer(ComposerState(db, table)),
-          dataclassMapper: (p0) async =>
+          withReferenceMapper: (p0) =>
               p0.map((e) => $MytableWithReferences(db, e)).toList(),
           updateCompanionCallback: ({
             Value<int> someid = const Value.absent(),
@@ -2604,7 +2604,7 @@ class $EmailTableManager extends RootTableManager<
           table: table,
           filteringComposer: $EmailFilterComposer(ComposerState(db, table)),
           orderingComposer: $EmailOrderingComposer(ComposerState(db, table)),
-          dataclassMapper: (p0) async =>
+          withReferenceMapper: (p0) =>
               p0.map((e) => $EmailWithReferences(db, e)).toList(),
           updateCompanionCallback: ({
             Value<String> sender = const Value.absent(),
@@ -2716,7 +2716,7 @@ class $WeirdTableTableManager extends RootTableManager<
               $WeirdTableFilterComposer(ComposerState(db, table)),
           orderingComposer:
               $WeirdTableOrderingComposer(ComposerState(db, table)),
-          dataclassMapper: (p0) async =>
+          withReferenceMapper: (p0) =>
               p0.map((e) => $WeirdTableWithReferences(db, e)).toList(),
           updateCompanionCallback: ({
             Value<int> sqlClass = const Value.absent(),

--- a/drift/test/generated/custom_tables.g.dart
+++ b/drift/test/generated/custom_tables.g.dart
@@ -2031,6 +2031,22 @@ typedef $NoIdsUpdateCompanionBuilder = NoIdsCompanion Function({
   Value<Uint8List> payload,
 });
 
+class $NoIdsFilterComposer extends FilterComposer<_$CustomTablesDb, NoIds> {
+  $NoIdsFilterComposer(super.$state);
+  ColumnFilters<Uint8List> get payload => $state.composableBuilder(
+      column: $state.table.payload,
+      builder: (column, joinBuilders) =>
+          ColumnFilters(column, joinBuilders: joinBuilders));
+}
+
+class $NoIdsOrderingComposer extends OrderingComposer<_$CustomTablesDb, NoIds> {
+  $NoIdsOrderingComposer(super.$state);
+  ColumnOrderings<Uint8List> get payload => $state.composableBuilder(
+      column: $state.table.payload,
+      builder: (column, joinBuilders) =>
+          ColumnOrderings(column, joinBuilders: joinBuilders));
+}
+
 class $NoIdsTableManager extends RootTableManager<
     _$CustomTablesDb,
     NoIds,
@@ -2039,7 +2055,7 @@ class $NoIdsTableManager extends RootTableManager<
     $NoIdsOrderingComposer,
     $NoIdsCreateCompanionBuilder,
     $NoIdsUpdateCompanionBuilder,
-    (NoIdRow, $NoIdsWithReferences),
+    (NoIdRow, BaseWithReferences<_$CustomTablesDb, NoIdRow>),
     NoIdRow> {
   $NoIdsTableManager(_$CustomTablesDb db, NoIds table)
       : super(TableManagerState(
@@ -2048,7 +2064,7 @@ class $NoIdsTableManager extends RootTableManager<
           filteringComposer: $NoIdsFilterComposer(ComposerState(db, table)),
           orderingComposer: $NoIdsOrderingComposer(ComposerState(db, table)),
           withReferenceMapper: (p0) =>
-              p0.map((e) => (e, $NoIdsWithReferences(db, e))).toList(),
+              p0.map((e) => (e, BaseWithReferences(db, e))).toList(),
           updateCompanionCallback: ({
             Value<Uint8List> payload = const Value.absent(),
           }) =>
@@ -2072,33 +2088,8 @@ typedef $NoIdsProcessedTableManager = ProcessedTableManager<
     $NoIdsOrderingComposer,
     $NoIdsCreateCompanionBuilder,
     $NoIdsUpdateCompanionBuilder,
-    (NoIdRow, $NoIdsWithReferences),
+    (NoIdRow, BaseWithReferences<_$CustomTablesDb, NoIdRow>),
     NoIdRow>;
-
-class $NoIdsFilterComposer extends FilterComposer<_$CustomTablesDb, NoIds> {
-  $NoIdsFilterComposer(super.$state);
-  ColumnFilters<Uint8List> get payload => $state.composableBuilder(
-      column: $state.table.payload,
-      builder: (column, joinBuilders) =>
-          ColumnFilters(column, joinBuilders: joinBuilders));
-}
-
-class $NoIdsOrderingComposer extends OrderingComposer<_$CustomTablesDb, NoIds> {
-  $NoIdsOrderingComposer(super.$state);
-  ColumnOrderings<Uint8List> get payload => $state.composableBuilder(
-      column: $state.table.payload,
-      builder: (column, joinBuilders) =>
-          ColumnOrderings(column, joinBuilders: joinBuilders));
-}
-
-class $NoIdsWithReferences {
-  // ignore: unused_field
-  final _$CustomTablesDb _db;
-  // ignore: unused_field
-  final NoIdRow _item;
-  $NoIdsWithReferences(this._db, this._item);
-}
-
 typedef $WithDefaultsCreateCompanionBuilder = WithDefaultsCompanion Function({
   Value<String?> a,
   Value<int?> b,
@@ -2110,6 +2101,34 @@ typedef $WithDefaultsUpdateCompanionBuilder = WithDefaultsCompanion Function({
   Value<int> rowid,
 });
 
+class $WithDefaultsFilterComposer
+    extends FilterComposer<_$CustomTablesDb, WithDefaults> {
+  $WithDefaultsFilterComposer(super.$state);
+  ColumnFilters<String> get a => $state.composableBuilder(
+      column: $state.table.a,
+      builder: (column, joinBuilders) =>
+          ColumnFilters(column, joinBuilders: joinBuilders));
+
+  ColumnFilters<int> get b => $state.composableBuilder(
+      column: $state.table.b,
+      builder: (column, joinBuilders) =>
+          ColumnFilters(column, joinBuilders: joinBuilders));
+}
+
+class $WithDefaultsOrderingComposer
+    extends OrderingComposer<_$CustomTablesDb, WithDefaults> {
+  $WithDefaultsOrderingComposer(super.$state);
+  ColumnOrderings<String> get a => $state.composableBuilder(
+      column: $state.table.a,
+      builder: (column, joinBuilders) =>
+          ColumnOrderings(column, joinBuilders: joinBuilders));
+
+  ColumnOrderings<int> get b => $state.composableBuilder(
+      column: $state.table.b,
+      builder: (column, joinBuilders) =>
+          ColumnOrderings(column, joinBuilders: joinBuilders));
+}
+
 class $WithDefaultsTableManager extends RootTableManager<
     _$CustomTablesDb,
     WithDefaults,
@@ -2118,7 +2137,7 @@ class $WithDefaultsTableManager extends RootTableManager<
     $WithDefaultsOrderingComposer,
     $WithDefaultsCreateCompanionBuilder,
     $WithDefaultsUpdateCompanionBuilder,
-    (WithDefault, $WithDefaultsWithReferences),
+    (WithDefault, BaseWithReferences<_$CustomTablesDb, WithDefault>),
     WithDefault> {
   $WithDefaultsTableManager(_$CustomTablesDb db, WithDefaults table)
       : super(TableManagerState(
@@ -2129,7 +2148,7 @@ class $WithDefaultsTableManager extends RootTableManager<
           orderingComposer:
               $WithDefaultsOrderingComposer(ComposerState(db, table)),
           withReferenceMapper: (p0) =>
-              p0.map((e) => (e, $WithDefaultsWithReferences(db, e))).toList(),
+              p0.map((e) => (e, BaseWithReferences(db, e))).toList(),
           updateCompanionCallback: ({
             Value<String?> a = const Value.absent(),
             Value<int?> b = const Value.absent(),
@@ -2161,45 +2180,8 @@ typedef $WithDefaultsProcessedTableManager = ProcessedTableManager<
     $WithDefaultsOrderingComposer,
     $WithDefaultsCreateCompanionBuilder,
     $WithDefaultsUpdateCompanionBuilder,
-    (WithDefault, $WithDefaultsWithReferences),
+    (WithDefault, BaseWithReferences<_$CustomTablesDb, WithDefault>),
     WithDefault>;
-
-class $WithDefaultsFilterComposer
-    extends FilterComposer<_$CustomTablesDb, WithDefaults> {
-  $WithDefaultsFilterComposer(super.$state);
-  ColumnFilters<String> get a => $state.composableBuilder(
-      column: $state.table.a,
-      builder: (column, joinBuilders) =>
-          ColumnFilters(column, joinBuilders: joinBuilders));
-
-  ColumnFilters<int> get b => $state.composableBuilder(
-      column: $state.table.b,
-      builder: (column, joinBuilders) =>
-          ColumnFilters(column, joinBuilders: joinBuilders));
-}
-
-class $WithDefaultsOrderingComposer
-    extends OrderingComposer<_$CustomTablesDb, WithDefaults> {
-  $WithDefaultsOrderingComposer(super.$state);
-  ColumnOrderings<String> get a => $state.composableBuilder(
-      column: $state.table.a,
-      builder: (column, joinBuilders) =>
-          ColumnOrderings(column, joinBuilders: joinBuilders));
-
-  ColumnOrderings<int> get b => $state.composableBuilder(
-      column: $state.table.b,
-      builder: (column, joinBuilders) =>
-          ColumnOrderings(column, joinBuilders: joinBuilders));
-}
-
-class $WithDefaultsWithReferences {
-  // ignore: unused_field
-  final _$CustomTablesDb _db;
-  // ignore: unused_field
-  final WithDefault _item;
-  $WithDefaultsWithReferences(this._db, this._item);
-}
-
 typedef $WithConstraintsCreateCompanionBuilder = WithConstraintsCompanion
     Function({
   Value<String?> a,
@@ -2214,65 +2196,6 @@ typedef $WithConstraintsUpdateCompanionBuilder = WithConstraintsCompanion
   Value<double?> c,
   Value<int> rowid,
 });
-
-class $WithConstraintsTableManager extends RootTableManager<
-    _$CustomTablesDb,
-    WithConstraints,
-    WithConstraint,
-    $WithConstraintsFilterComposer,
-    $WithConstraintsOrderingComposer,
-    $WithConstraintsCreateCompanionBuilder,
-    $WithConstraintsUpdateCompanionBuilder,
-    (WithConstraint, $WithConstraintsWithReferences),
-    WithConstraint> {
-  $WithConstraintsTableManager(_$CustomTablesDb db, WithConstraints table)
-      : super(TableManagerState(
-          db: db,
-          table: table,
-          filteringComposer:
-              $WithConstraintsFilterComposer(ComposerState(db, table)),
-          orderingComposer:
-              $WithConstraintsOrderingComposer(ComposerState(db, table)),
-          withReferenceMapper: (p0) => p0
-              .map((e) => (e, $WithConstraintsWithReferences(db, e)))
-              .toList(),
-          updateCompanionCallback: ({
-            Value<String?> a = const Value.absent(),
-            Value<int> b = const Value.absent(),
-            Value<double?> c = const Value.absent(),
-            Value<int> rowid = const Value.absent(),
-          }) =>
-              WithConstraintsCompanion(
-            a: a,
-            b: b,
-            c: c,
-            rowid: rowid,
-          ),
-          createCompanionCallback: ({
-            Value<String?> a = const Value.absent(),
-            required int b,
-            Value<double?> c = const Value.absent(),
-            Value<int> rowid = const Value.absent(),
-          }) =>
-              WithConstraintsCompanion.insert(
-            a: a,
-            b: b,
-            c: c,
-            rowid: rowid,
-          ),
-        ));
-}
-
-typedef $WithConstraintsProcessedTableManager = ProcessedTableManager<
-    _$CustomTablesDb,
-    WithConstraints,
-    WithConstraint,
-    $WithConstraintsFilterComposer,
-    $WithConstraintsOrderingComposer,
-    $WithConstraintsCreateCompanionBuilder,
-    $WithConstraintsUpdateCompanionBuilder,
-    (WithConstraint, $WithConstraintsWithReferences),
-    WithConstraint>;
 
 class $WithConstraintsFilterComposer
     extends FilterComposer<_$CustomTablesDb, WithConstraints> {
@@ -2312,14 +2235,63 @@ class $WithConstraintsOrderingComposer
           ColumnOrderings(column, joinBuilders: joinBuilders));
 }
 
-class $WithConstraintsWithReferences {
-  // ignore: unused_field
-  final _$CustomTablesDb _db;
-  // ignore: unused_field
-  final WithConstraint _item;
-  $WithConstraintsWithReferences(this._db, this._item);
+class $WithConstraintsTableManager extends RootTableManager<
+    _$CustomTablesDb,
+    WithConstraints,
+    WithConstraint,
+    $WithConstraintsFilterComposer,
+    $WithConstraintsOrderingComposer,
+    $WithConstraintsCreateCompanionBuilder,
+    $WithConstraintsUpdateCompanionBuilder,
+    (WithConstraint, BaseWithReferences<_$CustomTablesDb, WithConstraint>),
+    WithConstraint> {
+  $WithConstraintsTableManager(_$CustomTablesDb db, WithConstraints table)
+      : super(TableManagerState(
+          db: db,
+          table: table,
+          filteringComposer:
+              $WithConstraintsFilterComposer(ComposerState(db, table)),
+          orderingComposer:
+              $WithConstraintsOrderingComposer(ComposerState(db, table)),
+          withReferenceMapper: (p0) =>
+              p0.map((e) => (e, BaseWithReferences(db, e))).toList(),
+          updateCompanionCallback: ({
+            Value<String?> a = const Value.absent(),
+            Value<int> b = const Value.absent(),
+            Value<double?> c = const Value.absent(),
+            Value<int> rowid = const Value.absent(),
+          }) =>
+              WithConstraintsCompanion(
+            a: a,
+            b: b,
+            c: c,
+            rowid: rowid,
+          ),
+          createCompanionCallback: ({
+            Value<String?> a = const Value.absent(),
+            required int b,
+            Value<double?> c = const Value.absent(),
+            Value<int> rowid = const Value.absent(),
+          }) =>
+              WithConstraintsCompanion.insert(
+            a: a,
+            b: b,
+            c: c,
+            rowid: rowid,
+          ),
+        ));
 }
 
+typedef $WithConstraintsProcessedTableManager = ProcessedTableManager<
+    _$CustomTablesDb,
+    WithConstraints,
+    WithConstraint,
+    $WithConstraintsFilterComposer,
+    $WithConstraintsOrderingComposer,
+    $WithConstraintsCreateCompanionBuilder,
+    $WithConstraintsUpdateCompanionBuilder,
+    (WithConstraint, BaseWithReferences<_$CustomTablesDb, WithConstraint>),
+    WithConstraint>;
 typedef $ConfigTableCreateCompanionBuilder = ConfigCompanion Function({
   required String configKey,
   Value<DriftAny?> configValue,
@@ -2334,68 +2306,6 @@ typedef $ConfigTableUpdateCompanionBuilder = ConfigCompanion Function({
   Value<SyncType?> syncStateImplicit,
   Value<int> rowid,
 });
-
-class $ConfigTableTableManager extends RootTableManager<
-    _$CustomTablesDb,
-    ConfigTable,
-    Config,
-    $ConfigTableFilterComposer,
-    $ConfigTableOrderingComposer,
-    $ConfigTableCreateCompanionBuilder,
-    $ConfigTableUpdateCompanionBuilder,
-    (Config, $ConfigTableWithReferences),
-    Config> {
-  $ConfigTableTableManager(_$CustomTablesDb db, ConfigTable table)
-      : super(TableManagerState(
-          db: db,
-          table: table,
-          filteringComposer:
-              $ConfigTableFilterComposer(ComposerState(db, table)),
-          orderingComposer:
-              $ConfigTableOrderingComposer(ComposerState(db, table)),
-          withReferenceMapper: (p0) =>
-              p0.map((e) => (e, $ConfigTableWithReferences(db, e))).toList(),
-          updateCompanionCallback: ({
-            Value<String> configKey = const Value.absent(),
-            Value<DriftAny?> configValue = const Value.absent(),
-            Value<SyncType?> syncState = const Value.absent(),
-            Value<SyncType?> syncStateImplicit = const Value.absent(),
-            Value<int> rowid = const Value.absent(),
-          }) =>
-              ConfigCompanion(
-            configKey: configKey,
-            configValue: configValue,
-            syncState: syncState,
-            syncStateImplicit: syncStateImplicit,
-            rowid: rowid,
-          ),
-          createCompanionCallback: ({
-            required String configKey,
-            Value<DriftAny?> configValue = const Value.absent(),
-            Value<SyncType?> syncState = const Value.absent(),
-            Value<SyncType?> syncStateImplicit = const Value.absent(),
-            Value<int> rowid = const Value.absent(),
-          }) =>
-              ConfigCompanion.insert(
-            configKey: configKey,
-            configValue: configValue,
-            syncState: syncState,
-            syncStateImplicit: syncStateImplicit,
-            rowid: rowid,
-          ),
-        ));
-}
-
-typedef $ConfigTableProcessedTableManager = ProcessedTableManager<
-    _$CustomTablesDb,
-    ConfigTable,
-    Config,
-    $ConfigTableFilterComposer,
-    $ConfigTableOrderingComposer,
-    $ConfigTableCreateCompanionBuilder,
-    $ConfigTableUpdateCompanionBuilder,
-    (Config, $ConfigTableWithReferences),
-    Config>;
 
 class $ConfigTableFilterComposer
     extends FilterComposer<_$CustomTablesDb, ConfigTable> {
@@ -2449,14 +2359,67 @@ class $ConfigTableOrderingComposer
           ColumnOrderings(column, joinBuilders: joinBuilders));
 }
 
-class $ConfigTableWithReferences {
-  // ignore: unused_field
-  final _$CustomTablesDb _db;
-  // ignore: unused_field
-  final Config _item;
-  $ConfigTableWithReferences(this._db, this._item);
+class $ConfigTableTableManager extends RootTableManager<
+    _$CustomTablesDb,
+    ConfigTable,
+    Config,
+    $ConfigTableFilterComposer,
+    $ConfigTableOrderingComposer,
+    $ConfigTableCreateCompanionBuilder,
+    $ConfigTableUpdateCompanionBuilder,
+    (Config, BaseWithReferences<_$CustomTablesDb, Config>),
+    Config> {
+  $ConfigTableTableManager(_$CustomTablesDb db, ConfigTable table)
+      : super(TableManagerState(
+          db: db,
+          table: table,
+          filteringComposer:
+              $ConfigTableFilterComposer(ComposerState(db, table)),
+          orderingComposer:
+              $ConfigTableOrderingComposer(ComposerState(db, table)),
+          withReferenceMapper: (p0) =>
+              p0.map((e) => (e, BaseWithReferences(db, e))).toList(),
+          updateCompanionCallback: ({
+            Value<String> configKey = const Value.absent(),
+            Value<DriftAny?> configValue = const Value.absent(),
+            Value<SyncType?> syncState = const Value.absent(),
+            Value<SyncType?> syncStateImplicit = const Value.absent(),
+            Value<int> rowid = const Value.absent(),
+          }) =>
+              ConfigCompanion(
+            configKey: configKey,
+            configValue: configValue,
+            syncState: syncState,
+            syncStateImplicit: syncStateImplicit,
+            rowid: rowid,
+          ),
+          createCompanionCallback: ({
+            required String configKey,
+            Value<DriftAny?> configValue = const Value.absent(),
+            Value<SyncType?> syncState = const Value.absent(),
+            Value<SyncType?> syncStateImplicit = const Value.absent(),
+            Value<int> rowid = const Value.absent(),
+          }) =>
+              ConfigCompanion.insert(
+            configKey: configKey,
+            configValue: configValue,
+            syncState: syncState,
+            syncStateImplicit: syncStateImplicit,
+            rowid: rowid,
+          ),
+        ));
 }
 
+typedef $ConfigTableProcessedTableManager = ProcessedTableManager<
+    _$CustomTablesDb,
+    ConfigTable,
+    Config,
+    $ConfigTableFilterComposer,
+    $ConfigTableOrderingComposer,
+    $ConfigTableCreateCompanionBuilder,
+    $ConfigTableUpdateCompanionBuilder,
+    (Config, BaseWithReferences<_$CustomTablesDb, Config>),
+    Config>;
 typedef $MytableCreateCompanionBuilder = MytableCompanion Function({
   Value<int> someid,
   Value<String?> sometext,
@@ -2469,62 +2432,6 @@ typedef $MytableUpdateCompanionBuilder = MytableCompanion Function({
   Value<bool?> isInserting,
   Value<DateTime?> somedate,
 });
-
-class $MytableTableManager extends RootTableManager<
-    _$CustomTablesDb,
-    Mytable,
-    MytableData,
-    $MytableFilterComposer,
-    $MytableOrderingComposer,
-    $MytableCreateCompanionBuilder,
-    $MytableUpdateCompanionBuilder,
-    (MytableData, $MytableWithReferences),
-    MytableData> {
-  $MytableTableManager(_$CustomTablesDb db, Mytable table)
-      : super(TableManagerState(
-          db: db,
-          table: table,
-          filteringComposer: $MytableFilterComposer(ComposerState(db, table)),
-          orderingComposer: $MytableOrderingComposer(ComposerState(db, table)),
-          withReferenceMapper: (p0) =>
-              p0.map((e) => (e, $MytableWithReferences(db, e))).toList(),
-          updateCompanionCallback: ({
-            Value<int> someid = const Value.absent(),
-            Value<String?> sometext = const Value.absent(),
-            Value<bool?> isInserting = const Value.absent(),
-            Value<DateTime?> somedate = const Value.absent(),
-          }) =>
-              MytableCompanion(
-            someid: someid,
-            sometext: sometext,
-            isInserting: isInserting,
-            somedate: somedate,
-          ),
-          createCompanionCallback: ({
-            Value<int> someid = const Value.absent(),
-            Value<String?> sometext = const Value.absent(),
-            Value<bool?> isInserting = const Value.absent(),
-            Value<DateTime?> somedate = const Value.absent(),
-          }) =>
-              MytableCompanion.insert(
-            someid: someid,
-            sometext: sometext,
-            isInserting: isInserting,
-            somedate: somedate,
-          ),
-        ));
-}
-
-typedef $MytableProcessedTableManager = ProcessedTableManager<
-    _$CustomTablesDb,
-    Mytable,
-    MytableData,
-    $MytableFilterComposer,
-    $MytableOrderingComposer,
-    $MytableCreateCompanionBuilder,
-    $MytableUpdateCompanionBuilder,
-    (MytableData, $MytableWithReferences),
-    MytableData>;
 
 class $MytableFilterComposer extends FilterComposer<_$CustomTablesDb, Mytable> {
   $MytableFilterComposer(super.$state);
@@ -2573,14 +2480,61 @@ class $MytableOrderingComposer
           ColumnOrderings(column, joinBuilders: joinBuilders));
 }
 
-class $MytableWithReferences {
-  // ignore: unused_field
-  final _$CustomTablesDb _db;
-  // ignore: unused_field
-  final MytableData _item;
-  $MytableWithReferences(this._db, this._item);
+class $MytableTableManager extends RootTableManager<
+    _$CustomTablesDb,
+    Mytable,
+    MytableData,
+    $MytableFilterComposer,
+    $MytableOrderingComposer,
+    $MytableCreateCompanionBuilder,
+    $MytableUpdateCompanionBuilder,
+    (MytableData, BaseWithReferences<_$CustomTablesDb, MytableData>),
+    MytableData> {
+  $MytableTableManager(_$CustomTablesDb db, Mytable table)
+      : super(TableManagerState(
+          db: db,
+          table: table,
+          filteringComposer: $MytableFilterComposer(ComposerState(db, table)),
+          orderingComposer: $MytableOrderingComposer(ComposerState(db, table)),
+          withReferenceMapper: (p0) =>
+              p0.map((e) => (e, BaseWithReferences(db, e))).toList(),
+          updateCompanionCallback: ({
+            Value<int> someid = const Value.absent(),
+            Value<String?> sometext = const Value.absent(),
+            Value<bool?> isInserting = const Value.absent(),
+            Value<DateTime?> somedate = const Value.absent(),
+          }) =>
+              MytableCompanion(
+            someid: someid,
+            sometext: sometext,
+            isInserting: isInserting,
+            somedate: somedate,
+          ),
+          createCompanionCallback: ({
+            Value<int> someid = const Value.absent(),
+            Value<String?> sometext = const Value.absent(),
+            Value<bool?> isInserting = const Value.absent(),
+            Value<DateTime?> somedate = const Value.absent(),
+          }) =>
+              MytableCompanion.insert(
+            someid: someid,
+            sometext: sometext,
+            isInserting: isInserting,
+            somedate: somedate,
+          ),
+        ));
 }
 
+typedef $MytableProcessedTableManager = ProcessedTableManager<
+    _$CustomTablesDb,
+    Mytable,
+    MytableData,
+    $MytableFilterComposer,
+    $MytableOrderingComposer,
+    $MytableCreateCompanionBuilder,
+    $MytableUpdateCompanionBuilder,
+    (MytableData, BaseWithReferences<_$CustomTablesDb, MytableData>),
+    MytableData>;
 typedef $EmailCreateCompanionBuilder = EmailCompanion Function({
   required String sender,
   required String title,
@@ -2593,62 +2547,6 @@ typedef $EmailUpdateCompanionBuilder = EmailCompanion Function({
   Value<String> body,
   Value<int> rowid,
 });
-
-class $EmailTableManager extends RootTableManager<
-    _$CustomTablesDb,
-    Email,
-    EMail,
-    $EmailFilterComposer,
-    $EmailOrderingComposer,
-    $EmailCreateCompanionBuilder,
-    $EmailUpdateCompanionBuilder,
-    (EMail, $EmailWithReferences),
-    EMail> {
-  $EmailTableManager(_$CustomTablesDb db, Email table)
-      : super(TableManagerState(
-          db: db,
-          table: table,
-          filteringComposer: $EmailFilterComposer(ComposerState(db, table)),
-          orderingComposer: $EmailOrderingComposer(ComposerState(db, table)),
-          withReferenceMapper: (p0) =>
-              p0.map((e) => (e, $EmailWithReferences(db, e))).toList(),
-          updateCompanionCallback: ({
-            Value<String> sender = const Value.absent(),
-            Value<String> title = const Value.absent(),
-            Value<String> body = const Value.absent(),
-            Value<int> rowid = const Value.absent(),
-          }) =>
-              EmailCompanion(
-            sender: sender,
-            title: title,
-            body: body,
-            rowid: rowid,
-          ),
-          createCompanionCallback: ({
-            required String sender,
-            required String title,
-            required String body,
-            Value<int> rowid = const Value.absent(),
-          }) =>
-              EmailCompanion.insert(
-            sender: sender,
-            title: title,
-            body: body,
-            rowid: rowid,
-          ),
-        ));
-}
-
-typedef $EmailProcessedTableManager = ProcessedTableManager<
-    _$CustomTablesDb,
-    Email,
-    EMail,
-    $EmailFilterComposer,
-    $EmailOrderingComposer,
-    $EmailCreateCompanionBuilder,
-    $EmailUpdateCompanionBuilder,
-    (EMail, $EmailWithReferences),
-    EMail>;
 
 class $EmailFilterComposer extends FilterComposer<_$CustomTablesDb, Email> {
   $EmailFilterComposer(super.$state);
@@ -2686,14 +2584,61 @@ class $EmailOrderingComposer extends OrderingComposer<_$CustomTablesDb, Email> {
           ColumnOrderings(column, joinBuilders: joinBuilders));
 }
 
-class $EmailWithReferences {
-  // ignore: unused_field
-  final _$CustomTablesDb _db;
-  // ignore: unused_field
-  final EMail _item;
-  $EmailWithReferences(this._db, this._item);
+class $EmailTableManager extends RootTableManager<
+    _$CustomTablesDb,
+    Email,
+    EMail,
+    $EmailFilterComposer,
+    $EmailOrderingComposer,
+    $EmailCreateCompanionBuilder,
+    $EmailUpdateCompanionBuilder,
+    (EMail, BaseWithReferences<_$CustomTablesDb, EMail>),
+    EMail> {
+  $EmailTableManager(_$CustomTablesDb db, Email table)
+      : super(TableManagerState(
+          db: db,
+          table: table,
+          filteringComposer: $EmailFilterComposer(ComposerState(db, table)),
+          orderingComposer: $EmailOrderingComposer(ComposerState(db, table)),
+          withReferenceMapper: (p0) =>
+              p0.map((e) => (e, BaseWithReferences(db, e))).toList(),
+          updateCompanionCallback: ({
+            Value<String> sender = const Value.absent(),
+            Value<String> title = const Value.absent(),
+            Value<String> body = const Value.absent(),
+            Value<int> rowid = const Value.absent(),
+          }) =>
+              EmailCompanion(
+            sender: sender,
+            title: title,
+            body: body,
+            rowid: rowid,
+          ),
+          createCompanionCallback: ({
+            required String sender,
+            required String title,
+            required String body,
+            Value<int> rowid = const Value.absent(),
+          }) =>
+              EmailCompanion.insert(
+            sender: sender,
+            title: title,
+            body: body,
+            rowid: rowid,
+          ),
+        ));
 }
 
+typedef $EmailProcessedTableManager = ProcessedTableManager<
+    _$CustomTablesDb,
+    Email,
+    EMail,
+    $EmailFilterComposer,
+    $EmailOrderingComposer,
+    $EmailCreateCompanionBuilder,
+    $EmailUpdateCompanionBuilder,
+    (EMail, BaseWithReferences<_$CustomTablesDb, EMail>),
+    EMail>;
 typedef $WeirdTableCreateCompanionBuilder = WeirdTableCompanion Function({
   required int sqlClass,
   required String textColumn,
@@ -2705,6 +2650,34 @@ typedef $WeirdTableUpdateCompanionBuilder = WeirdTableCompanion Function({
   Value<int> rowid,
 });
 
+class $WeirdTableFilterComposer
+    extends FilterComposer<_$CustomTablesDb, WeirdTable> {
+  $WeirdTableFilterComposer(super.$state);
+  ColumnFilters<int> get sqlClass => $state.composableBuilder(
+      column: $state.table.sqlClass,
+      builder: (column, joinBuilders) =>
+          ColumnFilters(column, joinBuilders: joinBuilders));
+
+  ColumnFilters<String> get textColumn => $state.composableBuilder(
+      column: $state.table.textColumn,
+      builder: (column, joinBuilders) =>
+          ColumnFilters(column, joinBuilders: joinBuilders));
+}
+
+class $WeirdTableOrderingComposer
+    extends OrderingComposer<_$CustomTablesDb, WeirdTable> {
+  $WeirdTableOrderingComposer(super.$state);
+  ColumnOrderings<int> get sqlClass => $state.composableBuilder(
+      column: $state.table.sqlClass,
+      builder: (column, joinBuilders) =>
+          ColumnOrderings(column, joinBuilders: joinBuilders));
+
+  ColumnOrderings<String> get textColumn => $state.composableBuilder(
+      column: $state.table.textColumn,
+      builder: (column, joinBuilders) =>
+          ColumnOrderings(column, joinBuilders: joinBuilders));
+}
+
 class $WeirdTableTableManager extends RootTableManager<
     _$CustomTablesDb,
     WeirdTable,
@@ -2713,7 +2686,7 @@ class $WeirdTableTableManager extends RootTableManager<
     $WeirdTableOrderingComposer,
     $WeirdTableCreateCompanionBuilder,
     $WeirdTableUpdateCompanionBuilder,
-    (WeirdData, $WeirdTableWithReferences),
+    (WeirdData, BaseWithReferences<_$CustomTablesDb, WeirdData>),
     WeirdData> {
   $WeirdTableTableManager(_$CustomTablesDb db, WeirdTable table)
       : super(TableManagerState(
@@ -2724,7 +2697,7 @@ class $WeirdTableTableManager extends RootTableManager<
           orderingComposer:
               $WeirdTableOrderingComposer(ComposerState(db, table)),
           withReferenceMapper: (p0) =>
-              p0.map((e) => (e, $WeirdTableWithReferences(db, e))).toList(),
+              p0.map((e) => (e, BaseWithReferences(db, e))).toList(),
           updateCompanionCallback: ({
             Value<int> sqlClass = const Value.absent(),
             Value<String> textColumn = const Value.absent(),
@@ -2756,44 +2729,8 @@ typedef $WeirdTableProcessedTableManager = ProcessedTableManager<
     $WeirdTableOrderingComposer,
     $WeirdTableCreateCompanionBuilder,
     $WeirdTableUpdateCompanionBuilder,
-    (WeirdData, $WeirdTableWithReferences),
+    (WeirdData, BaseWithReferences<_$CustomTablesDb, WeirdData>),
     WeirdData>;
-
-class $WeirdTableFilterComposer
-    extends FilterComposer<_$CustomTablesDb, WeirdTable> {
-  $WeirdTableFilterComposer(super.$state);
-  ColumnFilters<int> get sqlClass => $state.composableBuilder(
-      column: $state.table.sqlClass,
-      builder: (column, joinBuilders) =>
-          ColumnFilters(column, joinBuilders: joinBuilders));
-
-  ColumnFilters<String> get textColumn => $state.composableBuilder(
-      column: $state.table.textColumn,
-      builder: (column, joinBuilders) =>
-          ColumnFilters(column, joinBuilders: joinBuilders));
-}
-
-class $WeirdTableOrderingComposer
-    extends OrderingComposer<_$CustomTablesDb, WeirdTable> {
-  $WeirdTableOrderingComposer(super.$state);
-  ColumnOrderings<int> get sqlClass => $state.composableBuilder(
-      column: $state.table.sqlClass,
-      builder: (column, joinBuilders) =>
-          ColumnOrderings(column, joinBuilders: joinBuilders));
-
-  ColumnOrderings<String> get textColumn => $state.composableBuilder(
-      column: $state.table.textColumn,
-      builder: (column, joinBuilders) =>
-          ColumnOrderings(column, joinBuilders: joinBuilders));
-}
-
-class $WeirdTableWithReferences {
-  // ignore: unused_field
-  final _$CustomTablesDb _db;
-  // ignore: unused_field
-  final WeirdData _item;
-  $WeirdTableWithReferences(this._db, this._item);
-}
 
 class $CustomTablesDbManager {
   final _$CustomTablesDb _db;

--- a/drift/test/generated/todos.dart
+++ b/drift/test/generated/todos.dart
@@ -31,6 +31,7 @@ class TodosTable extends Table with AutoIncrement {
   @ReferenceName("todos")
   IntColumn get category => integer()
       .references(Categories, #id, initiallyDeferred: true)
+      .map(TypeConverter.extensionType<RowId, int>())
       .nullable()();
 
   TextColumn get status => textEnum<TodoStatus>().nullable()();

--- a/drift/test/generated/todos.g.dart
+++ b/drift/test/generated/todos.g.dart
@@ -3453,61 +3453,6 @@ typedef $$CategoriesTableUpdateCompanionBuilder = CategoriesCompanion Function({
   Value<CategoryPriority> priority,
 });
 
-class $$CategoriesTableTableManager extends RootTableManager<
-    _$TodoDb,
-    $CategoriesTable,
-    Category,
-    $$CategoriesTableFilterComposer,
-    $$CategoriesTableOrderingComposer,
-    $$CategoriesTableCreateCompanionBuilder,
-    $$CategoriesTableUpdateCompanionBuilder,
-    (Category, $$CategoriesTableWithReferences),
-    Category> {
-  $$CategoriesTableTableManager(_$TodoDb db, $CategoriesTable table)
-      : super(TableManagerState(
-          db: db,
-          table: table,
-          filteringComposer:
-              $$CategoriesTableFilterComposer(ComposerState(db, table)),
-          orderingComposer:
-              $$CategoriesTableOrderingComposer(ComposerState(db, table)),
-          withReferenceMapper: (p0) => p0
-              .map((e) => (e, $$CategoriesTableWithReferences(db, e)))
-              .toList(),
-          updateCompanionCallback: ({
-            Value<RowId> id = const Value.absent(),
-            Value<String> description = const Value.absent(),
-            Value<CategoryPriority> priority = const Value.absent(),
-          }) =>
-              CategoriesCompanion(
-            id: id,
-            description: description,
-            priority: priority,
-          ),
-          createCompanionCallback: ({
-            Value<RowId> id = const Value.absent(),
-            required String description,
-            Value<CategoryPriority> priority = const Value.absent(),
-          }) =>
-              CategoriesCompanion.insert(
-            id: id,
-            description: description,
-            priority: priority,
-          ),
-        ));
-}
-
-typedef $$CategoriesTableProcessedTableManager = ProcessedTableManager<
-    _$TodoDb,
-    $CategoriesTable,
-    Category,
-    $$CategoriesTableFilterComposer,
-    $$CategoriesTableOrderingComposer,
-    $$CategoriesTableCreateCompanionBuilder,
-    $$CategoriesTableUpdateCompanionBuilder,
-    (Category, $$CategoriesTableWithReferences),
-    Category>;
-
 class $$CategoriesTableFilterComposer
     extends FilterComposer<_$TodoDb, $CategoriesTable> {
   $$CategoriesTableFilterComposer(super.$state);
@@ -3574,19 +3519,70 @@ class $$CategoriesTableOrderingComposer
               ColumnOrderings(column, joinBuilders: joinBuilders));
 }
 
-class $$CategoriesTableWithReferences {
-  // ignore: unused_field
-  final _$TodoDb _db;
-  // ignore: unused_field
-  final Category _item;
-  $$CategoriesTableWithReferences(this._db, this._item);
+class $$CategoriesTableWithReferences
+    extends BaseWithReferences<_$TodoDb, Category> {
+  $$CategoriesTableWithReferences(super.$_db, super.$_item);
 
   $$TodosTableTableProcessedTableManager get todos {
-    return $$TodosTableTableTableManager(_db, _db.todosTable)
-        .filter((f) => f.category.id(_item.id));
+    return $$TodosTableTableTableManager($_db, $_db.todosTable)
+        .filter((f) => f.category.id($_item.id));
   }
 }
 
+class $$CategoriesTableTableManager extends RootTableManager<
+    _$TodoDb,
+    $CategoriesTable,
+    Category,
+    $$CategoriesTableFilterComposer,
+    $$CategoriesTableOrderingComposer,
+    $$CategoriesTableCreateCompanionBuilder,
+    $$CategoriesTableUpdateCompanionBuilder,
+    (Category, $$CategoriesTableWithReferences),
+    Category> {
+  $$CategoriesTableTableManager(_$TodoDb db, $CategoriesTable table)
+      : super(TableManagerState(
+          db: db,
+          table: table,
+          filteringComposer:
+              $$CategoriesTableFilterComposer(ComposerState(db, table)),
+          orderingComposer:
+              $$CategoriesTableOrderingComposer(ComposerState(db, table)),
+          withReferenceMapper: (p0) => p0
+              .map((e) => (e, $$CategoriesTableWithReferences(db, e)))
+              .toList(),
+          updateCompanionCallback: ({
+            Value<RowId> id = const Value.absent(),
+            Value<String> description = const Value.absent(),
+            Value<CategoryPriority> priority = const Value.absent(),
+          }) =>
+              CategoriesCompanion(
+            id: id,
+            description: description,
+            priority: priority,
+          ),
+          createCompanionCallback: ({
+            Value<RowId> id = const Value.absent(),
+            required String description,
+            Value<CategoryPriority> priority = const Value.absent(),
+          }) =>
+              CategoriesCompanion.insert(
+            id: id,
+            description: description,
+            priority: priority,
+          ),
+        ));
+}
+
+typedef $$CategoriesTableProcessedTableManager = ProcessedTableManager<
+    _$TodoDb,
+    $CategoriesTable,
+    Category,
+    $$CategoriesTableFilterComposer,
+    $$CategoriesTableOrderingComposer,
+    $$CategoriesTableCreateCompanionBuilder,
+    $$CategoriesTableUpdateCompanionBuilder,
+    (Category, $$CategoriesTableWithReferences),
+    Category>;
 typedef $$TodosTableTableCreateCompanionBuilder = TodosTableCompanion Function({
   Value<RowId> id,
   Value<String?> title,
@@ -3603,73 +3599,6 @@ typedef $$TodosTableTableUpdateCompanionBuilder = TodosTableCompanion Function({
   Value<RowId?> category,
   Value<TodoStatus?> status,
 });
-
-class $$TodosTableTableTableManager extends RootTableManager<
-    _$TodoDb,
-    $TodosTableTable,
-    TodoEntry,
-    $$TodosTableTableFilterComposer,
-    $$TodosTableTableOrderingComposer,
-    $$TodosTableTableCreateCompanionBuilder,
-    $$TodosTableTableUpdateCompanionBuilder,
-    (TodoEntry, $$TodosTableTableWithReferences),
-    TodoEntry> {
-  $$TodosTableTableTableManager(_$TodoDb db, $TodosTableTable table)
-      : super(TableManagerState(
-          db: db,
-          table: table,
-          filteringComposer:
-              $$TodosTableTableFilterComposer(ComposerState(db, table)),
-          orderingComposer:
-              $$TodosTableTableOrderingComposer(ComposerState(db, table)),
-          withReferenceMapper: (p0) => p0
-              .map((e) => (e, $$TodosTableTableWithReferences(db, e)))
-              .toList(),
-          updateCompanionCallback: ({
-            Value<RowId> id = const Value.absent(),
-            Value<String?> title = const Value.absent(),
-            Value<String> content = const Value.absent(),
-            Value<DateTime?> targetDate = const Value.absent(),
-            Value<RowId?> category = const Value.absent(),
-            Value<TodoStatus?> status = const Value.absent(),
-          }) =>
-              TodosTableCompanion(
-            id: id,
-            title: title,
-            content: content,
-            targetDate: targetDate,
-            category: category,
-            status: status,
-          ),
-          createCompanionCallback: ({
-            Value<RowId> id = const Value.absent(),
-            Value<String?> title = const Value.absent(),
-            required String content,
-            Value<DateTime?> targetDate = const Value.absent(),
-            Value<RowId?> category = const Value.absent(),
-            Value<TodoStatus?> status = const Value.absent(),
-          }) =>
-              TodosTableCompanion.insert(
-            id: id,
-            title: title,
-            content: content,
-            targetDate: targetDate,
-            category: category,
-            status: status,
-          ),
-        ));
-}
-
-typedef $$TodosTableTableProcessedTableManager = ProcessedTableManager<
-    _$TodoDb,
-    $TodosTableTable,
-    TodoEntry,
-    $$TodosTableTableFilterComposer,
-    $$TodosTableTableOrderingComposer,
-    $$TodosTableTableCreateCompanionBuilder,
-    $$TodosTableTableUpdateCompanionBuilder,
-    (TodoEntry, $$TodosTableTableWithReferences),
-    TodoEntry>;
 
 class $$TodosTableTableFilterComposer
     extends FilterComposer<_$TodoDb, $TodosTableTable> {
@@ -3757,20 +3686,83 @@ class $$TodosTableTableOrderingComposer
   }
 }
 
-class $$TodosTableTableWithReferences {
-  // ignore: unused_field
-  final _$TodoDb _db;
-  // ignore: unused_field
-  final TodoEntry _item;
-  $$TodosTableTableWithReferences(this._db, this._item);
+class $$TodosTableTableWithReferences
+    extends BaseWithReferences<_$TodoDb, TodoEntry> {
+  $$TodosTableTableWithReferences(super.$_db, super.$_item);
 
   $$CategoriesTableProcessedTableManager? get category {
-    if (_item.category == null) return null;
-    return $$CategoriesTableTableManager(_db, _db.categories)
-        .filter((f) => f.id(_item.category!));
+    if ($_item.category == null) return null;
+    return $$CategoriesTableTableManager($_db, $_db.categories)
+        .filter((f) => f.id($_item.category!));
   }
 }
 
+class $$TodosTableTableTableManager extends RootTableManager<
+    _$TodoDb,
+    $TodosTableTable,
+    TodoEntry,
+    $$TodosTableTableFilterComposer,
+    $$TodosTableTableOrderingComposer,
+    $$TodosTableTableCreateCompanionBuilder,
+    $$TodosTableTableUpdateCompanionBuilder,
+    (TodoEntry, $$TodosTableTableWithReferences),
+    TodoEntry> {
+  $$TodosTableTableTableManager(_$TodoDb db, $TodosTableTable table)
+      : super(TableManagerState(
+          db: db,
+          table: table,
+          filteringComposer:
+              $$TodosTableTableFilterComposer(ComposerState(db, table)),
+          orderingComposer:
+              $$TodosTableTableOrderingComposer(ComposerState(db, table)),
+          withReferenceMapper: (p0) => p0
+              .map((e) => (e, $$TodosTableTableWithReferences(db, e)))
+              .toList(),
+          updateCompanionCallback: ({
+            Value<RowId> id = const Value.absent(),
+            Value<String?> title = const Value.absent(),
+            Value<String> content = const Value.absent(),
+            Value<DateTime?> targetDate = const Value.absent(),
+            Value<RowId?> category = const Value.absent(),
+            Value<TodoStatus?> status = const Value.absent(),
+          }) =>
+              TodosTableCompanion(
+            id: id,
+            title: title,
+            content: content,
+            targetDate: targetDate,
+            category: category,
+            status: status,
+          ),
+          createCompanionCallback: ({
+            Value<RowId> id = const Value.absent(),
+            Value<String?> title = const Value.absent(),
+            required String content,
+            Value<DateTime?> targetDate = const Value.absent(),
+            Value<RowId?> category = const Value.absent(),
+            Value<TodoStatus?> status = const Value.absent(),
+          }) =>
+              TodosTableCompanion.insert(
+            id: id,
+            title: title,
+            content: content,
+            targetDate: targetDate,
+            category: category,
+            status: status,
+          ),
+        ));
+}
+
+typedef $$TodosTableTableProcessedTableManager = ProcessedTableManager<
+    _$TodoDb,
+    $TodosTableTable,
+    TodoEntry,
+    $$TodosTableTableFilterComposer,
+    $$TodosTableTableOrderingComposer,
+    $$TodosTableTableCreateCompanionBuilder,
+    $$TodosTableTableUpdateCompanionBuilder,
+    (TodoEntry, $$TodosTableTableWithReferences),
+    TodoEntry>;
 typedef $$UsersTableCreateCompanionBuilder = UsersCompanion Function({
   Value<RowId> id,
   required String name,
@@ -3785,68 +3777,6 @@ typedef $$UsersTableUpdateCompanionBuilder = UsersCompanion Function({
   Value<Uint8List> profilePicture,
   Value<DateTime> creationTime,
 });
-
-class $$UsersTableTableManager extends RootTableManager<
-    _$TodoDb,
-    $UsersTable,
-    User,
-    $$UsersTableFilterComposer,
-    $$UsersTableOrderingComposer,
-    $$UsersTableCreateCompanionBuilder,
-    $$UsersTableUpdateCompanionBuilder,
-    (User, $$UsersTableWithReferences),
-    User> {
-  $$UsersTableTableManager(_$TodoDb db, $UsersTable table)
-      : super(TableManagerState(
-          db: db,
-          table: table,
-          filteringComposer:
-              $$UsersTableFilterComposer(ComposerState(db, table)),
-          orderingComposer:
-              $$UsersTableOrderingComposer(ComposerState(db, table)),
-          withReferenceMapper: (p0) =>
-              p0.map((e) => (e, $$UsersTableWithReferences(db, e))).toList(),
-          updateCompanionCallback: ({
-            Value<RowId> id = const Value.absent(),
-            Value<String> name = const Value.absent(),
-            Value<bool> isAwesome = const Value.absent(),
-            Value<Uint8List> profilePicture = const Value.absent(),
-            Value<DateTime> creationTime = const Value.absent(),
-          }) =>
-              UsersCompanion(
-            id: id,
-            name: name,
-            isAwesome: isAwesome,
-            profilePicture: profilePicture,
-            creationTime: creationTime,
-          ),
-          createCompanionCallback: ({
-            Value<RowId> id = const Value.absent(),
-            required String name,
-            Value<bool> isAwesome = const Value.absent(),
-            required Uint8List profilePicture,
-            Value<DateTime> creationTime = const Value.absent(),
-          }) =>
-              UsersCompanion.insert(
-            id: id,
-            name: name,
-            isAwesome: isAwesome,
-            profilePicture: profilePicture,
-            creationTime: creationTime,
-          ),
-        ));
-}
-
-typedef $$UsersTableProcessedTableManager = ProcessedTableManager<
-    _$TodoDb,
-    $UsersTable,
-    User,
-    $$UsersTableFilterComposer,
-    $$UsersTableOrderingComposer,
-    $$UsersTableCreateCompanionBuilder,
-    $$UsersTableUpdateCompanionBuilder,
-    (User, $$UsersTableWithReferences),
-    User>;
 
 class $$UsersTableFilterComposer extends FilterComposer<_$TodoDb, $UsersTable> {
   $$UsersTableFilterComposer(super.$state);
@@ -3907,14 +3837,67 @@ class $$UsersTableOrderingComposer
           ColumnOrderings(column, joinBuilders: joinBuilders));
 }
 
-class $$UsersTableWithReferences {
-  // ignore: unused_field
-  final _$TodoDb _db;
-  // ignore: unused_field
-  final User _item;
-  $$UsersTableWithReferences(this._db, this._item);
+class $$UsersTableTableManager extends RootTableManager<
+    _$TodoDb,
+    $UsersTable,
+    User,
+    $$UsersTableFilterComposer,
+    $$UsersTableOrderingComposer,
+    $$UsersTableCreateCompanionBuilder,
+    $$UsersTableUpdateCompanionBuilder,
+    (User, BaseWithReferences<_$TodoDb, User>),
+    User> {
+  $$UsersTableTableManager(_$TodoDb db, $UsersTable table)
+      : super(TableManagerState(
+          db: db,
+          table: table,
+          filteringComposer:
+              $$UsersTableFilterComposer(ComposerState(db, table)),
+          orderingComposer:
+              $$UsersTableOrderingComposer(ComposerState(db, table)),
+          withReferenceMapper: (p0) =>
+              p0.map((e) => (e, BaseWithReferences(db, e))).toList(),
+          updateCompanionCallback: ({
+            Value<RowId> id = const Value.absent(),
+            Value<String> name = const Value.absent(),
+            Value<bool> isAwesome = const Value.absent(),
+            Value<Uint8List> profilePicture = const Value.absent(),
+            Value<DateTime> creationTime = const Value.absent(),
+          }) =>
+              UsersCompanion(
+            id: id,
+            name: name,
+            isAwesome: isAwesome,
+            profilePicture: profilePicture,
+            creationTime: creationTime,
+          ),
+          createCompanionCallback: ({
+            Value<RowId> id = const Value.absent(),
+            required String name,
+            Value<bool> isAwesome = const Value.absent(),
+            required Uint8List profilePicture,
+            Value<DateTime> creationTime = const Value.absent(),
+          }) =>
+              UsersCompanion.insert(
+            id: id,
+            name: name,
+            isAwesome: isAwesome,
+            profilePicture: profilePicture,
+            creationTime: creationTime,
+          ),
+        ));
 }
 
+typedef $$UsersTableProcessedTableManager = ProcessedTableManager<
+    _$TodoDb,
+    $UsersTable,
+    User,
+    $$UsersTableFilterComposer,
+    $$UsersTableOrderingComposer,
+    $$UsersTableCreateCompanionBuilder,
+    $$UsersTableUpdateCompanionBuilder,
+    (User, BaseWithReferences<_$TodoDb, User>),
+    User>;
 typedef $$SharedTodosTableCreateCompanionBuilder = SharedTodosCompanion
     Function({
   required int todo,
@@ -3928,6 +3911,34 @@ typedef $$SharedTodosTableUpdateCompanionBuilder = SharedTodosCompanion
   Value<int> rowid,
 });
 
+class $$SharedTodosTableFilterComposer
+    extends FilterComposer<_$TodoDb, $SharedTodosTable> {
+  $$SharedTodosTableFilterComposer(super.$state);
+  ColumnFilters<int> get todo => $state.composableBuilder(
+      column: $state.table.todo,
+      builder: (column, joinBuilders) =>
+          ColumnFilters(column, joinBuilders: joinBuilders));
+
+  ColumnFilters<int> get user => $state.composableBuilder(
+      column: $state.table.user,
+      builder: (column, joinBuilders) =>
+          ColumnFilters(column, joinBuilders: joinBuilders));
+}
+
+class $$SharedTodosTableOrderingComposer
+    extends OrderingComposer<_$TodoDb, $SharedTodosTable> {
+  $$SharedTodosTableOrderingComposer(super.$state);
+  ColumnOrderings<int> get todo => $state.composableBuilder(
+      column: $state.table.todo,
+      builder: (column, joinBuilders) =>
+          ColumnOrderings(column, joinBuilders: joinBuilders));
+
+  ColumnOrderings<int> get user => $state.composableBuilder(
+      column: $state.table.user,
+      builder: (column, joinBuilders) =>
+          ColumnOrderings(column, joinBuilders: joinBuilders));
+}
+
 class $$SharedTodosTableTableManager extends RootTableManager<
     _$TodoDb,
     $SharedTodosTable,
@@ -3936,7 +3947,7 @@ class $$SharedTodosTableTableManager extends RootTableManager<
     $$SharedTodosTableOrderingComposer,
     $$SharedTodosTableCreateCompanionBuilder,
     $$SharedTodosTableUpdateCompanionBuilder,
-    (SharedTodo, $$SharedTodosTableWithReferences),
+    (SharedTodo, BaseWithReferences<_$TodoDb, SharedTodo>),
     SharedTodo> {
   $$SharedTodosTableTableManager(_$TodoDb db, $SharedTodosTable table)
       : super(TableManagerState(
@@ -3946,9 +3957,8 @@ class $$SharedTodosTableTableManager extends RootTableManager<
               $$SharedTodosTableFilterComposer(ComposerState(db, table)),
           orderingComposer:
               $$SharedTodosTableOrderingComposer(ComposerState(db, table)),
-          withReferenceMapper: (p0) => p0
-              .map((e) => (e, $$SharedTodosTableWithReferences(db, e)))
-              .toList(),
+          withReferenceMapper: (p0) =>
+              p0.map((e) => (e, BaseWithReferences(db, e))).toList(),
           updateCompanionCallback: ({
             Value<int> todo = const Value.absent(),
             Value<int> user = const Value.absent(),
@@ -3980,45 +3990,8 @@ typedef $$SharedTodosTableProcessedTableManager = ProcessedTableManager<
     $$SharedTodosTableOrderingComposer,
     $$SharedTodosTableCreateCompanionBuilder,
     $$SharedTodosTableUpdateCompanionBuilder,
-    (SharedTodo, $$SharedTodosTableWithReferences),
+    (SharedTodo, BaseWithReferences<_$TodoDb, SharedTodo>),
     SharedTodo>;
-
-class $$SharedTodosTableFilterComposer
-    extends FilterComposer<_$TodoDb, $SharedTodosTable> {
-  $$SharedTodosTableFilterComposer(super.$state);
-  ColumnFilters<int> get todo => $state.composableBuilder(
-      column: $state.table.todo,
-      builder: (column, joinBuilders) =>
-          ColumnFilters(column, joinBuilders: joinBuilders));
-
-  ColumnFilters<int> get user => $state.composableBuilder(
-      column: $state.table.user,
-      builder: (column, joinBuilders) =>
-          ColumnFilters(column, joinBuilders: joinBuilders));
-}
-
-class $$SharedTodosTableOrderingComposer
-    extends OrderingComposer<_$TodoDb, $SharedTodosTable> {
-  $$SharedTodosTableOrderingComposer(super.$state);
-  ColumnOrderings<int> get todo => $state.composableBuilder(
-      column: $state.table.todo,
-      builder: (column, joinBuilders) =>
-          ColumnOrderings(column, joinBuilders: joinBuilders));
-
-  ColumnOrderings<int> get user => $state.composableBuilder(
-      column: $state.table.user,
-      builder: (column, joinBuilders) =>
-          ColumnOrderings(column, joinBuilders: joinBuilders));
-}
-
-class $$SharedTodosTableWithReferences {
-  // ignore: unused_field
-  final _$TodoDb _db;
-  // ignore: unused_field
-  final SharedTodo _item;
-  $$SharedTodosTableWithReferences(this._db, this._item);
-}
-
 typedef $$TableWithoutPKTableCreateCompanionBuilder = TableWithoutPKCompanion
     Function({
   required int notReallyAnId,
@@ -4035,69 +4008,6 @@ typedef $$TableWithoutPKTableUpdateCompanionBuilder = TableWithoutPKCompanion
   Value<MyCustomObject> custom,
   Value<int> rowid,
 });
-
-class $$TableWithoutPKTableTableManager extends RootTableManager<
-    _$TodoDb,
-    $TableWithoutPKTable,
-    CustomRowClass,
-    $$TableWithoutPKTableFilterComposer,
-    $$TableWithoutPKTableOrderingComposer,
-    $$TableWithoutPKTableCreateCompanionBuilder,
-    $$TableWithoutPKTableUpdateCompanionBuilder,
-    (CustomRowClass, $$TableWithoutPKTableWithReferences),
-    CustomRowClass> {
-  $$TableWithoutPKTableTableManager(_$TodoDb db, $TableWithoutPKTable table)
-      : super(TableManagerState(
-          db: db,
-          table: table,
-          filteringComposer:
-              $$TableWithoutPKTableFilterComposer(ComposerState(db, table)),
-          orderingComposer:
-              $$TableWithoutPKTableOrderingComposer(ComposerState(db, table)),
-          withReferenceMapper: (p0) => p0
-              .map((e) => (e, $$TableWithoutPKTableWithReferences(db, e)))
-              .toList(),
-          updateCompanionCallback: ({
-            Value<int> notReallyAnId = const Value.absent(),
-            Value<double> someFloat = const Value.absent(),
-            Value<BigInt?> webSafeInt = const Value.absent(),
-            Value<MyCustomObject> custom = const Value.absent(),
-            Value<int> rowid = const Value.absent(),
-          }) =>
-              TableWithoutPKCompanion(
-            notReallyAnId: notReallyAnId,
-            someFloat: someFloat,
-            webSafeInt: webSafeInt,
-            custom: custom,
-            rowid: rowid,
-          ),
-          createCompanionCallback: ({
-            required int notReallyAnId,
-            required double someFloat,
-            Value<BigInt?> webSafeInt = const Value.absent(),
-            Value<MyCustomObject> custom = const Value.absent(),
-            Value<int> rowid = const Value.absent(),
-          }) =>
-              TableWithoutPKCompanion.insert(
-            notReallyAnId: notReallyAnId,
-            someFloat: someFloat,
-            webSafeInt: webSafeInt,
-            custom: custom,
-            rowid: rowid,
-          ),
-        ));
-}
-
-typedef $$TableWithoutPKTableProcessedTableManager = ProcessedTableManager<
-    _$TodoDb,
-    $TableWithoutPKTable,
-    CustomRowClass,
-    $$TableWithoutPKTableFilterComposer,
-    $$TableWithoutPKTableOrderingComposer,
-    $$TableWithoutPKTableCreateCompanionBuilder,
-    $$TableWithoutPKTableUpdateCompanionBuilder,
-    (CustomRowClass, $$TableWithoutPKTableWithReferences),
-    CustomRowClass>;
 
 class $$TableWithoutPKTableFilterComposer
     extends FilterComposer<_$TodoDb, $TableWithoutPKTable> {
@@ -4149,14 +4059,67 @@ class $$TableWithoutPKTableOrderingComposer
           ColumnOrderings(column, joinBuilders: joinBuilders));
 }
 
-class $$TableWithoutPKTableWithReferences {
-  // ignore: unused_field
-  final _$TodoDb _db;
-  // ignore: unused_field
-  final CustomRowClass _item;
-  $$TableWithoutPKTableWithReferences(this._db, this._item);
+class $$TableWithoutPKTableTableManager extends RootTableManager<
+    _$TodoDb,
+    $TableWithoutPKTable,
+    CustomRowClass,
+    $$TableWithoutPKTableFilterComposer,
+    $$TableWithoutPKTableOrderingComposer,
+    $$TableWithoutPKTableCreateCompanionBuilder,
+    $$TableWithoutPKTableUpdateCompanionBuilder,
+    (CustomRowClass, BaseWithReferences<_$TodoDb, CustomRowClass>),
+    CustomRowClass> {
+  $$TableWithoutPKTableTableManager(_$TodoDb db, $TableWithoutPKTable table)
+      : super(TableManagerState(
+          db: db,
+          table: table,
+          filteringComposer:
+              $$TableWithoutPKTableFilterComposer(ComposerState(db, table)),
+          orderingComposer:
+              $$TableWithoutPKTableOrderingComposer(ComposerState(db, table)),
+          withReferenceMapper: (p0) =>
+              p0.map((e) => (e, BaseWithReferences(db, e))).toList(),
+          updateCompanionCallback: ({
+            Value<int> notReallyAnId = const Value.absent(),
+            Value<double> someFloat = const Value.absent(),
+            Value<BigInt?> webSafeInt = const Value.absent(),
+            Value<MyCustomObject> custom = const Value.absent(),
+            Value<int> rowid = const Value.absent(),
+          }) =>
+              TableWithoutPKCompanion(
+            notReallyAnId: notReallyAnId,
+            someFloat: someFloat,
+            webSafeInt: webSafeInt,
+            custom: custom,
+            rowid: rowid,
+          ),
+          createCompanionCallback: ({
+            required int notReallyAnId,
+            required double someFloat,
+            Value<BigInt?> webSafeInt = const Value.absent(),
+            Value<MyCustomObject> custom = const Value.absent(),
+            Value<int> rowid = const Value.absent(),
+          }) =>
+              TableWithoutPKCompanion.insert(
+            notReallyAnId: notReallyAnId,
+            someFloat: someFloat,
+            webSafeInt: webSafeInt,
+            custom: custom,
+            rowid: rowid,
+          ),
+        ));
 }
 
+typedef $$TableWithoutPKTableProcessedTableManager = ProcessedTableManager<
+    _$TodoDb,
+    $TableWithoutPKTable,
+    CustomRowClass,
+    $$TableWithoutPKTableFilterComposer,
+    $$TableWithoutPKTableOrderingComposer,
+    $$TableWithoutPKTableCreateCompanionBuilder,
+    $$TableWithoutPKTableUpdateCompanionBuilder,
+    (CustomRowClass, BaseWithReferences<_$TodoDb, CustomRowClass>),
+    CustomRowClass>;
 typedef $$PureDefaultsTableCreateCompanionBuilder = PureDefaultsCompanion
     Function({
   Value<MyCustomObject?> txt,
@@ -4168,6 +4131,26 @@ typedef $$PureDefaultsTableUpdateCompanionBuilder = PureDefaultsCompanion
   Value<int> rowid,
 });
 
+class $$PureDefaultsTableFilterComposer
+    extends FilterComposer<_$TodoDb, $PureDefaultsTable> {
+  $$PureDefaultsTableFilterComposer(super.$state);
+  ColumnWithTypeConverterFilters<MyCustomObject?, MyCustomObject, String>
+      get txt => $state.composableBuilder(
+          column: $state.table.txt,
+          builder: (column, joinBuilders) => ColumnWithTypeConverterFilters(
+              column,
+              joinBuilders: joinBuilders));
+}
+
+class $$PureDefaultsTableOrderingComposer
+    extends OrderingComposer<_$TodoDb, $PureDefaultsTable> {
+  $$PureDefaultsTableOrderingComposer(super.$state);
+  ColumnOrderings<String> get txt => $state.composableBuilder(
+      column: $state.table.txt,
+      builder: (column, joinBuilders) =>
+          ColumnOrderings(column, joinBuilders: joinBuilders));
+}
+
 class $$PureDefaultsTableTableManager extends RootTableManager<
     _$TodoDb,
     $PureDefaultsTable,
@@ -4176,7 +4159,7 @@ class $$PureDefaultsTableTableManager extends RootTableManager<
     $$PureDefaultsTableOrderingComposer,
     $$PureDefaultsTableCreateCompanionBuilder,
     $$PureDefaultsTableUpdateCompanionBuilder,
-    (PureDefault, $$PureDefaultsTableWithReferences),
+    (PureDefault, BaseWithReferences<_$TodoDb, PureDefault>),
     PureDefault> {
   $$PureDefaultsTableTableManager(_$TodoDb db, $PureDefaultsTable table)
       : super(TableManagerState(
@@ -4186,9 +4169,8 @@ class $$PureDefaultsTableTableManager extends RootTableManager<
               $$PureDefaultsTableFilterComposer(ComposerState(db, table)),
           orderingComposer:
               $$PureDefaultsTableOrderingComposer(ComposerState(db, table)),
-          withReferenceMapper: (p0) => p0
-              .map((e) => (e, $$PureDefaultsTableWithReferences(db, e)))
-              .toList(),
+          withReferenceMapper: (p0) =>
+              p0.map((e) => (e, BaseWithReferences(db, e))).toList(),
           updateCompanionCallback: ({
             Value<MyCustomObject?> txt = const Value.absent(),
             Value<int> rowid = const Value.absent(),
@@ -4216,37 +4198,8 @@ typedef $$PureDefaultsTableProcessedTableManager = ProcessedTableManager<
     $$PureDefaultsTableOrderingComposer,
     $$PureDefaultsTableCreateCompanionBuilder,
     $$PureDefaultsTableUpdateCompanionBuilder,
-    (PureDefault, $$PureDefaultsTableWithReferences),
+    (PureDefault, BaseWithReferences<_$TodoDb, PureDefault>),
     PureDefault>;
-
-class $$PureDefaultsTableFilterComposer
-    extends FilterComposer<_$TodoDb, $PureDefaultsTable> {
-  $$PureDefaultsTableFilterComposer(super.$state);
-  ColumnWithTypeConverterFilters<MyCustomObject?, MyCustomObject, String>
-      get txt => $state.composableBuilder(
-          column: $state.table.txt,
-          builder: (column, joinBuilders) => ColumnWithTypeConverterFilters(
-              column,
-              joinBuilders: joinBuilders));
-}
-
-class $$PureDefaultsTableOrderingComposer
-    extends OrderingComposer<_$TodoDb, $PureDefaultsTable> {
-  $$PureDefaultsTableOrderingComposer(super.$state);
-  ColumnOrderings<String> get txt => $state.composableBuilder(
-      column: $state.table.txt,
-      builder: (column, joinBuilders) =>
-          ColumnOrderings(column, joinBuilders: joinBuilders));
-}
-
-class $$PureDefaultsTableWithReferences {
-  // ignore: unused_field
-  final _$TodoDb _db;
-  // ignore: unused_field
-  final PureDefault _item;
-  $$PureDefaultsTableWithReferences(this._db, this._item);
-}
-
 typedef $$WithCustomTypeTableCreateCompanionBuilder = WithCustomTypeCompanion
     Function({
   required UuidValue id,
@@ -4258,6 +4211,24 @@ typedef $$WithCustomTypeTableUpdateCompanionBuilder = WithCustomTypeCompanion
   Value<int> rowid,
 });
 
+class $$WithCustomTypeTableFilterComposer
+    extends FilterComposer<_$TodoDb, $WithCustomTypeTable> {
+  $$WithCustomTypeTableFilterComposer(super.$state);
+  ColumnFilters<UuidValue> get id => $state.composableBuilder(
+      column: $state.table.id,
+      builder: (column, joinBuilders) =>
+          ColumnFilters(column, joinBuilders: joinBuilders));
+}
+
+class $$WithCustomTypeTableOrderingComposer
+    extends OrderingComposer<_$TodoDb, $WithCustomTypeTable> {
+  $$WithCustomTypeTableOrderingComposer(super.$state);
+  ColumnOrderings<UuidValue> get id => $state.composableBuilder(
+      column: $state.table.id,
+      builder: (column, joinBuilders) =>
+          ColumnOrderings(column, joinBuilders: joinBuilders));
+}
+
 class $$WithCustomTypeTableTableManager extends RootTableManager<
     _$TodoDb,
     $WithCustomTypeTable,
@@ -4266,7 +4237,7 @@ class $$WithCustomTypeTableTableManager extends RootTableManager<
     $$WithCustomTypeTableOrderingComposer,
     $$WithCustomTypeTableCreateCompanionBuilder,
     $$WithCustomTypeTableUpdateCompanionBuilder,
-    (WithCustomTypeData, $$WithCustomTypeTableWithReferences),
+    (WithCustomTypeData, BaseWithReferences<_$TodoDb, WithCustomTypeData>),
     WithCustomTypeData> {
   $$WithCustomTypeTableTableManager(_$TodoDb db, $WithCustomTypeTable table)
       : super(TableManagerState(
@@ -4276,9 +4247,8 @@ class $$WithCustomTypeTableTableManager extends RootTableManager<
               $$WithCustomTypeTableFilterComposer(ComposerState(db, table)),
           orderingComposer:
               $$WithCustomTypeTableOrderingComposer(ComposerState(db, table)),
-          withReferenceMapper: (p0) => p0
-              .map((e) => (e, $$WithCustomTypeTableWithReferences(db, e)))
-              .toList(),
+          withReferenceMapper: (p0) =>
+              p0.map((e) => (e, BaseWithReferences(db, e))).toList(),
           updateCompanionCallback: ({
             Value<UuidValue> id = const Value.absent(),
             Value<int> rowid = const Value.absent(),
@@ -4306,35 +4276,8 @@ typedef $$WithCustomTypeTableProcessedTableManager = ProcessedTableManager<
     $$WithCustomTypeTableOrderingComposer,
     $$WithCustomTypeTableCreateCompanionBuilder,
     $$WithCustomTypeTableUpdateCompanionBuilder,
-    (WithCustomTypeData, $$WithCustomTypeTableWithReferences),
+    (WithCustomTypeData, BaseWithReferences<_$TodoDb, WithCustomTypeData>),
     WithCustomTypeData>;
-
-class $$WithCustomTypeTableFilterComposer
-    extends FilterComposer<_$TodoDb, $WithCustomTypeTable> {
-  $$WithCustomTypeTableFilterComposer(super.$state);
-  ColumnFilters<UuidValue> get id => $state.composableBuilder(
-      column: $state.table.id,
-      builder: (column, joinBuilders) =>
-          ColumnFilters(column, joinBuilders: joinBuilders));
-}
-
-class $$WithCustomTypeTableOrderingComposer
-    extends OrderingComposer<_$TodoDb, $WithCustomTypeTable> {
-  $$WithCustomTypeTableOrderingComposer(super.$state);
-  ColumnOrderings<UuidValue> get id => $state.composableBuilder(
-      column: $state.table.id,
-      builder: (column, joinBuilders) =>
-          ColumnOrderings(column, joinBuilders: joinBuilders));
-}
-
-class $$WithCustomTypeTableWithReferences {
-  // ignore: unused_field
-  final _$TodoDb _db;
-  // ignore: unused_field
-  final WithCustomTypeData _item;
-  $$WithCustomTypeTableWithReferences(this._db, this._item);
-}
-
 typedef $$TableWithEveryColumnTypeTableCreateCompanionBuilder
     = TableWithEveryColumnTypeCompanion Function({
   Value<RowId> id,
@@ -4361,98 +4304,6 @@ typedef $$TableWithEveryColumnTypeTableUpdateCompanionBuilder
   Value<TodoStatus?> anIntEnum,
   Value<MyCustomObject?> aTextWithConverter,
 });
-
-class $$TableWithEveryColumnTypeTableTableManager extends RootTableManager<
-    _$TodoDb,
-    $TableWithEveryColumnTypeTable,
-    TableWithEveryColumnTypeData,
-    $$TableWithEveryColumnTypeTableFilterComposer,
-    $$TableWithEveryColumnTypeTableOrderingComposer,
-    $$TableWithEveryColumnTypeTableCreateCompanionBuilder,
-    $$TableWithEveryColumnTypeTableUpdateCompanionBuilder,
-    (
-      TableWithEveryColumnTypeData,
-      $$TableWithEveryColumnTypeTableWithReferences
-    ),
-    TableWithEveryColumnTypeData> {
-  $$TableWithEveryColumnTypeTableTableManager(
-      _$TodoDb db, $TableWithEveryColumnTypeTable table)
-      : super(TableManagerState(
-          db: db,
-          table: table,
-          filteringComposer: $$TableWithEveryColumnTypeTableFilterComposer(
-              ComposerState(db, table)),
-          orderingComposer: $$TableWithEveryColumnTypeTableOrderingComposer(
-              ComposerState(db, table)),
-          withReferenceMapper: (p0) => p0
-              .map((e) =>
-                  (e, $$TableWithEveryColumnTypeTableWithReferences(db, e)))
-              .toList(),
-          updateCompanionCallback: ({
-            Value<RowId> id = const Value.absent(),
-            Value<bool?> aBool = const Value.absent(),
-            Value<DateTime?> aDateTime = const Value.absent(),
-            Value<String?> aText = const Value.absent(),
-            Value<int?> anInt = const Value.absent(),
-            Value<BigInt?> anInt64 = const Value.absent(),
-            Value<double?> aReal = const Value.absent(),
-            Value<Uint8List?> aBlob = const Value.absent(),
-            Value<TodoStatus?> anIntEnum = const Value.absent(),
-            Value<MyCustomObject?> aTextWithConverter = const Value.absent(),
-          }) =>
-              TableWithEveryColumnTypeCompanion(
-            id: id,
-            aBool: aBool,
-            aDateTime: aDateTime,
-            aText: aText,
-            anInt: anInt,
-            anInt64: anInt64,
-            aReal: aReal,
-            aBlob: aBlob,
-            anIntEnum: anIntEnum,
-            aTextWithConverter: aTextWithConverter,
-          ),
-          createCompanionCallback: ({
-            Value<RowId> id = const Value.absent(),
-            Value<bool?> aBool = const Value.absent(),
-            Value<DateTime?> aDateTime = const Value.absent(),
-            Value<String?> aText = const Value.absent(),
-            Value<int?> anInt = const Value.absent(),
-            Value<BigInt?> anInt64 = const Value.absent(),
-            Value<double?> aReal = const Value.absent(),
-            Value<Uint8List?> aBlob = const Value.absent(),
-            Value<TodoStatus?> anIntEnum = const Value.absent(),
-            Value<MyCustomObject?> aTextWithConverter = const Value.absent(),
-          }) =>
-              TableWithEveryColumnTypeCompanion.insert(
-            id: id,
-            aBool: aBool,
-            aDateTime: aDateTime,
-            aText: aText,
-            anInt: anInt,
-            anInt64: anInt64,
-            aReal: aReal,
-            aBlob: aBlob,
-            anIntEnum: anIntEnum,
-            aTextWithConverter: aTextWithConverter,
-          ),
-        ));
-}
-
-typedef $$TableWithEveryColumnTypeTableProcessedTableManager
-    = ProcessedTableManager<
-        _$TodoDb,
-        $TableWithEveryColumnTypeTable,
-        TableWithEveryColumnTypeData,
-        $$TableWithEveryColumnTypeTableFilterComposer,
-        $$TableWithEveryColumnTypeTableOrderingComposer,
-        $$TableWithEveryColumnTypeTableCreateCompanionBuilder,
-        $$TableWithEveryColumnTypeTableUpdateCompanionBuilder,
-        (
-          TableWithEveryColumnTypeData,
-          $$TableWithEveryColumnTypeTableWithReferences
-        ),
-        TableWithEveryColumnTypeData>;
 
 class $$TableWithEveryColumnTypeTableFilterComposer
     extends FilterComposer<_$TodoDb, $TableWithEveryColumnTypeTable> {
@@ -4568,14 +4419,95 @@ class $$TableWithEveryColumnTypeTableOrderingComposer
           ColumnOrderings(column, joinBuilders: joinBuilders));
 }
 
-class $$TableWithEveryColumnTypeTableWithReferences {
-  // ignore: unused_field
-  final _$TodoDb _db;
-  // ignore: unused_field
-  final TableWithEveryColumnTypeData _item;
-  $$TableWithEveryColumnTypeTableWithReferences(this._db, this._item);
+class $$TableWithEveryColumnTypeTableTableManager extends RootTableManager<
+    _$TodoDb,
+    $TableWithEveryColumnTypeTable,
+    TableWithEveryColumnTypeData,
+    $$TableWithEveryColumnTypeTableFilterComposer,
+    $$TableWithEveryColumnTypeTableOrderingComposer,
+    $$TableWithEveryColumnTypeTableCreateCompanionBuilder,
+    $$TableWithEveryColumnTypeTableUpdateCompanionBuilder,
+    (
+      TableWithEveryColumnTypeData,
+      BaseWithReferences<_$TodoDb, TableWithEveryColumnTypeData>
+    ),
+    TableWithEveryColumnTypeData> {
+  $$TableWithEveryColumnTypeTableTableManager(
+      _$TodoDb db, $TableWithEveryColumnTypeTable table)
+      : super(TableManagerState(
+          db: db,
+          table: table,
+          filteringComposer: $$TableWithEveryColumnTypeTableFilterComposer(
+              ComposerState(db, table)),
+          orderingComposer: $$TableWithEveryColumnTypeTableOrderingComposer(
+              ComposerState(db, table)),
+          withReferenceMapper: (p0) =>
+              p0.map((e) => (e, BaseWithReferences(db, e))).toList(),
+          updateCompanionCallback: ({
+            Value<RowId> id = const Value.absent(),
+            Value<bool?> aBool = const Value.absent(),
+            Value<DateTime?> aDateTime = const Value.absent(),
+            Value<String?> aText = const Value.absent(),
+            Value<int?> anInt = const Value.absent(),
+            Value<BigInt?> anInt64 = const Value.absent(),
+            Value<double?> aReal = const Value.absent(),
+            Value<Uint8List?> aBlob = const Value.absent(),
+            Value<TodoStatus?> anIntEnum = const Value.absent(),
+            Value<MyCustomObject?> aTextWithConverter = const Value.absent(),
+          }) =>
+              TableWithEveryColumnTypeCompanion(
+            id: id,
+            aBool: aBool,
+            aDateTime: aDateTime,
+            aText: aText,
+            anInt: anInt,
+            anInt64: anInt64,
+            aReal: aReal,
+            aBlob: aBlob,
+            anIntEnum: anIntEnum,
+            aTextWithConverter: aTextWithConverter,
+          ),
+          createCompanionCallback: ({
+            Value<RowId> id = const Value.absent(),
+            Value<bool?> aBool = const Value.absent(),
+            Value<DateTime?> aDateTime = const Value.absent(),
+            Value<String?> aText = const Value.absent(),
+            Value<int?> anInt = const Value.absent(),
+            Value<BigInt?> anInt64 = const Value.absent(),
+            Value<double?> aReal = const Value.absent(),
+            Value<Uint8List?> aBlob = const Value.absent(),
+            Value<TodoStatus?> anIntEnum = const Value.absent(),
+            Value<MyCustomObject?> aTextWithConverter = const Value.absent(),
+          }) =>
+              TableWithEveryColumnTypeCompanion.insert(
+            id: id,
+            aBool: aBool,
+            aDateTime: aDateTime,
+            aText: aText,
+            anInt: anInt,
+            anInt64: anInt64,
+            aReal: aReal,
+            aBlob: aBlob,
+            anIntEnum: anIntEnum,
+            aTextWithConverter: aTextWithConverter,
+          ),
+        ));
 }
 
+typedef $$TableWithEveryColumnTypeTableProcessedTableManager
+    = ProcessedTableManager<
+        _$TodoDb,
+        $TableWithEveryColumnTypeTable,
+        TableWithEveryColumnTypeData,
+        $$TableWithEveryColumnTypeTableFilterComposer,
+        $$TableWithEveryColumnTypeTableOrderingComposer,
+        $$TableWithEveryColumnTypeTableCreateCompanionBuilder,
+        $$TableWithEveryColumnTypeTableUpdateCompanionBuilder,
+        (
+          TableWithEveryColumnTypeData,
+          BaseWithReferences<_$TodoDb, TableWithEveryColumnTypeData>
+        ),
+        TableWithEveryColumnTypeData>;
 typedef $$DepartmentTableCreateCompanionBuilder = DepartmentCompanion Function({
   Value<int> id,
   Value<String?> name,
@@ -4584,6 +4516,57 @@ typedef $$DepartmentTableUpdateCompanionBuilder = DepartmentCompanion Function({
   Value<int> id,
   Value<String?> name,
 });
+
+class $$DepartmentTableFilterComposer
+    extends FilterComposer<_$TodoDb, $DepartmentTable> {
+  $$DepartmentTableFilterComposer(super.$state);
+  ColumnFilters<int> get id => $state.composableBuilder(
+      column: $state.table.id,
+      builder: (column, joinBuilders) =>
+          ColumnFilters(column, joinBuilders: joinBuilders));
+
+  ColumnFilters<String> get name => $state.composableBuilder(
+      column: $state.table.name,
+      builder: (column, joinBuilders) =>
+          ColumnFilters(column, joinBuilders: joinBuilders));
+
+  ComposableFilter productRefs(
+      ComposableFilter Function($$ProductTableFilterComposer f) f) {
+    final $$ProductTableFilterComposer composer = $state.composerBuilder(
+        composer: this,
+        getCurrentColumn: (t) => t.id,
+        referencedTable: $state.db.product,
+        getReferencedColumn: (t) => t.department,
+        builder: (joinBuilder, parentComposers) => $$ProductTableFilterComposer(
+            ComposerState(
+                $state.db, $state.db.product, joinBuilder, parentComposers)));
+    return f(composer);
+  }
+}
+
+class $$DepartmentTableOrderingComposer
+    extends OrderingComposer<_$TodoDb, $DepartmentTable> {
+  $$DepartmentTableOrderingComposer(super.$state);
+  ColumnOrderings<int> get id => $state.composableBuilder(
+      column: $state.table.id,
+      builder: (column, joinBuilders) =>
+          ColumnOrderings(column, joinBuilders: joinBuilders));
+
+  ColumnOrderings<String> get name => $state.composableBuilder(
+      column: $state.table.name,
+      builder: (column, joinBuilders) =>
+          ColumnOrderings(column, joinBuilders: joinBuilders));
+}
+
+class $$DepartmentTableWithReferences
+    extends BaseWithReferences<_$TodoDb, DepartmentData> {
+  $$DepartmentTableWithReferences(super.$_db, super.$_item);
+
+  $$ProductTableProcessedTableManager get productRefs {
+    return $$ProductTableTableManager($_db, $_db.product)
+        .filter((f) => f.department.id($_item.id));
+  }
+}
 
 class $$DepartmentTableTableManager extends RootTableManager<
     _$TodoDb,
@@ -4635,61 +4618,6 @@ typedef $$DepartmentTableProcessedTableManager = ProcessedTableManager<
     $$DepartmentTableUpdateCompanionBuilder,
     (DepartmentData, $$DepartmentTableWithReferences),
     DepartmentData>;
-
-class $$DepartmentTableFilterComposer
-    extends FilterComposer<_$TodoDb, $DepartmentTable> {
-  $$DepartmentTableFilterComposer(super.$state);
-  ColumnFilters<int> get id => $state.composableBuilder(
-      column: $state.table.id,
-      builder: (column, joinBuilders) =>
-          ColumnFilters(column, joinBuilders: joinBuilders));
-
-  ColumnFilters<String> get name => $state.composableBuilder(
-      column: $state.table.name,
-      builder: (column, joinBuilders) =>
-          ColumnFilters(column, joinBuilders: joinBuilders));
-
-  ComposableFilter productRefs(
-      ComposableFilter Function($$ProductTableFilterComposer f) f) {
-    final $$ProductTableFilterComposer composer = $state.composerBuilder(
-        composer: this,
-        getCurrentColumn: (t) => t.id,
-        referencedTable: $state.db.product,
-        getReferencedColumn: (t) => t.department,
-        builder: (joinBuilder, parentComposers) => $$ProductTableFilterComposer(
-            ComposerState(
-                $state.db, $state.db.product, joinBuilder, parentComposers)));
-    return f(composer);
-  }
-}
-
-class $$DepartmentTableOrderingComposer
-    extends OrderingComposer<_$TodoDb, $DepartmentTable> {
-  $$DepartmentTableOrderingComposer(super.$state);
-  ColumnOrderings<int> get id => $state.composableBuilder(
-      column: $state.table.id,
-      builder: (column, joinBuilders) =>
-          ColumnOrderings(column, joinBuilders: joinBuilders));
-
-  ColumnOrderings<String> get name => $state.composableBuilder(
-      column: $state.table.name,
-      builder: (column, joinBuilders) =>
-          ColumnOrderings(column, joinBuilders: joinBuilders));
-}
-
-class $$DepartmentTableWithReferences {
-  // ignore: unused_field
-  final _$TodoDb _db;
-  // ignore: unused_field
-  final DepartmentData _item;
-  $$DepartmentTableWithReferences(this._db, this._item);
-
-  $$ProductTableProcessedTableManager get productRefs {
-    return $$ProductTableTableManager(_db, _db.product)
-        .filter((f) => f.department.id(_item.id));
-  }
-}
-
 typedef $$ProductTableCreateCompanionBuilder = ProductCompanion Function({
   Value<int> id,
   Value<String?> name,
@@ -4700,60 +4628,6 @@ typedef $$ProductTableUpdateCompanionBuilder = ProductCompanion Function({
   Value<String?> name,
   Value<int?> department,
 });
-
-class $$ProductTableTableManager extends RootTableManager<
-    _$TodoDb,
-    $ProductTable,
-    ProductData,
-    $$ProductTableFilterComposer,
-    $$ProductTableOrderingComposer,
-    $$ProductTableCreateCompanionBuilder,
-    $$ProductTableUpdateCompanionBuilder,
-    (ProductData, $$ProductTableWithReferences),
-    ProductData> {
-  $$ProductTableTableManager(_$TodoDb db, $ProductTable table)
-      : super(TableManagerState(
-          db: db,
-          table: table,
-          filteringComposer:
-              $$ProductTableFilterComposer(ComposerState(db, table)),
-          orderingComposer:
-              $$ProductTableOrderingComposer(ComposerState(db, table)),
-          withReferenceMapper: (p0) =>
-              p0.map((e) => (e, $$ProductTableWithReferences(db, e))).toList(),
-          updateCompanionCallback: ({
-            Value<int> id = const Value.absent(),
-            Value<String?> name = const Value.absent(),
-            Value<int?> department = const Value.absent(),
-          }) =>
-              ProductCompanion(
-            id: id,
-            name: name,
-            department: department,
-          ),
-          createCompanionCallback: ({
-            Value<int> id = const Value.absent(),
-            Value<String?> name = const Value.absent(),
-            Value<int?> department = const Value.absent(),
-          }) =>
-              ProductCompanion.insert(
-            id: id,
-            name: name,
-            department: department,
-          ),
-        ));
-}
-
-typedef $$ProductTableProcessedTableManager = ProcessedTableManager<
-    _$TodoDb,
-    $ProductTable,
-    ProductData,
-    $$ProductTableFilterComposer,
-    $$ProductTableOrderingComposer,
-    $$ProductTableCreateCompanionBuilder,
-    $$ProductTableUpdateCompanionBuilder,
-    (ProductData, $$ProductTableWithReferences),
-    ProductData>;
 
 class $$ProductTableFilterComposer
     extends FilterComposer<_$TodoDb, $ProductTable> {
@@ -4820,25 +4694,75 @@ class $$ProductTableOrderingComposer
   }
 }
 
-class $$ProductTableWithReferences {
-  // ignore: unused_field
-  final _$TodoDb _db;
-  // ignore: unused_field
-  final ProductData _item;
-  $$ProductTableWithReferences(this._db, this._item);
+class $$ProductTableWithReferences
+    extends BaseWithReferences<_$TodoDb, ProductData> {
+  $$ProductTableWithReferences(super.$_db, super.$_item);
 
   $$DepartmentTableProcessedTableManager? get department {
-    if (_item.department == null) return null;
-    return $$DepartmentTableTableManager(_db, _db.department)
-        .filter((f) => f.id(_item.department!));
+    if ($_item.department == null) return null;
+    return $$DepartmentTableTableManager($_db, $_db.department)
+        .filter((f) => f.id($_item.department!));
   }
 
   $$ListingTableProcessedTableManager get listings {
-    return $$ListingTableTableManager(_db, _db.listing)
-        .filter((f) => f.product.id(_item.id));
+    return $$ListingTableTableManager($_db, $_db.listing)
+        .filter((f) => f.product.id($_item.id));
   }
 }
 
+class $$ProductTableTableManager extends RootTableManager<
+    _$TodoDb,
+    $ProductTable,
+    ProductData,
+    $$ProductTableFilterComposer,
+    $$ProductTableOrderingComposer,
+    $$ProductTableCreateCompanionBuilder,
+    $$ProductTableUpdateCompanionBuilder,
+    (ProductData, $$ProductTableWithReferences),
+    ProductData> {
+  $$ProductTableTableManager(_$TodoDb db, $ProductTable table)
+      : super(TableManagerState(
+          db: db,
+          table: table,
+          filteringComposer:
+              $$ProductTableFilterComposer(ComposerState(db, table)),
+          orderingComposer:
+              $$ProductTableOrderingComposer(ComposerState(db, table)),
+          withReferenceMapper: (p0) =>
+              p0.map((e) => (e, $$ProductTableWithReferences(db, e))).toList(),
+          updateCompanionCallback: ({
+            Value<int> id = const Value.absent(),
+            Value<String?> name = const Value.absent(),
+            Value<int?> department = const Value.absent(),
+          }) =>
+              ProductCompanion(
+            id: id,
+            name: name,
+            department: department,
+          ),
+          createCompanionCallback: ({
+            Value<int> id = const Value.absent(),
+            Value<String?> name = const Value.absent(),
+            Value<int?> department = const Value.absent(),
+          }) =>
+              ProductCompanion.insert(
+            id: id,
+            name: name,
+            department: department,
+          ),
+        ));
+}
+
+typedef $$ProductTableProcessedTableManager = ProcessedTableManager<
+    _$TodoDb,
+    $ProductTable,
+    ProductData,
+    $$ProductTableFilterComposer,
+    $$ProductTableOrderingComposer,
+    $$ProductTableCreateCompanionBuilder,
+    $$ProductTableUpdateCompanionBuilder,
+    (ProductData, $$ProductTableWithReferences),
+    ProductData>;
 typedef $$StoreTableCreateCompanionBuilder = StoreCompanion Function({
   Value<int> id,
   Value<String?> name,
@@ -4847,6 +4771,56 @@ typedef $$StoreTableUpdateCompanionBuilder = StoreCompanion Function({
   Value<int> id,
   Value<String?> name,
 });
+
+class $$StoreTableFilterComposer extends FilterComposer<_$TodoDb, $StoreTable> {
+  $$StoreTableFilterComposer(super.$state);
+  ColumnFilters<int> get id => $state.composableBuilder(
+      column: $state.table.id,
+      builder: (column, joinBuilders) =>
+          ColumnFilters(column, joinBuilders: joinBuilders));
+
+  ColumnFilters<String> get name => $state.composableBuilder(
+      column: $state.table.name,
+      builder: (column, joinBuilders) =>
+          ColumnFilters(column, joinBuilders: joinBuilders));
+
+  ComposableFilter listings(
+      ComposableFilter Function($$ListingTableFilterComposer f) f) {
+    final $$ListingTableFilterComposer composer = $state.composerBuilder(
+        composer: this,
+        getCurrentColumn: (t) => t.id,
+        referencedTable: $state.db.listing,
+        getReferencedColumn: (t) => t.store,
+        builder: (joinBuilder, parentComposers) => $$ListingTableFilterComposer(
+            ComposerState(
+                $state.db, $state.db.listing, joinBuilder, parentComposers)));
+    return f(composer);
+  }
+}
+
+class $$StoreTableOrderingComposer
+    extends OrderingComposer<_$TodoDb, $StoreTable> {
+  $$StoreTableOrderingComposer(super.$state);
+  ColumnOrderings<int> get id => $state.composableBuilder(
+      column: $state.table.id,
+      builder: (column, joinBuilders) =>
+          ColumnOrderings(column, joinBuilders: joinBuilders));
+
+  ColumnOrderings<String> get name => $state.composableBuilder(
+      column: $state.table.name,
+      builder: (column, joinBuilders) =>
+          ColumnOrderings(column, joinBuilders: joinBuilders));
+}
+
+class $$StoreTableWithReferences
+    extends BaseWithReferences<_$TodoDb, StoreData> {
+  $$StoreTableWithReferences(super.$_db, super.$_item);
+
+  $$ListingTableProcessedTableManager get listings {
+    return $$ListingTableTableManager($_db, $_db.listing)
+        .filter((f) => f.store.id($_item.id));
+  }
+}
 
 class $$StoreTableTableManager extends RootTableManager<
     _$TodoDb,
@@ -4897,60 +4871,6 @@ typedef $$StoreTableProcessedTableManager = ProcessedTableManager<
     $$StoreTableUpdateCompanionBuilder,
     (StoreData, $$StoreTableWithReferences),
     StoreData>;
-
-class $$StoreTableFilterComposer extends FilterComposer<_$TodoDb, $StoreTable> {
-  $$StoreTableFilterComposer(super.$state);
-  ColumnFilters<int> get id => $state.composableBuilder(
-      column: $state.table.id,
-      builder: (column, joinBuilders) =>
-          ColumnFilters(column, joinBuilders: joinBuilders));
-
-  ColumnFilters<String> get name => $state.composableBuilder(
-      column: $state.table.name,
-      builder: (column, joinBuilders) =>
-          ColumnFilters(column, joinBuilders: joinBuilders));
-
-  ComposableFilter listings(
-      ComposableFilter Function($$ListingTableFilterComposer f) f) {
-    final $$ListingTableFilterComposer composer = $state.composerBuilder(
-        composer: this,
-        getCurrentColumn: (t) => t.id,
-        referencedTable: $state.db.listing,
-        getReferencedColumn: (t) => t.store,
-        builder: (joinBuilder, parentComposers) => $$ListingTableFilterComposer(
-            ComposerState(
-                $state.db, $state.db.listing, joinBuilder, parentComposers)));
-    return f(composer);
-  }
-}
-
-class $$StoreTableOrderingComposer
-    extends OrderingComposer<_$TodoDb, $StoreTable> {
-  $$StoreTableOrderingComposer(super.$state);
-  ColumnOrderings<int> get id => $state.composableBuilder(
-      column: $state.table.id,
-      builder: (column, joinBuilders) =>
-          ColumnOrderings(column, joinBuilders: joinBuilders));
-
-  ColumnOrderings<String> get name => $state.composableBuilder(
-      column: $state.table.name,
-      builder: (column, joinBuilders) =>
-          ColumnOrderings(column, joinBuilders: joinBuilders));
-}
-
-class $$StoreTableWithReferences {
-  // ignore: unused_field
-  final _$TodoDb _db;
-  // ignore: unused_field
-  final StoreData _item;
-  $$StoreTableWithReferences(this._db, this._item);
-
-  $$ListingTableProcessedTableManager get listings {
-    return $$ListingTableTableManager(_db, _db.listing)
-        .filter((f) => f.store.id(_item.id));
-  }
-}
-
 typedef $$ListingTableCreateCompanionBuilder = ListingCompanion Function({
   Value<int> id,
   Value<int?> product,
@@ -4963,64 +4883,6 @@ typedef $$ListingTableUpdateCompanionBuilder = ListingCompanion Function({
   Value<int?> store,
   Value<double?> price,
 });
-
-class $$ListingTableTableManager extends RootTableManager<
-    _$TodoDb,
-    $ListingTable,
-    ListingData,
-    $$ListingTableFilterComposer,
-    $$ListingTableOrderingComposer,
-    $$ListingTableCreateCompanionBuilder,
-    $$ListingTableUpdateCompanionBuilder,
-    (ListingData, $$ListingTableWithReferences),
-    ListingData> {
-  $$ListingTableTableManager(_$TodoDb db, $ListingTable table)
-      : super(TableManagerState(
-          db: db,
-          table: table,
-          filteringComposer:
-              $$ListingTableFilterComposer(ComposerState(db, table)),
-          orderingComposer:
-              $$ListingTableOrderingComposer(ComposerState(db, table)),
-          withReferenceMapper: (p0) =>
-              p0.map((e) => (e, $$ListingTableWithReferences(db, e))).toList(),
-          updateCompanionCallback: ({
-            Value<int> id = const Value.absent(),
-            Value<int?> product = const Value.absent(),
-            Value<int?> store = const Value.absent(),
-            Value<double?> price = const Value.absent(),
-          }) =>
-              ListingCompanion(
-            id: id,
-            product: product,
-            store: store,
-            price: price,
-          ),
-          createCompanionCallback: ({
-            Value<int> id = const Value.absent(),
-            Value<int?> product = const Value.absent(),
-            Value<int?> store = const Value.absent(),
-            Value<double?> price = const Value.absent(),
-          }) =>
-              ListingCompanion.insert(
-            id: id,
-            product: product,
-            store: store,
-            price: price,
-          ),
-        ));
-}
-
-typedef $$ListingTableProcessedTableManager = ProcessedTableManager<
-    _$TodoDb,
-    $ListingTable,
-    ListingData,
-    $$ListingTableFilterComposer,
-    $$ListingTableOrderingComposer,
-    $$ListingTableCreateCompanionBuilder,
-    $$ListingTableUpdateCompanionBuilder,
-    (ListingData, $$ListingTableWithReferences),
-    ListingData>;
 
 class $$ListingTableFilterComposer
     extends FilterComposer<_$TodoDb, $ListingTable> {
@@ -5098,25 +4960,80 @@ class $$ListingTableOrderingComposer
   }
 }
 
-class $$ListingTableWithReferences {
-  // ignore: unused_field
-  final _$TodoDb _db;
-  // ignore: unused_field
-  final ListingData _item;
-  $$ListingTableWithReferences(this._db, this._item);
+class $$ListingTableWithReferences
+    extends BaseWithReferences<_$TodoDb, ListingData> {
+  $$ListingTableWithReferences(super.$_db, super.$_item);
 
   $$ProductTableProcessedTableManager? get product {
-    if (_item.product == null) return null;
-    return $$ProductTableTableManager(_db, _db.product)
-        .filter((f) => f.id(_item.product!));
+    if ($_item.product == null) return null;
+    return $$ProductTableTableManager($_db, $_db.product)
+        .filter((f) => f.id($_item.product!));
   }
 
   $$StoreTableProcessedTableManager? get store {
-    if (_item.store == null) return null;
-    return $$StoreTableTableManager(_db, _db.store)
-        .filter((f) => f.id(_item.store!));
+    if ($_item.store == null) return null;
+    return $$StoreTableTableManager($_db, $_db.store)
+        .filter((f) => f.id($_item.store!));
   }
 }
+
+class $$ListingTableTableManager extends RootTableManager<
+    _$TodoDb,
+    $ListingTable,
+    ListingData,
+    $$ListingTableFilterComposer,
+    $$ListingTableOrderingComposer,
+    $$ListingTableCreateCompanionBuilder,
+    $$ListingTableUpdateCompanionBuilder,
+    (ListingData, $$ListingTableWithReferences),
+    ListingData> {
+  $$ListingTableTableManager(_$TodoDb db, $ListingTable table)
+      : super(TableManagerState(
+          db: db,
+          table: table,
+          filteringComposer:
+              $$ListingTableFilterComposer(ComposerState(db, table)),
+          orderingComposer:
+              $$ListingTableOrderingComposer(ComposerState(db, table)),
+          withReferenceMapper: (p0) =>
+              p0.map((e) => (e, $$ListingTableWithReferences(db, e))).toList(),
+          updateCompanionCallback: ({
+            Value<int> id = const Value.absent(),
+            Value<int?> product = const Value.absent(),
+            Value<int?> store = const Value.absent(),
+            Value<double?> price = const Value.absent(),
+          }) =>
+              ListingCompanion(
+            id: id,
+            product: product,
+            store: store,
+            price: price,
+          ),
+          createCompanionCallback: ({
+            Value<int> id = const Value.absent(),
+            Value<int?> product = const Value.absent(),
+            Value<int?> store = const Value.absent(),
+            Value<double?> price = const Value.absent(),
+          }) =>
+              ListingCompanion.insert(
+            id: id,
+            product: product,
+            store: store,
+            price: price,
+          ),
+        ));
+}
+
+typedef $$ListingTableProcessedTableManager = ProcessedTableManager<
+    _$TodoDb,
+    $ListingTable,
+    ListingData,
+    $$ListingTableFilterComposer,
+    $$ListingTableOrderingComposer,
+    $$ListingTableCreateCompanionBuilder,
+    $$ListingTableUpdateCompanionBuilder,
+    (ListingData, $$ListingTableWithReferences),
+    ListingData>;
 
 class $TodoDbManager {
   final _$TodoDb _db;

--- a/drift/test/generated/todos.g.dart
+++ b/drift/test/generated/todos.g.dart
@@ -3461,7 +3461,7 @@ class $$CategoriesTableTableManager extends RootTableManager<
     $$CategoriesTableOrderingComposer,
     $$CategoriesTableCreateCompanionBuilder,
     $$CategoriesTableUpdateCompanionBuilder,
-    $$CategoriesTableWithReferences,
+    (Category, $$CategoriesTableWithReferences),
     Category> {
   $$CategoriesTableTableManager(_$TodoDb db, $CategoriesTable table)
       : super(TableManagerState(
@@ -3471,8 +3471,9 @@ class $$CategoriesTableTableManager extends RootTableManager<
               $$CategoriesTableFilterComposer(ComposerState(db, table)),
           orderingComposer:
               $$CategoriesTableOrderingComposer(ComposerState(db, table)),
-          withReferenceMapper: (p0) =>
-              p0.map((e) => $$CategoriesTableWithReferences(db, e)).toList(),
+          withReferenceMapper: (p0) => p0
+              .map((e) => (e, $$CategoriesTableWithReferences(db, e)))
+              .toList(),
           updateCompanionCallback: ({
             Value<RowId> id = const Value.absent(),
             Value<String> description = const Value.absent(),
@@ -3504,7 +3505,7 @@ typedef $$CategoriesTableProcessedTableManager = ProcessedTableManager<
     $$CategoriesTableOrderingComposer,
     $$CategoriesTableCreateCompanionBuilder,
     $$CategoriesTableUpdateCompanionBuilder,
-    $$CategoriesTableWithReferences,
+    (Category, $$CategoriesTableWithReferences),
     Category>;
 
 class $$CategoriesTableFilterComposer
@@ -3576,12 +3577,12 @@ class $$CategoriesTableOrderingComposer
 class $$CategoriesTableWithReferences {
   // ignore: unused_field
   final _$TodoDb _db;
-  final Category category;
-  $$CategoriesTableWithReferences(this._db, this.category);
+  final Category _item;
+  $$CategoriesTableWithReferences(this._db, this._item);
 
   $$TodosTableTableProcessedTableManager get todos {
     return $$TodosTableTableTableManager(_db, _db.todosTable)
-        .filter((f) => f.category.id(category.id));
+        .filter((f) => f.category.id(_item.id));
   }
 }
 
@@ -3610,7 +3611,7 @@ class $$TodosTableTableTableManager extends RootTableManager<
     $$TodosTableTableOrderingComposer,
     $$TodosTableTableCreateCompanionBuilder,
     $$TodosTableTableUpdateCompanionBuilder,
-    $$TodosTableTableWithReferences,
+    (TodoEntry, $$TodosTableTableWithReferences),
     TodoEntry> {
   $$TodosTableTableTableManager(_$TodoDb db, $TodosTableTable table)
       : super(TableManagerState(
@@ -3620,8 +3621,9 @@ class $$TodosTableTableTableManager extends RootTableManager<
               $$TodosTableTableFilterComposer(ComposerState(db, table)),
           orderingComposer:
               $$TodosTableTableOrderingComposer(ComposerState(db, table)),
-          withReferenceMapper: (p0) =>
-              p0.map((e) => $$TodosTableTableWithReferences(db, e)).toList(),
+          withReferenceMapper: (p0) => p0
+              .map((e) => (e, $$TodosTableTableWithReferences(db, e)))
+              .toList(),
           updateCompanionCallback: ({
             Value<RowId> id = const Value.absent(),
             Value<String?> title = const Value.absent(),
@@ -3665,7 +3667,7 @@ typedef $$TodosTableTableProcessedTableManager = ProcessedTableManager<
     $$TodosTableTableOrderingComposer,
     $$TodosTableTableCreateCompanionBuilder,
     $$TodosTableTableUpdateCompanionBuilder,
-    $$TodosTableTableWithReferences,
+    (TodoEntry, $$TodosTableTableWithReferences),
     TodoEntry>;
 
 class $$TodosTableTableFilterComposer
@@ -3757,13 +3759,13 @@ class $$TodosTableTableOrderingComposer
 class $$TodosTableTableWithReferences {
   // ignore: unused_field
   final _$TodoDb _db;
-  final TodoEntry todoEntry;
-  $$TodosTableTableWithReferences(this._db, this.todoEntry);
+  final TodoEntry _item;
+  $$TodosTableTableWithReferences(this._db, this._item);
 
   $$CategoriesTableProcessedTableManager? get category {
-    if (todoEntry.category == null) return null;
+    if (_item.category == null) return null;
     return $$CategoriesTableTableManager(_db, _db.categories)
-        .filter((f) => f.id(todoEntry.category!));
+        .filter((f) => f.id(_item.category!));
   }
 }
 
@@ -3790,7 +3792,7 @@ class $$UsersTableTableManager extends RootTableManager<
     $$UsersTableOrderingComposer,
     $$UsersTableCreateCompanionBuilder,
     $$UsersTableUpdateCompanionBuilder,
-    $$UsersTableWithReferences,
+    (User, $$UsersTableWithReferences),
     User> {
   $$UsersTableTableManager(_$TodoDb db, $UsersTable table)
       : super(TableManagerState(
@@ -3801,7 +3803,7 @@ class $$UsersTableTableManager extends RootTableManager<
           orderingComposer:
               $$UsersTableOrderingComposer(ComposerState(db, table)),
           withReferenceMapper: (p0) =>
-              p0.map((e) => $$UsersTableWithReferences(db, e)).toList(),
+              p0.map((e) => (e, $$UsersTableWithReferences(db, e))).toList(),
           updateCompanionCallback: ({
             Value<RowId> id = const Value.absent(),
             Value<String> name = const Value.absent(),
@@ -3841,7 +3843,7 @@ typedef $$UsersTableProcessedTableManager = ProcessedTableManager<
     $$UsersTableOrderingComposer,
     $$UsersTableCreateCompanionBuilder,
     $$UsersTableUpdateCompanionBuilder,
-    $$UsersTableWithReferences,
+    (User, $$UsersTableWithReferences),
     User>;
 
 class $$UsersTableFilterComposer extends FilterComposer<_$TodoDb, $UsersTable> {
@@ -3906,8 +3908,8 @@ class $$UsersTableOrderingComposer
 class $$UsersTableWithReferences {
   // ignore: unused_field
   final _$TodoDb _db;
-  final User user;
-  $$UsersTableWithReferences(this._db, this.user);
+  final User _item;
+  $$UsersTableWithReferences(this._db, this._item);
 }
 
 typedef $$SharedTodosTableCreateCompanionBuilder = SharedTodosCompanion
@@ -3931,7 +3933,7 @@ class $$SharedTodosTableTableManager extends RootTableManager<
     $$SharedTodosTableOrderingComposer,
     $$SharedTodosTableCreateCompanionBuilder,
     $$SharedTodosTableUpdateCompanionBuilder,
-    $$SharedTodosTableWithReferences,
+    (SharedTodo, $$SharedTodosTableWithReferences),
     SharedTodo> {
   $$SharedTodosTableTableManager(_$TodoDb db, $SharedTodosTable table)
       : super(TableManagerState(
@@ -3941,8 +3943,9 @@ class $$SharedTodosTableTableManager extends RootTableManager<
               $$SharedTodosTableFilterComposer(ComposerState(db, table)),
           orderingComposer:
               $$SharedTodosTableOrderingComposer(ComposerState(db, table)),
-          withReferenceMapper: (p0) =>
-              p0.map((e) => $$SharedTodosTableWithReferences(db, e)).toList(),
+          withReferenceMapper: (p0) => p0
+              .map((e) => (e, $$SharedTodosTableWithReferences(db, e)))
+              .toList(),
           updateCompanionCallback: ({
             Value<int> todo = const Value.absent(),
             Value<int> user = const Value.absent(),
@@ -3974,7 +3977,7 @@ typedef $$SharedTodosTableProcessedTableManager = ProcessedTableManager<
     $$SharedTodosTableOrderingComposer,
     $$SharedTodosTableCreateCompanionBuilder,
     $$SharedTodosTableUpdateCompanionBuilder,
-    $$SharedTodosTableWithReferences,
+    (SharedTodo, $$SharedTodosTableWithReferences),
     SharedTodo>;
 
 class $$SharedTodosTableFilterComposer
@@ -4008,8 +4011,8 @@ class $$SharedTodosTableOrderingComposer
 class $$SharedTodosTableWithReferences {
   // ignore: unused_field
   final _$TodoDb _db;
-  final SharedTodo sharedTodo;
-  $$SharedTodosTableWithReferences(this._db, this.sharedTodo);
+  final SharedTodo _item;
+  $$SharedTodosTableWithReferences(this._db, this._item);
 }
 
 typedef $$TableWithoutPKTableCreateCompanionBuilder = TableWithoutPKCompanion
@@ -4037,7 +4040,7 @@ class $$TableWithoutPKTableTableManager extends RootTableManager<
     $$TableWithoutPKTableOrderingComposer,
     $$TableWithoutPKTableCreateCompanionBuilder,
     $$TableWithoutPKTableUpdateCompanionBuilder,
-    $$TableWithoutPKTableWithReferences,
+    (CustomRowClass, $$TableWithoutPKTableWithReferences),
     CustomRowClass> {
   $$TableWithoutPKTableTableManager(_$TodoDb db, $TableWithoutPKTable table)
       : super(TableManagerState(
@@ -4048,7 +4051,7 @@ class $$TableWithoutPKTableTableManager extends RootTableManager<
           orderingComposer:
               $$TableWithoutPKTableOrderingComposer(ComposerState(db, table)),
           withReferenceMapper: (p0) => p0
-              .map((e) => $$TableWithoutPKTableWithReferences(db, e))
+              .map((e) => (e, $$TableWithoutPKTableWithReferences(db, e)))
               .toList(),
           updateCompanionCallback: ({
             Value<int> notReallyAnId = const Value.absent(),
@@ -4089,7 +4092,7 @@ typedef $$TableWithoutPKTableProcessedTableManager = ProcessedTableManager<
     $$TableWithoutPKTableOrderingComposer,
     $$TableWithoutPKTableCreateCompanionBuilder,
     $$TableWithoutPKTableUpdateCompanionBuilder,
-    $$TableWithoutPKTableWithReferences,
+    (CustomRowClass, $$TableWithoutPKTableWithReferences),
     CustomRowClass>;
 
 class $$TableWithoutPKTableFilterComposer
@@ -4145,8 +4148,8 @@ class $$TableWithoutPKTableOrderingComposer
 class $$TableWithoutPKTableWithReferences {
   // ignore: unused_field
   final _$TodoDb _db;
-  final CustomRowClass customRowClass;
-  $$TableWithoutPKTableWithReferences(this._db, this.customRowClass);
+  final CustomRowClass _item;
+  $$TableWithoutPKTableWithReferences(this._db, this._item);
 }
 
 typedef $$PureDefaultsTableCreateCompanionBuilder = PureDefaultsCompanion
@@ -4168,7 +4171,7 @@ class $$PureDefaultsTableTableManager extends RootTableManager<
     $$PureDefaultsTableOrderingComposer,
     $$PureDefaultsTableCreateCompanionBuilder,
     $$PureDefaultsTableUpdateCompanionBuilder,
-    $$PureDefaultsTableWithReferences,
+    (PureDefault, $$PureDefaultsTableWithReferences),
     PureDefault> {
   $$PureDefaultsTableTableManager(_$TodoDb db, $PureDefaultsTable table)
       : super(TableManagerState(
@@ -4178,8 +4181,9 @@ class $$PureDefaultsTableTableManager extends RootTableManager<
               $$PureDefaultsTableFilterComposer(ComposerState(db, table)),
           orderingComposer:
               $$PureDefaultsTableOrderingComposer(ComposerState(db, table)),
-          withReferenceMapper: (p0) =>
-              p0.map((e) => $$PureDefaultsTableWithReferences(db, e)).toList(),
+          withReferenceMapper: (p0) => p0
+              .map((e) => (e, $$PureDefaultsTableWithReferences(db, e)))
+              .toList(),
           updateCompanionCallback: ({
             Value<MyCustomObject?> txt = const Value.absent(),
             Value<int> rowid = const Value.absent(),
@@ -4207,7 +4211,7 @@ typedef $$PureDefaultsTableProcessedTableManager = ProcessedTableManager<
     $$PureDefaultsTableOrderingComposer,
     $$PureDefaultsTableCreateCompanionBuilder,
     $$PureDefaultsTableUpdateCompanionBuilder,
-    $$PureDefaultsTableWithReferences,
+    (PureDefault, $$PureDefaultsTableWithReferences),
     PureDefault>;
 
 class $$PureDefaultsTableFilterComposer
@@ -4233,8 +4237,8 @@ class $$PureDefaultsTableOrderingComposer
 class $$PureDefaultsTableWithReferences {
   // ignore: unused_field
   final _$TodoDb _db;
-  final PureDefault pureDefault;
-  $$PureDefaultsTableWithReferences(this._db, this.pureDefault);
+  final PureDefault _item;
+  $$PureDefaultsTableWithReferences(this._db, this._item);
 }
 
 typedef $$WithCustomTypeTableCreateCompanionBuilder = WithCustomTypeCompanion
@@ -4256,7 +4260,7 @@ class $$WithCustomTypeTableTableManager extends RootTableManager<
     $$WithCustomTypeTableOrderingComposer,
     $$WithCustomTypeTableCreateCompanionBuilder,
     $$WithCustomTypeTableUpdateCompanionBuilder,
-    $$WithCustomTypeTableWithReferences,
+    (WithCustomTypeData, $$WithCustomTypeTableWithReferences),
     WithCustomTypeData> {
   $$WithCustomTypeTableTableManager(_$TodoDb db, $WithCustomTypeTable table)
       : super(TableManagerState(
@@ -4267,7 +4271,7 @@ class $$WithCustomTypeTableTableManager extends RootTableManager<
           orderingComposer:
               $$WithCustomTypeTableOrderingComposer(ComposerState(db, table)),
           withReferenceMapper: (p0) => p0
-              .map((e) => $$WithCustomTypeTableWithReferences(db, e))
+              .map((e) => (e, $$WithCustomTypeTableWithReferences(db, e)))
               .toList(),
           updateCompanionCallback: ({
             Value<UuidValue> id = const Value.absent(),
@@ -4296,7 +4300,7 @@ typedef $$WithCustomTypeTableProcessedTableManager = ProcessedTableManager<
     $$WithCustomTypeTableOrderingComposer,
     $$WithCustomTypeTableCreateCompanionBuilder,
     $$WithCustomTypeTableUpdateCompanionBuilder,
-    $$WithCustomTypeTableWithReferences,
+    (WithCustomTypeData, $$WithCustomTypeTableWithReferences),
     WithCustomTypeData>;
 
 class $$WithCustomTypeTableFilterComposer
@@ -4320,8 +4324,8 @@ class $$WithCustomTypeTableOrderingComposer
 class $$WithCustomTypeTableWithReferences {
   // ignore: unused_field
   final _$TodoDb _db;
-  final WithCustomTypeData withCustomTypeData;
-  $$WithCustomTypeTableWithReferences(this._db, this.withCustomTypeData);
+  final WithCustomTypeData _item;
+  $$WithCustomTypeTableWithReferences(this._db, this._item);
 }
 
 typedef $$TableWithEveryColumnTypeTableCreateCompanionBuilder
@@ -4359,7 +4363,10 @@ class $$TableWithEveryColumnTypeTableTableManager extends RootTableManager<
     $$TableWithEveryColumnTypeTableOrderingComposer,
     $$TableWithEveryColumnTypeTableCreateCompanionBuilder,
     $$TableWithEveryColumnTypeTableUpdateCompanionBuilder,
-    $$TableWithEveryColumnTypeTableWithReferences,
+    (
+      TableWithEveryColumnTypeData,
+      $$TableWithEveryColumnTypeTableWithReferences
+    ),
     TableWithEveryColumnTypeData> {
   $$TableWithEveryColumnTypeTableTableManager(
       _$TodoDb db, $TableWithEveryColumnTypeTable table)
@@ -4371,7 +4378,8 @@ class $$TableWithEveryColumnTypeTableTableManager extends RootTableManager<
           orderingComposer: $$TableWithEveryColumnTypeTableOrderingComposer(
               ComposerState(db, table)),
           withReferenceMapper: (p0) => p0
-              .map((e) => $$TableWithEveryColumnTypeTableWithReferences(db, e))
+              .map((e) =>
+                  (e, $$TableWithEveryColumnTypeTableWithReferences(db, e)))
               .toList(),
           updateCompanionCallback: ({
             Value<RowId> id = const Value.absent(),
@@ -4433,7 +4441,10 @@ typedef $$TableWithEveryColumnTypeTableProcessedTableManager
         $$TableWithEveryColumnTypeTableOrderingComposer,
         $$TableWithEveryColumnTypeTableCreateCompanionBuilder,
         $$TableWithEveryColumnTypeTableUpdateCompanionBuilder,
-        $$TableWithEveryColumnTypeTableWithReferences,
+        (
+          TableWithEveryColumnTypeData,
+          $$TableWithEveryColumnTypeTableWithReferences
+        ),
         TableWithEveryColumnTypeData>;
 
 class $$TableWithEveryColumnTypeTableFilterComposer
@@ -4553,9 +4564,8 @@ class $$TableWithEveryColumnTypeTableOrderingComposer
 class $$TableWithEveryColumnTypeTableWithReferences {
   // ignore: unused_field
   final _$TodoDb _db;
-  final TableWithEveryColumnTypeData tableWithEveryColumnTypeData;
-  $$TableWithEveryColumnTypeTableWithReferences(
-      this._db, this.tableWithEveryColumnTypeData);
+  final TableWithEveryColumnTypeData _item;
+  $$TableWithEveryColumnTypeTableWithReferences(this._db, this._item);
 }
 
 typedef $$DepartmentTableCreateCompanionBuilder = DepartmentCompanion Function({
@@ -4575,7 +4585,7 @@ class $$DepartmentTableTableManager extends RootTableManager<
     $$DepartmentTableOrderingComposer,
     $$DepartmentTableCreateCompanionBuilder,
     $$DepartmentTableUpdateCompanionBuilder,
-    $$DepartmentTableWithReferences,
+    (DepartmentData, $$DepartmentTableWithReferences),
     DepartmentData> {
   $$DepartmentTableTableManager(_$TodoDb db, $DepartmentTable table)
       : super(TableManagerState(
@@ -4585,8 +4595,9 @@ class $$DepartmentTableTableManager extends RootTableManager<
               $$DepartmentTableFilterComposer(ComposerState(db, table)),
           orderingComposer:
               $$DepartmentTableOrderingComposer(ComposerState(db, table)),
-          withReferenceMapper: (p0) =>
-              p0.map((e) => $$DepartmentTableWithReferences(db, e)).toList(),
+          withReferenceMapper: (p0) => p0
+              .map((e) => (e, $$DepartmentTableWithReferences(db, e)))
+              .toList(),
           updateCompanionCallback: ({
             Value<int> id = const Value.absent(),
             Value<String?> name = const Value.absent(),
@@ -4614,7 +4625,7 @@ typedef $$DepartmentTableProcessedTableManager = ProcessedTableManager<
     $$DepartmentTableOrderingComposer,
     $$DepartmentTableCreateCompanionBuilder,
     $$DepartmentTableUpdateCompanionBuilder,
-    $$DepartmentTableWithReferences,
+    (DepartmentData, $$DepartmentTableWithReferences),
     DepartmentData>;
 
 class $$DepartmentTableFilterComposer
@@ -4661,12 +4672,12 @@ class $$DepartmentTableOrderingComposer
 class $$DepartmentTableWithReferences {
   // ignore: unused_field
   final _$TodoDb _db;
-  final DepartmentData departmentData;
-  $$DepartmentTableWithReferences(this._db, this.departmentData);
+  final DepartmentData _item;
+  $$DepartmentTableWithReferences(this._db, this._item);
 
   $$ProductTableProcessedTableManager get productRefs {
     return $$ProductTableTableManager(_db, _db.product)
-        .filter((f) => f.department.id(departmentData.id));
+        .filter((f) => f.department.id(_item.id));
   }
 }
 
@@ -4689,7 +4700,7 @@ class $$ProductTableTableManager extends RootTableManager<
     $$ProductTableOrderingComposer,
     $$ProductTableCreateCompanionBuilder,
     $$ProductTableUpdateCompanionBuilder,
-    $$ProductTableWithReferences,
+    (ProductData, $$ProductTableWithReferences),
     ProductData> {
   $$ProductTableTableManager(_$TodoDb db, $ProductTable table)
       : super(TableManagerState(
@@ -4700,7 +4711,7 @@ class $$ProductTableTableManager extends RootTableManager<
           orderingComposer:
               $$ProductTableOrderingComposer(ComposerState(db, table)),
           withReferenceMapper: (p0) =>
-              p0.map((e) => $$ProductTableWithReferences(db, e)).toList(),
+              p0.map((e) => (e, $$ProductTableWithReferences(db, e))).toList(),
           updateCompanionCallback: ({
             Value<int> id = const Value.absent(),
             Value<String?> name = const Value.absent(),
@@ -4732,7 +4743,7 @@ typedef $$ProductTableProcessedTableManager = ProcessedTableManager<
     $$ProductTableOrderingComposer,
     $$ProductTableCreateCompanionBuilder,
     $$ProductTableUpdateCompanionBuilder,
-    $$ProductTableWithReferences,
+    (ProductData, $$ProductTableWithReferences),
     ProductData>;
 
 class $$ProductTableFilterComposer
@@ -4803,18 +4814,18 @@ class $$ProductTableOrderingComposer
 class $$ProductTableWithReferences {
   // ignore: unused_field
   final _$TodoDb _db;
-  final ProductData productData;
-  $$ProductTableWithReferences(this._db, this.productData);
+  final ProductData _item;
+  $$ProductTableWithReferences(this._db, this._item);
 
   $$DepartmentTableProcessedTableManager? get department {
-    if (productData.department == null) return null;
+    if (_item.department == null) return null;
     return $$DepartmentTableTableManager(_db, _db.department)
-        .filter((f) => f.id(productData.department!));
+        .filter((f) => f.id(_item.department!));
   }
 
   $$ListingTableProcessedTableManager get listings {
     return $$ListingTableTableManager(_db, _db.listing)
-        .filter((f) => f.product.id(productData.id));
+        .filter((f) => f.product.id(_item.id));
   }
 }
 
@@ -4835,7 +4846,7 @@ class $$StoreTableTableManager extends RootTableManager<
     $$StoreTableOrderingComposer,
     $$StoreTableCreateCompanionBuilder,
     $$StoreTableUpdateCompanionBuilder,
-    $$StoreTableWithReferences,
+    (StoreData, $$StoreTableWithReferences),
     StoreData> {
   $$StoreTableTableManager(_$TodoDb db, $StoreTable table)
       : super(TableManagerState(
@@ -4846,7 +4857,7 @@ class $$StoreTableTableManager extends RootTableManager<
           orderingComposer:
               $$StoreTableOrderingComposer(ComposerState(db, table)),
           withReferenceMapper: (p0) =>
-              p0.map((e) => $$StoreTableWithReferences(db, e)).toList(),
+              p0.map((e) => (e, $$StoreTableWithReferences(db, e))).toList(),
           updateCompanionCallback: ({
             Value<int> id = const Value.absent(),
             Value<String?> name = const Value.absent(),
@@ -4874,7 +4885,7 @@ typedef $$StoreTableProcessedTableManager = ProcessedTableManager<
     $$StoreTableOrderingComposer,
     $$StoreTableCreateCompanionBuilder,
     $$StoreTableUpdateCompanionBuilder,
-    $$StoreTableWithReferences,
+    (StoreData, $$StoreTableWithReferences),
     StoreData>;
 
 class $$StoreTableFilterComposer extends FilterComposer<_$TodoDb, $StoreTable> {
@@ -4920,12 +4931,12 @@ class $$StoreTableOrderingComposer
 class $$StoreTableWithReferences {
   // ignore: unused_field
   final _$TodoDb _db;
-  final StoreData storeData;
-  $$StoreTableWithReferences(this._db, this.storeData);
+  final StoreData _item;
+  $$StoreTableWithReferences(this._db, this._item);
 
   $$ListingTableProcessedTableManager get listings {
     return $$ListingTableTableManager(_db, _db.listing)
-        .filter((f) => f.store.id(storeData.id));
+        .filter((f) => f.store.id(_item.id));
   }
 }
 
@@ -4950,7 +4961,7 @@ class $$ListingTableTableManager extends RootTableManager<
     $$ListingTableOrderingComposer,
     $$ListingTableCreateCompanionBuilder,
     $$ListingTableUpdateCompanionBuilder,
-    $$ListingTableWithReferences,
+    (ListingData, $$ListingTableWithReferences),
     ListingData> {
   $$ListingTableTableManager(_$TodoDb db, $ListingTable table)
       : super(TableManagerState(
@@ -4961,7 +4972,7 @@ class $$ListingTableTableManager extends RootTableManager<
           orderingComposer:
               $$ListingTableOrderingComposer(ComposerState(db, table)),
           withReferenceMapper: (p0) =>
-              p0.map((e) => $$ListingTableWithReferences(db, e)).toList(),
+              p0.map((e) => (e, $$ListingTableWithReferences(db, e))).toList(),
           updateCompanionCallback: ({
             Value<int> id = const Value.absent(),
             Value<int?> product = const Value.absent(),
@@ -4997,7 +5008,7 @@ typedef $$ListingTableProcessedTableManager = ProcessedTableManager<
     $$ListingTableOrderingComposer,
     $$ListingTableCreateCompanionBuilder,
     $$ListingTableUpdateCompanionBuilder,
-    $$ListingTableWithReferences,
+    (ListingData, $$ListingTableWithReferences),
     ListingData>;
 
 class $$ListingTableFilterComposer
@@ -5079,19 +5090,19 @@ class $$ListingTableOrderingComposer
 class $$ListingTableWithReferences {
   // ignore: unused_field
   final _$TodoDb _db;
-  final ListingData listingData;
-  $$ListingTableWithReferences(this._db, this.listingData);
+  final ListingData _item;
+  $$ListingTableWithReferences(this._db, this._item);
 
   $$ProductTableProcessedTableManager? get product {
-    if (listingData.product == null) return null;
+    if (_item.product == null) return null;
     return $$ProductTableTableManager(_db, _db.product)
-        .filter((f) => f.id(listingData.product!));
+        .filter((f) => f.id(_item.product!));
   }
 
   $$StoreTableProcessedTableManager? get store {
-    if (listingData.store == null) return null;
+    if (_item.store == null) return null;
     return $$StoreTableTableManager(_db, _db.store)
-        .filter((f) => f.id(listingData.store!));
+        .filter((f) => f.id(_item.store!));
   }
 }
 

--- a/drift/test/generated/todos.g.dart
+++ b/drift/test/generated/todos.g.dart
@@ -3471,7 +3471,7 @@ class $$CategoriesTableTableManager extends RootTableManager<
               $$CategoriesTableFilterComposer(ComposerState(db, table)),
           orderingComposer:
               $$CategoriesTableOrderingComposer(ComposerState(db, table)),
-          dataclassMapper: (p0) async =>
+          withReferenceMapper: (p0) =>
               p0.map((e) => $$CategoriesTableWithReferences(db, e)).toList(),
           updateCompanionCallback: ({
             Value<RowId> id = const Value.absent(),
@@ -3620,7 +3620,7 @@ class $$TodosTableTableTableManager extends RootTableManager<
               $$TodosTableTableFilterComposer(ComposerState(db, table)),
           orderingComposer:
               $$TodosTableTableOrderingComposer(ComposerState(db, table)),
-          dataclassMapper: (p0) async =>
+          withReferenceMapper: (p0) =>
               p0.map((e) => $$TodosTableTableWithReferences(db, e)).toList(),
           updateCompanionCallback: ({
             Value<RowId> id = const Value.absent(),
@@ -3800,7 +3800,7 @@ class $$UsersTableTableManager extends RootTableManager<
               $$UsersTableFilterComposer(ComposerState(db, table)),
           orderingComposer:
               $$UsersTableOrderingComposer(ComposerState(db, table)),
-          dataclassMapper: (p0) async =>
+          withReferenceMapper: (p0) =>
               p0.map((e) => $$UsersTableWithReferences(db, e)).toList(),
           updateCompanionCallback: ({
             Value<RowId> id = const Value.absent(),
@@ -3941,7 +3941,7 @@ class $$SharedTodosTableTableManager extends RootTableManager<
               $$SharedTodosTableFilterComposer(ComposerState(db, table)),
           orderingComposer:
               $$SharedTodosTableOrderingComposer(ComposerState(db, table)),
-          dataclassMapper: (p0) async =>
+          withReferenceMapper: (p0) =>
               p0.map((e) => $$SharedTodosTableWithReferences(db, e)).toList(),
           updateCompanionCallback: ({
             Value<int> todo = const Value.absent(),
@@ -4047,7 +4047,7 @@ class $$TableWithoutPKTableTableManager extends RootTableManager<
               $$TableWithoutPKTableFilterComposer(ComposerState(db, table)),
           orderingComposer:
               $$TableWithoutPKTableOrderingComposer(ComposerState(db, table)),
-          dataclassMapper: (p0) async => p0
+          withReferenceMapper: (p0) => p0
               .map((e) => $$TableWithoutPKTableWithReferences(db, e))
               .toList(),
           updateCompanionCallback: ({
@@ -4178,7 +4178,7 @@ class $$PureDefaultsTableTableManager extends RootTableManager<
               $$PureDefaultsTableFilterComposer(ComposerState(db, table)),
           orderingComposer:
               $$PureDefaultsTableOrderingComposer(ComposerState(db, table)),
-          dataclassMapper: (p0) async =>
+          withReferenceMapper: (p0) =>
               p0.map((e) => $$PureDefaultsTableWithReferences(db, e)).toList(),
           updateCompanionCallback: ({
             Value<MyCustomObject?> txt = const Value.absent(),
@@ -4266,7 +4266,7 @@ class $$WithCustomTypeTableTableManager extends RootTableManager<
               $$WithCustomTypeTableFilterComposer(ComposerState(db, table)),
           orderingComposer:
               $$WithCustomTypeTableOrderingComposer(ComposerState(db, table)),
-          dataclassMapper: (p0) async => p0
+          withReferenceMapper: (p0) => p0
               .map((e) => $$WithCustomTypeTableWithReferences(db, e))
               .toList(),
           updateCompanionCallback: ({
@@ -4370,7 +4370,7 @@ class $$TableWithEveryColumnTypeTableTableManager extends RootTableManager<
               ComposerState(db, table)),
           orderingComposer: $$TableWithEveryColumnTypeTableOrderingComposer(
               ComposerState(db, table)),
-          dataclassMapper: (p0) async => p0
+          withReferenceMapper: (p0) => p0
               .map((e) => $$TableWithEveryColumnTypeTableWithReferences(db, e))
               .toList(),
           updateCompanionCallback: ({
@@ -4585,7 +4585,7 @@ class $$DepartmentTableTableManager extends RootTableManager<
               $$DepartmentTableFilterComposer(ComposerState(db, table)),
           orderingComposer:
               $$DepartmentTableOrderingComposer(ComposerState(db, table)),
-          dataclassMapper: (p0) async =>
+          withReferenceMapper: (p0) =>
               p0.map((e) => $$DepartmentTableWithReferences(db, e)).toList(),
           updateCompanionCallback: ({
             Value<int> id = const Value.absent(),
@@ -4699,7 +4699,7 @@ class $$ProductTableTableManager extends RootTableManager<
               $$ProductTableFilterComposer(ComposerState(db, table)),
           orderingComposer:
               $$ProductTableOrderingComposer(ComposerState(db, table)),
-          dataclassMapper: (p0) async =>
+          withReferenceMapper: (p0) =>
               p0.map((e) => $$ProductTableWithReferences(db, e)).toList(),
           updateCompanionCallback: ({
             Value<int> id = const Value.absent(),
@@ -4845,7 +4845,7 @@ class $$StoreTableTableManager extends RootTableManager<
               $$StoreTableFilterComposer(ComposerState(db, table)),
           orderingComposer:
               $$StoreTableOrderingComposer(ComposerState(db, table)),
-          dataclassMapper: (p0) async =>
+          withReferenceMapper: (p0) =>
               p0.map((e) => $$StoreTableWithReferences(db, e)).toList(),
           updateCompanionCallback: ({
             Value<int> id = const Value.absent(),
@@ -4960,7 +4960,7 @@ class $$ListingTableTableManager extends RootTableManager<
               $$ListingTableFilterComposer(ComposerState(db, table)),
           orderingComposer:
               $$ListingTableOrderingComposer(ComposerState(db, table)),
-          dataclassMapper: (p0) async =>
+          withReferenceMapper: (p0) =>
               p0.map((e) => $$ListingTableWithReferences(db, e)).toList(),
           updateCompanionCallback: ({
             Value<int> id = const Value.absent(),

--- a/drift/test/generated/todos.g.dart
+++ b/drift/test/generated/todos.g.dart
@@ -3451,7 +3451,9 @@ class $$CategoriesTableTableManager extends RootTableManager<
     $$CategoriesTableFilterComposer,
     $$CategoriesTableOrderingComposer,
     $$CategoriesTableCreateCompanionBuilder,
-    $$CategoriesTableUpdateCompanionBuilder> {
+    $$CategoriesTableUpdateCompanionBuilder,
+    $$CategoriesTableWithReferences,
+    Category> {
   $$CategoriesTableTableManager(_$TodoDb db, $CategoriesTable table)
       : super(TableManagerState(
           db: db,
@@ -3460,6 +3462,8 @@ class $$CategoriesTableTableManager extends RootTableManager<
               $$CategoriesTableFilterComposer(ComposerState(db, table)),
           orderingComposer:
               $$CategoriesTableOrderingComposer(ComposerState(db, table)),
+          dataclassMapper: (p0) async =>
+              p0.map((e) => $$CategoriesTableWithReferences(db, e)).toList(),
           updateCompanionCallback: ({
             Value<RowId> id = const Value.absent(),
             Value<String> description = const Value.absent(),
@@ -3482,6 +3486,17 @@ class $$CategoriesTableTableManager extends RootTableManager<
           ),
         ));
 }
+
+typedef $$CategoriesTableProcessedTableManager = ProcessedTableManager<
+    _$TodoDb,
+    $CategoriesTable,
+    Category,
+    $$CategoriesTableFilterComposer,
+    $$CategoriesTableOrderingComposer,
+    $$CategoriesTableCreateCompanionBuilder,
+    $$CategoriesTableUpdateCompanionBuilder,
+    $$CategoriesTableWithReferences,
+    Category>;
 
 class $$CategoriesTableFilterComposer
     extends FilterComposer<_$TodoDb, $CategoriesTable> {
@@ -3549,6 +3564,18 @@ class $$CategoriesTableOrderingComposer
               ColumnOrderings(column, joinBuilders: joinBuilders));
 }
 
+class $$CategoriesTableWithReferences {
+  // ignore: unused_field
+  final _$TodoDb _db;
+  final Category category;
+  $$CategoriesTableWithReferences(this._db, this.category);
+
+  $$TodosTableTableProcessedTableManager get todos {
+    return $$TodosTableTableTableManager(_db, _db.todosTable)
+        .filter((f) => f.category.id(category.id));
+  }
+}
+
 typedef $$TodosTableTableCreateCompanionBuilder = TodosTableCompanion Function({
   Value<RowId> id,
   Value<String?> title,
@@ -3573,7 +3600,9 @@ class $$TodosTableTableTableManager extends RootTableManager<
     $$TodosTableTableFilterComposer,
     $$TodosTableTableOrderingComposer,
     $$TodosTableTableCreateCompanionBuilder,
-    $$TodosTableTableUpdateCompanionBuilder> {
+    $$TodosTableTableUpdateCompanionBuilder,
+    $$TodosTableTableWithReferences,
+    TodoEntry> {
   $$TodosTableTableTableManager(_$TodoDb db, $TodosTableTable table)
       : super(TableManagerState(
           db: db,
@@ -3582,6 +3611,8 @@ class $$TodosTableTableTableManager extends RootTableManager<
               $$TodosTableTableFilterComposer(ComposerState(db, table)),
           orderingComposer:
               $$TodosTableTableOrderingComposer(ComposerState(db, table)),
+          dataclassMapper: (p0) async =>
+              p0.map((e) => $$TodosTableTableWithReferences(db, e)).toList(),
           updateCompanionCallback: ({
             Value<RowId> id = const Value.absent(),
             Value<String?> title = const Value.absent(),
@@ -3616,6 +3647,17 @@ class $$TodosTableTableTableManager extends RootTableManager<
           ),
         ));
 }
+
+typedef $$TodosTableTableProcessedTableManager = ProcessedTableManager<
+    _$TodoDb,
+    $TodosTableTable,
+    TodoEntry,
+    $$TodosTableTableFilterComposer,
+    $$TodosTableTableOrderingComposer,
+    $$TodosTableTableCreateCompanionBuilder,
+    $$TodosTableTableUpdateCompanionBuilder,
+    $$TodosTableTableWithReferences,
+    TodoEntry>;
 
 class $$TodosTableTableFilterComposer
     extends FilterComposer<_$TodoDb, $TodosTableTable> {
@@ -3703,6 +3745,19 @@ class $$TodosTableTableOrderingComposer
   }
 }
 
+class $$TodosTableTableWithReferences {
+  // ignore: unused_field
+  final _$TodoDb _db;
+  final TodoEntry todoEntry;
+  $$TodosTableTableWithReferences(this._db, this.todoEntry);
+
+  $$CategoriesTableProcessedTableManager? get category {
+    if (todoEntry.category == null) return null;
+    return $$CategoriesTableTableManager(_db, _db.categories)
+        .filter((f) => f.id(todoEntry.category!));
+  }
+}
+
 typedef $$UsersTableCreateCompanionBuilder = UsersCompanion Function({
   Value<RowId> id,
   required String name,
@@ -3725,7 +3780,9 @@ class $$UsersTableTableManager extends RootTableManager<
     $$UsersTableFilterComposer,
     $$UsersTableOrderingComposer,
     $$UsersTableCreateCompanionBuilder,
-    $$UsersTableUpdateCompanionBuilder> {
+    $$UsersTableUpdateCompanionBuilder,
+    $$UsersTableWithReferences,
+    User> {
   $$UsersTableTableManager(_$TodoDb db, $UsersTable table)
       : super(TableManagerState(
           db: db,
@@ -3734,6 +3791,8 @@ class $$UsersTableTableManager extends RootTableManager<
               $$UsersTableFilterComposer(ComposerState(db, table)),
           orderingComposer:
               $$UsersTableOrderingComposer(ComposerState(db, table)),
+          dataclassMapper: (p0) async =>
+              p0.map((e) => $$UsersTableWithReferences(db, e)).toList(),
           updateCompanionCallback: ({
             Value<RowId> id = const Value.absent(),
             Value<String> name = const Value.absent(),
@@ -3764,6 +3823,17 @@ class $$UsersTableTableManager extends RootTableManager<
           ),
         ));
 }
+
+typedef $$UsersTableProcessedTableManager = ProcessedTableManager<
+    _$TodoDb,
+    $UsersTable,
+    User,
+    $$UsersTableFilterComposer,
+    $$UsersTableOrderingComposer,
+    $$UsersTableCreateCompanionBuilder,
+    $$UsersTableUpdateCompanionBuilder,
+    $$UsersTableWithReferences,
+    User>;
 
 class $$UsersTableFilterComposer extends FilterComposer<_$TodoDb, $UsersTable> {
   $$UsersTableFilterComposer(super.$state);
@@ -3824,6 +3894,13 @@ class $$UsersTableOrderingComposer
           ColumnOrderings(column, joinBuilders: joinBuilders));
 }
 
+class $$UsersTableWithReferences {
+  // ignore: unused_field
+  final _$TodoDb _db;
+  final User user;
+  $$UsersTableWithReferences(this._db, this.user);
+}
+
 typedef $$SharedTodosTableCreateCompanionBuilder = SharedTodosCompanion
     Function({
   required int todo,
@@ -3844,7 +3921,9 @@ class $$SharedTodosTableTableManager extends RootTableManager<
     $$SharedTodosTableFilterComposer,
     $$SharedTodosTableOrderingComposer,
     $$SharedTodosTableCreateCompanionBuilder,
-    $$SharedTodosTableUpdateCompanionBuilder> {
+    $$SharedTodosTableUpdateCompanionBuilder,
+    $$SharedTodosTableWithReferences,
+    SharedTodo> {
   $$SharedTodosTableTableManager(_$TodoDb db, $SharedTodosTable table)
       : super(TableManagerState(
           db: db,
@@ -3853,6 +3932,8 @@ class $$SharedTodosTableTableManager extends RootTableManager<
               $$SharedTodosTableFilterComposer(ComposerState(db, table)),
           orderingComposer:
               $$SharedTodosTableOrderingComposer(ComposerState(db, table)),
+          dataclassMapper: (p0) async =>
+              p0.map((e) => $$SharedTodosTableWithReferences(db, e)).toList(),
           updateCompanionCallback: ({
             Value<int> todo = const Value.absent(),
             Value<int> user = const Value.absent(),
@@ -3875,6 +3956,17 @@ class $$SharedTodosTableTableManager extends RootTableManager<
           ),
         ));
 }
+
+typedef $$SharedTodosTableProcessedTableManager = ProcessedTableManager<
+    _$TodoDb,
+    $SharedTodosTable,
+    SharedTodo,
+    $$SharedTodosTableFilterComposer,
+    $$SharedTodosTableOrderingComposer,
+    $$SharedTodosTableCreateCompanionBuilder,
+    $$SharedTodosTableUpdateCompanionBuilder,
+    $$SharedTodosTableWithReferences,
+    SharedTodo>;
 
 class $$SharedTodosTableFilterComposer
     extends FilterComposer<_$TodoDb, $SharedTodosTable> {
@@ -3904,6 +3996,13 @@ class $$SharedTodosTableOrderingComposer
           ColumnOrderings(column, joinBuilders: joinBuilders));
 }
 
+class $$SharedTodosTableWithReferences {
+  // ignore: unused_field
+  final _$TodoDb _db;
+  final SharedTodo sharedTodo;
+  $$SharedTodosTableWithReferences(this._db, this.sharedTodo);
+}
+
 typedef $$TableWithoutPKTableCreateCompanionBuilder = TableWithoutPKCompanion
     Function({
   required int notReallyAnId,
@@ -3928,7 +4027,9 @@ class $$TableWithoutPKTableTableManager extends RootTableManager<
     $$TableWithoutPKTableFilterComposer,
     $$TableWithoutPKTableOrderingComposer,
     $$TableWithoutPKTableCreateCompanionBuilder,
-    $$TableWithoutPKTableUpdateCompanionBuilder> {
+    $$TableWithoutPKTableUpdateCompanionBuilder,
+    $$TableWithoutPKTableWithReferences,
+    CustomRowClass> {
   $$TableWithoutPKTableTableManager(_$TodoDb db, $TableWithoutPKTable table)
       : super(TableManagerState(
           db: db,
@@ -3937,6 +4038,9 @@ class $$TableWithoutPKTableTableManager extends RootTableManager<
               $$TableWithoutPKTableFilterComposer(ComposerState(db, table)),
           orderingComposer:
               $$TableWithoutPKTableOrderingComposer(ComposerState(db, table)),
+          dataclassMapper: (p0) async => p0
+              .map((e) => $$TableWithoutPKTableWithReferences(db, e))
+              .toList(),
           updateCompanionCallback: ({
             Value<int> notReallyAnId = const Value.absent(),
             Value<double> someFloat = const Value.absent(),
@@ -3967,6 +4071,17 @@ class $$TableWithoutPKTableTableManager extends RootTableManager<
           ),
         ));
 }
+
+typedef $$TableWithoutPKTableProcessedTableManager = ProcessedTableManager<
+    _$TodoDb,
+    $TableWithoutPKTable,
+    CustomRowClass,
+    $$TableWithoutPKTableFilterComposer,
+    $$TableWithoutPKTableOrderingComposer,
+    $$TableWithoutPKTableCreateCompanionBuilder,
+    $$TableWithoutPKTableUpdateCompanionBuilder,
+    $$TableWithoutPKTableWithReferences,
+    CustomRowClass>;
 
 class $$TableWithoutPKTableFilterComposer
     extends FilterComposer<_$TodoDb, $TableWithoutPKTable> {
@@ -4018,6 +4133,13 @@ class $$TableWithoutPKTableOrderingComposer
           ColumnOrderings(column, joinBuilders: joinBuilders));
 }
 
+class $$TableWithoutPKTableWithReferences {
+  // ignore: unused_field
+  final _$TodoDb _db;
+  final CustomRowClass customRowClass;
+  $$TableWithoutPKTableWithReferences(this._db, this.customRowClass);
+}
+
 typedef $$PureDefaultsTableCreateCompanionBuilder = PureDefaultsCompanion
     Function({
   Value<MyCustomObject?> txt,
@@ -4036,7 +4158,9 @@ class $$PureDefaultsTableTableManager extends RootTableManager<
     $$PureDefaultsTableFilterComposer,
     $$PureDefaultsTableOrderingComposer,
     $$PureDefaultsTableCreateCompanionBuilder,
-    $$PureDefaultsTableUpdateCompanionBuilder> {
+    $$PureDefaultsTableUpdateCompanionBuilder,
+    $$PureDefaultsTableWithReferences,
+    PureDefault> {
   $$PureDefaultsTableTableManager(_$TodoDb db, $PureDefaultsTable table)
       : super(TableManagerState(
           db: db,
@@ -4045,6 +4169,8 @@ class $$PureDefaultsTableTableManager extends RootTableManager<
               $$PureDefaultsTableFilterComposer(ComposerState(db, table)),
           orderingComposer:
               $$PureDefaultsTableOrderingComposer(ComposerState(db, table)),
+          dataclassMapper: (p0) async =>
+              p0.map((e) => $$PureDefaultsTableWithReferences(db, e)).toList(),
           updateCompanionCallback: ({
             Value<MyCustomObject?> txt = const Value.absent(),
             Value<int> rowid = const Value.absent(),
@@ -4063,6 +4189,17 @@ class $$PureDefaultsTableTableManager extends RootTableManager<
           ),
         ));
 }
+
+typedef $$PureDefaultsTableProcessedTableManager = ProcessedTableManager<
+    _$TodoDb,
+    $PureDefaultsTable,
+    PureDefault,
+    $$PureDefaultsTableFilterComposer,
+    $$PureDefaultsTableOrderingComposer,
+    $$PureDefaultsTableCreateCompanionBuilder,
+    $$PureDefaultsTableUpdateCompanionBuilder,
+    $$PureDefaultsTableWithReferences,
+    PureDefault>;
 
 class $$PureDefaultsTableFilterComposer
     extends FilterComposer<_$TodoDb, $PureDefaultsTable> {
@@ -4084,6 +4221,13 @@ class $$PureDefaultsTableOrderingComposer
           ColumnOrderings(column, joinBuilders: joinBuilders));
 }
 
+class $$PureDefaultsTableWithReferences {
+  // ignore: unused_field
+  final _$TodoDb _db;
+  final PureDefault pureDefault;
+  $$PureDefaultsTableWithReferences(this._db, this.pureDefault);
+}
+
 typedef $$WithCustomTypeTableCreateCompanionBuilder = WithCustomTypeCompanion
     Function({
   required UuidValue id,
@@ -4102,7 +4246,9 @@ class $$WithCustomTypeTableTableManager extends RootTableManager<
     $$WithCustomTypeTableFilterComposer,
     $$WithCustomTypeTableOrderingComposer,
     $$WithCustomTypeTableCreateCompanionBuilder,
-    $$WithCustomTypeTableUpdateCompanionBuilder> {
+    $$WithCustomTypeTableUpdateCompanionBuilder,
+    $$WithCustomTypeTableWithReferences,
+    WithCustomTypeData> {
   $$WithCustomTypeTableTableManager(_$TodoDb db, $WithCustomTypeTable table)
       : super(TableManagerState(
           db: db,
@@ -4111,6 +4257,9 @@ class $$WithCustomTypeTableTableManager extends RootTableManager<
               $$WithCustomTypeTableFilterComposer(ComposerState(db, table)),
           orderingComposer:
               $$WithCustomTypeTableOrderingComposer(ComposerState(db, table)),
+          dataclassMapper: (p0) async => p0
+              .map((e) => $$WithCustomTypeTableWithReferences(db, e))
+              .toList(),
           updateCompanionCallback: ({
             Value<UuidValue> id = const Value.absent(),
             Value<int> rowid = const Value.absent(),
@@ -4130,6 +4279,17 @@ class $$WithCustomTypeTableTableManager extends RootTableManager<
         ));
 }
 
+typedef $$WithCustomTypeTableProcessedTableManager = ProcessedTableManager<
+    _$TodoDb,
+    $WithCustomTypeTable,
+    WithCustomTypeData,
+    $$WithCustomTypeTableFilterComposer,
+    $$WithCustomTypeTableOrderingComposer,
+    $$WithCustomTypeTableCreateCompanionBuilder,
+    $$WithCustomTypeTableUpdateCompanionBuilder,
+    $$WithCustomTypeTableWithReferences,
+    WithCustomTypeData>;
+
 class $$WithCustomTypeTableFilterComposer
     extends FilterComposer<_$TodoDb, $WithCustomTypeTable> {
   $$WithCustomTypeTableFilterComposer(super.$state);
@@ -4146,6 +4306,13 @@ class $$WithCustomTypeTableOrderingComposer
       column: $state.table.id,
       builder: (column, joinBuilders) =>
           ColumnOrderings(column, joinBuilders: joinBuilders));
+}
+
+class $$WithCustomTypeTableWithReferences {
+  // ignore: unused_field
+  final _$TodoDb _db;
+  final WithCustomTypeData withCustomTypeData;
+  $$WithCustomTypeTableWithReferences(this._db, this.withCustomTypeData);
 }
 
 typedef $$TableWithEveryColumnTypeTableCreateCompanionBuilder
@@ -4182,7 +4349,9 @@ class $$TableWithEveryColumnTypeTableTableManager extends RootTableManager<
     $$TableWithEveryColumnTypeTableFilterComposer,
     $$TableWithEveryColumnTypeTableOrderingComposer,
     $$TableWithEveryColumnTypeTableCreateCompanionBuilder,
-    $$TableWithEveryColumnTypeTableUpdateCompanionBuilder> {
+    $$TableWithEveryColumnTypeTableUpdateCompanionBuilder,
+    $$TableWithEveryColumnTypeTableWithReferences,
+    TableWithEveryColumnTypeData> {
   $$TableWithEveryColumnTypeTableTableManager(
       _$TodoDb db, $TableWithEveryColumnTypeTable table)
       : super(TableManagerState(
@@ -4192,6 +4361,9 @@ class $$TableWithEveryColumnTypeTableTableManager extends RootTableManager<
               ComposerState(db, table)),
           orderingComposer: $$TableWithEveryColumnTypeTableOrderingComposer(
               ComposerState(db, table)),
+          dataclassMapper: (p0) async => p0
+              .map((e) => $$TableWithEveryColumnTypeTableWithReferences(db, e))
+              .toList(),
           updateCompanionCallback: ({
             Value<RowId> id = const Value.absent(),
             Value<bool?> aBool = const Value.absent(),
@@ -4242,6 +4414,18 @@ class $$TableWithEveryColumnTypeTableTableManager extends RootTableManager<
           ),
         ));
 }
+
+typedef $$TableWithEveryColumnTypeTableProcessedTableManager
+    = ProcessedTableManager<
+        _$TodoDb,
+        $TableWithEveryColumnTypeTable,
+        TableWithEveryColumnTypeData,
+        $$TableWithEveryColumnTypeTableFilterComposer,
+        $$TableWithEveryColumnTypeTableOrderingComposer,
+        $$TableWithEveryColumnTypeTableCreateCompanionBuilder,
+        $$TableWithEveryColumnTypeTableUpdateCompanionBuilder,
+        $$TableWithEveryColumnTypeTableWithReferences,
+        TableWithEveryColumnTypeData>;
 
 class $$TableWithEveryColumnTypeTableFilterComposer
     extends FilterComposer<_$TodoDb, $TableWithEveryColumnTypeTable> {
@@ -4357,6 +4541,14 @@ class $$TableWithEveryColumnTypeTableOrderingComposer
           ColumnOrderings(column, joinBuilders: joinBuilders));
 }
 
+class $$TableWithEveryColumnTypeTableWithReferences {
+  // ignore: unused_field
+  final _$TodoDb _db;
+  final TableWithEveryColumnTypeData tableWithEveryColumnTypeData;
+  $$TableWithEveryColumnTypeTableWithReferences(
+      this._db, this.tableWithEveryColumnTypeData);
+}
+
 typedef $$DepartmentTableCreateCompanionBuilder = DepartmentCompanion Function({
   Value<int> id,
   Value<String?> name,
@@ -4373,7 +4565,9 @@ class $$DepartmentTableTableManager extends RootTableManager<
     $$DepartmentTableFilterComposer,
     $$DepartmentTableOrderingComposer,
     $$DepartmentTableCreateCompanionBuilder,
-    $$DepartmentTableUpdateCompanionBuilder> {
+    $$DepartmentTableUpdateCompanionBuilder,
+    $$DepartmentTableWithReferences,
+    DepartmentData> {
   $$DepartmentTableTableManager(_$TodoDb db, $DepartmentTable table)
       : super(TableManagerState(
           db: db,
@@ -4382,6 +4576,8 @@ class $$DepartmentTableTableManager extends RootTableManager<
               $$DepartmentTableFilterComposer(ComposerState(db, table)),
           orderingComposer:
               $$DepartmentTableOrderingComposer(ComposerState(db, table)),
+          dataclassMapper: (p0) async =>
+              p0.map((e) => $$DepartmentTableWithReferences(db, e)).toList(),
           updateCompanionCallback: ({
             Value<int> id = const Value.absent(),
             Value<String?> name = const Value.absent(),
@@ -4400,6 +4596,17 @@ class $$DepartmentTableTableManager extends RootTableManager<
           ),
         ));
 }
+
+typedef $$DepartmentTableProcessedTableManager = ProcessedTableManager<
+    _$TodoDb,
+    $DepartmentTable,
+    DepartmentData,
+    $$DepartmentTableFilterComposer,
+    $$DepartmentTableOrderingComposer,
+    $$DepartmentTableCreateCompanionBuilder,
+    $$DepartmentTableUpdateCompanionBuilder,
+    $$DepartmentTableWithReferences,
+    DepartmentData>;
 
 class $$DepartmentTableFilterComposer
     extends FilterComposer<_$TodoDb, $DepartmentTable> {
@@ -4442,6 +4649,18 @@ class $$DepartmentTableOrderingComposer
           ColumnOrderings(column, joinBuilders: joinBuilders));
 }
 
+class $$DepartmentTableWithReferences {
+  // ignore: unused_field
+  final _$TodoDb _db;
+  final DepartmentData departmentData;
+  $$DepartmentTableWithReferences(this._db, this.departmentData);
+
+  $$ProductTableProcessedTableManager get productRefs {
+    return $$ProductTableTableManager(_db, _db.product)
+        .filter((f) => f.department.id(departmentData.id));
+  }
+}
+
 typedef $$ProductTableCreateCompanionBuilder = ProductCompanion Function({
   Value<int> id,
   Value<String?> name,
@@ -4460,7 +4679,9 @@ class $$ProductTableTableManager extends RootTableManager<
     $$ProductTableFilterComposer,
     $$ProductTableOrderingComposer,
     $$ProductTableCreateCompanionBuilder,
-    $$ProductTableUpdateCompanionBuilder> {
+    $$ProductTableUpdateCompanionBuilder,
+    $$ProductTableWithReferences,
+    ProductData> {
   $$ProductTableTableManager(_$TodoDb db, $ProductTable table)
       : super(TableManagerState(
           db: db,
@@ -4469,6 +4690,8 @@ class $$ProductTableTableManager extends RootTableManager<
               $$ProductTableFilterComposer(ComposerState(db, table)),
           orderingComposer:
               $$ProductTableOrderingComposer(ComposerState(db, table)),
+          dataclassMapper: (p0) async =>
+              p0.map((e) => $$ProductTableWithReferences(db, e)).toList(),
           updateCompanionCallback: ({
             Value<int> id = const Value.absent(),
             Value<String?> name = const Value.absent(),
@@ -4491,6 +4714,17 @@ class $$ProductTableTableManager extends RootTableManager<
           ),
         ));
 }
+
+typedef $$ProductTableProcessedTableManager = ProcessedTableManager<
+    _$TodoDb,
+    $ProductTable,
+    ProductData,
+    $$ProductTableFilterComposer,
+    $$ProductTableOrderingComposer,
+    $$ProductTableCreateCompanionBuilder,
+    $$ProductTableUpdateCompanionBuilder,
+    $$ProductTableWithReferences,
+    ProductData>;
 
 class $$ProductTableFilterComposer
     extends FilterComposer<_$TodoDb, $ProductTable> {
@@ -4557,6 +4791,24 @@ class $$ProductTableOrderingComposer
   }
 }
 
+class $$ProductTableWithReferences {
+  // ignore: unused_field
+  final _$TodoDb _db;
+  final ProductData productData;
+  $$ProductTableWithReferences(this._db, this.productData);
+
+  $$DepartmentTableProcessedTableManager? get department {
+    if (productData.department == null) return null;
+    return $$DepartmentTableTableManager(_db, _db.department)
+        .filter((f) => f.id(productData.department!));
+  }
+
+  $$ListingTableProcessedTableManager get listings {
+    return $$ListingTableTableManager(_db, _db.listing)
+        .filter((f) => f.product.id(productData.id));
+  }
+}
+
 typedef $$StoreTableCreateCompanionBuilder = StoreCompanion Function({
   Value<int> id,
   Value<String?> name,
@@ -4573,7 +4825,9 @@ class $$StoreTableTableManager extends RootTableManager<
     $$StoreTableFilterComposer,
     $$StoreTableOrderingComposer,
     $$StoreTableCreateCompanionBuilder,
-    $$StoreTableUpdateCompanionBuilder> {
+    $$StoreTableUpdateCompanionBuilder,
+    $$StoreTableWithReferences,
+    StoreData> {
   $$StoreTableTableManager(_$TodoDb db, $StoreTable table)
       : super(TableManagerState(
           db: db,
@@ -4582,6 +4836,8 @@ class $$StoreTableTableManager extends RootTableManager<
               $$StoreTableFilterComposer(ComposerState(db, table)),
           orderingComposer:
               $$StoreTableOrderingComposer(ComposerState(db, table)),
+          dataclassMapper: (p0) async =>
+              p0.map((e) => $$StoreTableWithReferences(db, e)).toList(),
           updateCompanionCallback: ({
             Value<int> id = const Value.absent(),
             Value<String?> name = const Value.absent(),
@@ -4600,6 +4856,17 @@ class $$StoreTableTableManager extends RootTableManager<
           ),
         ));
 }
+
+typedef $$StoreTableProcessedTableManager = ProcessedTableManager<
+    _$TodoDb,
+    $StoreTable,
+    StoreData,
+    $$StoreTableFilterComposer,
+    $$StoreTableOrderingComposer,
+    $$StoreTableCreateCompanionBuilder,
+    $$StoreTableUpdateCompanionBuilder,
+    $$StoreTableWithReferences,
+    StoreData>;
 
 class $$StoreTableFilterComposer extends FilterComposer<_$TodoDb, $StoreTable> {
   $$StoreTableFilterComposer(super.$state);
@@ -4641,6 +4908,18 @@ class $$StoreTableOrderingComposer
           ColumnOrderings(column, joinBuilders: joinBuilders));
 }
 
+class $$StoreTableWithReferences {
+  // ignore: unused_field
+  final _$TodoDb _db;
+  final StoreData storeData;
+  $$StoreTableWithReferences(this._db, this.storeData);
+
+  $$ListingTableProcessedTableManager get listings {
+    return $$ListingTableTableManager(_db, _db.listing)
+        .filter((f) => f.store.id(storeData.id));
+  }
+}
+
 typedef $$ListingTableCreateCompanionBuilder = ListingCompanion Function({
   Value<int> id,
   Value<int?> product,
@@ -4661,7 +4940,9 @@ class $$ListingTableTableManager extends RootTableManager<
     $$ListingTableFilterComposer,
     $$ListingTableOrderingComposer,
     $$ListingTableCreateCompanionBuilder,
-    $$ListingTableUpdateCompanionBuilder> {
+    $$ListingTableUpdateCompanionBuilder,
+    $$ListingTableWithReferences,
+    ListingData> {
   $$ListingTableTableManager(_$TodoDb db, $ListingTable table)
       : super(TableManagerState(
           db: db,
@@ -4670,6 +4951,8 @@ class $$ListingTableTableManager extends RootTableManager<
               $$ListingTableFilterComposer(ComposerState(db, table)),
           orderingComposer:
               $$ListingTableOrderingComposer(ComposerState(db, table)),
+          dataclassMapper: (p0) async =>
+              p0.map((e) => $$ListingTableWithReferences(db, e)).toList(),
           updateCompanionCallback: ({
             Value<int> id = const Value.absent(),
             Value<int?> product = const Value.absent(),
@@ -4696,6 +4979,17 @@ class $$ListingTableTableManager extends RootTableManager<
           ),
         ));
 }
+
+typedef $$ListingTableProcessedTableManager = ProcessedTableManager<
+    _$TodoDb,
+    $ListingTable,
+    ListingData,
+    $$ListingTableFilterComposer,
+    $$ListingTableOrderingComposer,
+    $$ListingTableCreateCompanionBuilder,
+    $$ListingTableUpdateCompanionBuilder,
+    $$ListingTableWithReferences,
+    ListingData>;
 
 class $$ListingTableFilterComposer
     extends FilterComposer<_$TodoDb, $ListingTable> {
@@ -4770,6 +5064,25 @@ class $$ListingTableOrderingComposer
             ComposerState(
                 $state.db, $state.db.store, joinBuilder, parentComposers)));
     return composer;
+  }
+}
+
+class $$ListingTableWithReferences {
+  // ignore: unused_field
+  final _$TodoDb _db;
+  final ListingData listingData;
+  $$ListingTableWithReferences(this._db, this.listingData);
+
+  $$ProductTableProcessedTableManager? get product {
+    if (listingData.product == null) return null;
+    return $$ProductTableTableManager(_db, _db.product)
+        .filter((f) => f.id(listingData.product!));
+  }
+
+  $$StoreTableProcessedTableManager? get store {
+    if (listingData.store == null) return null;
+    return $$StoreTableTableManager(_db, _db.store)
+        .filter((f) => f.id(listingData.store!));
   }
 }
 

--- a/drift/test/generated/todos.g.dart
+++ b/drift/test/generated/todos.g.dart
@@ -308,12 +308,13 @@ class $TodosTableTable extends TodosTable
   static const VerificationMeta _categoryMeta =
       const VerificationMeta('category');
   @override
-  late final GeneratedColumn<int> category = GeneratedColumn<int>(
-      'category', aliasedName, true,
-      type: DriftSqlType.int,
-      requiredDuringInsert: false,
-      defaultConstraints: GeneratedColumn.constraintIsAlways(
-          'REFERENCES categories (id) DEFERRABLE INITIALLY DEFERRED'));
+  late final GeneratedColumnWithTypeConverter<RowId?, int> category =
+      GeneratedColumn<int>('category', aliasedName, true,
+              type: DriftSqlType.int,
+              requiredDuringInsert: false,
+              defaultConstraints: GeneratedColumn.constraintIsAlways(
+                  'REFERENCES categories (id) DEFERRABLE INITIALLY DEFERRED'))
+          .withConverter<RowId?>($TodosTableTable.$convertercategoryn);
   static const VerificationMeta _statusMeta = const VerificationMeta('status');
   @override
   late final GeneratedColumnWithTypeConverter<TodoStatus?, String> status =
@@ -350,10 +351,7 @@ class $TodosTableTable extends TodosTable
           targetDate.isAcceptableOrUnknown(
               data['target_date']!, _targetDateMeta));
     }
-    if (data.containsKey('category')) {
-      context.handle(_categoryMeta,
-          category.isAcceptableOrUnknown(data['category']!, _categoryMeta));
-    }
+    context.handle(_categoryMeta, const VerificationResult.success());
     context.handle(_statusMeta, const VerificationResult.success());
     return context;
   }
@@ -377,8 +375,9 @@ class $TodosTableTable extends TodosTable
           .read(DriftSqlType.string, data['${effectivePrefix}content'])!,
       targetDate: attachedDatabase.typeMapping
           .read(DriftSqlType.dateTime, data['${effectivePrefix}target_date']),
-      category: attachedDatabase.typeMapping
-          .read(DriftSqlType.int, data['${effectivePrefix}category']),
+      category: $TodosTableTable.$convertercategoryn.fromSql(attachedDatabase
+          .typeMapping
+          .read(DriftSqlType.int, data['${effectivePrefix}category'])),
       status: $TodosTableTable.$converterstatusn.fromSql(attachedDatabase
           .typeMapping
           .read(DriftSqlType.string, data['${effectivePrefix}status'])),
@@ -392,6 +391,10 @@ class $TodosTableTable extends TodosTable
 
   static JsonTypeConverter2<RowId, int, int> $converterid =
       TypeConverter.extensionType<RowId, int>();
+  static JsonTypeConverter2<RowId, int, int> $convertercategory =
+      TypeConverter.extensionType<RowId, int>();
+  static JsonTypeConverter2<RowId?, int?, int?> $convertercategoryn =
+      JsonTypeConverter2.asNullable($convertercategory);
   static JsonTypeConverter2<TodoStatus, String, String> $converterstatus =
       const EnumNameConverter<TodoStatus>(TodoStatus.values);
   static JsonTypeConverter2<TodoStatus?, String?, String?> $converterstatusn =
@@ -403,7 +406,7 @@ class TodoEntry extends DataClass implements Insertable<TodoEntry> {
   final String? title;
   final String content;
   final DateTime? targetDate;
-  final int? category;
+  final RowId? category;
   final TodoStatus? status;
   const TodoEntry(
       {required this.id,
@@ -426,7 +429,8 @@ class TodoEntry extends DataClass implements Insertable<TodoEntry> {
       map['target_date'] = Variable<DateTime>(targetDate);
     }
     if (!nullToAbsent || category != null) {
-      map['category'] = Variable<int>(category);
+      map['category'] =
+          Variable<int>($TodosTableTable.$convertercategoryn.toSql(category));
     }
     if (!nullToAbsent || status != null) {
       map['status'] =
@@ -461,7 +465,8 @@ class TodoEntry extends DataClass implements Insertable<TodoEntry> {
       title: serializer.fromJson<String?>(json['title']),
       content: serializer.fromJson<String>(json['content']),
       targetDate: serializer.fromJson<DateTime?>(json['target_date']),
-      category: serializer.fromJson<int?>(json['category']),
+      category: $TodosTableTable.$convertercategoryn
+          .fromJson(serializer.fromJson<int?>(json['category'])),
       status: $TodosTableTable.$converterstatusn
           .fromJson(serializer.fromJson<String?>(json['status'])),
     );
@@ -479,7 +484,8 @@ class TodoEntry extends DataClass implements Insertable<TodoEntry> {
       'title': serializer.toJson<String?>(title),
       'content': serializer.toJson<String>(content),
       'target_date': serializer.toJson<DateTime?>(targetDate),
-      'category': serializer.toJson<int?>(category),
+      'category': serializer
+          .toJson<int?>($TodosTableTable.$convertercategoryn.toJson(category)),
       'status': serializer
           .toJson<String?>($TodosTableTable.$converterstatusn.toJson(status)),
     };
@@ -490,7 +496,7 @@ class TodoEntry extends DataClass implements Insertable<TodoEntry> {
           Value<String?> title = const Value.absent(),
           String? content,
           Value<DateTime?> targetDate = const Value.absent(),
-          Value<int?> category = const Value.absent(),
+          Value<RowId?> category = const Value.absent(),
           Value<TodoStatus?> status = const Value.absent()}) =>
       TodoEntry(
         id: id ?? this.id,
@@ -545,7 +551,7 @@ class TodosTableCompanion extends UpdateCompanion<TodoEntry> {
   final Value<String?> title;
   final Value<String> content;
   final Value<DateTime?> targetDate;
-  final Value<int?> category;
+  final Value<RowId?> category;
   final Value<TodoStatus?> status;
   const TodosTableCompanion({
     this.id = const Value.absent(),
@@ -586,7 +592,7 @@ class TodosTableCompanion extends UpdateCompanion<TodoEntry> {
       Value<String?>? title,
       Value<String>? content,
       Value<DateTime?>? targetDate,
-      Value<int?>? category,
+      Value<RowId?>? category,
       Value<TodoStatus?>? status}) {
     return TodosTableCompanion(
       id: id ?? this.id,
@@ -614,7 +620,8 @@ class TodosTableCompanion extends UpdateCompanion<TodoEntry> {
       map['target_date'] = Variable<DateTime>(targetDate.value);
     }
     if (category.present) {
-      map['category'] = Variable<int>(category.value);
+      map['category'] = Variable<int>(
+          $TodosTableTable.$convertercategoryn.toSql(category.value));
     }
     if (status.present) {
       map['status'] = Variable<String>(
@@ -3355,7 +3362,9 @@ abstract class _$TodoDb extends GeneratedDatabase {
           title: row.readNullable<String>('title'),
           content: row.read<String>('content'),
           targetDate: row.readNullable<DateTime>('target_date'),
-          category: row.readNullable<int>('category'),
+          category: NullAwareTypeConverter.wrapFromSql(
+              $TodosTableTable.$convertercategory,
+              row.readNullable<int>('category')),
           status: NullAwareTypeConverter.wrapFromSql(
               $TodosTableTable.$converterstatus,
               row.readNullable<String>('status')),
@@ -3581,7 +3590,7 @@ typedef $$TodosTableTableCreateCompanionBuilder = TodosTableCompanion Function({
   Value<String?> title,
   required String content,
   Value<DateTime?> targetDate,
-  Value<int?> category,
+  Value<RowId?> category,
   Value<TodoStatus?> status,
 });
 typedef $$TodosTableTableUpdateCompanionBuilder = TodosTableCompanion Function({
@@ -3589,7 +3598,7 @@ typedef $$TodosTableTableUpdateCompanionBuilder = TodosTableCompanion Function({
   Value<String?> title,
   Value<String> content,
   Value<DateTime?> targetDate,
-  Value<int?> category,
+  Value<RowId?> category,
   Value<TodoStatus?> status,
 });
 
@@ -3618,7 +3627,7 @@ class $$TodosTableTableTableManager extends RootTableManager<
             Value<String?> title = const Value.absent(),
             Value<String> content = const Value.absent(),
             Value<DateTime?> targetDate = const Value.absent(),
-            Value<int?> category = const Value.absent(),
+            Value<RowId?> category = const Value.absent(),
             Value<TodoStatus?> status = const Value.absent(),
           }) =>
               TodosTableCompanion(
@@ -3634,7 +3643,7 @@ class $$TodosTableTableTableManager extends RootTableManager<
             Value<String?> title = const Value.absent(),
             required String content,
             Value<DateTime?> targetDate = const Value.absent(),
-            Value<int?> category = const Value.absent(),
+            Value<RowId?> category = const Value.absent(),
             Value<TodoStatus?> status = const Value.absent(),
           }) =>
               TodosTableCompanion.insert(
@@ -5121,7 +5130,7 @@ class AllTodosWithCategoryResult extends CustomResultSet {
   final String? title;
   final String content;
   final DateTime? targetDate;
-  final int? category;
+  final RowId? category;
   final TodoStatus? status;
   final RowId catId;
   final String catDesc;

--- a/drift/test/generated/todos.g.dart
+++ b/drift/test/generated/todos.g.dart
@@ -3577,6 +3577,7 @@ class $$CategoriesTableOrderingComposer
 class $$CategoriesTableWithReferences {
   // ignore: unused_field
   final _$TodoDb _db;
+  // ignore: unused_field
   final Category _item;
   $$CategoriesTableWithReferences(this._db, this._item);
 
@@ -3759,6 +3760,7 @@ class $$TodosTableTableOrderingComposer
 class $$TodosTableTableWithReferences {
   // ignore: unused_field
   final _$TodoDb _db;
+  // ignore: unused_field
   final TodoEntry _item;
   $$TodosTableTableWithReferences(this._db, this._item);
 
@@ -3908,6 +3910,7 @@ class $$UsersTableOrderingComposer
 class $$UsersTableWithReferences {
   // ignore: unused_field
   final _$TodoDb _db;
+  // ignore: unused_field
   final User _item;
   $$UsersTableWithReferences(this._db, this._item);
 }
@@ -4011,6 +4014,7 @@ class $$SharedTodosTableOrderingComposer
 class $$SharedTodosTableWithReferences {
   // ignore: unused_field
   final _$TodoDb _db;
+  // ignore: unused_field
   final SharedTodo _item;
   $$SharedTodosTableWithReferences(this._db, this._item);
 }
@@ -4148,6 +4152,7 @@ class $$TableWithoutPKTableOrderingComposer
 class $$TableWithoutPKTableWithReferences {
   // ignore: unused_field
   final _$TodoDb _db;
+  // ignore: unused_field
   final CustomRowClass _item;
   $$TableWithoutPKTableWithReferences(this._db, this._item);
 }
@@ -4237,6 +4242,7 @@ class $$PureDefaultsTableOrderingComposer
 class $$PureDefaultsTableWithReferences {
   // ignore: unused_field
   final _$TodoDb _db;
+  // ignore: unused_field
   final PureDefault _item;
   $$PureDefaultsTableWithReferences(this._db, this._item);
 }
@@ -4324,6 +4330,7 @@ class $$WithCustomTypeTableOrderingComposer
 class $$WithCustomTypeTableWithReferences {
   // ignore: unused_field
   final _$TodoDb _db;
+  // ignore: unused_field
   final WithCustomTypeData _item;
   $$WithCustomTypeTableWithReferences(this._db, this._item);
 }
@@ -4564,6 +4571,7 @@ class $$TableWithEveryColumnTypeTableOrderingComposer
 class $$TableWithEveryColumnTypeTableWithReferences {
   // ignore: unused_field
   final _$TodoDb _db;
+  // ignore: unused_field
   final TableWithEveryColumnTypeData _item;
   $$TableWithEveryColumnTypeTableWithReferences(this._db, this._item);
 }
@@ -4672,6 +4680,7 @@ class $$DepartmentTableOrderingComposer
 class $$DepartmentTableWithReferences {
   // ignore: unused_field
   final _$TodoDb _db;
+  // ignore: unused_field
   final DepartmentData _item;
   $$DepartmentTableWithReferences(this._db, this._item);
 
@@ -4814,6 +4823,7 @@ class $$ProductTableOrderingComposer
 class $$ProductTableWithReferences {
   // ignore: unused_field
   final _$TodoDb _db;
+  // ignore: unused_field
   final ProductData _item;
   $$ProductTableWithReferences(this._db, this._item);
 
@@ -4931,6 +4941,7 @@ class $$StoreTableOrderingComposer
 class $$StoreTableWithReferences {
   // ignore: unused_field
   final _$TodoDb _db;
+  // ignore: unused_field
   final StoreData _item;
   $$StoreTableWithReferences(this._db, this._item);
 
@@ -5090,6 +5101,7 @@ class $$ListingTableOrderingComposer
 class $$ListingTableWithReferences {
   // ignore: unused_field
   final _$TodoDb _db;
+  // ignore: unused_field
   final ListingData _item;
   $$ListingTableWithReferences(this._db, this._item);
 

--- a/drift/test/integration_tests/insert_integration_test.dart
+++ b/drift/test/integration_tests/insert_integration_test.dart
@@ -262,7 +262,7 @@ void main() {
       final id = await db.categories
           .insertOne(CategoriesCompanion.insert(description: 'with entry'));
       await db.todosTable.insertOne(TodosTableCompanion.insert(
-          content: 'my content', category: Value(id)));
+          content: 'my content', category: Value(RowId(id))));
 
       final amountOfTodos =
           db.todosTable.id.count(filter: db.todosTable.id.isNotNull());

--- a/drift/test/integration_tests/regress_1894_test.dart
+++ b/drift/test/integration_tests/regress_1894_test.dart
@@ -12,7 +12,7 @@ void main() {
     final nonEmptyId = await db.categories
         .insertOne(CategoriesCompanion.insert(description: 'category'));
     await db.todosTable.insertOne(TodosTableCompanion.insert(
-        content: 'entry', category: Value(nonEmptyId)));
+        content: 'entry', category: Value(RowId(nonEmptyId))));
 
     final emptyId = await db.categories.insertOne(
         CategoriesCompanion.insert(description: 'this category empty YEET'));

--- a/drift/test/integration_tests/regress_2166_test.g.dart
+++ b/drift/test/integration_tests/regress_2166_test.g.dart
@@ -291,6 +291,7 @@ class $$_SomeTableTableOrderingComposer
 class $$_SomeTableTableWithReferences {
   // ignore: unused_field
   final _$_SomeDb _db;
+  // ignore: unused_field
   final _SomeTableData _item;
   $$_SomeTableTableWithReferences(this._db, this._item);
 }

--- a/drift/test/integration_tests/regress_2166_test.g.dart
+++ b/drift/test/integration_tests/regress_2166_test.g.dart
@@ -209,57 +209,6 @@ typedef $$_SomeTableTableUpdateCompanionBuilder = _SomeTableCompanion Function({
   Value<String?> name,
 });
 
-class $$_SomeTableTableTableManager extends RootTableManager<
-    _$_SomeDb,
-    $_SomeTableTable,
-    _SomeTableData,
-    $$_SomeTableTableFilterComposer,
-    $$_SomeTableTableOrderingComposer,
-    $$_SomeTableTableCreateCompanionBuilder,
-    $$_SomeTableTableUpdateCompanionBuilder,
-    (_SomeTableData, $$_SomeTableTableWithReferences),
-    _SomeTableData> {
-  $$_SomeTableTableTableManager(_$_SomeDb db, $_SomeTableTable table)
-      : super(TableManagerState(
-          db: db,
-          table: table,
-          filteringComposer:
-              $$_SomeTableTableFilterComposer(ComposerState(db, table)),
-          orderingComposer:
-              $$_SomeTableTableOrderingComposer(ComposerState(db, table)),
-          withReferenceMapper: (p0) => p0
-              .map((e) => (e, $$_SomeTableTableWithReferences(db, e)))
-              .toList(),
-          updateCompanionCallback: ({
-            Value<int> id = const Value.absent(),
-            Value<String?> name = const Value.absent(),
-          }) =>
-              _SomeTableCompanion(
-            id: id,
-            name: name,
-          ),
-          createCompanionCallback: ({
-            Value<int> id = const Value.absent(),
-            Value<String?> name = const Value.absent(),
-          }) =>
-              _SomeTableCompanion.insert(
-            id: id,
-            name: name,
-          ),
-        ));
-}
-
-typedef $$_SomeTableTableProcessedTableManager = ProcessedTableManager<
-    _$_SomeDb,
-    $_SomeTableTable,
-    _SomeTableData,
-    $$_SomeTableTableFilterComposer,
-    $$_SomeTableTableOrderingComposer,
-    $$_SomeTableTableCreateCompanionBuilder,
-    $$_SomeTableTableUpdateCompanionBuilder,
-    (_SomeTableData, $$_SomeTableTableWithReferences),
-    _SomeTableData>;
-
 class $$_SomeTableTableFilterComposer
     extends FilterComposer<_$_SomeDb, $_SomeTableTable> {
   $$_SomeTableTableFilterComposer(super.$state);
@@ -288,13 +237,55 @@ class $$_SomeTableTableOrderingComposer
           ColumnOrderings(column, joinBuilders: joinBuilders));
 }
 
-class $$_SomeTableTableWithReferences {
-  // ignore: unused_field
-  final _$_SomeDb _db;
-  // ignore: unused_field
-  final _SomeTableData _item;
-  $$_SomeTableTableWithReferences(this._db, this._item);
+class $$_SomeTableTableTableManager extends RootTableManager<
+    _$_SomeDb,
+    $_SomeTableTable,
+    _SomeTableData,
+    $$_SomeTableTableFilterComposer,
+    $$_SomeTableTableOrderingComposer,
+    $$_SomeTableTableCreateCompanionBuilder,
+    $$_SomeTableTableUpdateCompanionBuilder,
+    (_SomeTableData, BaseWithReferences<_$_SomeDb, _SomeTableData>),
+    _SomeTableData> {
+  $$_SomeTableTableTableManager(_$_SomeDb db, $_SomeTableTable table)
+      : super(TableManagerState(
+          db: db,
+          table: table,
+          filteringComposer:
+              $$_SomeTableTableFilterComposer(ComposerState(db, table)),
+          orderingComposer:
+              $$_SomeTableTableOrderingComposer(ComposerState(db, table)),
+          withReferenceMapper: (p0) =>
+              p0.map((e) => (e, BaseWithReferences(db, e))).toList(),
+          updateCompanionCallback: ({
+            Value<int> id = const Value.absent(),
+            Value<String?> name = const Value.absent(),
+          }) =>
+              _SomeTableCompanion(
+            id: id,
+            name: name,
+          ),
+          createCompanionCallback: ({
+            Value<int> id = const Value.absent(),
+            Value<String?> name = const Value.absent(),
+          }) =>
+              _SomeTableCompanion.insert(
+            id: id,
+            name: name,
+          ),
+        ));
 }
+
+typedef $$_SomeTableTableProcessedTableManager = ProcessedTableManager<
+    _$_SomeDb,
+    $_SomeTableTable,
+    _SomeTableData,
+    $$_SomeTableTableFilterComposer,
+    $$_SomeTableTableOrderingComposer,
+    $$_SomeTableTableCreateCompanionBuilder,
+    $$_SomeTableTableUpdateCompanionBuilder,
+    (_SomeTableData, BaseWithReferences<_$_SomeDb, _SomeTableData>),
+    _SomeTableData>;
 
 class $_SomeDbManager {
   final _$_SomeDb _db;

--- a/drift/test/integration_tests/regress_2166_test.g.dart
+++ b/drift/test/integration_tests/regress_2166_test.g.dart
@@ -227,7 +227,7 @@ class $$_SomeTableTableTableManager extends RootTableManager<
               $$_SomeTableTableFilterComposer(ComposerState(db, table)),
           orderingComposer:
               $$_SomeTableTableOrderingComposer(ComposerState(db, table)),
-          dataclassMapper: (p0) async =>
+          withReferenceMapper: (p0) =>
               p0.map((e) => $$_SomeTableTableWithReferences(db, e)).toList(),
           updateCompanionCallback: ({
             Value<int> id = const Value.absent(),

--- a/drift/test/integration_tests/regress_2166_test.g.dart
+++ b/drift/test/integration_tests/regress_2166_test.g.dart
@@ -217,7 +217,7 @@ class $$_SomeTableTableTableManager extends RootTableManager<
     $$_SomeTableTableOrderingComposer,
     $$_SomeTableTableCreateCompanionBuilder,
     $$_SomeTableTableUpdateCompanionBuilder,
-    $$_SomeTableTableWithReferences,
+    (_SomeTableData, $$_SomeTableTableWithReferences),
     _SomeTableData> {
   $$_SomeTableTableTableManager(_$_SomeDb db, $_SomeTableTable table)
       : super(TableManagerState(
@@ -227,8 +227,9 @@ class $$_SomeTableTableTableManager extends RootTableManager<
               $$_SomeTableTableFilterComposer(ComposerState(db, table)),
           orderingComposer:
               $$_SomeTableTableOrderingComposer(ComposerState(db, table)),
-          withReferenceMapper: (p0) =>
-              p0.map((e) => $$_SomeTableTableWithReferences(db, e)).toList(),
+          withReferenceMapper: (p0) => p0
+              .map((e) => (e, $$_SomeTableTableWithReferences(db, e)))
+              .toList(),
           updateCompanionCallback: ({
             Value<int> id = const Value.absent(),
             Value<String?> name = const Value.absent(),
@@ -256,7 +257,7 @@ typedef $$_SomeTableTableProcessedTableManager = ProcessedTableManager<
     $$_SomeTableTableOrderingComposer,
     $$_SomeTableTableCreateCompanionBuilder,
     $$_SomeTableTableUpdateCompanionBuilder,
-    $$_SomeTableTableWithReferences,
+    (_SomeTableData, $$_SomeTableTableWithReferences),
     _SomeTableData>;
 
 class $$_SomeTableTableFilterComposer
@@ -290,8 +291,8 @@ class $$_SomeTableTableOrderingComposer
 class $$_SomeTableTableWithReferences {
   // ignore: unused_field
   final _$_SomeDb _db;
-  final _SomeTableData someTableData;
-  $$_SomeTableTableWithReferences(this._db, this.someTableData);
+  final _SomeTableData _item;
+  $$_SomeTableTableWithReferences(this._db, this._item);
 }
 
 class $_SomeDbManager {

--- a/drift/test/integration_tests/regress_2166_test.g.dart
+++ b/drift/test/integration_tests/regress_2166_test.g.dart
@@ -216,7 +216,9 @@ class $$_SomeTableTableTableManager extends RootTableManager<
     $$_SomeTableTableFilterComposer,
     $$_SomeTableTableOrderingComposer,
     $$_SomeTableTableCreateCompanionBuilder,
-    $$_SomeTableTableUpdateCompanionBuilder> {
+    $$_SomeTableTableUpdateCompanionBuilder,
+    $$_SomeTableTableWithReferences,
+    _SomeTableData> {
   $$_SomeTableTableTableManager(_$_SomeDb db, $_SomeTableTable table)
       : super(TableManagerState(
           db: db,
@@ -225,6 +227,8 @@ class $$_SomeTableTableTableManager extends RootTableManager<
               $$_SomeTableTableFilterComposer(ComposerState(db, table)),
           orderingComposer:
               $$_SomeTableTableOrderingComposer(ComposerState(db, table)),
+          dataclassMapper: (p0) async =>
+              p0.map((e) => $$_SomeTableTableWithReferences(db, e)).toList(),
           updateCompanionCallback: ({
             Value<int> id = const Value.absent(),
             Value<String?> name = const Value.absent(),
@@ -243,6 +247,17 @@ class $$_SomeTableTableTableManager extends RootTableManager<
           ),
         ));
 }
+
+typedef $$_SomeTableTableProcessedTableManager = ProcessedTableManager<
+    _$_SomeDb,
+    $_SomeTableTable,
+    _SomeTableData,
+    $$_SomeTableTableFilterComposer,
+    $$_SomeTableTableOrderingComposer,
+    $$_SomeTableTableCreateCompanionBuilder,
+    $$_SomeTableTableUpdateCompanionBuilder,
+    $$_SomeTableTableWithReferences,
+    _SomeTableData>;
 
 class $$_SomeTableTableFilterComposer
     extends FilterComposer<_$_SomeDb, $_SomeTableTable> {
@@ -270,6 +285,13 @@ class $$_SomeTableTableOrderingComposer
       column: $state.table.name,
       builder: (column, joinBuilders) =>
           ColumnOrderings(column, joinBuilders: joinBuilders));
+}
+
+class $$_SomeTableTableWithReferences {
+  // ignore: unused_field
+  final _$_SomeDb _db;
+  final _SomeTableData someTableData;
+  $$_SomeTableTableWithReferences(this._db, this.someTableData);
 }
 
 class $_SomeDbManager {

--- a/drift/test/integration_tests/select_integration_test.dart
+++ b/drift/test/integration_tests/select_integration_test.dart
@@ -35,7 +35,7 @@ void main() {
     await db.todosTable.insertOne(TodosTableCompanion.insert(
         content: 'some content',
         title: const Value('title'),
-        category: Value(category.id.id)));
+        category: Value(category.id)));
 
     final result = await db.todoWithCategoryView.select().getSingle();
     expect(
@@ -61,9 +61,11 @@ void main() {
       batch.insertAll(
         db.todosTable,
         [
-          TodosTableCompanion.insert(content: 'aaaaa', category: Value(1)),
-          TodosTableCompanion.insert(content: 'aa', category: Value(1)),
-          TodosTableCompanion.insert(content: 'bbbbbb', category: Value(2)),
+          TodosTableCompanion.insert(
+              content: 'aaaaa', category: Value(RowId(1))),
+          TodosTableCompanion.insert(content: 'aa', category: Value(RowId(1))),
+          TodosTableCompanion.insert(
+              content: 'bbbbbb', category: Value(RowId(2))),
         ],
       );
     });

--- a/drift/test/manager/manager_order_test.dart
+++ b/drift/test/manager/manager_order_test.dart
@@ -55,14 +55,14 @@ void main() {
         id: Value(RowId(1)),
         content: "Get that english homework done",
         title: Value("English Homework"),
-        category: Value(workCategoryId),
+        category: Value(RowId(workCategoryId)),
         status: Value(TodoStatus.open),
         targetDate: Value(DateTime.now().add(Duration(days: 1, seconds: 15)))));
     await db.managers.todosTable.create((o) => o(
         id: Value(RowId(2)),
         content: "Finish that Book report",
         title: Value("Book Report"),
-        category: Value(workCategoryId),
+        category: Value(RowId(workCategoryId)),
         status: Value(TodoStatus.done),
         targetDate:
             Value(DateTime.now().subtract(Duration(days: 2, seconds: 15)))));
@@ -70,14 +70,14 @@ void main() {
         id: Value(RowId(3)),
         content: "Get that math homework done",
         title: Value("Math Homework"),
-        category: Value(schoolCategoryId),
+        category: Value(RowId(schoolCategoryId)),
         status: Value(TodoStatus.open),
         targetDate: Value(DateTime.now().add(Duration(days: 1, seconds: 10)))));
     await db.managers.todosTable.create((o) => o(
         id: Value(RowId(4)),
         content: "Finish that report",
         title: Value("Report"),
-        category: Value(schoolCategoryId),
+        category: Value(RowId(schoolCategoryId)),
         status: Value(TodoStatus.workInProgress),
         targetDate: Value(DateTime.now().add(Duration(days: 2, seconds: 10)))));
     // Order by related

--- a/drift/test/manager/manager_referenced_filter_test.dart
+++ b/drift/test/manager/manager_referenced_filter_test.dart
@@ -22,7 +22,7 @@ void main() {
   late int workCategoryId;
   late List<
       ({
-        Value<int> category,
+        Value<RowId> category,
         String content,
         Value<TodoStatus> status,
         Value<DateTime> targetDate,
@@ -198,28 +198,28 @@ void main() {
       (
         content: "Get that math homework done",
         title: Value("Math Homework"),
-        category: Value(schoolCategoryId),
+        category: Value(RowId(schoolCategoryId)),
         status: Value(TodoStatus.open),
         targetDate: Value(DateTime.now().add(Duration(days: 1, seconds: 10)))
       ),
       (
         content: "Finish that report",
         title: Value("Report"),
-        category: Value(schoolCategoryId),
+        category: Value(RowId(schoolCategoryId)),
         status: Value(TodoStatus.workInProgress),
         targetDate: Value(DateTime.now().add(Duration(days: 2, seconds: 10)))
       ),
       (
         content: "Get that english homework done",
         title: Value("English Homework"),
-        category: Value(schoolCategoryId),
+        category: Value(RowId(schoolCategoryId)),
         status: Value(TodoStatus.open),
         targetDate: Value(DateTime.now().add(Duration(days: 1, seconds: 15)))
       ),
       (
         content: "Finish that Book report",
         title: Value("Book Report"),
-        category: Value(schoolCategoryId),
+        category: Value(RowId(schoolCategoryId)),
         status: Value(TodoStatus.done),
         targetDate:
             Value(DateTime.now().subtract(Duration(days: 2, seconds: 15)))
@@ -228,28 +228,28 @@ void main() {
       (
         content: "File those reports",
         title: Value("File Reports"),
-        category: Value(workCategoryId),
+        category: Value(RowId(workCategoryId)),
         status: Value(TodoStatus.open),
         targetDate: Value(DateTime.now().add(Duration(days: 1, seconds: 20)))
       ),
       (
         content: "Clean the office",
         title: Value("Clean Office"),
-        category: Value(workCategoryId),
+        category: Value(RowId(workCategoryId)),
         status: Value(TodoStatus.workInProgress),
         targetDate: Value(DateTime.now().add(Duration(days: 2, seconds: 20)))
       ),
       (
         content: "Nail that presentation",
         title: Value("Presentation"),
-        category: Value(workCategoryId),
+        category: Value(RowId(workCategoryId)),
         status: Value(TodoStatus.open),
         targetDate: Value(DateTime.now().add(Duration(days: 1, seconds: 25)))
       ),
       (
         content: "Take a break",
         title: Value("Break"),
-        category: Value(workCategoryId),
+        category: Value(RowId(workCategoryId)),
         status: Value(TodoStatus.done),
         targetDate:
             Value(DateTime.now().subtract(Duration(days: 2, seconds: 25)))

--- a/drift/test/manager/manager_referenced_filter_test.dart
+++ b/drift/test/manager/manager_referenced_filter_test.dart
@@ -1,5 +1,7 @@
 // ignore_for_file: unused_local_variable
 
+import 'dart:async';
+
 import 'package:drift/drift.dart';
 import 'package:test/test.dart';
 
@@ -8,21 +10,33 @@ import '../test_utils/test_utils.dart';
 
 void main() {
   late TodoDb db;
+  late List<StoreData> stores;
+  late List<DepartmentData> departments;
+  late List<ProductData> products;
+  late List<int> listings;
+  final categoryData = [
+    (description: "School", priority: Value(CategoryPriority.high)),
+    (description: "Work", priority: Value(CategoryPriority.low)),
+  ];
+  late int schoolCategoryId;
+  late int workCategoryId;
+  late List<
+      ({
+        Value<int> category,
+        String content,
+        Value<TodoStatus> status,
+        Value<DateTime> targetDate,
+        Value<String> title
+      })> todoData;
 
-  setUp(() {
+  setUp(() async {
     db = TodoDb(testInMemoryDatabase());
-  });
-
-  tearDown(() => db.close());
-
-  test('manager - filter related with regualar id', () async {
-    final stores = [
+    stores = [
       await db.managers.store.createReturning((o) => o(name: Value("Walmart"))),
       await db.managers.store.createReturning((o) => o(name: Value("Target"))),
       await db.managers.store.createReturning((o) => o(name: Value("Costco")))
     ];
-
-    final departments = [
+    departments = [
       await db.managers.department
           .createReturning((o) => o(name: Value("Electronics"))),
       await db.managers.department
@@ -30,8 +44,7 @@ void main() {
       await db.managers.department
           .createReturning((o) => o(name: Value("Clothing")))
     ];
-
-    final products = [
+    products = [
       // Electronics
       await db.managers.product.createReturning(
           (o) => o(name: Value("TV"), department: Value(departments[0].id))),
@@ -54,8 +67,7 @@ void main() {
       await db.managers.product.createReturning(
           (o) => o(name: Value("Cap"), department: Value(departments[2].id)))
     ];
-
-    final listings = [
+    listings = [
       // Walmart - Electronics
       await db.managers.listing.create((o) => o(
           product: Value(products[0].id),
@@ -173,28 +185,104 @@ void main() {
           product: Value(products[4].id),
           store: Value(stores[2].id),
           price: Value(900.0))),
-
-      // Costco - Clothing
-
-      // Does not have any clothing
-      // await db.managers.listing.create((o) => o(
-      //     product: Value(products[5].id),
-      //     store: Value(stores[0].id),
-      //     price: Value(20.0))),
-      // await db.managers.listing.create((o) => o(
-      //     product: Value(products[6].id),
-      //     store: Value(stores[0].id),
-      //     price: Value(30.0))),
-      // await db.managers.listing.create((o) => o(
-      //     product: Value(products[7].id),
-      //     store: Value(stores[0].id),
-      //     price: Value(5.0))),
-      // await db.managers.listing.create((o) => o(
-      //     product: Value(products[8].id),
-      //     store: Value(stores[0].id),
-      //     price: Value(10.0))),
     ];
+    schoolCategoryId = await db.managers.categories.create((o) => o(
+        priority: categoryData[0].priority,
+        description: categoryData[0].description));
+    workCategoryId = await db.managers.categories.create((o) => o(
+        priority: categoryData[1].priority,
+        description: categoryData[1].description));
 
+    todoData = [
+      // School
+      (
+        content: "Get that math homework done",
+        title: Value("Math Homework"),
+        category: Value(schoolCategoryId),
+        status: Value(TodoStatus.open),
+        targetDate: Value(DateTime.now().add(Duration(days: 1, seconds: 10)))
+      ),
+      (
+        content: "Finish that report",
+        title: Value("Report"),
+        category: Value(schoolCategoryId),
+        status: Value(TodoStatus.workInProgress),
+        targetDate: Value(DateTime.now().add(Duration(days: 2, seconds: 10)))
+      ),
+      (
+        content: "Get that english homework done",
+        title: Value("English Homework"),
+        category: Value(schoolCategoryId),
+        status: Value(TodoStatus.open),
+        targetDate: Value(DateTime.now().add(Duration(days: 1, seconds: 15)))
+      ),
+      (
+        content: "Finish that Book report",
+        title: Value("Book Report"),
+        category: Value(schoolCategoryId),
+        status: Value(TodoStatus.done),
+        targetDate:
+            Value(DateTime.now().subtract(Duration(days: 2, seconds: 15)))
+      ),
+      // Work
+      (
+        content: "File those reports",
+        title: Value("File Reports"),
+        category: Value(workCategoryId),
+        status: Value(TodoStatus.open),
+        targetDate: Value(DateTime.now().add(Duration(days: 1, seconds: 20)))
+      ),
+      (
+        content: "Clean the office",
+        title: Value("Clean Office"),
+        category: Value(workCategoryId),
+        status: Value(TodoStatus.workInProgress),
+        targetDate: Value(DateTime.now().add(Duration(days: 2, seconds: 20)))
+      ),
+      (
+        content: "Nail that presentation",
+        title: Value("Presentation"),
+        category: Value(workCategoryId),
+        status: Value(TodoStatus.open),
+        targetDate: Value(DateTime.now().add(Duration(days: 1, seconds: 25)))
+      ),
+      (
+        content: "Take a break",
+        title: Value("Break"),
+        category: Value(workCategoryId),
+        status: Value(TodoStatus.done),
+        targetDate:
+            Value(DateTime.now().subtract(Duration(days: 2, seconds: 25)))
+      ),
+      // Items with no category
+      (
+        content: "Get Whiteboard",
+        title: Value("Whiteboard"),
+        status: Value(TodoStatus.open),
+        targetDate: Value(DateTime.now().add(Duration(days: 1, seconds: 50))),
+        category: Value.absent(),
+      ),
+      (
+        category: Value.absent(),
+        content: "Drink Water",
+        title: Value("Water"),
+        status: Value(TodoStatus.workInProgress),
+        targetDate: Value(DateTime.now().add(Duration(days: 2, seconds: 50)))
+      ),
+    ];
+    for (var i in todoData) {
+      await db.managers.todosTable.create((o) => o(
+          content: i.content,
+          title: i.title,
+          category: i.category,
+          status: i.status,
+          targetDate: i.targetDate));
+    }
+  });
+
+  tearDown(() => db.close());
+
+  test('manager - filter related with regualar id', () async {
     // Filter on related table's reference id - Does not require a join
     ComposableFilter? filter;
     expect(
@@ -348,111 +436,6 @@ void main() {
   });
 
   test('manager - filter related with custom type for primary key', () async {
-    final categoryData = [
-      (description: "School", priority: Value(CategoryPriority.high)),
-      (description: "Work", priority: Value(CategoryPriority.low)),
-    ];
-
-    final schoolCategoryId = await db.managers.categories.create((o) => o(
-        priority: categoryData[0].priority,
-        description: categoryData[0].description));
-    final workCategoryId = await db.managers.categories.create((o) => o(
-        priority: categoryData[1].priority,
-        description: categoryData[1].description));
-
-    final todoData = <({
-      Value<int> category,
-      String content,
-      Value<TodoStatus> status,
-      Value<DateTime> targetDate,
-      Value<String> title
-    })>[
-      // School
-      (
-        content: "Get that math homework done",
-        title: Value("Math Homework"),
-        category: Value(schoolCategoryId),
-        status: Value(TodoStatus.open),
-        targetDate: Value(DateTime.now().add(Duration(days: 1, seconds: 10)))
-      ),
-      (
-        content: "Finish that report",
-        title: Value("Report"),
-        category: Value(schoolCategoryId),
-        status: Value(TodoStatus.workInProgress),
-        targetDate: Value(DateTime.now().add(Duration(days: 2, seconds: 10)))
-      ),
-      (
-        content: "Get that english homework done",
-        title: Value("English Homework"),
-        category: Value(schoolCategoryId),
-        status: Value(TodoStatus.open),
-        targetDate: Value(DateTime.now().add(Duration(days: 1, seconds: 15)))
-      ),
-      (
-        content: "Finish that Book report",
-        title: Value("Book Report"),
-        category: Value(schoolCategoryId),
-        status: Value(TodoStatus.done),
-        targetDate:
-            Value(DateTime.now().subtract(Duration(days: 2, seconds: 15)))
-      ),
-      // Work
-      (
-        content: "File those reports",
-        title: Value("File Reports"),
-        category: Value(workCategoryId),
-        status: Value(TodoStatus.open),
-        targetDate: Value(DateTime.now().add(Duration(days: 1, seconds: 20)))
-      ),
-      (
-        content: "Clean the office",
-        title: Value("Clean Office"),
-        category: Value(workCategoryId),
-        status: Value(TodoStatus.workInProgress),
-        targetDate: Value(DateTime.now().add(Duration(days: 2, seconds: 20)))
-      ),
-      (
-        content: "Nail that presentation",
-        title: Value("Presentation"),
-        category: Value(workCategoryId),
-        status: Value(TodoStatus.open),
-        targetDate: Value(DateTime.now().add(Duration(days: 1, seconds: 25)))
-      ),
-      (
-        content: "Take a break",
-        title: Value("Break"),
-        category: Value(workCategoryId),
-        status: Value(TodoStatus.done),
-        targetDate:
-            Value(DateTime.now().subtract(Duration(days: 2, seconds: 25)))
-      ),
-      // Items with no category
-      (
-        content: "Get Whiteboard",
-        title: Value("Whiteboard"),
-        status: Value(TodoStatus.open),
-        targetDate: Value(DateTime.now().add(Duration(days: 1, seconds: 50))),
-        category: Value.absent(),
-      ),
-      (
-        category: Value.absent(),
-        content: "Drink Water",
-        title: Value("Water"),
-        status: Value(TodoStatus.workInProgress),
-        targetDate: Value(DateTime.now().add(Duration(days: 2, seconds: 50)))
-      ),
-    ];
-
-    for (var i in todoData) {
-      await db.managers.todosTable.create((o) => o(
-          content: i.content,
-          title: i.title,
-          category: i.category,
-          status: i.status,
-          targetDate: i.targetDate));
-    }
-
     // item without title
 
     // Equals
@@ -515,5 +498,339 @@ void main() {
             .getSingle()
             .then((value) => value.description),
         completion("School"));
+  });
+
+  test('manager - filter related with regualar id with references', () async {
+    // Filter on related table's reference id - Does not require a join
+    ComposableFilter? filter;
+    expect(
+        db.managers.product
+            .filter((f) {
+              filter = f.department.id(departments[0].id);
+              return filter!;
+            })
+            .withReferences()
+            .get(distinct: true)
+            .then((value) => value.length),
+        completion(3));
+    expect(filter?.joinBuilders.length, 0);
+
+    // Filter on a unrelated column on a related table - Requires a join
+    expect(
+        db.managers.product
+            .filter((f) {
+              filter = f.department.name("Electronics");
+              return filter!;
+            })
+            .withReferences()
+            .get(distinct: true)
+            .then((value) => value.length),
+        completion(3));
+    expect(filter?.joinBuilders.length, 1);
+
+    // Filter on a unrelated column on a related table & on
+    // a related table's reference id - Requires a join
+    expect(
+        db.managers.product
+            .filter((f) {
+              filter = f.department.name("Electronics") |
+                  f.department.id(departments[1].id);
+              return filter!;
+            })
+            .withReferences()
+            .get(distinct: true)
+            .then((value) => value.length),
+        completion(5));
+    expect(filter?.joinBuilders.length, 1);
+
+    // Ordering on current table & Filtering on related table
+    expect(
+        db.managers.product
+            .filter((f) => f.department.name("Electronics"))
+            .orderBy((f) => f.name.asc())
+            .withReferences()
+            .get()
+            .then((value) => value.map((e) => e.productData).toList()),
+        completion([
+          products[1],
+          products[2],
+          products[0],
+        ]));
+
+    // Ordering on related table & Filtering on current table
+    expect(
+        db.managers.product
+            .filter((f) => f.name.startsWith("c"))
+            .orderBy((f) => f.department.name.asc() & f.name.desc())
+            .withReferences()
+            .get()
+            .then((value) => value.map((e) => e.productData).toList()),
+        completion([
+          products[8],
+          products[2],
+          products[1],
+          products[3],
+        ]));
+
+    // Filtering on reverse related table
+    expect(
+        // Any product that is available for more than $10
+        // Socks & Cap are excluded
+        db.managers.product
+            .filter((f) => f.listings((f) => f.price.isBiggerThan(10.0)))
+            .withReferences()
+            .get(distinct: true)
+            .then((value) => value.length),
+        completion(7));
+
+    // Filtering on reverse related table with ordering
+    expect(
+        // Any product that is available for more than $10
+        // Socks & Cap are excluded, and the rest are ordered by name
+        db.managers.product
+            .filter((f) => f.listings((f) => f.price.isBiggerThan(10.0)))
+            .orderBy((f) => f.name.asc())
+            .withReferences()
+            .get(distinct: true)
+            .then((value) => value.map((e) => e.productData).toList()),
+        completion([
+          products[1],
+          products[3],
+          products[2],
+          products[4],
+          products[6],
+          products[5],
+          products[0],
+        ]));
+
+    // Filter on reverse related column and then a related column
+    expect(
+        db.managers.product
+            .filter((f) {
+              filter = f.listings((f) => f.store.name("Target"));
+              return filter!;
+            })
+            .withReferences()
+            .get(distinct: true)
+            .then((value) => value.length),
+        completion(6));
+    expect(filter?.joinBuilders.length, 2);
+    expect(
+        db.managers.product
+            .filter((f) {
+              filter = f.listings((f) => f.store.name("Target")) | f.name("TV");
+              return filter!;
+            })
+            .withReferences()
+            .get(distinct: true)
+            .then((value) => value.length),
+        completion(7));
+    expect(filter?.joinBuilders.length, 2);
+
+    // Filter on a related column and then a related column
+    expect(
+        db.managers.listing
+            .filter((f) {
+              // Listings of products in the electronics department
+              filter = f.product.department.name("Electronics");
+              return filter!;
+            })
+            .withReferences()
+            .get(distinct: true)
+            .then((value) => value.length),
+        completion(8));
+    expect(
+        db.managers.listing
+            .filter((f) {
+              // Listings of products in the electronics department
+              filter = f.product.department.name("Electronics") |
+                  f.price.isBiggerThan(150.0);
+              return filter!;
+            })
+            .withReferences()
+            .get(distinct: true)
+            .then((value) => value.length),
+        completion(9));
+
+    // Filter on a reverse related column and then a reverse related column
+    expect(
+        db.managers.department
+            .filter((f) {
+              // Departments that have products listed for more than $10
+              filter = f.productRefs(
+                  (f) => f.listings((f) => f.price.isBiggerThan(100.0)));
+              return filter!;
+            })
+            .withReferences()
+            .get(distinct: true)
+            .then((value) => value.length),
+        completion(2));
+    expect(
+        db.managers.department
+            .filter((f) {
+              // Departments that have products listed for more than $10 or is available at Walmart
+              filter = f.productRefs((f) => f.listings((f) =>
+                  f.price.isBiggerThan(100.0) | f.store.name("Walmart")));
+              return filter!;
+            })
+            .withReferences()
+            .get(distinct: true)
+            .then((value) => value.length),
+        completion(3));
+
+    // Stores that have products in the clothing department
+    expect(
+        db.managers.store
+            .filter((f) {
+              // Products that are sold in a store that sells clothing
+              filter = f.listings((f) => f.product.department.name("Clothing"));
+              return filter!;
+            })
+            .withReferences()
+            .get(distinct: true)
+            .then((value) => value.length),
+        completion(2));
+
+    // Any product that is sold in a store that sells clothing
+    expect(
+        db.managers.product
+            .filter((f) {
+              filter = f.listings((f) => f.store
+                  .listings((f) => f.product.department.name("Clothing")));
+              return filter!;
+            })
+            .withReferences()
+            .get(distinct: true)
+            .then((value) => value.length),
+        completion(9));
+  });
+
+  test(
+      'manager - filter related with custom type for primary key with references',
+      () async {
+    // Equals
+    expect(
+        db.managers.todosTable
+            .filter((f) => f.category.id(RowId(schoolCategoryId)))
+            .withReferences()
+            .get(distinct: true)
+            .then((value) => value.length),
+        completion(4));
+
+    // Not Equals
+    expect(
+        db.managers.todosTable
+            .filter((f) => f.category.id.not(RowId(schoolCategoryId)))
+            .withReferences()
+            .get(distinct: true)
+            .then((value) => value.length),
+        completion(4));
+
+    // Multiple filters
+    expect(
+        db.managers.todosTable
+            .filter((f) => f.category.id(
+                  RowId(schoolCategoryId),
+                ))
+            .filter((f) => f.status.equals(TodoStatus.open))
+            .withReferences()
+            .get(distinct: true)
+            .then((value) => value.length),
+        completion(2));
+
+    // Multiple use related filters twice
+    expect(
+        db.managers.todosTable
+            .filter((f) =>
+                f.category.priority(CategoryPriority.low) |
+                f.category.descriptionInUpperCase("SCHOOL"))
+            .withReferences()
+            .get(distinct: true)
+            .then((value) => value.length),
+        completion(8));
+
+    // Use .filter multiple times
+    expect(
+        db.managers.todosTable
+            .filter((f) => f.category.priority.equals(CategoryPriority.high))
+            .filter((f) => f.category.descriptionInUpperCase("SCHOOL"))
+            .withReferences()
+            .get(distinct: true)
+            .then((value) => value.length),
+        completion(4));
+
+    // Use backreference
+    expect(
+        db.managers.categories
+            .filter((f) => f.todos((f) => f.title.equals("Math Homework")))
+            .withReferences()
+            .getSingle()
+            .then((value) => value.category.description),
+        completion("School"));
+
+    // Nested backreference
+    expect(
+        db.managers.categories
+            .filter((f) => f.todos((f) {
+                  final q =
+                      f.category.todos((f) => f.title.equals("Math Homework"));
+                  return q;
+                }))
+            .withReferences()
+            .getSingle()
+            .then((value) => value.category.description),
+        completion("School"));
+  });
+
+  test('manager - with references tests', () async {
+    // Get department for the 1st product
+    expect(
+        db.managers.product
+            .withReferences()
+            .get(distinct: true)
+            .then((value) =>
+                value.first.department?.getSingle() ?? Future.value(null))
+            .then(
+              (value) => value?.id,
+            ),
+        completion(departments[0].id));
+
+    // Get the amount of products in the 1st department
+    expect(
+        db.managers.department
+            .withReferences()
+            .get(distinct: true)
+            .then((value) => value.first.productRefs.count()),
+        completion(3));
+
+    // Get all the products with all their listings
+    final listingsWithProducts = <ProductData, List<ListingData>>{};
+    for (final i
+        in await db.managers.listing.withReferences().get(distinct: true)) {
+      final product = await i.product?.getSingle();
+      if (product != null) {
+        if (!listingsWithProducts.containsKey(product)) {
+          listingsWithProducts[product] = [i.listingData];
+        } else {
+          listingsWithProducts[product]!.add(i.listingData);
+        }
+      }
+    }
+    expect(listingsWithProducts.length, 9);
+    expect(
+        listingsWithProducts.entries.fold(
+          0,
+          (i, o) => i + o.value.length,
+        ),
+        20);
+
+    // Get the amount of products in the department id 2
+    expect(
+        db.managers.department
+            .filter((f) => f.id.equals(2))
+            .withReferences()
+            .getSingle()
+            .then((value) => value.productRefs.count()),
+        completion(2));
   });
 }

--- a/drift/test/manager/manager_referenced_filter_test.dart
+++ b/drift/test/manager/manager_referenced_filter_test.dart
@@ -325,7 +325,7 @@ void main() {
             .orderBy((f) => f.name.asc())
             .withReferences()
             .get()
-            .then((value) => value.map((e) => e.productData).toList()),
+            .then((value) => value.map((e) => e.$1).toList()),
         completion([
           products[1],
           products[2],
@@ -339,7 +339,7 @@ void main() {
             .orderBy((f) => f.department.name.asc() & f.name.desc())
             .withReferences()
             .get()
-            .then((value) => value.map((e) => e.productData).toList()),
+            .then((value) => value.map((e) => e.$1).toList()),
         completion([
           products[8],
           products[2],
@@ -367,7 +367,7 @@ void main() {
             .orderBy((f) => f.name.asc())
             .withReferences()
             .get(distinct: true)
-            .then((value) => value.map((e) => e.productData).toList()),
+            .then((value) => value.map((e) => e.$1).toList()),
         completion([
           products[1],
           products[3],
@@ -540,7 +540,7 @@ void main() {
             .filter((f) => f.todos((f) => f.title.equals("Math Homework")))
             .withReferences()
             .getSingle()
-            .then((value) => value.category.description),
+            .then((value) => value.$1.description),
         completion("School"));
 
     // Nested backreference
@@ -553,7 +553,7 @@ void main() {
                 }))
             .withReferences()
             .getSingle()
-            .then((value) => value.category.description),
+            .then((value) => value.$1.description),
         completion("School"));
   });
 
@@ -564,7 +564,7 @@ void main() {
             .withReferences()
             .get(distinct: true)
             .then((value) =>
-                value.first.department?.getSingle() ?? Future.value(null))
+                value.first.$2.department?.getSingle() ?? Future.value(null))
             .then(
               (value) => value?.id,
             ),
@@ -575,19 +575,19 @@ void main() {
         db.managers.department
             .withReferences()
             .get(distinct: true)
-            .then((value) => value.first.productRefs.count()),
+            .then((value) => value.first.$2.productRefs.count()),
         completion(3));
 
     // Get all the products with all their listings
     final listingsWithProducts = <ProductData, List<ListingData>>{};
     for (final i
         in await db.managers.listing.withReferences().get(distinct: true)) {
-      final product = await i.product?.getSingle();
+      final product = await i.$2.product?.getSingle();
       if (product != null) {
         if (!listingsWithProducts.containsKey(product)) {
-          listingsWithProducts[product] = [i.listingData];
+          listingsWithProducts[product] = [i.$1];
         } else {
-          listingsWithProducts[product]!.add(i.listingData);
+          listingsWithProducts[product]!.add(i.$1);
         }
       }
     }
@@ -605,7 +605,7 @@ void main() {
             .filter((f) => f.id.equals(2))
             .withReferences()
             .getSingle()
-            .then((value) => value.productRefs.count()),
+            .then((value) => value.$2.productRefs.count()),
         completion(2));
   });
 }

--- a/drift/test/manager/manager_selectable_test.dart
+++ b/drift/test/manager/manager_selectable_test.dart
@@ -1,0 +1,217 @@
+// ignore_for_file: unused_local_variable
+
+import 'package:drift/drift.dart';
+import 'package:test/test.dart';
+
+import '../generated/todos.dart';
+import '../test_utils/test_utils.dart';
+
+/// All managers `Managers` are Selectable classes that
+/// are used by the Manager API to return results.
+/// This test will ensure that they all behave as expected, no matter what filters/ordering/limit/offsets/references are applied.
+
+void main() {
+  late TodoDb db;
+
+  setUp(() {
+    db = TodoDb(testInMemoryDatabase());
+  });
+
+  tearDown(() => db.close());
+
+  test('manager - selectable tests', () async {
+    final stores = [
+      await db.managers.store.createReturning((o) => o(name: Value("Walmart"))),
+      await db.managers.store.createReturning((o) => o(name: Value("Target"))),
+      await db.managers.store.createReturning((o) => o(name: Value("Costco")))
+    ];
+
+    final departments = [
+      await db.managers.department
+          .createReturning((o) => o(name: Value("Electronics"))),
+      await db.managers.department
+          .createReturning((o) => o(name: Value("Grocery"))),
+      await db.managers.department
+          .createReturning((o) => o(name: Value("Clothing")))
+    ];
+
+    final products = [
+      // Electronics
+      await db.managers.product.createReturning(
+          (o) => o(name: Value("TV"), department: Value(departments[0].id))),
+      await db.managers.product.createReturning((o) =>
+          o(name: Value("Cell Phone"), department: Value(departments[0].id))),
+      await db.managers.product.createReturning((o) =>
+          o(name: Value("Charger"), department: Value(departments[0].id))),
+      // Grocery
+      await db.managers.product.createReturning((o) =>
+          o(name: Value("Cereal"), department: Value(departments[1].id))),
+      await db.managers.product.createReturning(
+          (o) => o(name: Value("Meat"), department: Value(departments[1].id))),
+      // Clothing
+      await db.managers.product.createReturning(
+          (o) => o(name: Value("Shirt"), department: Value(departments[2].id))),
+      await db.managers.product.createReturning(
+          (o) => o(name: Value("Pants"), department: Value(departments[2].id))),
+      await db.managers.product.createReturning(
+          (o) => o(name: Value("Socks"), department: Value(departments[2].id))),
+      await db.managers.product.createReturning(
+          (o) => o(name: Value("Cap"), department: Value(departments[2].id)))
+    ];
+
+    final listings = [
+      // Walmart - Electronics
+      await db.managers.listing.create((o) => o(
+          product: Value(products[0].id),
+          store: Value(stores[0].id),
+          price: Value(100.0))),
+      await db.managers.listing.create((o) => o(
+          product: Value(products[1].id),
+          store: Value(stores[0].id),
+          price: Value(200.0))),
+      await db.managers.listing.create((o) => o(
+          product: Value(products[2].id),
+          store: Value(stores[0].id),
+          price: Value(10.0))),
+
+      // Walmart - Grocery
+      await db.managers.listing.create((o) => o(
+          product: Value(products[3].id),
+          store: Value(stores[0].id),
+          price: Value(5.0))),
+      await db.managers.listing.create((o) => o(
+          product: Value(products[4].id),
+          store: Value(stores[0].id),
+          price: Value(15.0))),
+
+      // Walmart - Clothing
+      await db.managers.listing.create((o) => o(
+          product: Value(products[5].id),
+          store: Value(stores[0].id),
+          price: Value(20.0))),
+      await db.managers.listing.create((o) => o(
+          product: Value(products[6].id),
+          store: Value(stores[0].id),
+          price: Value(30.0))),
+      await db.managers.listing.create((o) => o(
+          product: Value(products[7].id),
+          store: Value(stores[0].id),
+          price: Value(5.0))),
+      await db.managers.listing.create((o) => o(
+          product: Value(products[8].id),
+          store: Value(stores[0].id),
+          price: Value(10.0))),
+
+      // Target - Electronics
+
+      // Target does not have any TVs
+      // But is otherwise cheaper on electronics
+      // await db.managers.listing.create((o) => o(
+      //     product: Value(products[0].id),
+      //     store: Value(stores[0].id),
+      //     price: Value(100.0))),
+      await db.managers.listing.create((o) => o(
+          product: Value(products[1].id),
+          store: Value(stores[1].id),
+          price: Value(150.0))),
+      await db.managers.listing.create((o) => o(
+          product: Value(products[2].id),
+          store: Value(stores[1].id),
+          price: Value(15.0))),
+
+      // Target - Grocery
+
+      // More expensive groceries
+      await db.managers.listing.create((o) => o(
+          product: Value(products[3].id),
+          store: Value(stores[1].id),
+          price: Value(10.0))),
+      await db.managers.listing.create((o) => o(
+          product: Value(products[4].id),
+          store: Value(stores[1].id),
+          price: Value(20.0))),
+
+      // Target - Clothing
+
+      // Does not have any shirts or pants
+      // await db.managers.listing.create((o) => o(
+      //     product: Value(products[5].id),
+      //     store: Value(stores[1].id),
+      //     price: Value(20.0))),
+      // await db.managers.listing.create((o) => o(
+      //     product: Value(products[6].id),
+      //     store: Value(stores[1].id),
+      //     price: Value(30.0))),
+      await db.managers.listing.create((o) => o(
+          product: Value(products[7].id),
+          store: Value(stores[1].id),
+          price: Value(5.0))),
+      await db.managers.listing.create((o) => o(
+          product: Value(products[8].id),
+          store: Value(stores[1].id),
+          price: Value(10.0))),
+
+      // Costco - Electronics
+      // Much cheaper electronics
+      await db.managers.listing.create((o) => o(
+          product: Value(products[0].id),
+          store: Value(stores[2].id),
+          price: Value(50.0))),
+      await db.managers.listing.create((o) => o(
+          product: Value(products[1].id),
+          store: Value(stores[2].id),
+          price: Value(100.0))),
+      await db.managers.listing.create((o) => o(
+          product: Value(products[2].id),
+          store: Value(stores[2].id),
+          price: Value(2.50))),
+
+      // Costco - Grocery
+
+      // More expensive groceries
+      await db.managers.listing.create((o) => o(
+          product: Value(products[3].id),
+          store: Value(stores[2].id),
+          price: Value(20.0))),
+      await db.managers.listing.create((o) => o(
+          product: Value(products[4].id),
+          store: Value(stores[2].id),
+          price: Value(900.0)))
+    ];
+
+    final getAllStores = db.managers.store;
+    final getAllStoresWithFilter =
+        db.managers.store.filter((f) => f.id.not(10));
+    final getAllStoresWithOrdering =
+        db.managers.store.orderBy((f) => f.id.asc());
+    final getAllStoresWithFilterAndOrdering = db.managers.store
+        .filter((f) => f.id.not(10))
+        .orderBy((f) => f.id.asc());
+    final getAllStoresWithFilterAndOrderingWithReferences = db.managers.store
+        .filter((f) => f.id.not(10))
+        .orderBy((f) => f.id.asc())
+        .withReferences();
+
+    void testManager<T, M>(
+        BaseTableManager<dynamic, dynamic, T, dynamic, dynamic, dynamic,
+                dynamic, M, T>
+            selectable) {
+      expect(selectable.get().then((v) => v.length), completion(3));
+      expect(selectable.get(limit: 1).then((v) => v.length), completion(1));
+      expect(selectable.get(offset: 1, limit: 2).then((v) => v.length),
+          completion(2));
+      expect(selectable.get(offset: 1, limit: 2).then((v) => v.length),
+          completion(2));
+    }
+
+    for (final selectable in <BaseTableManager>[
+      getAllStores,
+      getAllStoresWithFilter,
+      getAllStoresWithOrdering,
+      getAllStoresWithFilterAndOrdering,
+      getAllStoresWithFilterAndOrderingWithReferences,
+    ]) {
+      testManager(selectable);
+    }
+  });
+}

--- a/drift/test/manager/manager_selectable_test.dart
+++ b/drift/test/manager/manager_selectable_test.dart
@@ -21,6 +21,9 @@ void main() {
   tearDown(() => db.close());
 
   test('manager - selectable tests', () async {
+    final stores = await _storeData.mapAsyncAndAwait((p0) => db.managers.store
+        .createReturning((o) => o(name: Value(p0.name), id: Value(p0.id))));
+
     final departments = await _departmentData.mapAsyncAndAwait(
       (p0) => db.managers.department
           .createReturning((o) => o(name: Value(p0.name), id: Value(p0.id))),

--- a/drift/test/manager/manager_selectable_test.dart
+++ b/drift/test/manager/manager_selectable_test.dart
@@ -1,6 +1,7 @@
 // ignore_for_file: unused_local_variable
 
 import 'package:drift/drift.dart';
+import 'package:drift/src/utils/async.dart';
 import 'package:test/test.dart';
 
 import '../generated/todos.dart';
@@ -20,164 +21,22 @@ void main() {
   tearDown(() => db.close());
 
   test('manager - selectable tests', () async {
-    final stores = [
-      await db.managers.store.createReturning((o) => o(name: Value("Walmart"))),
-      await db.managers.store.createReturning((o) => o(name: Value("Target"))),
-      await db.managers.store.createReturning((o) => o(name: Value("Costco")))
-    ];
+    final departments = await _departmentData.mapAsyncAndAwait(
+      (p0) => db.managers.department
+          .createReturning((o) => o(name: Value(p0.name), id: Value(p0.id))),
+    );
 
-    final departments = [
-      await db.managers.department
-          .createReturning((o) => o(name: Value("Electronics"))),
-      await db.managers.department
-          .createReturning((o) => o(name: Value("Grocery"))),
-      await db.managers.department
-          .createReturning((o) => o(name: Value("Clothing")))
-    ];
+    final products = await _productData.mapAsyncAndAwait(
+      (p0) => db.managers.product.createReturning(
+          (o) => o(name: p0.name, department: p0.department, id: Value(p0.id))),
+    );
 
-    final products = [
-      // Electronics
-      await db.managers.product.createReturning(
-          (o) => o(name: Value("TV"), department: Value(departments[0].id))),
-      await db.managers.product.createReturning((o) =>
-          o(name: Value("Cell Phone"), department: Value(departments[0].id))),
-      await db.managers.product.createReturning((o) =>
-          o(name: Value("Charger"), department: Value(departments[0].id))),
-      // Grocery
-      await db.managers.product.createReturning((o) =>
-          o(name: Value("Cereal"), department: Value(departments[1].id))),
-      await db.managers.product.createReturning(
-          (o) => o(name: Value("Meat"), department: Value(departments[1].id))),
-      // Clothing
-      await db.managers.product.createReturning(
-          (o) => o(name: Value("Shirt"), department: Value(departments[2].id))),
-      await db.managers.product.createReturning(
-          (o) => o(name: Value("Pants"), department: Value(departments[2].id))),
-      await db.managers.product.createReturning(
-          (o) => o(name: Value("Socks"), department: Value(departments[2].id))),
-      await db.managers.product.createReturning(
-          (o) => o(name: Value("Cap"), department: Value(departments[2].id)))
-    ];
-
-    final listings = [
-      // Walmart - Electronics
-      await db.managers.listing.create((o) => o(
-          product: Value(products[0].id),
-          store: Value(stores[0].id),
-          price: Value(100.0))),
-      await db.managers.listing.create((o) => o(
-          product: Value(products[1].id),
-          store: Value(stores[0].id),
-          price: Value(200.0))),
-      await db.managers.listing.create((o) => o(
-          product: Value(products[2].id),
-          store: Value(stores[0].id),
-          price: Value(10.0))),
-
-      // Walmart - Grocery
-      await db.managers.listing.create((o) => o(
-          product: Value(products[3].id),
-          store: Value(stores[0].id),
-          price: Value(5.0))),
-      await db.managers.listing.create((o) => o(
-          product: Value(products[4].id),
-          store: Value(stores[0].id),
-          price: Value(15.0))),
-
-      // Walmart - Clothing
-      await db.managers.listing.create((o) => o(
-          product: Value(products[5].id),
-          store: Value(stores[0].id),
-          price: Value(20.0))),
-      await db.managers.listing.create((o) => o(
-          product: Value(products[6].id),
-          store: Value(stores[0].id),
-          price: Value(30.0))),
-      await db.managers.listing.create((o) => o(
-          product: Value(products[7].id),
-          store: Value(stores[0].id),
-          price: Value(5.0))),
-      await db.managers.listing.create((o) => o(
-          product: Value(products[8].id),
-          store: Value(stores[0].id),
-          price: Value(10.0))),
-
-      // Target - Electronics
-
-      // Target does not have any TVs
-      // But is otherwise cheaper on electronics
-      // await db.managers.listing.create((o) => o(
-      //     product: Value(products[0].id),
-      //     store: Value(stores[0].id),
-      //     price: Value(100.0))),
-      await db.managers.listing.create((o) => o(
-          product: Value(products[1].id),
-          store: Value(stores[1].id),
-          price: Value(150.0))),
-      await db.managers.listing.create((o) => o(
-          product: Value(products[2].id),
-          store: Value(stores[1].id),
-          price: Value(15.0))),
-
-      // Target - Grocery
-
-      // More expensive groceries
-      await db.managers.listing.create((o) => o(
-          product: Value(products[3].id),
-          store: Value(stores[1].id),
-          price: Value(10.0))),
-      await db.managers.listing.create((o) => o(
-          product: Value(products[4].id),
-          store: Value(stores[1].id),
-          price: Value(20.0))),
-
-      // Target - Clothing
-
-      // Does not have any shirts or pants
-      // await db.managers.listing.create((o) => o(
-      //     product: Value(products[5].id),
-      //     store: Value(stores[1].id),
-      //     price: Value(20.0))),
-      // await db.managers.listing.create((o) => o(
-      //     product: Value(products[6].id),
-      //     store: Value(stores[1].id),
-      //     price: Value(30.0))),
-      await db.managers.listing.create((o) => o(
-          product: Value(products[7].id),
-          store: Value(stores[1].id),
-          price: Value(5.0))),
-      await db.managers.listing.create((o) => o(
-          product: Value(products[8].id),
-          store: Value(stores[1].id),
-          price: Value(10.0))),
-
-      // Costco - Electronics
-      // Much cheaper electronics
-      await db.managers.listing.create((o) => o(
-          product: Value(products[0].id),
-          store: Value(stores[2].id),
-          price: Value(50.0))),
-      await db.managers.listing.create((o) => o(
-          product: Value(products[1].id),
-          store: Value(stores[2].id),
-          price: Value(100.0))),
-      await db.managers.listing.create((o) => o(
-          product: Value(products[2].id),
-          store: Value(stores[2].id),
-          price: Value(2.50))),
-
-      // Costco - Grocery
-
-      // More expensive groceries
-      await db.managers.listing.create((o) => o(
-          product: Value(products[3].id),
-          store: Value(stores[2].id),
-          price: Value(20.0))),
-      await db.managers.listing.create((o) => o(
-          product: Value(products[4].id),
-          store: Value(stores[2].id),
-          price: Value(900.0)))
-    ];
+    final listings = await _listingsData.mapAsyncAndAwait(
+      (p0) => db.managers.listing.createReturning((o) => o(
+          product: Value(p0.product),
+          store: Value(p0.store),
+          price: Value(p0.price))),
+    );
 
     final getAllStores = db.managers.store;
     final getAllStoresWithFilter =
@@ -192,16 +51,14 @@ void main() {
         .orderBy((f) => f.id.asc())
         .withReferences();
 
-    void testManager<T, M>(
+    Future testManager<T, M>(
         BaseTableManager<dynamic, dynamic, T, dynamic, dynamic, dynamic,
                 dynamic, M, T>
-            selectable) {
-      expect(selectable.get().then((v) => v.length), completion(3));
-      expect(selectable.get(limit: 1).then((v) => v.length), completion(1));
-      expect(selectable.get(offset: 1, limit: 2).then((v) => v.length),
-          completion(2));
-      expect(selectable.get(offset: 1, limit: 2).then((v) => v.length),
-          completion(2));
+            selectable) async {
+      expect(await selectable.get(), hasLength(3));
+      expect(await selectable.get(limit: 1), hasLength(1));
+      expect(await selectable.get(offset: 1, limit: 2), hasLength(2));
+      expect(await selectable.get(offset: 1, limit: 2), hasLength(2));
     }
 
     for (final selectable in <BaseTableManager>[
@@ -211,7 +68,61 @@ void main() {
       getAllStoresWithFilterAndOrdering,
       getAllStoresWithFilterAndOrderingWithReferences,
     ]) {
-      testManager(selectable);
+      await testManager(selectable);
     }
   });
 }
+
+const _storeData = [
+  (name: "Walmart", id: 1),
+  (name: "Target", id: 2),
+  (name: "Costco", id: 3),
+];
+
+const _departmentData = [
+  (name: "Electronics", id: 1),
+  (name: "Grocery", id: 2),
+  (name: "Clothing", id: 3),
+];
+
+final _productData = [
+  (name: Value("TV"), department: Value(_departmentData[0].id), id: 1),
+  (name: Value("Cell Phone"), department: Value(_departmentData[0].id), id: 2),
+  (name: Value("Charger"), department: Value(_departmentData[0].id), id: 3),
+  (name: Value("Cereal"), department: Value(_departmentData[1].id), id: 4),
+  (name: Value("Meat"), department: Value(_departmentData[1].id), id: 5),
+  (name: Value("Shirt"), department: Value(_departmentData[2].id), id: 6),
+  (name: Value("Pants"), department: Value(_departmentData[2].id), id: 7),
+  (name: Value("Socks"), department: Value(_departmentData[2].id), id: 8),
+  (name: Value("Cap"), department: Value(_departmentData[2].id), id: 9),
+];
+final _listingsData = [
+  // Walmart - Electronics
+  (product: 1, store: 1, price: 100.0),
+  (product: 2, store: 1, price: 200.0),
+  (product: 3, store: 1, price: 10.0),
+  // Walmart - Grocery
+  (product: 4, store: 1, price: 5.0),
+  (product: 5, store: 1, price: 15.0),
+  // Walmart - Clothing
+  (product: 6, store: 1, price: 20.0),
+  (product: 7, store: 1, price: 30.0),
+  (product: 8, store: 1, price: 5.0),
+  (product: 9, store: 1, price: 10.0),
+  // Target - Electronics
+  (product: 2, store: 2, price: 150.0),
+  (product: 3, store: 2, price: 15.0),
+  // Target - Grocery
+  (product: 4, store: 2, price: 10.0),
+  (product: 5, store: 2, price: 20.0),
+  // Target - Clothing
+  (product: 8, store: 2, price: 5.0),
+  (product: 9, store: 2, price: 10.0),
+  // Costco - Electronics
+  (product: 1, store: 3, price: 50.0),
+  (product: 2, store: 3, price: 100.0),
+  (product: 3, store: 3, price: 2.50),
+  // Costco - Grocery
+  (product: 4, store: 3, price: 20.0),
+  (product: 5, store: 3, price: 900.0),
+];

--- a/drift/test/serialization_test.dart
+++ b/drift/test/serialization_test.dart
@@ -10,7 +10,7 @@ final TodoEntry _someTodoEntry = TodoEntry(
   title: null,
   content: 'content',
   targetDate: _someDate,
-  category: 3,
+  category: RowId(3),
   status: TodoStatus.open,
 );
 

--- a/drift_dev/lib/src/writer/manager/database_manager_writer.dart
+++ b/drift_dev/lib/src/writer/manager/database_manager_writer.dart
@@ -3,6 +3,7 @@ import 'package:drift_dev/src/analysis/results/results.dart';
 import 'package:drift_dev/src/writer/modules.dart';
 import 'package:drift_dev/src/writer/tables/update_companion_writer.dart';
 import 'package:drift_dev/src/writer/writer.dart';
+import 'package:recase/recase.dart';
 
 part 'manager_templates.dart';
 part 'table_manager_writer.dart';

--- a/drift_dev/lib/src/writer/manager/database_manager_writer.dart
+++ b/drift_dev/lib/src/writer/manager/database_manager_writer.dart
@@ -3,7 +3,6 @@ import 'package:drift_dev/src/analysis/results/results.dart';
 import 'package:drift_dev/src/writer/modules.dart';
 import 'package:drift_dev/src/writer/tables/update_companion_writer.dart';
 import 'package:drift_dev/src/writer/writer.dart';
-import 'package:recase/recase.dart';
 
 part 'manager_templates.dart';
 part 'table_manager_writer.dart';

--- a/drift_dev/lib/src/writer/manager/manager_templates.dart
+++ b/drift_dev/lib/src/writer/manager/manager_templates.dart
@@ -236,7 +236,7 @@ class _ManagerCodeTemplates {
         table: table,
         filteringComposer: ${filterComposerNameWithPrefix(table, leaf)}(${leaf.drift("ComposerState")}(db, table)),
         orderingComposer: ${orderingComposerNameWithPrefix(table, leaf)}(${leaf.drift("ComposerState")}(db, table)),
-        dataclassMapper: (p0)  async => p0.map((e) => ${rowWithReferencesClassName(table)}(db,e)).toList() ,
+        dataclassMapper: (p0) => p0.map((e) => ${rowWithReferencesClassName(table)}(db,e)).toList() ,
         updateCompanionCallback: $updateCompanionBuilder,
         createCompanionCallback: $createCompanionBuilder,));
         }

--- a/drift_dev/lib/src/writer/manager/manager_templates.dart
+++ b/drift_dev/lib/src/writer/manager/manager_templates.dart
@@ -236,7 +236,7 @@ class _ManagerCodeTemplates {
         table: table,
         filteringComposer: ${filterComposerNameWithPrefix(table, leaf)}(${leaf.drift("ComposerState")}(db, table)),
         orderingComposer: ${orderingComposerNameWithPrefix(table, leaf)}(${leaf.drift("ComposerState")}(db, table)),
-        dataclassMapper: (p0) => p0.map((e) => ${rowWithReferencesClassName(table)}(db,e)).toList() ,
+        withReferenceMapper: (p0) => p0.map((e) => ${rowWithReferencesClassName(table)}(db,e)).toList() ,
         updateCompanionCallback: $updateCompanionBuilder,
         createCompanionCallback: $createCompanionBuilder,));
         }

--- a/drift_dev/lib/src/writer/manager/manager_templates.dart
+++ b/drift_dev/lib/src/writer/manager/manager_templates.dart
@@ -379,14 +379,14 @@ class _ManagerCodeTemplates {
       required List<_Relation> relations,
       required TextEmitter leaf,
       required String dbClassName}) {
-    final currentRowField = "_item"; // TODO: Replace
     return """
 
         class ${rowWithReferencesClassName(currentTable)} {
         // ignore: unused_field
         final ${databaseType(leaf, dbClassName)} _db;
-        final ${rowClassWithPrefix(currentTable, leaf)} $currentRowField;
-        ${rowWithReferencesClassName(currentTable)}(this._db, this.$currentRowField);
+        // ignore: unused_field
+        final ${rowClassWithPrefix(currentTable, leaf)} _item;
+        ${rowWithReferencesClassName(currentTable)}(this._db, this._item);
 
         ${relations.map((relation) {
       if (_scope.generationOptions.isModular) {
@@ -397,14 +397,14 @@ class _ManagerCodeTemplates {
         // For a reverse relation, we return a filtered table manager
         return """
         ${processedTableManagerTypeDefName(relation.referencedTable)} get ${relation.fieldName} {
-          return ${rootTableManagerWithPrefix(relation.referencedTable, leaf)}(_db,_db.${relation.referencedTable.dbGetterName}).filter((f) => f.${relation.referencedColumn.nameInDart}.${relation.currentColumn.nameInDart}($currentRowField.${relation.currentColumn.nameInDart}));
+          return ${rootTableManagerWithPrefix(relation.referencedTable, leaf)}(_db,_db.${relation.referencedTable.dbGetterName}).filter((f) => f.${relation.referencedColumn.nameInDart}.${relation.currentColumn.nameInDart}(_item.${relation.currentColumn.nameInDart}));
         }
         """;
       } else {
         return """
         ${processedTableManagerTypeDefName(relation.referencedTable)}? get ${relation.fieldName} {
-          if ($currentRowField.${relation.currentColumn.nameInDart} == null) return null;
-          return ${rootTableManagerWithPrefix(relation.referencedTable, leaf)}(_db, _db.${relation.referencedTable.dbGetterName}).filter((f) => f.${relation.referencedColumn.nameInDart}($currentRowField.${relation.currentColumn.nameInDart}!));
+          if (_item.${relation.currentColumn.nameInDart} == null) return null;
+          return ${rootTableManagerWithPrefix(relation.referencedTable, leaf)}(_db, _db.${relation.referencedTable.dbGetterName}).filter((f) => f.${relation.referencedColumn.nameInDart}(_item.${relation.currentColumn.nameInDart}!));
         }
         """;
       }

--- a/drift_dev/lib/src/writer/manager/manager_templates.dart
+++ b/drift_dev/lib/src/writer/manager/manager_templates.dart
@@ -236,6 +236,7 @@ class _ManagerCodeTemplates {
         table: table,
         filteringComposer: ${filterComposerNameWithPrefix(table, leaf)}(${leaf.drift("ComposerState")}(db, table)),
         orderingComposer: ${orderingComposerNameWithPrefix(table, leaf)}(${leaf.drift("ComposerState")}(db, table)),
+        dataclassMapper: (p0)  async => p0.map((e) => ${rowWithReferencesClassName(table)}(db,e)).toList() ,
         updateCompanionCallback: $updateCompanionBuilder,
         createCompanionCallback: $createCompanionBuilder,));
         }

--- a/drift_dev/lib/src/writer/manager/manager_templates.dart
+++ b/drift_dev/lib/src/writer/manager/manager_templates.dart
@@ -204,7 +204,7 @@ class _ManagerCodeTemplates {
     ${orderingComposerNameWithPrefix(table, leaf)},
     ${createCompanionBuilderTypeDef(table)},
     ${updateCompanionBuilderTypeDefName(table)},
-    ${rowWithReferencesClassName(table)},
+    (${rowClassWithPrefix(table, leaf)},${rowWithReferencesClassName(table)}),
     ${rowClassWithPrefix(table, leaf)}>""";
   }
 
@@ -236,7 +236,7 @@ class _ManagerCodeTemplates {
         table: table,
         filteringComposer: ${filterComposerNameWithPrefix(table, leaf)}(${leaf.drift("ComposerState")}(db, table)),
         orderingComposer: ${orderingComposerNameWithPrefix(table, leaf)}(${leaf.drift("ComposerState")}(db, table)),
-        withReferenceMapper: (p0) => p0.map((e) => ${rowWithReferencesClassName(table)}(db,e)).toList() ,
+        withReferenceMapper: (p0) => p0.map((e) => (e,${rowWithReferencesClassName(table)}(db,e))).toList() ,
         updateCompanionCallback: $updateCompanionBuilder,
         createCompanionCallback: $createCompanionBuilder,));
         }
@@ -379,7 +379,7 @@ class _ManagerCodeTemplates {
       required List<_Relation> relations,
       required TextEmitter leaf,
       required String dbClassName}) {
-    final currentRowField = rowClassWithPrefix(currentTable, leaf).camelCase;
+    final currentRowField = "_item"; // TODO: Replace
     return """
 
         class ${rowWithReferencesClassName(currentTable)} {

--- a/drift_dev/lib/src/writer/manager/table_manager_writer.dart
+++ b/drift_dev/lib/src/writer/manager/table_manager_writer.dart
@@ -95,6 +95,28 @@ class _TableManagerWriter {
       return true;
     }).toList();
 
+    // Remove any relations where the type isnt exactly the same (num and int)
+    // This is caused by using different type converters
+    relations = relations.where((relation) {
+      String typeForColumn(DriftColumn column) {
+        return column.typeConverter?.dartType.getDisplayString(
+                withNullability: false) ?? // ignore: deprecated_member_use
+            leaf.dartCode(leaf.innerColumnType(column.sqlType));
+      }
+
+      final currentType = typeForColumn(relation.currentColumn);
+      final referencedType = typeForColumn(relation.referencedColumn);
+      if (currentType != referencedType) {
+        print(
+            "\"${relation.currentTable.baseDartName}.${relation.currentColumn.nameInSql}\" has a type of \"$currentType\""
+            " and \"${relation.referencedTable.baseDartName}.${relation.referencedColumn.nameInSql}\" has a type of \"$referencedType\"."
+            " This is caused by using different type converters for the columns."
+            " Filters, orderings and reference getters for this relation wont be generated.");
+        return false;
+      }
+      return true;
+    }).toList();
+
     final columnFilters = <String>[];
     final columnOrderings = <String>[];
 

--- a/drift_dev/lib/src/writer/manager/table_manager_writer.dart
+++ b/drift_dev/lib/src/writer/manager/table_manager_writer.dart
@@ -46,6 +46,8 @@ class _TableManagerWriter {
         leaf: leaf,
         updateCompanionBuilder: updateCompanionBuilder,
         createCompanionBuilder: insertCompanionBuilder));
+    leaf.write(_templates.processedTableManagerTypeDef(
+        table: table, dbClassName: dbClassName, leaf: leaf));
 
     // Gather the relationships to and from this table
     List<_Relation> relations =
@@ -136,6 +138,11 @@ class _TableManagerWriter {
         leaf: leaf,
         dbClassName: dbClassName,
         columnOrderings: columnOrderings));
+    leaf.write(_templates.rowClassWithReferences(
+        currentTable: table,
+        relations: relations,
+        leaf: leaf,
+        dbClassName: dbClassName));
   }
 }
 

--- a/drift_dev/lib/src/writer/manager/table_manager_writer.dart
+++ b/drift_dev/lib/src/writer/manager/table_manager_writer.dart
@@ -39,16 +39,6 @@ class _TableManagerWriter {
     leaf.writeln(insertCompanionBuilderTypeDef);
     leaf.writeln(updateCompanionBuilderTypeDef);
 
-    // Write the root and processed table managers
-    leaf.write(_templates.rootTableManager(
-        table: table,
-        dbClassName: dbClassName,
-        leaf: leaf,
-        updateCompanionBuilder: updateCompanionBuilder,
-        createCompanionBuilder: insertCompanionBuilder));
-    leaf.write(_templates.processedTableManagerTypeDef(
-        table: table, dbClassName: dbClassName, leaf: leaf));
-
     // Gather the relationships to and from this table
     List<_Relation> relations =
         table.columns.map((e) => _getRelationForColumn(e)).nonNulls.toList();
@@ -160,11 +150,27 @@ class _TableManagerWriter {
         leaf: leaf,
         dbClassName: dbClassName,
         columnOrderings: columnOrderings));
-    leaf.write(_templates.rowClassWithReferences(
-        currentTable: table,
-        relations: relations,
+    if (!scope.generationOptions.isModular && relations.isNotEmpty) {
+      leaf.write(_templates.rowClassWithReferences(
+          currentTable: table,
+          relations: relations,
+          leaf: leaf,
+          dbClassName: dbClassName));
+    }
+
+    // Write the root and processed table managers
+    leaf.write(_templates.rootTableManager(
+        table: table,
+        dbClassName: dbClassName,
         leaf: leaf,
-        dbClassName: dbClassName));
+        updateCompanionBuilder: updateCompanionBuilder,
+        createCompanionBuilder: insertCompanionBuilder,
+        relations: relations));
+    leaf.write(_templates.processedTableManagerTypeDef(
+        table: table,
+        dbClassName: dbClassName,
+        leaf: leaf,
+        relations: relations));
   }
 }
 

--- a/drift_flutter/example/main.g.dart
+++ b/drift_flutter/example/main.g.dart
@@ -217,7 +217,7 @@ class $$ExampleTableTableTableManager extends RootTableManager<
     $$ExampleTableTableOrderingComposer,
     $$ExampleTableTableCreateCompanionBuilder,
     $$ExampleTableTableUpdateCompanionBuilder,
-    $$ExampleTableTableWithReferences,
+    (ExampleTableData, $$ExampleTableTableWithReferences),
     ExampleTableData> {
   $$ExampleTableTableTableManager(
       _$ExampleDatabase db, $ExampleTableTable table)
@@ -228,8 +228,9 @@ class $$ExampleTableTableTableManager extends RootTableManager<
               $$ExampleTableTableFilterComposer(ComposerState(db, table)),
           orderingComposer:
               $$ExampleTableTableOrderingComposer(ComposerState(db, table)),
-          withReferenceMapper: (p0) =>
-              p0.map((e) => $$ExampleTableTableWithReferences(db, e)).toList(),
+          withReferenceMapper: (p0) => p0
+              .map((e) => (e, $$ExampleTableTableWithReferences(db, e)))
+              .toList(),
           updateCompanionCallback: ({
             Value<int> id = const Value.absent(),
             Value<String> description = const Value.absent(),
@@ -257,7 +258,7 @@ typedef $$ExampleTableTableProcessedTableManager = ProcessedTableManager<
     $$ExampleTableTableOrderingComposer,
     $$ExampleTableTableCreateCompanionBuilder,
     $$ExampleTableTableUpdateCompanionBuilder,
-    $$ExampleTableTableWithReferences,
+    (ExampleTableData, $$ExampleTableTableWithReferences),
     ExampleTableData>;
 
 class $$ExampleTableTableFilterComposer
@@ -291,8 +292,8 @@ class $$ExampleTableTableOrderingComposer
 class $$ExampleTableTableWithReferences {
   // ignore: unused_field
   final _$ExampleDatabase _db;
-  final ExampleTableData exampleTableData;
-  $$ExampleTableTableWithReferences(this._db, this.exampleTableData);
+  final ExampleTableData _item;
+  $$ExampleTableTableWithReferences(this._db, this._item);
 }
 
 class $ExampleDatabaseManager {

--- a/drift_flutter/example/main.g.dart
+++ b/drift_flutter/example/main.g.dart
@@ -110,6 +110,14 @@ class ExampleTableData extends DataClass
         id: id ?? this.id,
         description: description ?? this.description,
       );
+  ExampleTableData copyWithCompanion(ExampleTableCompanion data) {
+    return ExampleTableData(
+      id: data.id.present ? data.id.value : this.id,
+      description:
+          data.description.present ? data.description.value : this.description,
+    );
+  }
+
   @override
   String toString() {
     return (StringBuffer('ExampleTableData(')
@@ -181,7 +189,7 @@ class ExampleTableCompanion extends UpdateCompanion<ExampleTableData> {
 
 abstract class _$ExampleDatabase extends GeneratedDatabase {
   _$ExampleDatabase(QueryExecutor e) : super(e);
-  _$ExampleDatabaseManager get managers => _$ExampleDatabaseManager(this);
+  $ExampleDatabaseManager get managers => $ExampleDatabaseManager(this);
   late final $ExampleTableTable exampleTable = $ExampleTableTable(this);
   @override
   Iterable<TableInfo<Table, Object?>> get allTables =>
@@ -190,7 +198,7 @@ abstract class _$ExampleDatabase extends GeneratedDatabase {
   List<DatabaseSchemaEntity> get allSchemaEntities => [exampleTable];
 }
 
-typedef $$ExampleTableTableInsertCompanionBuilder = ExampleTableCompanion
+typedef $$ExampleTableTableCreateCompanionBuilder = ExampleTableCompanion
     Function({
   Value<int> id,
   required String description,
@@ -207,9 +215,10 @@ class $$ExampleTableTableTableManager extends RootTableManager<
     ExampleTableData,
     $$ExampleTableTableFilterComposer,
     $$ExampleTableTableOrderingComposer,
-    $$ExampleTableTableProcessedTableManager,
-    $$ExampleTableTableInsertCompanionBuilder,
-    $$ExampleTableTableUpdateCompanionBuilder> {
+    $$ExampleTableTableCreateCompanionBuilder,
+    $$ExampleTableTableUpdateCompanionBuilder,
+    $$ExampleTableTableWithReferences,
+    ExampleTableData> {
   $$ExampleTableTableTableManager(
       _$ExampleDatabase db, $ExampleTableTable table)
       : super(TableManagerState(
@@ -219,9 +228,9 @@ class $$ExampleTableTableTableManager extends RootTableManager<
               $$ExampleTableTableFilterComposer(ComposerState(db, table)),
           orderingComposer:
               $$ExampleTableTableOrderingComposer(ComposerState(db, table)),
-          getChildManagerBuilder: (p) =>
-              $$ExampleTableTableProcessedTableManager(p),
-          getUpdateCompanionBuilder: ({
+          dataclassMapper: (p0) async =>
+              p0.map((e) => $$ExampleTableTableWithReferences(db, e)).toList(),
+          updateCompanionCallback: ({
             Value<int> id = const Value.absent(),
             Value<String> description = const Value.absent(),
           }) =>
@@ -229,7 +238,7 @@ class $$ExampleTableTableTableManager extends RootTableManager<
             id: id,
             description: description,
           ),
-          getInsertCompanionBuilder: ({
+          createCompanionCallback: ({
             Value<int> id = const Value.absent(),
             required String description,
           }) =>
@@ -240,17 +249,16 @@ class $$ExampleTableTableTableManager extends RootTableManager<
         ));
 }
 
-class $$ExampleTableTableProcessedTableManager extends ProcessedTableManager<
+typedef $$ExampleTableTableProcessedTableManager = ProcessedTableManager<
     _$ExampleDatabase,
     $ExampleTableTable,
     ExampleTableData,
     $$ExampleTableTableFilterComposer,
     $$ExampleTableTableOrderingComposer,
-    $$ExampleTableTableProcessedTableManager,
-    $$ExampleTableTableInsertCompanionBuilder,
-    $$ExampleTableTableUpdateCompanionBuilder> {
-  $$ExampleTableTableProcessedTableManager(super.$state);
-}
+    $$ExampleTableTableCreateCompanionBuilder,
+    $$ExampleTableTableUpdateCompanionBuilder,
+    $$ExampleTableTableWithReferences,
+    ExampleTableData>;
 
 class $$ExampleTableTableFilterComposer
     extends FilterComposer<_$ExampleDatabase, $ExampleTableTable> {
@@ -280,9 +288,16 @@ class $$ExampleTableTableOrderingComposer
           ColumnOrderings(column, joinBuilders: joinBuilders));
 }
 
-class _$ExampleDatabaseManager {
+class $$ExampleTableTableWithReferences {
+  // ignore: unused_field
   final _$ExampleDatabase _db;
-  _$ExampleDatabaseManager(this._db);
+  final ExampleTableData exampleTableData;
+  $$ExampleTableTableWithReferences(this._db, this.exampleTableData);
+}
+
+class $ExampleDatabaseManager {
+  final _$ExampleDatabase _db;
+  $ExampleDatabaseManager(this._db);
   $$ExampleTableTableTableManager get exampleTable =>
       $$ExampleTableTableTableManager(_db, _db.exampleTable);
 }

--- a/drift_flutter/example/main.g.dart
+++ b/drift_flutter/example/main.g.dart
@@ -292,6 +292,7 @@ class $$ExampleTableTableOrderingComposer
 class $$ExampleTableTableWithReferences {
   // ignore: unused_field
   final _$ExampleDatabase _db;
+  // ignore: unused_field
   final ExampleTableData _item;
   $$ExampleTableTableWithReferences(this._db, this._item);
 }

--- a/drift_flutter/example/main.g.dart
+++ b/drift_flutter/example/main.g.dart
@@ -228,7 +228,7 @@ class $$ExampleTableTableTableManager extends RootTableManager<
               $$ExampleTableTableFilterComposer(ComposerState(db, table)),
           orderingComposer:
               $$ExampleTableTableOrderingComposer(ComposerState(db, table)),
-          dataclassMapper: (p0) async =>
+          withReferenceMapper: (p0) =>
               p0.map((e) => $$ExampleTableTableWithReferences(db, e)).toList(),
           updateCompanionCallback: ({
             Value<int> id = const Value.absent(),

--- a/drift_flutter/example/main.g.dart
+++ b/drift_flutter/example/main.g.dart
@@ -209,64 +209,6 @@ typedef $$ExampleTableTableUpdateCompanionBuilder = ExampleTableCompanion
   Value<String> description,
 });
 
-class $$ExampleTableTableTableManager extends RootTableManager<
-    _$ExampleDatabase,
-    $ExampleTableTable,
-    ExampleTableData,
-    $$ExampleTableTableFilterComposer,
-    $$ExampleTableTableOrderingComposer,
-    $$ExampleTableTableCreateCompanionBuilder,
-
-    $$ExampleTableTableUpdateCompanionBuilder,
-    (ExampleTableData, $$ExampleTableTableWithReferences),
-    ExampleTableData> {
-
-  $$ExampleTableTableTableManager(
-      _$ExampleDatabase db, $ExampleTableTable table)
-      : super(TableManagerState(
-          db: db,
-          table: table,
-          filteringComposer:
-              $$ExampleTableTableFilterComposer(ComposerState(db, table)),
-          orderingComposer:
-              $$ExampleTableTableOrderingComposer(ComposerState(db, table)),
-
-          withReferenceMapper: (p0) => p0
-              .map((e) => (e, $$ExampleTableTableWithReferences(db, e)))
-              .toList(),
-
-          updateCompanionCallback: ({
-            Value<int> id = const Value.absent(),
-            Value<String> description = const Value.absent(),
-          }) =>
-              ExampleTableCompanion(
-            id: id,
-            description: description,
-          ),
-          createCompanionCallback: ({
-            Value<int> id = const Value.absent(),
-            required String description,
-          }) =>
-              ExampleTableCompanion.insert(
-            id: id,
-            description: description,
-          ),
-        ));
-}
-
-
-typedef $$ExampleTableTableProcessedTableManager = ProcessedTableManager<
-    _$ExampleDatabase,
-    $ExampleTableTable,
-    ExampleTableData,
-    $$ExampleTableTableFilterComposer,
-    $$ExampleTableTableOrderingComposer,
-    $$ExampleTableTableCreateCompanionBuilder,
-    $$ExampleTableTableUpdateCompanionBuilder,
-    (ExampleTableData, $$ExampleTableTableWithReferences),
-    ExampleTableData>;
-
-
 class $$ExampleTableTableFilterComposer
     extends FilterComposer<_$ExampleDatabase, $ExampleTableTable> {
   $$ExampleTableTableFilterComposer(super.$state);
@@ -295,14 +237,56 @@ class $$ExampleTableTableOrderingComposer
           ColumnOrderings(column, joinBuilders: joinBuilders));
 }
 
-
-class $$ExampleTableTableWithReferences {
-  // ignore: unused_field
-  final _$ExampleDatabase _db;
-  // ignore: unused_field
-  final ExampleTableData _item;
-  $$ExampleTableTableWithReferences(this._db, this._item);
+class $$ExampleTableTableTableManager extends RootTableManager<
+    _$ExampleDatabase,
+    $ExampleTableTable,
+    ExampleTableData,
+    $$ExampleTableTableFilterComposer,
+    $$ExampleTableTableOrderingComposer,
+    $$ExampleTableTableCreateCompanionBuilder,
+    $$ExampleTableTableUpdateCompanionBuilder,
+    (ExampleTableData, BaseWithReferences<_$ExampleDatabase, ExampleTableData>),
+    ExampleTableData> {
+  $$ExampleTableTableTableManager(
+      _$ExampleDatabase db, $ExampleTableTable table)
+      : super(TableManagerState(
+          db: db,
+          table: table,
+          filteringComposer:
+              $$ExampleTableTableFilterComposer(ComposerState(db, table)),
+          orderingComposer:
+              $$ExampleTableTableOrderingComposer(ComposerState(db, table)),
+          withReferenceMapper: (p0) =>
+              p0.map((e) => (e, BaseWithReferences(db, e))).toList(),
+          updateCompanionCallback: ({
+            Value<int> id = const Value.absent(),
+            Value<String> description = const Value.absent(),
+          }) =>
+              ExampleTableCompanion(
+            id: id,
+            description: description,
+          ),
+          createCompanionCallback: ({
+            Value<int> id = const Value.absent(),
+            required String description,
+          }) =>
+              ExampleTableCompanion.insert(
+            id: id,
+            description: description,
+          ),
+        ));
 }
+
+typedef $$ExampleTableTableProcessedTableManager = ProcessedTableManager<
+    _$ExampleDatabase,
+    $ExampleTableTable,
+    ExampleTableData,
+    $$ExampleTableTableFilterComposer,
+    $$ExampleTableTableOrderingComposer,
+    $$ExampleTableTableCreateCompanionBuilder,
+    $$ExampleTableTableUpdateCompanionBuilder,
+    (ExampleTableData, BaseWithReferences<_$ExampleDatabase, ExampleTableData>),
+    ExampleTableData>;
 
 class $ExampleDatabaseManager {
   final _$ExampleDatabase _db;

--- a/examples/app/lib/database/database.g.dart
+++ b/examples/app/lib/database/database.g.dart
@@ -773,7 +773,7 @@ class $$CategoriesTableTableManager extends RootTableManager<
               $$CategoriesTableFilterComposer(ComposerState(db, table)),
           orderingComposer:
               $$CategoriesTableOrderingComposer(ComposerState(db, table)),
-          dataclassMapper: (p0) async =>
+          withReferenceMapper: (p0) =>
               p0.map((e) => $$CategoriesTableWithReferences(db, e)).toList(),
           updateCompanionCallback: ({
             Value<int> id = const Value.absent(),
@@ -907,7 +907,7 @@ class $$TodoEntriesTableTableManager extends RootTableManager<
               $$TodoEntriesTableFilterComposer(ComposerState(db, table)),
           orderingComposer:
               $$TodoEntriesTableOrderingComposer(ComposerState(db, table)),
-          dataclassMapper: (p0) async =>
+          withReferenceMapper: (p0) =>
               p0.map((e) => $$TodoEntriesTableWithReferences(db, e)).toList(),
           updateCompanionCallback: ({
             Value<int> id = const Value.absent(),
@@ -1049,7 +1049,7 @@ class $TextEntriesTableManager extends RootTableManager<
               $TextEntriesFilterComposer(ComposerState(db, table)),
           orderingComposer:
               $TextEntriesOrderingComposer(ComposerState(db, table)),
-          dataclassMapper: (p0) async =>
+          withReferenceMapper: (p0) =>
               p0.map((e) => $TextEntriesWithReferences(db, e)).toList(),
           updateCompanionCallback: ({
             Value<String> description = const Value.absent(),

--- a/examples/app/lib/database/database.g.dart
+++ b/examples/app/lib/database/database.g.dart
@@ -763,7 +763,7 @@ class $$CategoriesTableTableManager extends RootTableManager<
     $$CategoriesTableOrderingComposer,
     $$CategoriesTableCreateCompanionBuilder,
     $$CategoriesTableUpdateCompanionBuilder,
-    $$CategoriesTableWithReferences,
+    (Category, $$CategoriesTableWithReferences),
     Category> {
   $$CategoriesTableTableManager(_$AppDatabase db, $CategoriesTable table)
       : super(TableManagerState(
@@ -773,8 +773,9 @@ class $$CategoriesTableTableManager extends RootTableManager<
               $$CategoriesTableFilterComposer(ComposerState(db, table)),
           orderingComposer:
               $$CategoriesTableOrderingComposer(ComposerState(db, table)),
-          withReferenceMapper: (p0) =>
-              p0.map((e) => $$CategoriesTableWithReferences(db, e)).toList(),
+          withReferenceMapper: (p0) => p0
+              .map((e) => (e, $$CategoriesTableWithReferences(db, e)))
+              .toList(),
           updateCompanionCallback: ({
             Value<int> id = const Value.absent(),
             Value<String> name = const Value.absent(),
@@ -806,7 +807,7 @@ typedef $$CategoriesTableProcessedTableManager = ProcessedTableManager<
     $$CategoriesTableOrderingComposer,
     $$CategoriesTableCreateCompanionBuilder,
     $$CategoriesTableUpdateCompanionBuilder,
-    $$CategoriesTableWithReferences,
+    (Category, $$CategoriesTableWithReferences),
     Category>;
 
 class $$CategoriesTableFilterComposer
@@ -865,12 +866,12 @@ class $$CategoriesTableOrderingComposer
 class $$CategoriesTableWithReferences {
   // ignore: unused_field
   final _$AppDatabase _db;
-  final Category category;
-  $$CategoriesTableWithReferences(this._db, this.category);
+  final Category _item;
+  $$CategoriesTableWithReferences(this._db, this._item);
 
   $$TodoEntriesTableProcessedTableManager get todoEntriesRefs {
     return $$TodoEntriesTableTableManager(_db, _db.todoEntries)
-        .filter((f) => f.category.id(category.id));
+        .filter((f) => f.category.id(_item.id));
   }
 }
 
@@ -897,7 +898,7 @@ class $$TodoEntriesTableTableManager extends RootTableManager<
     $$TodoEntriesTableOrderingComposer,
     $$TodoEntriesTableCreateCompanionBuilder,
     $$TodoEntriesTableUpdateCompanionBuilder,
-    $$TodoEntriesTableWithReferences,
+    (TodoEntry, $$TodoEntriesTableWithReferences),
     TodoEntry> {
   $$TodoEntriesTableTableManager(_$AppDatabase db, $TodoEntriesTable table)
       : super(TableManagerState(
@@ -907,8 +908,9 @@ class $$TodoEntriesTableTableManager extends RootTableManager<
               $$TodoEntriesTableFilterComposer(ComposerState(db, table)),
           orderingComposer:
               $$TodoEntriesTableOrderingComposer(ComposerState(db, table)),
-          withReferenceMapper: (p0) =>
-              p0.map((e) => $$TodoEntriesTableWithReferences(db, e)).toList(),
+          withReferenceMapper: (p0) => p0
+              .map((e) => (e, $$TodoEntriesTableWithReferences(db, e)))
+              .toList(),
           updateCompanionCallback: ({
             Value<int> id = const Value.absent(),
             Value<String> description = const Value.absent(),
@@ -944,7 +946,7 @@ typedef $$TodoEntriesTableProcessedTableManager = ProcessedTableManager<
     $$TodoEntriesTableOrderingComposer,
     $$TodoEntriesTableCreateCompanionBuilder,
     $$TodoEntriesTableUpdateCompanionBuilder,
-    $$TodoEntriesTableWithReferences,
+    (TodoEntry, $$TodoEntriesTableWithReferences),
     TodoEntry>;
 
 class $$TodoEntriesTableFilterComposer
@@ -1012,13 +1014,13 @@ class $$TodoEntriesTableOrderingComposer
 class $$TodoEntriesTableWithReferences {
   // ignore: unused_field
   final _$AppDatabase _db;
-  final TodoEntry todoEntry;
-  $$TodoEntriesTableWithReferences(this._db, this.todoEntry);
+  final TodoEntry _item;
+  $$TodoEntriesTableWithReferences(this._db, this._item);
 
   $$CategoriesTableProcessedTableManager? get category {
-    if (todoEntry.category == null) return null;
+    if (_item.category == null) return null;
     return $$CategoriesTableTableManager(_db, _db.categories)
-        .filter((f) => f.id(todoEntry.category!));
+        .filter((f) => f.id(_item.category!));
   }
 }
 
@@ -1039,7 +1041,7 @@ class $TextEntriesTableManager extends RootTableManager<
     $TextEntriesOrderingComposer,
     $TextEntriesCreateCompanionBuilder,
     $TextEntriesUpdateCompanionBuilder,
-    $TextEntriesWithReferences,
+    (TextEntry, $TextEntriesWithReferences),
     TextEntry> {
   $TextEntriesTableManager(_$AppDatabase db, TextEntries table)
       : super(TableManagerState(
@@ -1050,7 +1052,7 @@ class $TextEntriesTableManager extends RootTableManager<
           orderingComposer:
               $TextEntriesOrderingComposer(ComposerState(db, table)),
           withReferenceMapper: (p0) =>
-              p0.map((e) => $TextEntriesWithReferences(db, e)).toList(),
+              p0.map((e) => (e, $TextEntriesWithReferences(db, e))).toList(),
           updateCompanionCallback: ({
             Value<String> description = const Value.absent(),
             Value<int> rowid = const Value.absent(),
@@ -1078,7 +1080,7 @@ typedef $TextEntriesProcessedTableManager = ProcessedTableManager<
     $TextEntriesOrderingComposer,
     $TextEntriesCreateCompanionBuilder,
     $TextEntriesUpdateCompanionBuilder,
-    $TextEntriesWithReferences,
+    (TextEntry, $TextEntriesWithReferences),
     TextEntry>;
 
 class $TextEntriesFilterComposer
@@ -1102,8 +1104,8 @@ class $TextEntriesOrderingComposer
 class $TextEntriesWithReferences {
   // ignore: unused_field
   final _$AppDatabase _db;
-  final TextEntry textEntry;
-  $TextEntriesWithReferences(this._db, this.textEntry);
+  final TextEntry _item;
+  $TextEntriesWithReferences(this._db, this._item);
 }
 
 class $AppDatabaseManager {

--- a/examples/app/lib/database/database.g.dart
+++ b/examples/app/lib/database/database.g.dart
@@ -762,7 +762,9 @@ class $$CategoriesTableTableManager extends RootTableManager<
     $$CategoriesTableFilterComposer,
     $$CategoriesTableOrderingComposer,
     $$CategoriesTableCreateCompanionBuilder,
-    $$CategoriesTableUpdateCompanionBuilder> {
+    $$CategoriesTableUpdateCompanionBuilder,
+    $$CategoriesTableWithReferences,
+    Category> {
   $$CategoriesTableTableManager(_$AppDatabase db, $CategoriesTable table)
       : super(TableManagerState(
           db: db,
@@ -771,6 +773,8 @@ class $$CategoriesTableTableManager extends RootTableManager<
               $$CategoriesTableFilterComposer(ComposerState(db, table)),
           orderingComposer:
               $$CategoriesTableOrderingComposer(ComposerState(db, table)),
+          dataclassMapper: (p0) async =>
+              p0.map((e) => $$CategoriesTableWithReferences(db, e)).toList(),
           updateCompanionCallback: ({
             Value<int> id = const Value.absent(),
             Value<String> name = const Value.absent(),
@@ -793,6 +797,17 @@ class $$CategoriesTableTableManager extends RootTableManager<
           ),
         ));
 }
+
+typedef $$CategoriesTableProcessedTableManager = ProcessedTableManager<
+    _$AppDatabase,
+    $CategoriesTable,
+    Category,
+    $$CategoriesTableFilterComposer,
+    $$CategoriesTableOrderingComposer,
+    $$CategoriesTableCreateCompanionBuilder,
+    $$CategoriesTableUpdateCompanionBuilder,
+    $$CategoriesTableWithReferences,
+    Category>;
 
 class $$CategoriesTableFilterComposer
     extends FilterComposer<_$AppDatabase, $CategoriesTable> {
@@ -847,6 +862,18 @@ class $$CategoriesTableOrderingComposer
           ColumnOrderings(column, joinBuilders: joinBuilders));
 }
 
+class $$CategoriesTableWithReferences {
+  // ignore: unused_field
+  final _$AppDatabase _db;
+  final Category category;
+  $$CategoriesTableWithReferences(this._db, this.category);
+
+  $$TodoEntriesTableProcessedTableManager get todoEntriesRefs {
+    return $$TodoEntriesTableTableManager(_db, _db.todoEntries)
+        .filter((f) => f.category.id(category.id));
+  }
+}
+
 typedef $$TodoEntriesTableCreateCompanionBuilder = TodoEntriesCompanion
     Function({
   Value<int> id,
@@ -869,7 +896,9 @@ class $$TodoEntriesTableTableManager extends RootTableManager<
     $$TodoEntriesTableFilterComposer,
     $$TodoEntriesTableOrderingComposer,
     $$TodoEntriesTableCreateCompanionBuilder,
-    $$TodoEntriesTableUpdateCompanionBuilder> {
+    $$TodoEntriesTableUpdateCompanionBuilder,
+    $$TodoEntriesTableWithReferences,
+    TodoEntry> {
   $$TodoEntriesTableTableManager(_$AppDatabase db, $TodoEntriesTable table)
       : super(TableManagerState(
           db: db,
@@ -878,6 +907,8 @@ class $$TodoEntriesTableTableManager extends RootTableManager<
               $$TodoEntriesTableFilterComposer(ComposerState(db, table)),
           orderingComposer:
               $$TodoEntriesTableOrderingComposer(ComposerState(db, table)),
+          dataclassMapper: (p0) async =>
+              p0.map((e) => $$TodoEntriesTableWithReferences(db, e)).toList(),
           updateCompanionCallback: ({
             Value<int> id = const Value.absent(),
             Value<String> description = const Value.absent(),
@@ -904,6 +935,17 @@ class $$TodoEntriesTableTableManager extends RootTableManager<
           ),
         ));
 }
+
+typedef $$TodoEntriesTableProcessedTableManager = ProcessedTableManager<
+    _$AppDatabase,
+    $TodoEntriesTable,
+    TodoEntry,
+    $$TodoEntriesTableFilterComposer,
+    $$TodoEntriesTableOrderingComposer,
+    $$TodoEntriesTableCreateCompanionBuilder,
+    $$TodoEntriesTableUpdateCompanionBuilder,
+    $$TodoEntriesTableWithReferences,
+    TodoEntry>;
 
 class $$TodoEntriesTableFilterComposer
     extends FilterComposer<_$AppDatabase, $TodoEntriesTable> {
@@ -967,6 +1009,19 @@ class $$TodoEntriesTableOrderingComposer
   }
 }
 
+class $$TodoEntriesTableWithReferences {
+  // ignore: unused_field
+  final _$AppDatabase _db;
+  final TodoEntry todoEntry;
+  $$TodoEntriesTableWithReferences(this._db, this.todoEntry);
+
+  $$CategoriesTableProcessedTableManager? get category {
+    if (todoEntry.category == null) return null;
+    return $$CategoriesTableTableManager(_db, _db.categories)
+        .filter((f) => f.id(todoEntry.category!));
+  }
+}
+
 typedef $TextEntriesCreateCompanionBuilder = TextEntriesCompanion Function({
   required String description,
   Value<int> rowid,
@@ -983,7 +1038,9 @@ class $TextEntriesTableManager extends RootTableManager<
     $TextEntriesFilterComposer,
     $TextEntriesOrderingComposer,
     $TextEntriesCreateCompanionBuilder,
-    $TextEntriesUpdateCompanionBuilder> {
+    $TextEntriesUpdateCompanionBuilder,
+    $TextEntriesWithReferences,
+    TextEntry> {
   $TextEntriesTableManager(_$AppDatabase db, TextEntries table)
       : super(TableManagerState(
           db: db,
@@ -992,6 +1049,8 @@ class $TextEntriesTableManager extends RootTableManager<
               $TextEntriesFilterComposer(ComposerState(db, table)),
           orderingComposer:
               $TextEntriesOrderingComposer(ComposerState(db, table)),
+          dataclassMapper: (p0) async =>
+              p0.map((e) => $TextEntriesWithReferences(db, e)).toList(),
           updateCompanionCallback: ({
             Value<String> description = const Value.absent(),
             Value<int> rowid = const Value.absent(),
@@ -1011,6 +1070,17 @@ class $TextEntriesTableManager extends RootTableManager<
         ));
 }
 
+typedef $TextEntriesProcessedTableManager = ProcessedTableManager<
+    _$AppDatabase,
+    TextEntries,
+    TextEntry,
+    $TextEntriesFilterComposer,
+    $TextEntriesOrderingComposer,
+    $TextEntriesCreateCompanionBuilder,
+    $TextEntriesUpdateCompanionBuilder,
+    $TextEntriesWithReferences,
+    TextEntry>;
+
 class $TextEntriesFilterComposer
     extends FilterComposer<_$AppDatabase, TextEntries> {
   $TextEntriesFilterComposer(super.$state);
@@ -1027,6 +1097,13 @@ class $TextEntriesOrderingComposer
       column: $state.table.description,
       builder: (column, joinBuilders) =>
           ColumnOrderings(column, joinBuilders: joinBuilders));
+}
+
+class $TextEntriesWithReferences {
+  // ignore: unused_field
+  final _$AppDatabase _db;
+  final TextEntry textEntry;
+  $TextEntriesWithReferences(this._db, this.textEntry);
 }
 
 class $AppDatabaseManager {

--- a/examples/app/lib/database/database.g.dart
+++ b/examples/app/lib/database/database.g.dart
@@ -755,6 +755,69 @@ typedef $$CategoriesTableUpdateCompanionBuilder = CategoriesCompanion Function({
   Value<Color> color,
 });
 
+class $$CategoriesTableFilterComposer
+    extends FilterComposer<_$AppDatabase, $CategoriesTable> {
+  $$CategoriesTableFilterComposer(super.$state);
+  ColumnFilters<int> get id => $state.composableBuilder(
+      column: $state.table.id,
+      builder: (column, joinBuilders) =>
+          ColumnFilters(column, joinBuilders: joinBuilders));
+
+  ColumnFilters<String> get name => $state.composableBuilder(
+      column: $state.table.name,
+      builder: (column, joinBuilders) =>
+          ColumnFilters(column, joinBuilders: joinBuilders));
+
+  ColumnWithTypeConverterFilters<Color, Color, int> get color =>
+      $state.composableBuilder(
+          column: $state.table.color,
+          builder: (column, joinBuilders) => ColumnWithTypeConverterFilters(
+              column,
+              joinBuilders: joinBuilders));
+
+  ComposableFilter todoEntriesRefs(
+      ComposableFilter Function($$TodoEntriesTableFilterComposer f) f) {
+    final $$TodoEntriesTableFilterComposer composer = $state.composerBuilder(
+        composer: this,
+        getCurrentColumn: (t) => t.id,
+        referencedTable: $state.db.todoEntries,
+        getReferencedColumn: (t) => t.category,
+        builder: (joinBuilder, parentComposers) =>
+            $$TodoEntriesTableFilterComposer(ComposerState($state.db,
+                $state.db.todoEntries, joinBuilder, parentComposers)));
+    return f(composer);
+  }
+}
+
+class $$CategoriesTableOrderingComposer
+    extends OrderingComposer<_$AppDatabase, $CategoriesTable> {
+  $$CategoriesTableOrderingComposer(super.$state);
+  ColumnOrderings<int> get id => $state.composableBuilder(
+      column: $state.table.id,
+      builder: (column, joinBuilders) =>
+          ColumnOrderings(column, joinBuilders: joinBuilders));
+
+  ColumnOrderings<String> get name => $state.composableBuilder(
+      column: $state.table.name,
+      builder: (column, joinBuilders) =>
+          ColumnOrderings(column, joinBuilders: joinBuilders));
+
+  ColumnOrderings<int> get color => $state.composableBuilder(
+      column: $state.table.color,
+      builder: (column, joinBuilders) =>
+          ColumnOrderings(column, joinBuilders: joinBuilders));
+}
+
+class $$CategoriesTableWithReferences
+    extends BaseWithReferences<_$AppDatabase, Category> {
+  $$CategoriesTableWithReferences(super.$_db, super.$_item);
+
+  $$TodoEntriesTableProcessedTableManager get todoEntriesRefs {
+    return $$TodoEntriesTableTableManager($_db, $_db.todoEntries)
+        .filter((f) => f.category.id($_item.id));
+  }
+}
+
 class $$CategoriesTableTableManager extends RootTableManager<
     _$AppDatabase,
     $CategoriesTable,
@@ -809,73 +872,6 @@ typedef $$CategoriesTableProcessedTableManager = ProcessedTableManager<
     $$CategoriesTableUpdateCompanionBuilder,
     (Category, $$CategoriesTableWithReferences),
     Category>;
-
-class $$CategoriesTableFilterComposer
-    extends FilterComposer<_$AppDatabase, $CategoriesTable> {
-  $$CategoriesTableFilterComposer(super.$state);
-  ColumnFilters<int> get id => $state.composableBuilder(
-      column: $state.table.id,
-      builder: (column, joinBuilders) =>
-          ColumnFilters(column, joinBuilders: joinBuilders));
-
-  ColumnFilters<String> get name => $state.composableBuilder(
-      column: $state.table.name,
-      builder: (column, joinBuilders) =>
-          ColumnFilters(column, joinBuilders: joinBuilders));
-
-  ColumnWithTypeConverterFilters<Color, Color, int> get color =>
-      $state.composableBuilder(
-          column: $state.table.color,
-          builder: (column, joinBuilders) => ColumnWithTypeConverterFilters(
-              column,
-              joinBuilders: joinBuilders));
-
-  ComposableFilter todoEntriesRefs(
-      ComposableFilter Function($$TodoEntriesTableFilterComposer f) f) {
-    final $$TodoEntriesTableFilterComposer composer = $state.composerBuilder(
-        composer: this,
-        getCurrentColumn: (t) => t.id,
-        referencedTable: $state.db.todoEntries,
-        getReferencedColumn: (t) => t.category,
-        builder: (joinBuilder, parentComposers) =>
-            $$TodoEntriesTableFilterComposer(ComposerState($state.db,
-                $state.db.todoEntries, joinBuilder, parentComposers)));
-    return f(composer);
-  }
-}
-
-class $$CategoriesTableOrderingComposer
-    extends OrderingComposer<_$AppDatabase, $CategoriesTable> {
-  $$CategoriesTableOrderingComposer(super.$state);
-  ColumnOrderings<int> get id => $state.composableBuilder(
-      column: $state.table.id,
-      builder: (column, joinBuilders) =>
-          ColumnOrderings(column, joinBuilders: joinBuilders));
-
-  ColumnOrderings<String> get name => $state.composableBuilder(
-      column: $state.table.name,
-      builder: (column, joinBuilders) =>
-          ColumnOrderings(column, joinBuilders: joinBuilders));
-
-  ColumnOrderings<int> get color => $state.composableBuilder(
-      column: $state.table.color,
-      builder: (column, joinBuilders) =>
-          ColumnOrderings(column, joinBuilders: joinBuilders));
-}
-
-class $$CategoriesTableWithReferences {
-  // ignore: unused_field
-  final _$AppDatabase _db;
-  // ignore: unused_field
-  final Category _item;
-  $$CategoriesTableWithReferences(this._db, this._item);
-
-  $$TodoEntriesTableProcessedTableManager get todoEntriesRefs {
-    return $$TodoEntriesTableTableManager(_db, _db.todoEntries)
-        .filter((f) => f.category.id(_item.id));
-  }
-}
-
 typedef $$TodoEntriesTableCreateCompanionBuilder = TodoEntriesCompanion
     Function({
   Value<int> id,
@@ -890,65 +886,6 @@ typedef $$TodoEntriesTableUpdateCompanionBuilder = TodoEntriesCompanion
   Value<int?> category,
   Value<DateTime?> dueDate,
 });
-
-class $$TodoEntriesTableTableManager extends RootTableManager<
-    _$AppDatabase,
-    $TodoEntriesTable,
-    TodoEntry,
-    $$TodoEntriesTableFilterComposer,
-    $$TodoEntriesTableOrderingComposer,
-    $$TodoEntriesTableCreateCompanionBuilder,
-    $$TodoEntriesTableUpdateCompanionBuilder,
-    (TodoEntry, $$TodoEntriesTableWithReferences),
-    TodoEntry> {
-  $$TodoEntriesTableTableManager(_$AppDatabase db, $TodoEntriesTable table)
-      : super(TableManagerState(
-          db: db,
-          table: table,
-          filteringComposer:
-              $$TodoEntriesTableFilterComposer(ComposerState(db, table)),
-          orderingComposer:
-              $$TodoEntriesTableOrderingComposer(ComposerState(db, table)),
-          withReferenceMapper: (p0) => p0
-              .map((e) => (e, $$TodoEntriesTableWithReferences(db, e)))
-              .toList(),
-          updateCompanionCallback: ({
-            Value<int> id = const Value.absent(),
-            Value<String> description = const Value.absent(),
-            Value<int?> category = const Value.absent(),
-            Value<DateTime?> dueDate = const Value.absent(),
-          }) =>
-              TodoEntriesCompanion(
-            id: id,
-            description: description,
-            category: category,
-            dueDate: dueDate,
-          ),
-          createCompanionCallback: ({
-            Value<int> id = const Value.absent(),
-            required String description,
-            Value<int?> category = const Value.absent(),
-            Value<DateTime?> dueDate = const Value.absent(),
-          }) =>
-              TodoEntriesCompanion.insert(
-            id: id,
-            description: description,
-            category: category,
-            dueDate: dueDate,
-          ),
-        ));
-}
-
-typedef $$TodoEntriesTableProcessedTableManager = ProcessedTableManager<
-    _$AppDatabase,
-    $TodoEntriesTable,
-    TodoEntry,
-    $$TodoEntriesTableFilterComposer,
-    $$TodoEntriesTableOrderingComposer,
-    $$TodoEntriesTableCreateCompanionBuilder,
-    $$TodoEntriesTableUpdateCompanionBuilder,
-    (TodoEntry, $$TodoEntriesTableWithReferences),
-    TodoEntry>;
 
 class $$TodoEntriesTableFilterComposer
     extends FilterComposer<_$AppDatabase, $TodoEntriesTable> {
@@ -1012,20 +949,75 @@ class $$TodoEntriesTableOrderingComposer
   }
 }
 
-class $$TodoEntriesTableWithReferences {
-  // ignore: unused_field
-  final _$AppDatabase _db;
-  // ignore: unused_field
-  final TodoEntry _item;
-  $$TodoEntriesTableWithReferences(this._db, this._item);
+class $$TodoEntriesTableWithReferences
+    extends BaseWithReferences<_$AppDatabase, TodoEntry> {
+  $$TodoEntriesTableWithReferences(super.$_db, super.$_item);
 
   $$CategoriesTableProcessedTableManager? get category {
-    if (_item.category == null) return null;
-    return $$CategoriesTableTableManager(_db, _db.categories)
-        .filter((f) => f.id(_item.category!));
+    if ($_item.category == null) return null;
+    return $$CategoriesTableTableManager($_db, $_db.categories)
+        .filter((f) => f.id($_item.category!));
   }
 }
 
+class $$TodoEntriesTableTableManager extends RootTableManager<
+    _$AppDatabase,
+    $TodoEntriesTable,
+    TodoEntry,
+    $$TodoEntriesTableFilterComposer,
+    $$TodoEntriesTableOrderingComposer,
+    $$TodoEntriesTableCreateCompanionBuilder,
+    $$TodoEntriesTableUpdateCompanionBuilder,
+    (TodoEntry, $$TodoEntriesTableWithReferences),
+    TodoEntry> {
+  $$TodoEntriesTableTableManager(_$AppDatabase db, $TodoEntriesTable table)
+      : super(TableManagerState(
+          db: db,
+          table: table,
+          filteringComposer:
+              $$TodoEntriesTableFilterComposer(ComposerState(db, table)),
+          orderingComposer:
+              $$TodoEntriesTableOrderingComposer(ComposerState(db, table)),
+          withReferenceMapper: (p0) => p0
+              .map((e) => (e, $$TodoEntriesTableWithReferences(db, e)))
+              .toList(),
+          updateCompanionCallback: ({
+            Value<int> id = const Value.absent(),
+            Value<String> description = const Value.absent(),
+            Value<int?> category = const Value.absent(),
+            Value<DateTime?> dueDate = const Value.absent(),
+          }) =>
+              TodoEntriesCompanion(
+            id: id,
+            description: description,
+            category: category,
+            dueDate: dueDate,
+          ),
+          createCompanionCallback: ({
+            Value<int> id = const Value.absent(),
+            required String description,
+            Value<int?> category = const Value.absent(),
+            Value<DateTime?> dueDate = const Value.absent(),
+          }) =>
+              TodoEntriesCompanion.insert(
+            id: id,
+            description: description,
+            category: category,
+            dueDate: dueDate,
+          ),
+        ));
+}
+
+typedef $$TodoEntriesTableProcessedTableManager = ProcessedTableManager<
+    _$AppDatabase,
+    $TodoEntriesTable,
+    TodoEntry,
+    $$TodoEntriesTableFilterComposer,
+    $$TodoEntriesTableOrderingComposer,
+    $$TodoEntriesTableCreateCompanionBuilder,
+    $$TodoEntriesTableUpdateCompanionBuilder,
+    (TodoEntry, $$TodoEntriesTableWithReferences),
+    TodoEntry>;
 typedef $TextEntriesCreateCompanionBuilder = TextEntriesCompanion Function({
   required String description,
   Value<int> rowid,
@@ -1035,6 +1027,24 @@ typedef $TextEntriesUpdateCompanionBuilder = TextEntriesCompanion Function({
   Value<int> rowid,
 });
 
+class $TextEntriesFilterComposer
+    extends FilterComposer<_$AppDatabase, TextEntries> {
+  $TextEntriesFilterComposer(super.$state);
+  ColumnFilters<String> get description => $state.composableBuilder(
+      column: $state.table.description,
+      builder: (column, joinBuilders) =>
+          ColumnFilters(column, joinBuilders: joinBuilders));
+}
+
+class $TextEntriesOrderingComposer
+    extends OrderingComposer<_$AppDatabase, TextEntries> {
+  $TextEntriesOrderingComposer(super.$state);
+  ColumnOrderings<String> get description => $state.composableBuilder(
+      column: $state.table.description,
+      builder: (column, joinBuilders) =>
+          ColumnOrderings(column, joinBuilders: joinBuilders));
+}
+
 class $TextEntriesTableManager extends RootTableManager<
     _$AppDatabase,
     TextEntries,
@@ -1043,7 +1053,7 @@ class $TextEntriesTableManager extends RootTableManager<
     $TextEntriesOrderingComposer,
     $TextEntriesCreateCompanionBuilder,
     $TextEntriesUpdateCompanionBuilder,
-    (TextEntry, $TextEntriesWithReferences),
+    (TextEntry, BaseWithReferences<_$AppDatabase, TextEntry>),
     TextEntry> {
   $TextEntriesTableManager(_$AppDatabase db, TextEntries table)
       : super(TableManagerState(
@@ -1054,7 +1064,7 @@ class $TextEntriesTableManager extends RootTableManager<
           orderingComposer:
               $TextEntriesOrderingComposer(ComposerState(db, table)),
           withReferenceMapper: (p0) =>
-              p0.map((e) => (e, $TextEntriesWithReferences(db, e))).toList(),
+              p0.map((e) => (e, BaseWithReferences(db, e))).toList(),
           updateCompanionCallback: ({
             Value<String> description = const Value.absent(),
             Value<int> rowid = const Value.absent(),
@@ -1082,34 +1092,8 @@ typedef $TextEntriesProcessedTableManager = ProcessedTableManager<
     $TextEntriesOrderingComposer,
     $TextEntriesCreateCompanionBuilder,
     $TextEntriesUpdateCompanionBuilder,
-    (TextEntry, $TextEntriesWithReferences),
+    (TextEntry, BaseWithReferences<_$AppDatabase, TextEntry>),
     TextEntry>;
-
-class $TextEntriesFilterComposer
-    extends FilterComposer<_$AppDatabase, TextEntries> {
-  $TextEntriesFilterComposer(super.$state);
-  ColumnFilters<String> get description => $state.composableBuilder(
-      column: $state.table.description,
-      builder: (column, joinBuilders) =>
-          ColumnFilters(column, joinBuilders: joinBuilders));
-}
-
-class $TextEntriesOrderingComposer
-    extends OrderingComposer<_$AppDatabase, TextEntries> {
-  $TextEntriesOrderingComposer(super.$state);
-  ColumnOrderings<String> get description => $state.composableBuilder(
-      column: $state.table.description,
-      builder: (column, joinBuilders) =>
-          ColumnOrderings(column, joinBuilders: joinBuilders));
-}
-
-class $TextEntriesWithReferences {
-  // ignore: unused_field
-  final _$AppDatabase _db;
-  // ignore: unused_field
-  final TextEntry _item;
-  $TextEntriesWithReferences(this._db, this._item);
-}
 
 class $AppDatabaseManager {
   final _$AppDatabase _db;

--- a/examples/app/lib/database/database.g.dart
+++ b/examples/app/lib/database/database.g.dart
@@ -866,6 +866,7 @@ class $$CategoriesTableOrderingComposer
 class $$CategoriesTableWithReferences {
   // ignore: unused_field
   final _$AppDatabase _db;
+  // ignore: unused_field
   final Category _item;
   $$CategoriesTableWithReferences(this._db, this._item);
 
@@ -1014,6 +1015,7 @@ class $$TodoEntriesTableOrderingComposer
 class $$TodoEntriesTableWithReferences {
   // ignore: unused_field
   final _$AppDatabase _db;
+  // ignore: unused_field
   final TodoEntry _item;
   $$TodoEntriesTableWithReferences(this._db, this._item);
 
@@ -1104,6 +1106,7 @@ class $TextEntriesOrderingComposer
 class $TextEntriesWithReferences {
   // ignore: unused_field
   final _$AppDatabase _db;
+  // ignore: unused_field
   final TextEntry _item;
   $TextEntriesWithReferences(this._db, this._item);
 }

--- a/examples/encryption/lib/database.g.dart
+++ b/examples/encryption/lib/database.g.dart
@@ -207,7 +207,9 @@ class $$NotesTableTableManager extends RootTableManager<
     $$NotesTableFilterComposer,
     $$NotesTableOrderingComposer,
     $$NotesTableCreateCompanionBuilder,
-    $$NotesTableUpdateCompanionBuilder> {
+    $$NotesTableUpdateCompanionBuilder,
+    $$NotesTableWithReferences,
+    Note> {
   $$NotesTableTableManager(_$MyEncryptedDatabase db, $NotesTable table)
       : super(TableManagerState(
           db: db,
@@ -216,6 +218,8 @@ class $$NotesTableTableManager extends RootTableManager<
               $$NotesTableFilterComposer(ComposerState(db, table)),
           orderingComposer:
               $$NotesTableOrderingComposer(ComposerState(db, table)),
+          dataclassMapper: (p0) async =>
+              p0.map((e) => $$NotesTableWithReferences(db, e)).toList(),
           updateCompanionCallback: ({
             Value<int> id = const Value.absent(),
             Value<String> content = const Value.absent(),
@@ -234,6 +238,17 @@ class $$NotesTableTableManager extends RootTableManager<
           ),
         ));
 }
+
+typedef $$NotesTableProcessedTableManager = ProcessedTableManager<
+    _$MyEncryptedDatabase,
+    $NotesTable,
+    Note,
+    $$NotesTableFilterComposer,
+    $$NotesTableOrderingComposer,
+    $$NotesTableCreateCompanionBuilder,
+    $$NotesTableUpdateCompanionBuilder,
+    $$NotesTableWithReferences,
+    Note>;
 
 class $$NotesTableFilterComposer
     extends FilterComposer<_$MyEncryptedDatabase, $NotesTable> {
@@ -261,6 +276,13 @@ class $$NotesTableOrderingComposer
       column: $state.table.content,
       builder: (column, joinBuilders) =>
           ColumnOrderings(column, joinBuilders: joinBuilders));
+}
+
+class $$NotesTableWithReferences {
+  // ignore: unused_field
+  final _$MyEncryptedDatabase _db;
+  final Note note;
+  $$NotesTableWithReferences(this._db, this.note);
 }
 
 class $MyEncryptedDatabaseManager {

--- a/examples/encryption/lib/database.g.dart
+++ b/examples/encryption/lib/database.g.dart
@@ -208,7 +208,7 @@ class $$NotesTableTableManager extends RootTableManager<
     $$NotesTableOrderingComposer,
     $$NotesTableCreateCompanionBuilder,
     $$NotesTableUpdateCompanionBuilder,
-    $$NotesTableWithReferences,
+    (Note, $$NotesTableWithReferences),
     Note> {
   $$NotesTableTableManager(_$MyEncryptedDatabase db, $NotesTable table)
       : super(TableManagerState(
@@ -219,7 +219,7 @@ class $$NotesTableTableManager extends RootTableManager<
           orderingComposer:
               $$NotesTableOrderingComposer(ComposerState(db, table)),
           withReferenceMapper: (p0) =>
-              p0.map((e) => $$NotesTableWithReferences(db, e)).toList(),
+              p0.map((e) => (e, $$NotesTableWithReferences(db, e))).toList(),
           updateCompanionCallback: ({
             Value<int> id = const Value.absent(),
             Value<String> content = const Value.absent(),
@@ -247,7 +247,7 @@ typedef $$NotesTableProcessedTableManager = ProcessedTableManager<
     $$NotesTableOrderingComposer,
     $$NotesTableCreateCompanionBuilder,
     $$NotesTableUpdateCompanionBuilder,
-    $$NotesTableWithReferences,
+    (Note, $$NotesTableWithReferences),
     Note>;
 
 class $$NotesTableFilterComposer
@@ -281,8 +281,8 @@ class $$NotesTableOrderingComposer
 class $$NotesTableWithReferences {
   // ignore: unused_field
   final _$MyEncryptedDatabase _db;
-  final Note note;
-  $$NotesTableWithReferences(this._db, this.note);
+  final Note _item;
+  $$NotesTableWithReferences(this._db, this._item);
 }
 
 class $MyEncryptedDatabaseManager {

--- a/examples/encryption/lib/database.g.dart
+++ b/examples/encryption/lib/database.g.dart
@@ -281,6 +281,7 @@ class $$NotesTableOrderingComposer
 class $$NotesTableWithReferences {
   // ignore: unused_field
   final _$MyEncryptedDatabase _db;
+  // ignore: unused_field
   final Note _item;
   $$NotesTableWithReferences(this._db, this._item);
 }

--- a/examples/encryption/lib/database.g.dart
+++ b/examples/encryption/lib/database.g.dart
@@ -218,7 +218,7 @@ class $$NotesTableTableManager extends RootTableManager<
               $$NotesTableFilterComposer(ComposerState(db, table)),
           orderingComposer:
               $$NotesTableOrderingComposer(ComposerState(db, table)),
-          dataclassMapper: (p0) async =>
+          withReferenceMapper: (p0) =>
               p0.map((e) => $$NotesTableWithReferences(db, e)).toList(),
           updateCompanionCallback: ({
             Value<int> id = const Value.absent(),

--- a/examples/encryption/lib/database.g.dart
+++ b/examples/encryption/lib/database.g.dart
@@ -200,56 +200,6 @@ typedef $$NotesTableUpdateCompanionBuilder = NotesCompanion Function({
   Value<String> content,
 });
 
-class $$NotesTableTableManager extends RootTableManager<
-    _$MyEncryptedDatabase,
-    $NotesTable,
-    Note,
-    $$NotesTableFilterComposer,
-    $$NotesTableOrderingComposer,
-    $$NotesTableCreateCompanionBuilder,
-    $$NotesTableUpdateCompanionBuilder,
-    (Note, $$NotesTableWithReferences),
-    Note> {
-  $$NotesTableTableManager(_$MyEncryptedDatabase db, $NotesTable table)
-      : super(TableManagerState(
-          db: db,
-          table: table,
-          filteringComposer:
-              $$NotesTableFilterComposer(ComposerState(db, table)),
-          orderingComposer:
-              $$NotesTableOrderingComposer(ComposerState(db, table)),
-          withReferenceMapper: (p0) =>
-              p0.map((e) => (e, $$NotesTableWithReferences(db, e))).toList(),
-          updateCompanionCallback: ({
-            Value<int> id = const Value.absent(),
-            Value<String> content = const Value.absent(),
-          }) =>
-              NotesCompanion(
-            id: id,
-            content: content,
-          ),
-          createCompanionCallback: ({
-            Value<int> id = const Value.absent(),
-            required String content,
-          }) =>
-              NotesCompanion.insert(
-            id: id,
-            content: content,
-          ),
-        ));
-}
-
-typedef $$NotesTableProcessedTableManager = ProcessedTableManager<
-    _$MyEncryptedDatabase,
-    $NotesTable,
-    Note,
-    $$NotesTableFilterComposer,
-    $$NotesTableOrderingComposer,
-    $$NotesTableCreateCompanionBuilder,
-    $$NotesTableUpdateCompanionBuilder,
-    (Note, $$NotesTableWithReferences),
-    Note>;
-
 class $$NotesTableFilterComposer
     extends FilterComposer<_$MyEncryptedDatabase, $NotesTable> {
   $$NotesTableFilterComposer(super.$state);
@@ -278,13 +228,55 @@ class $$NotesTableOrderingComposer
           ColumnOrderings(column, joinBuilders: joinBuilders));
 }
 
-class $$NotesTableWithReferences {
-  // ignore: unused_field
-  final _$MyEncryptedDatabase _db;
-  // ignore: unused_field
-  final Note _item;
-  $$NotesTableWithReferences(this._db, this._item);
+class $$NotesTableTableManager extends RootTableManager<
+    _$MyEncryptedDatabase,
+    $NotesTable,
+    Note,
+    $$NotesTableFilterComposer,
+    $$NotesTableOrderingComposer,
+    $$NotesTableCreateCompanionBuilder,
+    $$NotesTableUpdateCompanionBuilder,
+    (Note, BaseWithReferences<_$MyEncryptedDatabase, Note>),
+    Note> {
+  $$NotesTableTableManager(_$MyEncryptedDatabase db, $NotesTable table)
+      : super(TableManagerState(
+          db: db,
+          table: table,
+          filteringComposer:
+              $$NotesTableFilterComposer(ComposerState(db, table)),
+          orderingComposer:
+              $$NotesTableOrderingComposer(ComposerState(db, table)),
+          withReferenceMapper: (p0) =>
+              p0.map((e) => (e, BaseWithReferences(db, e))).toList(),
+          updateCompanionCallback: ({
+            Value<int> id = const Value.absent(),
+            Value<String> content = const Value.absent(),
+          }) =>
+              NotesCompanion(
+            id: id,
+            content: content,
+          ),
+          createCompanionCallback: ({
+            Value<int> id = const Value.absent(),
+            required String content,
+          }) =>
+              NotesCompanion.insert(
+            id: id,
+            content: content,
+          ),
+        ));
 }
+
+typedef $$NotesTableProcessedTableManager = ProcessedTableManager<
+    _$MyEncryptedDatabase,
+    $NotesTable,
+    Note,
+    $$NotesTableFilterComposer,
+    $$NotesTableOrderingComposer,
+    $$NotesTableCreateCompanionBuilder,
+    $$NotesTableUpdateCompanionBuilder,
+    (Note, BaseWithReferences<_$MyEncryptedDatabase, Note>),
+    Note>;
 
 class $MyEncryptedDatabaseManager {
   final _$MyEncryptedDatabase _db;

--- a/examples/flutter_web_worker_example/lib/src/database/database.g.dart
+++ b/examples/flutter_web_worker_example/lib/src/database/database.g.dart
@@ -239,7 +239,7 @@ class $EntriesTableManager extends RootTableManager<
           table: table,
           filteringComposer: $EntriesFilterComposer(ComposerState(db, table)),
           orderingComposer: $EntriesOrderingComposer(ComposerState(db, table)),
-          dataclassMapper: (p0) async =>
+          withReferenceMapper: (p0) =>
               p0.map((e) => $EntriesWithReferences(db, e)).toList(),
           updateCompanionCallback: ({
             Value<int> id = const Value.absent(),

--- a/examples/flutter_web_worker_example/lib/src/database/database.g.dart
+++ b/examples/flutter_web_worker_example/lib/src/database/database.g.dart
@@ -230,13 +230,17 @@ class $EntriesTableManager extends RootTableManager<
     $EntriesFilterComposer,
     $EntriesOrderingComposer,
     $EntriesCreateCompanionBuilder,
-    $EntriesUpdateCompanionBuilder> {
+    $EntriesUpdateCompanionBuilder,
+    $EntriesWithReferences,
+    Entry> {
   $EntriesTableManager(_$MyDatabase db, Entries table)
       : super(TableManagerState(
           db: db,
           table: table,
           filteringComposer: $EntriesFilterComposer(ComposerState(db, table)),
           orderingComposer: $EntriesOrderingComposer(ComposerState(db, table)),
+          dataclassMapper: (p0) async =>
+              p0.map((e) => $EntriesWithReferences(db, e)).toList(),
           updateCompanionCallback: ({
             Value<int> id = const Value.absent(),
             Value<String> value = const Value.absent(),
@@ -255,6 +259,17 @@ class $EntriesTableManager extends RootTableManager<
           ),
         ));
 }
+
+typedef $EntriesProcessedTableManager = ProcessedTableManager<
+    _$MyDatabase,
+    Entries,
+    Entry,
+    $EntriesFilterComposer,
+    $EntriesOrderingComposer,
+    $EntriesCreateCompanionBuilder,
+    $EntriesUpdateCompanionBuilder,
+    $EntriesWithReferences,
+    Entry>;
 
 class $EntriesFilterComposer extends FilterComposer<_$MyDatabase, Entries> {
   $EntriesFilterComposer(super.$state);
@@ -280,6 +295,13 @@ class $EntriesOrderingComposer extends OrderingComposer<_$MyDatabase, Entries> {
       column: $state.table.value,
       builder: (column, joinBuilders) =>
           ColumnOrderings(column, joinBuilders: joinBuilders));
+}
+
+class $EntriesWithReferences {
+  // ignore: unused_field
+  final _$MyDatabase _db;
+  final Entry entry;
+  $EntriesWithReferences(this._db, this.entry);
 }
 
 class $MyDatabaseManager {

--- a/examples/flutter_web_worker_example/lib/src/database/database.g.dart
+++ b/examples/flutter_web_worker_example/lib/src/database/database.g.dart
@@ -300,6 +300,7 @@ class $EntriesOrderingComposer extends OrderingComposer<_$MyDatabase, Entries> {
 class $EntriesWithReferences {
   // ignore: unused_field
   final _$MyDatabase _db;
+  // ignore: unused_field
   final Entry _item;
   $EntriesWithReferences(this._db, this._item);
 }

--- a/examples/flutter_web_worker_example/lib/src/database/database.g.dart
+++ b/examples/flutter_web_worker_example/lib/src/database/database.g.dart
@@ -231,7 +231,7 @@ class $EntriesTableManager extends RootTableManager<
     $EntriesOrderingComposer,
     $EntriesCreateCompanionBuilder,
     $EntriesUpdateCompanionBuilder,
-    $EntriesWithReferences,
+    (Entry, $EntriesWithReferences),
     Entry> {
   $EntriesTableManager(_$MyDatabase db, Entries table)
       : super(TableManagerState(
@@ -240,7 +240,7 @@ class $EntriesTableManager extends RootTableManager<
           filteringComposer: $EntriesFilterComposer(ComposerState(db, table)),
           orderingComposer: $EntriesOrderingComposer(ComposerState(db, table)),
           withReferenceMapper: (p0) =>
-              p0.map((e) => $EntriesWithReferences(db, e)).toList(),
+              p0.map((e) => (e, $EntriesWithReferences(db, e))).toList(),
           updateCompanionCallback: ({
             Value<int> id = const Value.absent(),
             Value<String> value = const Value.absent(),
@@ -268,7 +268,7 @@ typedef $EntriesProcessedTableManager = ProcessedTableManager<
     $EntriesOrderingComposer,
     $EntriesCreateCompanionBuilder,
     $EntriesUpdateCompanionBuilder,
-    $EntriesWithReferences,
+    (Entry, $EntriesWithReferences),
     Entry>;
 
 class $EntriesFilterComposer extends FilterComposer<_$MyDatabase, Entries> {
@@ -300,8 +300,8 @@ class $EntriesOrderingComposer extends OrderingComposer<_$MyDatabase, Entries> {
 class $EntriesWithReferences {
   // ignore: unused_field
   final _$MyDatabase _db;
-  final Entry entry;
-  $EntriesWithReferences(this._db, this.entry);
+  final Entry _item;
+  $EntriesWithReferences(this._db, this._item);
 }
 
 class $MyDatabaseManager {

--- a/examples/flutter_web_worker_example/lib/src/database/database.g.dart
+++ b/examples/flutter_web_worker_example/lib/src/database/database.g.dart
@@ -223,6 +223,32 @@ typedef $EntriesUpdateCompanionBuilder = EntriesCompanion Function({
   Value<String> value,
 });
 
+class $EntriesFilterComposer extends FilterComposer<_$MyDatabase, Entries> {
+  $EntriesFilterComposer(super.$state);
+  ColumnFilters<int> get id => $state.composableBuilder(
+      column: $state.table.id,
+      builder: (column, joinBuilders) =>
+          ColumnFilters(column, joinBuilders: joinBuilders));
+
+  ColumnFilters<String> get value => $state.composableBuilder(
+      column: $state.table.value,
+      builder: (column, joinBuilders) =>
+          ColumnFilters(column, joinBuilders: joinBuilders));
+}
+
+class $EntriesOrderingComposer extends OrderingComposer<_$MyDatabase, Entries> {
+  $EntriesOrderingComposer(super.$state);
+  ColumnOrderings<int> get id => $state.composableBuilder(
+      column: $state.table.id,
+      builder: (column, joinBuilders) =>
+          ColumnOrderings(column, joinBuilders: joinBuilders));
+
+  ColumnOrderings<String> get value => $state.composableBuilder(
+      column: $state.table.value,
+      builder: (column, joinBuilders) =>
+          ColumnOrderings(column, joinBuilders: joinBuilders));
+}
+
 class $EntriesTableManager extends RootTableManager<
     _$MyDatabase,
     Entries,
@@ -231,7 +257,7 @@ class $EntriesTableManager extends RootTableManager<
     $EntriesOrderingComposer,
     $EntriesCreateCompanionBuilder,
     $EntriesUpdateCompanionBuilder,
-    (Entry, $EntriesWithReferences),
+    (Entry, BaseWithReferences<_$MyDatabase, Entry>),
     Entry> {
   $EntriesTableManager(_$MyDatabase db, Entries table)
       : super(TableManagerState(
@@ -240,7 +266,7 @@ class $EntriesTableManager extends RootTableManager<
           filteringComposer: $EntriesFilterComposer(ComposerState(db, table)),
           orderingComposer: $EntriesOrderingComposer(ComposerState(db, table)),
           withReferenceMapper: (p0) =>
-              p0.map((e) => (e, $EntriesWithReferences(db, e))).toList(),
+              p0.map((e) => (e, BaseWithReferences(db, e))).toList(),
           updateCompanionCallback: ({
             Value<int> id = const Value.absent(),
             Value<String> value = const Value.absent(),
@@ -268,42 +294,8 @@ typedef $EntriesProcessedTableManager = ProcessedTableManager<
     $EntriesOrderingComposer,
     $EntriesCreateCompanionBuilder,
     $EntriesUpdateCompanionBuilder,
-    (Entry, $EntriesWithReferences),
+    (Entry, BaseWithReferences<_$MyDatabase, Entry>),
     Entry>;
-
-class $EntriesFilterComposer extends FilterComposer<_$MyDatabase, Entries> {
-  $EntriesFilterComposer(super.$state);
-  ColumnFilters<int> get id => $state.composableBuilder(
-      column: $state.table.id,
-      builder: (column, joinBuilders) =>
-          ColumnFilters(column, joinBuilders: joinBuilders));
-
-  ColumnFilters<String> get value => $state.composableBuilder(
-      column: $state.table.value,
-      builder: (column, joinBuilders) =>
-          ColumnFilters(column, joinBuilders: joinBuilders));
-}
-
-class $EntriesOrderingComposer extends OrderingComposer<_$MyDatabase, Entries> {
-  $EntriesOrderingComposer(super.$state);
-  ColumnOrderings<int> get id => $state.composableBuilder(
-      column: $state.table.id,
-      builder: (column, joinBuilders) =>
-          ColumnOrderings(column, joinBuilders: joinBuilders));
-
-  ColumnOrderings<String> get value => $state.composableBuilder(
-      column: $state.table.value,
-      builder: (column, joinBuilders) =>
-          ColumnOrderings(column, joinBuilders: joinBuilders));
-}
-
-class $EntriesWithReferences {
-  // ignore: unused_field
-  final _$MyDatabase _db;
-  // ignore: unused_field
-  final Entry _item;
-  $EntriesWithReferences(this._db, this._item);
-}
 
 class $MyDatabaseManager {
   final _$MyDatabase _db;

--- a/examples/migrations_example/lib/database.g.dart
+++ b/examples/migrations_example/lib/database.g.dart
@@ -949,7 +949,9 @@ class $$UsersTableTableManager extends RootTableManager<
     $$UsersTableFilterComposer,
     $$UsersTableOrderingComposer,
     $$UsersTableCreateCompanionBuilder,
-    $$UsersTableUpdateCompanionBuilder> {
+    $$UsersTableUpdateCompanionBuilder,
+    $$UsersTableWithReferences,
+    User> {
   $$UsersTableTableManager(_$Database db, $UsersTable table)
       : super(TableManagerState(
           db: db,
@@ -958,6 +960,8 @@ class $$UsersTableTableManager extends RootTableManager<
               $$UsersTableFilterComposer(ComposerState(db, table)),
           orderingComposer:
               $$UsersTableOrderingComposer(ComposerState(db, table)),
+          dataclassMapper: (p0) async =>
+              p0.map((e) => $$UsersTableWithReferences(db, e)).toList(),
           updateCompanionCallback: ({
             Value<int> id = const Value.absent(),
             Value<String> name = const Value.absent(),
@@ -984,6 +988,17 @@ class $$UsersTableTableManager extends RootTableManager<
           ),
         ));
 }
+
+typedef $$UsersTableProcessedTableManager = ProcessedTableManager<
+    _$Database,
+    $UsersTable,
+    User,
+    $$UsersTableFilterComposer,
+    $$UsersTableOrderingComposer,
+    $$UsersTableCreateCompanionBuilder,
+    $$UsersTableUpdateCompanionBuilder,
+    $$UsersTableWithReferences,
+    User>;
 
 class $$UsersTableFilterComposer
     extends FilterComposer<_$Database, $UsersTable> {
@@ -1060,6 +1075,24 @@ class $$UsersTableOrderingComposer
   }
 }
 
+class $$UsersTableWithReferences {
+  // ignore: unused_field
+  final _$Database _db;
+  final User user;
+  $$UsersTableWithReferences(this._db, this.user);
+
+  $$UsersTableProcessedTableManager? get nextUser {
+    if (user.nextUser == null) return null;
+    return $$UsersTableTableManager(_db, _db.users)
+        .filter((f) => f.id(user.nextUser!));
+  }
+
+  $GroupsProcessedTableManager get groupsRefs {
+    return $GroupsTableManager(_db, _db.groups)
+        .filter((f) => f.owner.id(user.id));
+  }
+}
+
 typedef $GroupsCreateCompanionBuilder = GroupsCompanion Function({
   Value<int> id,
   required String title,
@@ -1080,13 +1113,17 @@ class $GroupsTableManager extends RootTableManager<
     $GroupsFilterComposer,
     $GroupsOrderingComposer,
     $GroupsCreateCompanionBuilder,
-    $GroupsUpdateCompanionBuilder> {
+    $GroupsUpdateCompanionBuilder,
+    $GroupsWithReferences,
+    Group> {
   $GroupsTableManager(_$Database db, Groups table)
       : super(TableManagerState(
           db: db,
           table: table,
           filteringComposer: $GroupsFilterComposer(ComposerState(db, table)),
           orderingComposer: $GroupsOrderingComposer(ComposerState(db, table)),
+          dataclassMapper: (p0) async =>
+              p0.map((e) => $GroupsWithReferences(db, e)).toList(),
           updateCompanionCallback: ({
             Value<int> id = const Value.absent(),
             Value<String> title = const Value.absent(),
@@ -1113,6 +1150,17 @@ class $GroupsTableManager extends RootTableManager<
           ),
         ));
 }
+
+typedef $GroupsProcessedTableManager = ProcessedTableManager<
+    _$Database,
+    Groups,
+    Group,
+    $GroupsFilterComposer,
+    $GroupsOrderingComposer,
+    $GroupsCreateCompanionBuilder,
+    $GroupsUpdateCompanionBuilder,
+    $GroupsWithReferences,
+    Group>;
 
 class $GroupsFilterComposer extends FilterComposer<_$Database, Groups> {
   $GroupsFilterComposer(super.$state);
@@ -1174,6 +1222,19 @@ class $GroupsOrderingComposer extends OrderingComposer<_$Database, Groups> {
   }
 }
 
+class $GroupsWithReferences {
+  // ignore: unused_field
+  final _$Database _db;
+  final Group group;
+  $GroupsWithReferences(this._db, this.group);
+
+  $$UsersTableProcessedTableManager? get owner {
+    if (group.owner == null) return null;
+    return $$UsersTableTableManager(_db, _db.users)
+        .filter((f) => f.id(group.owner!));
+  }
+}
+
 typedef $NotesCreateCompanionBuilder = NotesCompanion Function({
   required String title,
   required String content,
@@ -1194,13 +1255,17 @@ class $NotesTableManager extends RootTableManager<
     $NotesFilterComposer,
     $NotesOrderingComposer,
     $NotesCreateCompanionBuilder,
-    $NotesUpdateCompanionBuilder> {
+    $NotesUpdateCompanionBuilder,
+    $NotesWithReferences,
+    Note> {
   $NotesTableManager(_$Database db, Notes table)
       : super(TableManagerState(
           db: db,
           table: table,
           filteringComposer: $NotesFilterComposer(ComposerState(db, table)),
           orderingComposer: $NotesOrderingComposer(ComposerState(db, table)),
+          dataclassMapper: (p0) async =>
+              p0.map((e) => $NotesWithReferences(db, e)).toList(),
           updateCompanionCallback: ({
             Value<String> title = const Value.absent(),
             Value<String> content = const Value.absent(),
@@ -1227,6 +1292,17 @@ class $NotesTableManager extends RootTableManager<
           ),
         ));
 }
+
+typedef $NotesProcessedTableManager = ProcessedTableManager<
+    _$Database,
+    Notes,
+    Note,
+    $NotesFilterComposer,
+    $NotesOrderingComposer,
+    $NotesCreateCompanionBuilder,
+    $NotesUpdateCompanionBuilder,
+    $NotesWithReferences,
+    Note>;
 
 class $NotesFilterComposer extends FilterComposer<_$Database, Notes> {
   $NotesFilterComposer(super.$state);
@@ -1262,6 +1338,13 @@ class $NotesOrderingComposer extends OrderingComposer<_$Database, Notes> {
       column: $state.table.searchTerms,
       builder: (column, joinBuilders) =>
           ColumnOrderings(column, joinBuilders: joinBuilders));
+}
+
+class $NotesWithReferences {
+  // ignore: unused_field
+  final _$Database _db;
+  final Note note;
+  $NotesWithReferences(this._db, this.note);
 }
 
 class $DatabaseManager {

--- a/examples/migrations_example/lib/database.g.dart
+++ b/examples/migrations_example/lib/database.g.dart
@@ -950,7 +950,7 @@ class $$UsersTableTableManager extends RootTableManager<
     $$UsersTableOrderingComposer,
     $$UsersTableCreateCompanionBuilder,
     $$UsersTableUpdateCompanionBuilder,
-    $$UsersTableWithReferences,
+    (User, $$UsersTableWithReferences),
     User> {
   $$UsersTableTableManager(_$Database db, $UsersTable table)
       : super(TableManagerState(
@@ -961,7 +961,7 @@ class $$UsersTableTableManager extends RootTableManager<
           orderingComposer:
               $$UsersTableOrderingComposer(ComposerState(db, table)),
           withReferenceMapper: (p0) =>
-              p0.map((e) => $$UsersTableWithReferences(db, e)).toList(),
+              p0.map((e) => (e, $$UsersTableWithReferences(db, e))).toList(),
           updateCompanionCallback: ({
             Value<int> id = const Value.absent(),
             Value<String> name = const Value.absent(),
@@ -997,7 +997,7 @@ typedef $$UsersTableProcessedTableManager = ProcessedTableManager<
     $$UsersTableOrderingComposer,
     $$UsersTableCreateCompanionBuilder,
     $$UsersTableUpdateCompanionBuilder,
-    $$UsersTableWithReferences,
+    (User, $$UsersTableWithReferences),
     User>;
 
 class $$UsersTableFilterComposer
@@ -1078,18 +1078,18 @@ class $$UsersTableOrderingComposer
 class $$UsersTableWithReferences {
   // ignore: unused_field
   final _$Database _db;
-  final User user;
-  $$UsersTableWithReferences(this._db, this.user);
+  final User _item;
+  $$UsersTableWithReferences(this._db, this._item);
 
   $$UsersTableProcessedTableManager? get nextUser {
-    if (user.nextUser == null) return null;
+    if (_item.nextUser == null) return null;
     return $$UsersTableTableManager(_db, _db.users)
-        .filter((f) => f.id(user.nextUser!));
+        .filter((f) => f.id(_item.nextUser!));
   }
 
   $GroupsProcessedTableManager get groupsRefs {
     return $GroupsTableManager(_db, _db.groups)
-        .filter((f) => f.owner.id(user.id));
+        .filter((f) => f.owner.id(_item.id));
   }
 }
 
@@ -1114,7 +1114,7 @@ class $GroupsTableManager extends RootTableManager<
     $GroupsOrderingComposer,
     $GroupsCreateCompanionBuilder,
     $GroupsUpdateCompanionBuilder,
-    $GroupsWithReferences,
+    (Group, $GroupsWithReferences),
     Group> {
   $GroupsTableManager(_$Database db, Groups table)
       : super(TableManagerState(
@@ -1123,7 +1123,7 @@ class $GroupsTableManager extends RootTableManager<
           filteringComposer: $GroupsFilterComposer(ComposerState(db, table)),
           orderingComposer: $GroupsOrderingComposer(ComposerState(db, table)),
           withReferenceMapper: (p0) =>
-              p0.map((e) => $GroupsWithReferences(db, e)).toList(),
+              p0.map((e) => (e, $GroupsWithReferences(db, e))).toList(),
           updateCompanionCallback: ({
             Value<int> id = const Value.absent(),
             Value<String> title = const Value.absent(),
@@ -1159,7 +1159,7 @@ typedef $GroupsProcessedTableManager = ProcessedTableManager<
     $GroupsOrderingComposer,
     $GroupsCreateCompanionBuilder,
     $GroupsUpdateCompanionBuilder,
-    $GroupsWithReferences,
+    (Group, $GroupsWithReferences),
     Group>;
 
 class $GroupsFilterComposer extends FilterComposer<_$Database, Groups> {
@@ -1225,13 +1225,13 @@ class $GroupsOrderingComposer extends OrderingComposer<_$Database, Groups> {
 class $GroupsWithReferences {
   // ignore: unused_field
   final _$Database _db;
-  final Group group;
-  $GroupsWithReferences(this._db, this.group);
+  final Group _item;
+  $GroupsWithReferences(this._db, this._item);
 
   $$UsersTableProcessedTableManager? get owner {
-    if (group.owner == null) return null;
+    if (_item.owner == null) return null;
     return $$UsersTableTableManager(_db, _db.users)
-        .filter((f) => f.id(group.owner!));
+        .filter((f) => f.id(_item.owner!));
   }
 }
 
@@ -1256,7 +1256,7 @@ class $NotesTableManager extends RootTableManager<
     $NotesOrderingComposer,
     $NotesCreateCompanionBuilder,
     $NotesUpdateCompanionBuilder,
-    $NotesWithReferences,
+    (Note, $NotesWithReferences),
     Note> {
   $NotesTableManager(_$Database db, Notes table)
       : super(TableManagerState(
@@ -1265,7 +1265,7 @@ class $NotesTableManager extends RootTableManager<
           filteringComposer: $NotesFilterComposer(ComposerState(db, table)),
           orderingComposer: $NotesOrderingComposer(ComposerState(db, table)),
           withReferenceMapper: (p0) =>
-              p0.map((e) => $NotesWithReferences(db, e)).toList(),
+              p0.map((e) => (e, $NotesWithReferences(db, e))).toList(),
           updateCompanionCallback: ({
             Value<String> title = const Value.absent(),
             Value<String> content = const Value.absent(),
@@ -1301,7 +1301,7 @@ typedef $NotesProcessedTableManager = ProcessedTableManager<
     $NotesOrderingComposer,
     $NotesCreateCompanionBuilder,
     $NotesUpdateCompanionBuilder,
-    $NotesWithReferences,
+    (Note, $NotesWithReferences),
     Note>;
 
 class $NotesFilterComposer extends FilterComposer<_$Database, Notes> {
@@ -1343,8 +1343,8 @@ class $NotesOrderingComposer extends OrderingComposer<_$Database, Notes> {
 class $NotesWithReferences {
   // ignore: unused_field
   final _$Database _db;
-  final Note note;
-  $NotesWithReferences(this._db, this.note);
+  final Note _item;
+  $NotesWithReferences(this._db, this._item);
 }
 
 class $DatabaseManager {

--- a/examples/migrations_example/lib/database.g.dart
+++ b/examples/migrations_example/lib/database.g.dart
@@ -960,7 +960,7 @@ class $$UsersTableTableManager extends RootTableManager<
               $$UsersTableFilterComposer(ComposerState(db, table)),
           orderingComposer:
               $$UsersTableOrderingComposer(ComposerState(db, table)),
-          dataclassMapper: (p0) async =>
+          withReferenceMapper: (p0) =>
               p0.map((e) => $$UsersTableWithReferences(db, e)).toList(),
           updateCompanionCallback: ({
             Value<int> id = const Value.absent(),
@@ -1122,7 +1122,7 @@ class $GroupsTableManager extends RootTableManager<
           table: table,
           filteringComposer: $GroupsFilterComposer(ComposerState(db, table)),
           orderingComposer: $GroupsOrderingComposer(ComposerState(db, table)),
-          dataclassMapper: (p0) async =>
+          withReferenceMapper: (p0) =>
               p0.map((e) => $GroupsWithReferences(db, e)).toList(),
           updateCompanionCallback: ({
             Value<int> id = const Value.absent(),
@@ -1264,7 +1264,7 @@ class $NotesTableManager extends RootTableManager<
           table: table,
           filteringComposer: $NotesFilterComposer(ComposerState(db, table)),
           orderingComposer: $NotesOrderingComposer(ComposerState(db, table)),
-          dataclassMapper: (p0) async =>
+          withReferenceMapper: (p0) =>
               p0.map((e) => $NotesWithReferences(db, e)).toList(),
           updateCompanionCallback: ({
             Value<String> title = const Value.absent(),

--- a/examples/migrations_example/lib/database.g.dart
+++ b/examples/migrations_example/lib/database.g.dart
@@ -942,64 +942,6 @@ typedef $$UsersTableUpdateCompanionBuilder = UsersCompanion Function({
   Value<int?> nextUser,
 });
 
-class $$UsersTableTableManager extends RootTableManager<
-    _$Database,
-    $UsersTable,
-    User,
-    $$UsersTableFilterComposer,
-    $$UsersTableOrderingComposer,
-    $$UsersTableCreateCompanionBuilder,
-    $$UsersTableUpdateCompanionBuilder,
-    (User, $$UsersTableWithReferences),
-    User> {
-  $$UsersTableTableManager(_$Database db, $UsersTable table)
-      : super(TableManagerState(
-          db: db,
-          table: table,
-          filteringComposer:
-              $$UsersTableFilterComposer(ComposerState(db, table)),
-          orderingComposer:
-              $$UsersTableOrderingComposer(ComposerState(db, table)),
-          withReferenceMapper: (p0) =>
-              p0.map((e) => (e, $$UsersTableWithReferences(db, e))).toList(),
-          updateCompanionCallback: ({
-            Value<int> id = const Value.absent(),
-            Value<String> name = const Value.absent(),
-            Value<DateTime?> birthday = const Value.absent(),
-            Value<int?> nextUser = const Value.absent(),
-          }) =>
-              UsersCompanion(
-            id: id,
-            name: name,
-            birthday: birthday,
-            nextUser: nextUser,
-          ),
-          createCompanionCallback: ({
-            Value<int> id = const Value.absent(),
-            Value<String> name = const Value.absent(),
-            Value<DateTime?> birthday = const Value.absent(),
-            Value<int?> nextUser = const Value.absent(),
-          }) =>
-              UsersCompanion.insert(
-            id: id,
-            name: name,
-            birthday: birthday,
-            nextUser: nextUser,
-          ),
-        ));
-}
-
-typedef $$UsersTableProcessedTableManager = ProcessedTableManager<
-    _$Database,
-    $UsersTable,
-    User,
-    $$UsersTableFilterComposer,
-    $$UsersTableOrderingComposer,
-    $$UsersTableCreateCompanionBuilder,
-    $$UsersTableUpdateCompanionBuilder,
-    (User, $$UsersTableWithReferences),
-    User>;
-
 class $$UsersTableFilterComposer
     extends FilterComposer<_$Database, $UsersTable> {
   $$UsersTableFilterComposer(super.$state);
@@ -1075,25 +1017,78 @@ class $$UsersTableOrderingComposer
   }
 }
 
-class $$UsersTableWithReferences {
-  // ignore: unused_field
-  final _$Database _db;
-  // ignore: unused_field
-  final User _item;
-  $$UsersTableWithReferences(this._db, this._item);
+class $$UsersTableWithReferences extends BaseWithReferences<_$Database, User> {
+  $$UsersTableWithReferences(super.$_db, super.$_item);
 
   $$UsersTableProcessedTableManager? get nextUser {
-    if (_item.nextUser == null) return null;
-    return $$UsersTableTableManager(_db, _db.users)
-        .filter((f) => f.id(_item.nextUser!));
+    if ($_item.nextUser == null) return null;
+    return $$UsersTableTableManager($_db, $_db.users)
+        .filter((f) => f.id($_item.nextUser!));
   }
 
   $GroupsProcessedTableManager get groupsRefs {
-    return $GroupsTableManager(_db, _db.groups)
-        .filter((f) => f.owner.id(_item.id));
+    return $GroupsTableManager($_db, $_db.groups)
+        .filter((f) => f.owner.id($_item.id));
   }
 }
 
+class $$UsersTableTableManager extends RootTableManager<
+    _$Database,
+    $UsersTable,
+    User,
+    $$UsersTableFilterComposer,
+    $$UsersTableOrderingComposer,
+    $$UsersTableCreateCompanionBuilder,
+    $$UsersTableUpdateCompanionBuilder,
+    (User, $$UsersTableWithReferences),
+    User> {
+  $$UsersTableTableManager(_$Database db, $UsersTable table)
+      : super(TableManagerState(
+          db: db,
+          table: table,
+          filteringComposer:
+              $$UsersTableFilterComposer(ComposerState(db, table)),
+          orderingComposer:
+              $$UsersTableOrderingComposer(ComposerState(db, table)),
+          withReferenceMapper: (p0) =>
+              p0.map((e) => (e, $$UsersTableWithReferences(db, e))).toList(),
+          updateCompanionCallback: ({
+            Value<int> id = const Value.absent(),
+            Value<String> name = const Value.absent(),
+            Value<DateTime?> birthday = const Value.absent(),
+            Value<int?> nextUser = const Value.absent(),
+          }) =>
+              UsersCompanion(
+            id: id,
+            name: name,
+            birthday: birthday,
+            nextUser: nextUser,
+          ),
+          createCompanionCallback: ({
+            Value<int> id = const Value.absent(),
+            Value<String> name = const Value.absent(),
+            Value<DateTime?> birthday = const Value.absent(),
+            Value<int?> nextUser = const Value.absent(),
+          }) =>
+              UsersCompanion.insert(
+            id: id,
+            name: name,
+            birthday: birthday,
+            nextUser: nextUser,
+          ),
+        ));
+}
+
+typedef $$UsersTableProcessedTableManager = ProcessedTableManager<
+    _$Database,
+    $UsersTable,
+    User,
+    $$UsersTableFilterComposer,
+    $$UsersTableOrderingComposer,
+    $$UsersTableCreateCompanionBuilder,
+    $$UsersTableUpdateCompanionBuilder,
+    (User, $$UsersTableWithReferences),
+    User>;
 typedef $GroupsCreateCompanionBuilder = GroupsCompanion Function({
   Value<int> id,
   required String title,
@@ -1106,62 +1101,6 @@ typedef $GroupsUpdateCompanionBuilder = GroupsCompanion Function({
   Value<bool?> deleted,
   Value<int> owner,
 });
-
-class $GroupsTableManager extends RootTableManager<
-    _$Database,
-    Groups,
-    Group,
-    $GroupsFilterComposer,
-    $GroupsOrderingComposer,
-    $GroupsCreateCompanionBuilder,
-    $GroupsUpdateCompanionBuilder,
-    (Group, $GroupsWithReferences),
-    Group> {
-  $GroupsTableManager(_$Database db, Groups table)
-      : super(TableManagerState(
-          db: db,
-          table: table,
-          filteringComposer: $GroupsFilterComposer(ComposerState(db, table)),
-          orderingComposer: $GroupsOrderingComposer(ComposerState(db, table)),
-          withReferenceMapper: (p0) =>
-              p0.map((e) => (e, $GroupsWithReferences(db, e))).toList(),
-          updateCompanionCallback: ({
-            Value<int> id = const Value.absent(),
-            Value<String> title = const Value.absent(),
-            Value<bool?> deleted = const Value.absent(),
-            Value<int> owner = const Value.absent(),
-          }) =>
-              GroupsCompanion(
-            id: id,
-            title: title,
-            deleted: deleted,
-            owner: owner,
-          ),
-          createCompanionCallback: ({
-            Value<int> id = const Value.absent(),
-            required String title,
-            Value<bool?> deleted = const Value.absent(),
-            required int owner,
-          }) =>
-              GroupsCompanion.insert(
-            id: id,
-            title: title,
-            deleted: deleted,
-            owner: owner,
-          ),
-        ));
-}
-
-typedef $GroupsProcessedTableManager = ProcessedTableManager<
-    _$Database,
-    Groups,
-    Group,
-    $GroupsFilterComposer,
-    $GroupsOrderingComposer,
-    $GroupsCreateCompanionBuilder,
-    $GroupsUpdateCompanionBuilder,
-    (Group, $GroupsWithReferences),
-    Group>;
 
 class $GroupsFilterComposer extends FilterComposer<_$Database, Groups> {
   $GroupsFilterComposer(super.$state);
@@ -1223,20 +1162,71 @@ class $GroupsOrderingComposer extends OrderingComposer<_$Database, Groups> {
   }
 }
 
-class $GroupsWithReferences {
-  // ignore: unused_field
-  final _$Database _db;
-  // ignore: unused_field
-  final Group _item;
-  $GroupsWithReferences(this._db, this._item);
+class $GroupsWithReferences extends BaseWithReferences<_$Database, Group> {
+  $GroupsWithReferences(super.$_db, super.$_item);
 
   $$UsersTableProcessedTableManager? get owner {
-    if (_item.owner == null) return null;
-    return $$UsersTableTableManager(_db, _db.users)
-        .filter((f) => f.id(_item.owner!));
+    if ($_item.owner == null) return null;
+    return $$UsersTableTableManager($_db, $_db.users)
+        .filter((f) => f.id($_item.owner!));
   }
 }
 
+class $GroupsTableManager extends RootTableManager<
+    _$Database,
+    Groups,
+    Group,
+    $GroupsFilterComposer,
+    $GroupsOrderingComposer,
+    $GroupsCreateCompanionBuilder,
+    $GroupsUpdateCompanionBuilder,
+    (Group, $GroupsWithReferences),
+    Group> {
+  $GroupsTableManager(_$Database db, Groups table)
+      : super(TableManagerState(
+          db: db,
+          table: table,
+          filteringComposer: $GroupsFilterComposer(ComposerState(db, table)),
+          orderingComposer: $GroupsOrderingComposer(ComposerState(db, table)),
+          withReferenceMapper: (p0) =>
+              p0.map((e) => (e, $GroupsWithReferences(db, e))).toList(),
+          updateCompanionCallback: ({
+            Value<int> id = const Value.absent(),
+            Value<String> title = const Value.absent(),
+            Value<bool?> deleted = const Value.absent(),
+            Value<int> owner = const Value.absent(),
+          }) =>
+              GroupsCompanion(
+            id: id,
+            title: title,
+            deleted: deleted,
+            owner: owner,
+          ),
+          createCompanionCallback: ({
+            Value<int> id = const Value.absent(),
+            required String title,
+            Value<bool?> deleted = const Value.absent(),
+            required int owner,
+          }) =>
+              GroupsCompanion.insert(
+            id: id,
+            title: title,
+            deleted: deleted,
+            owner: owner,
+          ),
+        ));
+}
+
+typedef $GroupsProcessedTableManager = ProcessedTableManager<
+    _$Database,
+    Groups,
+    Group,
+    $GroupsFilterComposer,
+    $GroupsOrderingComposer,
+    $GroupsCreateCompanionBuilder,
+    $GroupsUpdateCompanionBuilder,
+    (Group, $GroupsWithReferences),
+    Group>;
 typedef $NotesCreateCompanionBuilder = NotesCompanion Function({
   required String title,
   required String content,
@@ -1249,62 +1239,6 @@ typedef $NotesUpdateCompanionBuilder = NotesCompanion Function({
   Value<String> searchTerms,
   Value<int> rowid,
 });
-
-class $NotesTableManager extends RootTableManager<
-    _$Database,
-    Notes,
-    Note,
-    $NotesFilterComposer,
-    $NotesOrderingComposer,
-    $NotesCreateCompanionBuilder,
-    $NotesUpdateCompanionBuilder,
-    (Note, $NotesWithReferences),
-    Note> {
-  $NotesTableManager(_$Database db, Notes table)
-      : super(TableManagerState(
-          db: db,
-          table: table,
-          filteringComposer: $NotesFilterComposer(ComposerState(db, table)),
-          orderingComposer: $NotesOrderingComposer(ComposerState(db, table)),
-          withReferenceMapper: (p0) =>
-              p0.map((e) => (e, $NotesWithReferences(db, e))).toList(),
-          updateCompanionCallback: ({
-            Value<String> title = const Value.absent(),
-            Value<String> content = const Value.absent(),
-            Value<String> searchTerms = const Value.absent(),
-            Value<int> rowid = const Value.absent(),
-          }) =>
-              NotesCompanion(
-            title: title,
-            content: content,
-            searchTerms: searchTerms,
-            rowid: rowid,
-          ),
-          createCompanionCallback: ({
-            required String title,
-            required String content,
-            required String searchTerms,
-            Value<int> rowid = const Value.absent(),
-          }) =>
-              NotesCompanion.insert(
-            title: title,
-            content: content,
-            searchTerms: searchTerms,
-            rowid: rowid,
-          ),
-        ));
-}
-
-typedef $NotesProcessedTableManager = ProcessedTableManager<
-    _$Database,
-    Notes,
-    Note,
-    $NotesFilterComposer,
-    $NotesOrderingComposer,
-    $NotesCreateCompanionBuilder,
-    $NotesUpdateCompanionBuilder,
-    (Note, $NotesWithReferences),
-    Note>;
 
 class $NotesFilterComposer extends FilterComposer<_$Database, Notes> {
   $NotesFilterComposer(super.$state);
@@ -1342,13 +1276,61 @@ class $NotesOrderingComposer extends OrderingComposer<_$Database, Notes> {
           ColumnOrderings(column, joinBuilders: joinBuilders));
 }
 
-class $NotesWithReferences {
-  // ignore: unused_field
-  final _$Database _db;
-  // ignore: unused_field
-  final Note _item;
-  $NotesWithReferences(this._db, this._item);
+class $NotesTableManager extends RootTableManager<
+    _$Database,
+    Notes,
+    Note,
+    $NotesFilterComposer,
+    $NotesOrderingComposer,
+    $NotesCreateCompanionBuilder,
+    $NotesUpdateCompanionBuilder,
+    (Note, BaseWithReferences<_$Database, Note>),
+    Note> {
+  $NotesTableManager(_$Database db, Notes table)
+      : super(TableManagerState(
+          db: db,
+          table: table,
+          filteringComposer: $NotesFilterComposer(ComposerState(db, table)),
+          orderingComposer: $NotesOrderingComposer(ComposerState(db, table)),
+          withReferenceMapper: (p0) =>
+              p0.map((e) => (e, BaseWithReferences(db, e))).toList(),
+          updateCompanionCallback: ({
+            Value<String> title = const Value.absent(),
+            Value<String> content = const Value.absent(),
+            Value<String> searchTerms = const Value.absent(),
+            Value<int> rowid = const Value.absent(),
+          }) =>
+              NotesCompanion(
+            title: title,
+            content: content,
+            searchTerms: searchTerms,
+            rowid: rowid,
+          ),
+          createCompanionCallback: ({
+            required String title,
+            required String content,
+            required String searchTerms,
+            Value<int> rowid = const Value.absent(),
+          }) =>
+              NotesCompanion.insert(
+            title: title,
+            content: content,
+            searchTerms: searchTerms,
+            rowid: rowid,
+          ),
+        ));
 }
+
+typedef $NotesProcessedTableManager = ProcessedTableManager<
+    _$Database,
+    Notes,
+    Note,
+    $NotesFilterComposer,
+    $NotesOrderingComposer,
+    $NotesCreateCompanionBuilder,
+    $NotesUpdateCompanionBuilder,
+    (Note, BaseWithReferences<_$Database, Note>),
+    Note>;
 
 class $DatabaseManager {
   final _$Database _db;

--- a/examples/migrations_example/lib/database.g.dart
+++ b/examples/migrations_example/lib/database.g.dart
@@ -1078,6 +1078,7 @@ class $$UsersTableOrderingComposer
 class $$UsersTableWithReferences {
   // ignore: unused_field
   final _$Database _db;
+  // ignore: unused_field
   final User _item;
   $$UsersTableWithReferences(this._db, this._item);
 
@@ -1225,6 +1226,7 @@ class $GroupsOrderingComposer extends OrderingComposer<_$Database, Groups> {
 class $GroupsWithReferences {
   // ignore: unused_field
   final _$Database _db;
+  // ignore: unused_field
   final Group _item;
   $GroupsWithReferences(this._db, this._item);
 
@@ -1343,6 +1345,7 @@ class $NotesOrderingComposer extends OrderingComposer<_$Database, Notes> {
 class $NotesWithReferences {
   // ignore: unused_field
   final _$Database _db;
+  // ignore: unused_field
   final Note _item;
   $NotesWithReferences(this._db, this._item);
 }

--- a/examples/modular/lib/src/posts.drift.dart
+++ b/examples/modular/lib/src/posts.drift.dart
@@ -236,60 +236,6 @@ typedef $PostsUpdateCompanionBuilder = i1.PostsCompanion Function({
   i0.Value<String?> content,
 });
 
-class $PostsTableManager extends i0.RootTableManager<
-    i0.GeneratedDatabase,
-    i1.Posts,
-    i1.Post,
-    i1.$PostsFilterComposer,
-    i1.$PostsOrderingComposer,
-    $PostsCreateCompanionBuilder,
-    $PostsUpdateCompanionBuilder,
-    (i1.Post, $PostsWithReferences),
-    i1.Post> {
-  $PostsTableManager(i0.GeneratedDatabase db, i1.Posts table)
-      : super(i0.TableManagerState(
-          db: db,
-          table: table,
-          filteringComposer:
-              i1.$PostsFilterComposer(i0.ComposerState(db, table)),
-          orderingComposer:
-              i1.$PostsOrderingComposer(i0.ComposerState(db, table)),
-          withReferenceMapper: (p0) =>
-              p0.map((e) => (e, $PostsWithReferences(db, e))).toList(),
-          updateCompanionCallback: ({
-            i0.Value<int> id = const i0.Value.absent(),
-            i0.Value<int> author = const i0.Value.absent(),
-            i0.Value<String?> content = const i0.Value.absent(),
-          }) =>
-              i1.PostsCompanion(
-            id: id,
-            author: author,
-            content: content,
-          ),
-          createCompanionCallback: ({
-            i0.Value<int> id = const i0.Value.absent(),
-            required int author,
-            i0.Value<String?> content = const i0.Value.absent(),
-          }) =>
-              i1.PostsCompanion.insert(
-            id: id,
-            author: author,
-            content: content,
-          ),
-        ));
-}
-
-typedef $PostsProcessedTableManager = i0.ProcessedTableManager<
-    i0.GeneratedDatabase,
-    i1.Posts,
-    i1.Post,
-    i1.$PostsFilterComposer,
-    i1.$PostsOrderingComposer,
-    $PostsCreateCompanionBuilder,
-    $PostsUpdateCompanionBuilder,
-    (i1.Post, $PostsWithReferences),
-    i1.Post>;
-
 class $PostsFilterComposer
     extends i0.FilterComposer<i0.GeneratedDatabase, i1.Posts> {
   $PostsFilterComposer(super.$state);
@@ -352,13 +298,59 @@ class $PostsOrderingComposer
   }
 }
 
-class $PostsWithReferences {
-  // ignore: unused_field
-  final i0.GeneratedDatabase _db;
-  // ignore: unused_field
-  final i1.Post _item;
-  $PostsWithReferences(this._db, this._item);
+class $PostsTableManager extends i0.RootTableManager<
+    i0.GeneratedDatabase,
+    i1.Posts,
+    i1.Post,
+    i1.$PostsFilterComposer,
+    i1.$PostsOrderingComposer,
+    $PostsCreateCompanionBuilder,
+    $PostsUpdateCompanionBuilder,
+    (i1.Post, i0.BaseWithReferences<i0.GeneratedDatabase, i1.Post>),
+    i1.Post> {
+  $PostsTableManager(i0.GeneratedDatabase db, i1.Posts table)
+      : super(i0.TableManagerState(
+          db: db,
+          table: table,
+          filteringComposer:
+              i1.$PostsFilterComposer(i0.ComposerState(db, table)),
+          orderingComposer:
+              i1.$PostsOrderingComposer(i0.ComposerState(db, table)),
+          withReferenceMapper: (p0) =>
+              p0.map((e) => (e, i0.BaseWithReferences(db, e))).toList(),
+          updateCompanionCallback: ({
+            i0.Value<int> id = const i0.Value.absent(),
+            i0.Value<int> author = const i0.Value.absent(),
+            i0.Value<String?> content = const i0.Value.absent(),
+          }) =>
+              i1.PostsCompanion(
+            id: id,
+            author: author,
+            content: content,
+          ),
+          createCompanionCallback: ({
+            i0.Value<int> id = const i0.Value.absent(),
+            required int author,
+            i0.Value<String?> content = const i0.Value.absent(),
+          }) =>
+              i1.PostsCompanion.insert(
+            id: id,
+            author: author,
+            content: content,
+          ),
+        ));
 }
+
+typedef $PostsProcessedTableManager = i0.ProcessedTableManager<
+    i0.GeneratedDatabase,
+    i1.Posts,
+    i1.Post,
+    i1.$PostsFilterComposer,
+    i1.$PostsOrderingComposer,
+    $PostsCreateCompanionBuilder,
+    $PostsUpdateCompanionBuilder,
+    (i1.Post, i0.BaseWithReferences<i0.GeneratedDatabase, i1.Post>),
+    i1.Post>;
 
 class Likes extends i0.Table with i0.TableInfo<Likes, i1.Like> {
   @override
@@ -567,60 +559,6 @@ typedef $LikesUpdateCompanionBuilder = i1.LikesCompanion Function({
   i0.Value<int> rowid,
 });
 
-class $LikesTableManager extends i0.RootTableManager<
-    i0.GeneratedDatabase,
-    i1.Likes,
-    i1.Like,
-    i1.$LikesFilterComposer,
-    i1.$LikesOrderingComposer,
-    $LikesCreateCompanionBuilder,
-    $LikesUpdateCompanionBuilder,
-    (i1.Like, $LikesWithReferences),
-    i1.Like> {
-  $LikesTableManager(i0.GeneratedDatabase db, i1.Likes table)
-      : super(i0.TableManagerState(
-          db: db,
-          table: table,
-          filteringComposer:
-              i1.$LikesFilterComposer(i0.ComposerState(db, table)),
-          orderingComposer:
-              i1.$LikesOrderingComposer(i0.ComposerState(db, table)),
-          withReferenceMapper: (p0) =>
-              p0.map((e) => (e, $LikesWithReferences(db, e))).toList(),
-          updateCompanionCallback: ({
-            i0.Value<int> post = const i0.Value.absent(),
-            i0.Value<int> likedBy = const i0.Value.absent(),
-            i0.Value<int> rowid = const i0.Value.absent(),
-          }) =>
-              i1.LikesCompanion(
-            post: post,
-            likedBy: likedBy,
-            rowid: rowid,
-          ),
-          createCompanionCallback: ({
-            required int post,
-            required int likedBy,
-            i0.Value<int> rowid = const i0.Value.absent(),
-          }) =>
-              i1.LikesCompanion.insert(
-            post: post,
-            likedBy: likedBy,
-            rowid: rowid,
-          ),
-        ));
-}
-
-typedef $LikesProcessedTableManager = i0.ProcessedTableManager<
-    i0.GeneratedDatabase,
-    i1.Likes,
-    i1.Like,
-    i1.$LikesFilterComposer,
-    i1.$LikesOrderingComposer,
-    $LikesCreateCompanionBuilder,
-    $LikesUpdateCompanionBuilder,
-    (i1.Like, $LikesWithReferences),
-    i1.Like>;
-
 class $LikesFilterComposer
     extends i0.FilterComposer<i0.GeneratedDatabase, i1.Likes> {
   $LikesFilterComposer(super.$state);
@@ -697,10 +635,56 @@ class $LikesOrderingComposer
   }
 }
 
-class $LikesWithReferences {
-  // ignore: unused_field
-  final i0.GeneratedDatabase _db;
-  // ignore: unused_field
-  final i1.Like _item;
-  $LikesWithReferences(this._db, this._item);
+class $LikesTableManager extends i0.RootTableManager<
+    i0.GeneratedDatabase,
+    i1.Likes,
+    i1.Like,
+    i1.$LikesFilterComposer,
+    i1.$LikesOrderingComposer,
+    $LikesCreateCompanionBuilder,
+    $LikesUpdateCompanionBuilder,
+    (i1.Like, i0.BaseWithReferences<i0.GeneratedDatabase, i1.Like>),
+    i1.Like> {
+  $LikesTableManager(i0.GeneratedDatabase db, i1.Likes table)
+      : super(i0.TableManagerState(
+          db: db,
+          table: table,
+          filteringComposer:
+              i1.$LikesFilterComposer(i0.ComposerState(db, table)),
+          orderingComposer:
+              i1.$LikesOrderingComposer(i0.ComposerState(db, table)),
+          withReferenceMapper: (p0) =>
+              p0.map((e) => (e, i0.BaseWithReferences(db, e))).toList(),
+          updateCompanionCallback: ({
+            i0.Value<int> post = const i0.Value.absent(),
+            i0.Value<int> likedBy = const i0.Value.absent(),
+            i0.Value<int> rowid = const i0.Value.absent(),
+          }) =>
+              i1.LikesCompanion(
+            post: post,
+            likedBy: likedBy,
+            rowid: rowid,
+          ),
+          createCompanionCallback: ({
+            required int post,
+            required int likedBy,
+            i0.Value<int> rowid = const i0.Value.absent(),
+          }) =>
+              i1.LikesCompanion.insert(
+            post: post,
+            likedBy: likedBy,
+            rowid: rowid,
+          ),
+        ));
 }
+
+typedef $LikesProcessedTableManager = i0.ProcessedTableManager<
+    i0.GeneratedDatabase,
+    i1.Likes,
+    i1.Like,
+    i1.$LikesFilterComposer,
+    i1.$LikesOrderingComposer,
+    $LikesCreateCompanionBuilder,
+    $LikesUpdateCompanionBuilder,
+    (i1.Like, i0.BaseWithReferences<i0.GeneratedDatabase, i1.Like>),
+    i1.Like>;

--- a/examples/modular/lib/src/posts.drift.dart
+++ b/examples/modular/lib/src/posts.drift.dart
@@ -244,7 +244,7 @@ class $PostsTableManager extends i0.RootTableManager<
     i1.$PostsOrderingComposer,
     $PostsCreateCompanionBuilder,
     $PostsUpdateCompanionBuilder,
-    $PostsWithReferences,
+    (i1.Post, $PostsWithReferences),
     i1.Post> {
   $PostsTableManager(i0.GeneratedDatabase db, i1.Posts table)
       : super(i0.TableManagerState(
@@ -255,7 +255,7 @@ class $PostsTableManager extends i0.RootTableManager<
           orderingComposer:
               i1.$PostsOrderingComposer(i0.ComposerState(db, table)),
           withReferenceMapper: (p0) =>
-              p0.map((e) => $PostsWithReferences(db, e)).toList(),
+              p0.map((e) => (e, $PostsWithReferences(db, e))).toList(),
           updateCompanionCallback: ({
             i0.Value<int> id = const i0.Value.absent(),
             i0.Value<int> author = const i0.Value.absent(),
@@ -287,7 +287,7 @@ typedef $PostsProcessedTableManager = i0.ProcessedTableManager<
     i1.$PostsOrderingComposer,
     $PostsCreateCompanionBuilder,
     $PostsUpdateCompanionBuilder,
-    $PostsWithReferences,
+    (i1.Post, $PostsWithReferences),
     i1.Post>;
 
 class $PostsFilterComposer
@@ -355,8 +355,8 @@ class $PostsOrderingComposer
 class $PostsWithReferences {
   // ignore: unused_field
   final i0.GeneratedDatabase _db;
-  final i1.Post i1Post;
-  $PostsWithReferences(this._db, this.i1Post);
+  final i1.Post _item;
+  $PostsWithReferences(this._db, this._item);
 }
 
 class Likes extends i0.Table with i0.TableInfo<Likes, i1.Like> {
@@ -574,7 +574,7 @@ class $LikesTableManager extends i0.RootTableManager<
     i1.$LikesOrderingComposer,
     $LikesCreateCompanionBuilder,
     $LikesUpdateCompanionBuilder,
-    $LikesWithReferences,
+    (i1.Like, $LikesWithReferences),
     i1.Like> {
   $LikesTableManager(i0.GeneratedDatabase db, i1.Likes table)
       : super(i0.TableManagerState(
@@ -585,7 +585,7 @@ class $LikesTableManager extends i0.RootTableManager<
           orderingComposer:
               i1.$LikesOrderingComposer(i0.ComposerState(db, table)),
           withReferenceMapper: (p0) =>
-              p0.map((e) => $LikesWithReferences(db, e)).toList(),
+              p0.map((e) => (e, $LikesWithReferences(db, e))).toList(),
           updateCompanionCallback: ({
             i0.Value<int> post = const i0.Value.absent(),
             i0.Value<int> likedBy = const i0.Value.absent(),
@@ -617,7 +617,7 @@ typedef $LikesProcessedTableManager = i0.ProcessedTableManager<
     i1.$LikesOrderingComposer,
     $LikesCreateCompanionBuilder,
     $LikesUpdateCompanionBuilder,
-    $LikesWithReferences,
+    (i1.Like, $LikesWithReferences),
     i1.Like>;
 
 class $LikesFilterComposer
@@ -699,6 +699,6 @@ class $LikesOrderingComposer
 class $LikesWithReferences {
   // ignore: unused_field
   final i0.GeneratedDatabase _db;
-  final i1.Like i1Like;
-  $LikesWithReferences(this._db, this.i1Like);
+  final i1.Like _item;
+  $LikesWithReferences(this._db, this._item);
 }

--- a/examples/modular/lib/src/posts.drift.dart
+++ b/examples/modular/lib/src/posts.drift.dart
@@ -243,7 +243,9 @@ class $PostsTableManager extends i0.RootTableManager<
     i1.$PostsFilterComposer,
     i1.$PostsOrderingComposer,
     $PostsCreateCompanionBuilder,
-    $PostsUpdateCompanionBuilder> {
+    $PostsUpdateCompanionBuilder,
+    $PostsWithReferences,
+    i1.Post> {
   $PostsTableManager(i0.GeneratedDatabase db, i1.Posts table)
       : super(i0.TableManagerState(
           db: db,
@@ -252,6 +254,8 @@ class $PostsTableManager extends i0.RootTableManager<
               i1.$PostsFilterComposer(i0.ComposerState(db, table)),
           orderingComposer:
               i1.$PostsOrderingComposer(i0.ComposerState(db, table)),
+          dataclassMapper: (p0) async =>
+              p0.map((e) => $PostsWithReferences(db, e)).toList(),
           updateCompanionCallback: ({
             i0.Value<int> id = const i0.Value.absent(),
             i0.Value<int> author = const i0.Value.absent(),
@@ -274,6 +278,17 @@ class $PostsTableManager extends i0.RootTableManager<
           ),
         ));
 }
+
+typedef $PostsProcessedTableManager = i0.ProcessedTableManager<
+    i0.GeneratedDatabase,
+    i1.Posts,
+    i1.Post,
+    i1.$PostsFilterComposer,
+    i1.$PostsOrderingComposer,
+    $PostsCreateCompanionBuilder,
+    $PostsUpdateCompanionBuilder,
+    $PostsWithReferences,
+    i1.Post>;
 
 class $PostsFilterComposer
     extends i0.FilterComposer<i0.GeneratedDatabase, i1.Posts> {
@@ -335,6 +350,13 @@ class $PostsOrderingComposer
                 parentComposers)));
     return composer;
   }
+}
+
+class $PostsWithReferences {
+  // ignore: unused_field
+  final i0.GeneratedDatabase _db;
+  final i1.Post i1Post;
+  $PostsWithReferences(this._db, this.i1Post);
 }
 
 class Likes extends i0.Table with i0.TableInfo<Likes, i1.Like> {
@@ -551,7 +573,9 @@ class $LikesTableManager extends i0.RootTableManager<
     i1.$LikesFilterComposer,
     i1.$LikesOrderingComposer,
     $LikesCreateCompanionBuilder,
-    $LikesUpdateCompanionBuilder> {
+    $LikesUpdateCompanionBuilder,
+    $LikesWithReferences,
+    i1.Like> {
   $LikesTableManager(i0.GeneratedDatabase db, i1.Likes table)
       : super(i0.TableManagerState(
           db: db,
@@ -560,6 +584,8 @@ class $LikesTableManager extends i0.RootTableManager<
               i1.$LikesFilterComposer(i0.ComposerState(db, table)),
           orderingComposer:
               i1.$LikesOrderingComposer(i0.ComposerState(db, table)),
+          dataclassMapper: (p0) async =>
+              p0.map((e) => $LikesWithReferences(db, e)).toList(),
           updateCompanionCallback: ({
             i0.Value<int> post = const i0.Value.absent(),
             i0.Value<int> likedBy = const i0.Value.absent(),
@@ -582,6 +608,17 @@ class $LikesTableManager extends i0.RootTableManager<
           ),
         ));
 }
+
+typedef $LikesProcessedTableManager = i0.ProcessedTableManager<
+    i0.GeneratedDatabase,
+    i1.Likes,
+    i1.Like,
+    i1.$LikesFilterComposer,
+    i1.$LikesOrderingComposer,
+    $LikesCreateCompanionBuilder,
+    $LikesUpdateCompanionBuilder,
+    $LikesWithReferences,
+    i1.Like>;
 
 class $LikesFilterComposer
     extends i0.FilterComposer<i0.GeneratedDatabase, i1.Likes> {
@@ -657,4 +694,11 @@ class $LikesOrderingComposer
                 parentComposers)));
     return composer;
   }
+}
+
+class $LikesWithReferences {
+  // ignore: unused_field
+  final i0.GeneratedDatabase _db;
+  final i1.Like i1Like;
+  $LikesWithReferences(this._db, this.i1Like);
 }

--- a/examples/modular/lib/src/posts.drift.dart
+++ b/examples/modular/lib/src/posts.drift.dart
@@ -355,6 +355,7 @@ class $PostsOrderingComposer
 class $PostsWithReferences {
   // ignore: unused_field
   final i0.GeneratedDatabase _db;
+  // ignore: unused_field
   final i1.Post _item;
   $PostsWithReferences(this._db, this._item);
 }
@@ -699,6 +700,7 @@ class $LikesOrderingComposer
 class $LikesWithReferences {
   // ignore: unused_field
   final i0.GeneratedDatabase _db;
+  // ignore: unused_field
   final i1.Like _item;
   $LikesWithReferences(this._db, this._item);
 }

--- a/examples/modular/lib/src/posts.drift.dart
+++ b/examples/modular/lib/src/posts.drift.dart
@@ -254,7 +254,7 @@ class $PostsTableManager extends i0.RootTableManager<
               i1.$PostsFilterComposer(i0.ComposerState(db, table)),
           orderingComposer:
               i1.$PostsOrderingComposer(i0.ComposerState(db, table)),
-          dataclassMapper: (p0) async =>
+          withReferenceMapper: (p0) =>
               p0.map((e) => $PostsWithReferences(db, e)).toList(),
           updateCompanionCallback: ({
             i0.Value<int> id = const i0.Value.absent(),
@@ -584,7 +584,7 @@ class $LikesTableManager extends i0.RootTableManager<
               i1.$LikesFilterComposer(i0.ComposerState(db, table)),
           orderingComposer:
               i1.$LikesOrderingComposer(i0.ComposerState(db, table)),
-          dataclassMapper: (p0) async =>
+          withReferenceMapper: (p0) =>
               p0.map((e) => $LikesWithReferences(db, e)).toList(),
           updateCompanionCallback: ({
             i0.Value<int> post = const i0.Value.absent(),

--- a/examples/modular/lib/src/search.drift.dart
+++ b/examples/modular/lib/src/search.drift.dart
@@ -309,6 +309,7 @@ class $SearchInPostsOrderingComposer
 class $SearchInPostsWithReferences {
   // ignore: unused_field
   final i0.GeneratedDatabase _db;
+  // ignore: unused_field
   final i1.SearchInPost _item;
   $SearchInPostsWithReferences(this._db, this._item);
 }

--- a/examples/modular/lib/src/search.drift.dart
+++ b/examples/modular/lib/src/search.drift.dart
@@ -231,7 +231,9 @@ class $SearchInPostsTableManager extends i0.RootTableManager<
     i1.$SearchInPostsFilterComposer,
     i1.$SearchInPostsOrderingComposer,
     $SearchInPostsCreateCompanionBuilder,
-    $SearchInPostsUpdateCompanionBuilder> {
+    $SearchInPostsUpdateCompanionBuilder,
+    $SearchInPostsWithReferences,
+    i1.SearchInPost> {
   $SearchInPostsTableManager(i0.GeneratedDatabase db, i1.SearchInPosts table)
       : super(i0.TableManagerState(
           db: db,
@@ -240,6 +242,8 @@ class $SearchInPostsTableManager extends i0.RootTableManager<
               i1.$SearchInPostsFilterComposer(i0.ComposerState(db, table)),
           orderingComposer:
               i1.$SearchInPostsOrderingComposer(i0.ComposerState(db, table)),
+          dataclassMapper: (p0) async =>
+              p0.map((e) => $SearchInPostsWithReferences(db, e)).toList(),
           updateCompanionCallback: ({
             i0.Value<String> author = const i0.Value.absent(),
             i0.Value<String> content = const i0.Value.absent(),
@@ -262,6 +266,17 @@ class $SearchInPostsTableManager extends i0.RootTableManager<
           ),
         ));
 }
+
+typedef $SearchInPostsProcessedTableManager = i0.ProcessedTableManager<
+    i0.GeneratedDatabase,
+    i1.SearchInPosts,
+    i1.SearchInPost,
+    i1.$SearchInPostsFilterComposer,
+    i1.$SearchInPostsOrderingComposer,
+    $SearchInPostsCreateCompanionBuilder,
+    $SearchInPostsUpdateCompanionBuilder,
+    $SearchInPostsWithReferences,
+    i1.SearchInPost>;
 
 class $SearchInPostsFilterComposer
     extends i0.FilterComposer<i0.GeneratedDatabase, i1.SearchInPosts> {
@@ -289,6 +304,13 @@ class $SearchInPostsOrderingComposer
       column: $state.table.content,
       builder: (column, joinBuilders) =>
           i0.ColumnOrderings(column, joinBuilders: joinBuilders));
+}
+
+class $SearchInPostsWithReferences {
+  // ignore: unused_field
+  final i0.GeneratedDatabase _db;
+  final i1.SearchInPost i1SearchInPost;
+  $SearchInPostsWithReferences(this._db, this.i1SearchInPost);
 }
 
 i0.Trigger get postsInsert => i0.Trigger(

--- a/examples/modular/lib/src/search.drift.dart
+++ b/examples/modular/lib/src/search.drift.dart
@@ -232,7 +232,7 @@ class $SearchInPostsTableManager extends i0.RootTableManager<
     i1.$SearchInPostsOrderingComposer,
     $SearchInPostsCreateCompanionBuilder,
     $SearchInPostsUpdateCompanionBuilder,
-    $SearchInPostsWithReferences,
+    (i1.SearchInPost, $SearchInPostsWithReferences),
     i1.SearchInPost> {
   $SearchInPostsTableManager(i0.GeneratedDatabase db, i1.SearchInPosts table)
       : super(i0.TableManagerState(
@@ -243,7 +243,7 @@ class $SearchInPostsTableManager extends i0.RootTableManager<
           orderingComposer:
               i1.$SearchInPostsOrderingComposer(i0.ComposerState(db, table)),
           withReferenceMapper: (p0) =>
-              p0.map((e) => $SearchInPostsWithReferences(db, e)).toList(),
+              p0.map((e) => (e, $SearchInPostsWithReferences(db, e))).toList(),
           updateCompanionCallback: ({
             i0.Value<String> author = const i0.Value.absent(),
             i0.Value<String> content = const i0.Value.absent(),
@@ -275,7 +275,7 @@ typedef $SearchInPostsProcessedTableManager = i0.ProcessedTableManager<
     i1.$SearchInPostsOrderingComposer,
     $SearchInPostsCreateCompanionBuilder,
     $SearchInPostsUpdateCompanionBuilder,
-    $SearchInPostsWithReferences,
+    (i1.SearchInPost, $SearchInPostsWithReferences),
     i1.SearchInPost>;
 
 class $SearchInPostsFilterComposer
@@ -309,8 +309,8 @@ class $SearchInPostsOrderingComposer
 class $SearchInPostsWithReferences {
   // ignore: unused_field
   final i0.GeneratedDatabase _db;
-  final i1.SearchInPost i1SearchInPost;
-  $SearchInPostsWithReferences(this._db, this.i1SearchInPost);
+  final i1.SearchInPost _item;
+  $SearchInPostsWithReferences(this._db, this._item);
 }
 
 i0.Trigger get postsInsert => i0.Trigger(

--- a/examples/modular/lib/src/search.drift.dart
+++ b/examples/modular/lib/src/search.drift.dart
@@ -242,7 +242,7 @@ class $SearchInPostsTableManager extends i0.RootTableManager<
               i1.$SearchInPostsFilterComposer(i0.ComposerState(db, table)),
           orderingComposer:
               i1.$SearchInPostsOrderingComposer(i0.ComposerState(db, table)),
-          dataclassMapper: (p0) async =>
+          withReferenceMapper: (p0) =>
               p0.map((e) => $SearchInPostsWithReferences(db, e)).toList(),
           updateCompanionCallback: ({
             i0.Value<String> author = const i0.Value.absent(),

--- a/examples/modular/lib/src/search.drift.dart
+++ b/examples/modular/lib/src/search.drift.dart
@@ -224,6 +224,34 @@ typedef $SearchInPostsUpdateCompanionBuilder = i1.SearchInPostsCompanion
   i0.Value<int> rowid,
 });
 
+class $SearchInPostsFilterComposer
+    extends i0.FilterComposer<i0.GeneratedDatabase, i1.SearchInPosts> {
+  $SearchInPostsFilterComposer(super.$state);
+  i0.ColumnFilters<String> get author => $state.composableBuilder(
+      column: $state.table.author,
+      builder: (column, joinBuilders) =>
+          i0.ColumnFilters(column, joinBuilders: joinBuilders));
+
+  i0.ColumnFilters<String> get content => $state.composableBuilder(
+      column: $state.table.content,
+      builder: (column, joinBuilders) =>
+          i0.ColumnFilters(column, joinBuilders: joinBuilders));
+}
+
+class $SearchInPostsOrderingComposer
+    extends i0.OrderingComposer<i0.GeneratedDatabase, i1.SearchInPosts> {
+  $SearchInPostsOrderingComposer(super.$state);
+  i0.ColumnOrderings<String> get author => $state.composableBuilder(
+      column: $state.table.author,
+      builder: (column, joinBuilders) =>
+          i0.ColumnOrderings(column, joinBuilders: joinBuilders));
+
+  i0.ColumnOrderings<String> get content => $state.composableBuilder(
+      column: $state.table.content,
+      builder: (column, joinBuilders) =>
+          i0.ColumnOrderings(column, joinBuilders: joinBuilders));
+}
+
 class $SearchInPostsTableManager extends i0.RootTableManager<
     i0.GeneratedDatabase,
     i1.SearchInPosts,
@@ -232,7 +260,10 @@ class $SearchInPostsTableManager extends i0.RootTableManager<
     i1.$SearchInPostsOrderingComposer,
     $SearchInPostsCreateCompanionBuilder,
     $SearchInPostsUpdateCompanionBuilder,
-    (i1.SearchInPost, $SearchInPostsWithReferences),
+    (
+      i1.SearchInPost,
+      i0.BaseWithReferences<i0.GeneratedDatabase, i1.SearchInPost>
+    ),
     i1.SearchInPost> {
   $SearchInPostsTableManager(i0.GeneratedDatabase db, i1.SearchInPosts table)
       : super(i0.TableManagerState(
@@ -243,7 +274,7 @@ class $SearchInPostsTableManager extends i0.RootTableManager<
           orderingComposer:
               i1.$SearchInPostsOrderingComposer(i0.ComposerState(db, table)),
           withReferenceMapper: (p0) =>
-              p0.map((e) => (e, $SearchInPostsWithReferences(db, e))).toList(),
+              p0.map((e) => (e, i0.BaseWithReferences(db, e))).toList(),
           updateCompanionCallback: ({
             i0.Value<String> author = const i0.Value.absent(),
             i0.Value<String> content = const i0.Value.absent(),
@@ -275,45 +306,11 @@ typedef $SearchInPostsProcessedTableManager = i0.ProcessedTableManager<
     i1.$SearchInPostsOrderingComposer,
     $SearchInPostsCreateCompanionBuilder,
     $SearchInPostsUpdateCompanionBuilder,
-    (i1.SearchInPost, $SearchInPostsWithReferences),
+    (
+      i1.SearchInPost,
+      i0.BaseWithReferences<i0.GeneratedDatabase, i1.SearchInPost>
+    ),
     i1.SearchInPost>;
-
-class $SearchInPostsFilterComposer
-    extends i0.FilterComposer<i0.GeneratedDatabase, i1.SearchInPosts> {
-  $SearchInPostsFilterComposer(super.$state);
-  i0.ColumnFilters<String> get author => $state.composableBuilder(
-      column: $state.table.author,
-      builder: (column, joinBuilders) =>
-          i0.ColumnFilters(column, joinBuilders: joinBuilders));
-
-  i0.ColumnFilters<String> get content => $state.composableBuilder(
-      column: $state.table.content,
-      builder: (column, joinBuilders) =>
-          i0.ColumnFilters(column, joinBuilders: joinBuilders));
-}
-
-class $SearchInPostsOrderingComposer
-    extends i0.OrderingComposer<i0.GeneratedDatabase, i1.SearchInPosts> {
-  $SearchInPostsOrderingComposer(super.$state);
-  i0.ColumnOrderings<String> get author => $state.composableBuilder(
-      column: $state.table.author,
-      builder: (column, joinBuilders) =>
-          i0.ColumnOrderings(column, joinBuilders: joinBuilders));
-
-  i0.ColumnOrderings<String> get content => $state.composableBuilder(
-      column: $state.table.content,
-      builder: (column, joinBuilders) =>
-          i0.ColumnOrderings(column, joinBuilders: joinBuilders));
-}
-
-class $SearchInPostsWithReferences {
-  // ignore: unused_field
-  final i0.GeneratedDatabase _db;
-  // ignore: unused_field
-  final i1.SearchInPost _item;
-  $SearchInPostsWithReferences(this._db, this._item);
-}
-
 i0.Trigger get postsInsert => i0.Trigger(
     'CREATE TRIGGER posts_insert AFTER INSERT ON posts BEGIN INSERT INTO search_in_posts ("rowid", author, content) VALUES (new.id, new.author, new.content);END',
     'posts_insert');

--- a/examples/modular/lib/src/users.drift.dart
+++ b/examples/modular/lib/src/users.drift.dart
@@ -468,6 +468,7 @@ class $UsersOrderingComposer
 class $UsersWithReferences {
   // ignore: unused_field
   final i0.GeneratedDatabase _db;
+  // ignore: unused_field
   final i1.User _item;
   $UsersWithReferences(this._db, this._item);
 }
@@ -820,6 +821,7 @@ class $FollowsOrderingComposer
 class $FollowsWithReferences {
   // ignore: unused_field
   final i0.GeneratedDatabase _db;
+  // ignore: unused_field
   final i1.Follow _item;
   $FollowsWithReferences(this._db, this._item);
 }

--- a/examples/modular/lib/src/users.drift.dart
+++ b/examples/modular/lib/src/users.drift.dart
@@ -349,7 +349,9 @@ class $UsersTableManager extends i0.RootTableManager<
     i1.$UsersFilterComposer,
     i1.$UsersOrderingComposer,
     $UsersCreateCompanionBuilder,
-    $UsersUpdateCompanionBuilder> {
+    $UsersUpdateCompanionBuilder,
+    $UsersWithReferences,
+    i1.User> {
   $UsersTableManager(i0.GeneratedDatabase db, i1.Users table)
       : super(i0.TableManagerState(
           db: db,
@@ -358,6 +360,8 @@ class $UsersTableManager extends i0.RootTableManager<
               i1.$UsersFilterComposer(i0.ComposerState(db, table)),
           orderingComposer:
               i1.$UsersOrderingComposer(i0.ComposerState(db, table)),
+          dataclassMapper: (p0) async =>
+              p0.map((e) => $UsersWithReferences(db, e)).toList(),
           updateCompanionCallback: ({
             i0.Value<int> id = const i0.Value.absent(),
             i0.Value<String> name = const i0.Value.absent(),
@@ -388,6 +392,17 @@ class $UsersTableManager extends i0.RootTableManager<
           ),
         ));
 }
+
+typedef $UsersProcessedTableManager = i0.ProcessedTableManager<
+    i0.GeneratedDatabase,
+    i1.Users,
+    i1.User,
+    i1.$UsersFilterComposer,
+    i1.$UsersOrderingComposer,
+    $UsersCreateCompanionBuilder,
+    $UsersUpdateCompanionBuilder,
+    $UsersWithReferences,
+    i1.User>;
 
 class $UsersFilterComposer
     extends i0.FilterComposer<i0.GeneratedDatabase, i1.Users> {
@@ -448,6 +463,13 @@ class $UsersOrderingComposer
           column: $state.table.profilePicture,
           builder: (column, joinBuilders) =>
               i0.ColumnOrderings(column, joinBuilders: joinBuilders));
+}
+
+class $UsersWithReferences {
+  // ignore: unused_field
+  final i0.GeneratedDatabase _db;
+  final i1.User i1User;
+  $UsersWithReferences(this._db, this.i1User);
 }
 
 i0.Index get usersName =>
@@ -672,7 +694,9 @@ class $FollowsTableManager extends i0.RootTableManager<
     i1.$FollowsFilterComposer,
     i1.$FollowsOrderingComposer,
     $FollowsCreateCompanionBuilder,
-    $FollowsUpdateCompanionBuilder> {
+    $FollowsUpdateCompanionBuilder,
+    $FollowsWithReferences,
+    i1.Follow> {
   $FollowsTableManager(i0.GeneratedDatabase db, i1.Follows table)
       : super(i0.TableManagerState(
           db: db,
@@ -681,6 +705,8 @@ class $FollowsTableManager extends i0.RootTableManager<
               i1.$FollowsFilterComposer(i0.ComposerState(db, table)),
           orderingComposer:
               i1.$FollowsOrderingComposer(i0.ComposerState(db, table)),
+          dataclassMapper: (p0) async =>
+              p0.map((e) => $FollowsWithReferences(db, e)).toList(),
           updateCompanionCallback: ({
             i0.Value<int> followed = const i0.Value.absent(),
             i0.Value<int> follower = const i0.Value.absent(),
@@ -703,6 +729,17 @@ class $FollowsTableManager extends i0.RootTableManager<
           ),
         ));
 }
+
+typedef $FollowsProcessedTableManager = i0.ProcessedTableManager<
+    i0.GeneratedDatabase,
+    i1.Follows,
+    i1.Follow,
+    i1.$FollowsFilterComposer,
+    i1.$FollowsOrderingComposer,
+    $FollowsCreateCompanionBuilder,
+    $FollowsUpdateCompanionBuilder,
+    $FollowsWithReferences,
+    i1.Follow>;
 
 class $FollowsFilterComposer
     extends i0.FilterComposer<i0.GeneratedDatabase, i1.Follows> {
@@ -778,6 +815,13 @@ class $FollowsOrderingComposer
                 parentComposers)));
     return composer;
   }
+}
+
+class $FollowsWithReferences {
+  // ignore: unused_field
+  final i0.GeneratedDatabase _db;
+  final i1.Follow i1Follow;
+  $FollowsWithReferences(this._db, this.i1Follow);
 }
 
 class PopularUser extends i0.DataClass {

--- a/examples/modular/lib/src/users.drift.dart
+++ b/examples/modular/lib/src/users.drift.dart
@@ -350,7 +350,7 @@ class $UsersTableManager extends i0.RootTableManager<
     i1.$UsersOrderingComposer,
     $UsersCreateCompanionBuilder,
     $UsersUpdateCompanionBuilder,
-    $UsersWithReferences,
+    (i1.User, $UsersWithReferences),
     i1.User> {
   $UsersTableManager(i0.GeneratedDatabase db, i1.Users table)
       : super(i0.TableManagerState(
@@ -361,7 +361,7 @@ class $UsersTableManager extends i0.RootTableManager<
           orderingComposer:
               i1.$UsersOrderingComposer(i0.ComposerState(db, table)),
           withReferenceMapper: (p0) =>
-              p0.map((e) => $UsersWithReferences(db, e)).toList(),
+              p0.map((e) => (e, $UsersWithReferences(db, e))).toList(),
           updateCompanionCallback: ({
             i0.Value<int> id = const i0.Value.absent(),
             i0.Value<String> name = const i0.Value.absent(),
@@ -401,7 +401,7 @@ typedef $UsersProcessedTableManager = i0.ProcessedTableManager<
     i1.$UsersOrderingComposer,
     $UsersCreateCompanionBuilder,
     $UsersUpdateCompanionBuilder,
-    $UsersWithReferences,
+    (i1.User, $UsersWithReferences),
     i1.User>;
 
 class $UsersFilterComposer
@@ -468,8 +468,8 @@ class $UsersOrderingComposer
 class $UsersWithReferences {
   // ignore: unused_field
   final i0.GeneratedDatabase _db;
-  final i1.User i1User;
-  $UsersWithReferences(this._db, this.i1User);
+  final i1.User _item;
+  $UsersWithReferences(this._db, this._item);
 }
 
 i0.Index get usersName =>
@@ -695,7 +695,7 @@ class $FollowsTableManager extends i0.RootTableManager<
     i1.$FollowsOrderingComposer,
     $FollowsCreateCompanionBuilder,
     $FollowsUpdateCompanionBuilder,
-    $FollowsWithReferences,
+    (i1.Follow, $FollowsWithReferences),
     i1.Follow> {
   $FollowsTableManager(i0.GeneratedDatabase db, i1.Follows table)
       : super(i0.TableManagerState(
@@ -706,7 +706,7 @@ class $FollowsTableManager extends i0.RootTableManager<
           orderingComposer:
               i1.$FollowsOrderingComposer(i0.ComposerState(db, table)),
           withReferenceMapper: (p0) =>
-              p0.map((e) => $FollowsWithReferences(db, e)).toList(),
+              p0.map((e) => (e, $FollowsWithReferences(db, e))).toList(),
           updateCompanionCallback: ({
             i0.Value<int> followed = const i0.Value.absent(),
             i0.Value<int> follower = const i0.Value.absent(),
@@ -738,7 +738,7 @@ typedef $FollowsProcessedTableManager = i0.ProcessedTableManager<
     i1.$FollowsOrderingComposer,
     $FollowsCreateCompanionBuilder,
     $FollowsUpdateCompanionBuilder,
-    $FollowsWithReferences,
+    (i1.Follow, $FollowsWithReferences),
     i1.Follow>;
 
 class $FollowsFilterComposer
@@ -820,8 +820,8 @@ class $FollowsOrderingComposer
 class $FollowsWithReferences {
   // ignore: unused_field
   final i0.GeneratedDatabase _db;
-  final i1.Follow i1Follow;
-  $FollowsWithReferences(this._db, this.i1Follow);
+  final i1.Follow _item;
+  $FollowsWithReferences(this._db, this._item);
 }
 
 class PopularUser extends i0.DataClass {

--- a/examples/modular/lib/src/users.drift.dart
+++ b/examples/modular/lib/src/users.drift.dart
@@ -360,7 +360,7 @@ class $UsersTableManager extends i0.RootTableManager<
               i1.$UsersFilterComposer(i0.ComposerState(db, table)),
           orderingComposer:
               i1.$UsersOrderingComposer(i0.ComposerState(db, table)),
-          dataclassMapper: (p0) async =>
+          withReferenceMapper: (p0) =>
               p0.map((e) => $UsersWithReferences(db, e)).toList(),
           updateCompanionCallback: ({
             i0.Value<int> id = const i0.Value.absent(),
@@ -705,7 +705,7 @@ class $FollowsTableManager extends i0.RootTableManager<
               i1.$FollowsFilterComposer(i0.ComposerState(db, table)),
           orderingComposer:
               i1.$FollowsOrderingComposer(i0.ComposerState(db, table)),
-          dataclassMapper: (p0) async =>
+          withReferenceMapper: (p0) =>
               p0.map((e) => $FollowsWithReferences(db, e)).toList(),
           updateCompanionCallback: ({
             i0.Value<int> followed = const i0.Value.absent(),

--- a/examples/modular/lib/src/users.drift.dart
+++ b/examples/modular/lib/src/users.drift.dart
@@ -342,68 +342,6 @@ typedef $UsersUpdateCompanionBuilder = i1.UsersCompanion Function({
   i0.Value<i3.Uint8List?> profilePicture,
 });
 
-class $UsersTableManager extends i0.RootTableManager<
-    i0.GeneratedDatabase,
-    i1.Users,
-    i1.User,
-    i1.$UsersFilterComposer,
-    i1.$UsersOrderingComposer,
-    $UsersCreateCompanionBuilder,
-    $UsersUpdateCompanionBuilder,
-    (i1.User, $UsersWithReferences),
-    i1.User> {
-  $UsersTableManager(i0.GeneratedDatabase db, i1.Users table)
-      : super(i0.TableManagerState(
-          db: db,
-          table: table,
-          filteringComposer:
-              i1.$UsersFilterComposer(i0.ComposerState(db, table)),
-          orderingComposer:
-              i1.$UsersOrderingComposer(i0.ComposerState(db, table)),
-          withReferenceMapper: (p0) =>
-              p0.map((e) => (e, $UsersWithReferences(db, e))).toList(),
-          updateCompanionCallback: ({
-            i0.Value<int> id = const i0.Value.absent(),
-            i0.Value<String> name = const i0.Value.absent(),
-            i0.Value<String?> biography = const i0.Value.absent(),
-            i0.Value<i2.Preferences?> preferences = const i0.Value.absent(),
-            i0.Value<i3.Uint8List?> profilePicture = const i0.Value.absent(),
-          }) =>
-              i1.UsersCompanion(
-            id: id,
-            name: name,
-            biography: biography,
-            preferences: preferences,
-            profilePicture: profilePicture,
-          ),
-          createCompanionCallback: ({
-            i0.Value<int> id = const i0.Value.absent(),
-            required String name,
-            i0.Value<String?> biography = const i0.Value.absent(),
-            i0.Value<i2.Preferences?> preferences = const i0.Value.absent(),
-            i0.Value<i3.Uint8List?> profilePicture = const i0.Value.absent(),
-          }) =>
-              i1.UsersCompanion.insert(
-            id: id,
-            name: name,
-            biography: biography,
-            preferences: preferences,
-            profilePicture: profilePicture,
-          ),
-        ));
-}
-
-typedef $UsersProcessedTableManager = i0.ProcessedTableManager<
-    i0.GeneratedDatabase,
-    i1.Users,
-    i1.User,
-    i1.$UsersFilterComposer,
-    i1.$UsersOrderingComposer,
-    $UsersCreateCompanionBuilder,
-    $UsersUpdateCompanionBuilder,
-    (i1.User, $UsersWithReferences),
-    i1.User>;
-
 class $UsersFilterComposer
     extends i0.FilterComposer<i0.GeneratedDatabase, i1.Users> {
   $UsersFilterComposer(super.$state);
@@ -465,14 +403,67 @@ class $UsersOrderingComposer
               i0.ColumnOrderings(column, joinBuilders: joinBuilders));
 }
 
-class $UsersWithReferences {
-  // ignore: unused_field
-  final i0.GeneratedDatabase _db;
-  // ignore: unused_field
-  final i1.User _item;
-  $UsersWithReferences(this._db, this._item);
+class $UsersTableManager extends i0.RootTableManager<
+    i0.GeneratedDatabase,
+    i1.Users,
+    i1.User,
+    i1.$UsersFilterComposer,
+    i1.$UsersOrderingComposer,
+    $UsersCreateCompanionBuilder,
+    $UsersUpdateCompanionBuilder,
+    (i1.User, i0.BaseWithReferences<i0.GeneratedDatabase, i1.User>),
+    i1.User> {
+  $UsersTableManager(i0.GeneratedDatabase db, i1.Users table)
+      : super(i0.TableManagerState(
+          db: db,
+          table: table,
+          filteringComposer:
+              i1.$UsersFilterComposer(i0.ComposerState(db, table)),
+          orderingComposer:
+              i1.$UsersOrderingComposer(i0.ComposerState(db, table)),
+          withReferenceMapper: (p0) =>
+              p0.map((e) => (e, i0.BaseWithReferences(db, e))).toList(),
+          updateCompanionCallback: ({
+            i0.Value<int> id = const i0.Value.absent(),
+            i0.Value<String> name = const i0.Value.absent(),
+            i0.Value<String?> biography = const i0.Value.absent(),
+            i0.Value<i2.Preferences?> preferences = const i0.Value.absent(),
+            i0.Value<i3.Uint8List?> profilePicture = const i0.Value.absent(),
+          }) =>
+              i1.UsersCompanion(
+            id: id,
+            name: name,
+            biography: biography,
+            preferences: preferences,
+            profilePicture: profilePicture,
+          ),
+          createCompanionCallback: ({
+            i0.Value<int> id = const i0.Value.absent(),
+            required String name,
+            i0.Value<String?> biography = const i0.Value.absent(),
+            i0.Value<i2.Preferences?> preferences = const i0.Value.absent(),
+            i0.Value<i3.Uint8List?> profilePicture = const i0.Value.absent(),
+          }) =>
+              i1.UsersCompanion.insert(
+            id: id,
+            name: name,
+            biography: biography,
+            preferences: preferences,
+            profilePicture: profilePicture,
+          ),
+        ));
 }
 
+typedef $UsersProcessedTableManager = i0.ProcessedTableManager<
+    i0.GeneratedDatabase,
+    i1.Users,
+    i1.User,
+    i1.$UsersFilterComposer,
+    i1.$UsersOrderingComposer,
+    $UsersCreateCompanionBuilder,
+    $UsersUpdateCompanionBuilder,
+    (i1.User, i0.BaseWithReferences<i0.GeneratedDatabase, i1.User>),
+    i1.User>;
 i0.Index get usersName =>
     i0.Index('users_name', 'CREATE INDEX users_name ON users (name)');
 
@@ -688,60 +679,6 @@ typedef $FollowsUpdateCompanionBuilder = i1.FollowsCompanion Function({
   i0.Value<int> rowid,
 });
 
-class $FollowsTableManager extends i0.RootTableManager<
-    i0.GeneratedDatabase,
-    i1.Follows,
-    i1.Follow,
-    i1.$FollowsFilterComposer,
-    i1.$FollowsOrderingComposer,
-    $FollowsCreateCompanionBuilder,
-    $FollowsUpdateCompanionBuilder,
-    (i1.Follow, $FollowsWithReferences),
-    i1.Follow> {
-  $FollowsTableManager(i0.GeneratedDatabase db, i1.Follows table)
-      : super(i0.TableManagerState(
-          db: db,
-          table: table,
-          filteringComposer:
-              i1.$FollowsFilterComposer(i0.ComposerState(db, table)),
-          orderingComposer:
-              i1.$FollowsOrderingComposer(i0.ComposerState(db, table)),
-          withReferenceMapper: (p0) =>
-              p0.map((e) => (e, $FollowsWithReferences(db, e))).toList(),
-          updateCompanionCallback: ({
-            i0.Value<int> followed = const i0.Value.absent(),
-            i0.Value<int> follower = const i0.Value.absent(),
-            i0.Value<int> rowid = const i0.Value.absent(),
-          }) =>
-              i1.FollowsCompanion(
-            followed: followed,
-            follower: follower,
-            rowid: rowid,
-          ),
-          createCompanionCallback: ({
-            required int followed,
-            required int follower,
-            i0.Value<int> rowid = const i0.Value.absent(),
-          }) =>
-              i1.FollowsCompanion.insert(
-            followed: followed,
-            follower: follower,
-            rowid: rowid,
-          ),
-        ));
-}
-
-typedef $FollowsProcessedTableManager = i0.ProcessedTableManager<
-    i0.GeneratedDatabase,
-    i1.Follows,
-    i1.Follow,
-    i1.$FollowsFilterComposer,
-    i1.$FollowsOrderingComposer,
-    $FollowsCreateCompanionBuilder,
-    $FollowsUpdateCompanionBuilder,
-    (i1.Follow, $FollowsWithReferences),
-    i1.Follow>;
-
 class $FollowsFilterComposer
     extends i0.FilterComposer<i0.GeneratedDatabase, i1.Follows> {
   $FollowsFilterComposer(super.$state);
@@ -818,13 +755,59 @@ class $FollowsOrderingComposer
   }
 }
 
-class $FollowsWithReferences {
-  // ignore: unused_field
-  final i0.GeneratedDatabase _db;
-  // ignore: unused_field
-  final i1.Follow _item;
-  $FollowsWithReferences(this._db, this._item);
+class $FollowsTableManager extends i0.RootTableManager<
+    i0.GeneratedDatabase,
+    i1.Follows,
+    i1.Follow,
+    i1.$FollowsFilterComposer,
+    i1.$FollowsOrderingComposer,
+    $FollowsCreateCompanionBuilder,
+    $FollowsUpdateCompanionBuilder,
+    (i1.Follow, i0.BaseWithReferences<i0.GeneratedDatabase, i1.Follow>),
+    i1.Follow> {
+  $FollowsTableManager(i0.GeneratedDatabase db, i1.Follows table)
+      : super(i0.TableManagerState(
+          db: db,
+          table: table,
+          filteringComposer:
+              i1.$FollowsFilterComposer(i0.ComposerState(db, table)),
+          orderingComposer:
+              i1.$FollowsOrderingComposer(i0.ComposerState(db, table)),
+          withReferenceMapper: (p0) =>
+              p0.map((e) => (e, i0.BaseWithReferences(db, e))).toList(),
+          updateCompanionCallback: ({
+            i0.Value<int> followed = const i0.Value.absent(),
+            i0.Value<int> follower = const i0.Value.absent(),
+            i0.Value<int> rowid = const i0.Value.absent(),
+          }) =>
+              i1.FollowsCompanion(
+            followed: followed,
+            follower: follower,
+            rowid: rowid,
+          ),
+          createCompanionCallback: ({
+            required int followed,
+            required int follower,
+            i0.Value<int> rowid = const i0.Value.absent(),
+          }) =>
+              i1.FollowsCompanion.insert(
+            followed: followed,
+            follower: follower,
+            rowid: rowid,
+          ),
+        ));
 }
+
+typedef $FollowsProcessedTableManager = i0.ProcessedTableManager<
+    i0.GeneratedDatabase,
+    i1.Follows,
+    i1.Follow,
+    i1.$FollowsFilterComposer,
+    i1.$FollowsOrderingComposer,
+    $FollowsCreateCompanionBuilder,
+    $FollowsUpdateCompanionBuilder,
+    (i1.Follow, i0.BaseWithReferences<i0.GeneratedDatabase, i1.Follow>),
+    i1.Follow>;
 
 class PopularUser extends i0.DataClass {
   final int id;

--- a/examples/multi_package/server/lib/database.drift.dart
+++ b/examples/multi_package/server/lib/database.drift.dart
@@ -364,6 +364,7 @@ class $$ActiveSessionsTableOrderingComposer
 class $$ActiveSessionsTableWithReferences {
   // ignore: unused_field
   final i0.GeneratedDatabase _db;
+  // ignore: unused_field
   final i3.ActiveSession _item;
   $$ActiveSessionsTableWithReferences(this._db, this._item);
 }

--- a/examples/multi_package/server/lib/database.drift.dart
+++ b/examples/multi_package/server/lib/database.drift.dart
@@ -272,7 +272,7 @@ class $$ActiveSessionsTableTableManager extends i0.RootTableManager<
               .$$ActiveSessionsTableFilterComposer(i0.ComposerState(db, table)),
           orderingComposer: i3.$$ActiveSessionsTableOrderingComposer(
               i0.ComposerState(db, table)),
-          dataclassMapper: (p0) async => p0
+          withReferenceMapper: (p0) => p0
               .map((e) => $$ActiveSessionsTableWithReferences(db, e))
               .toList(),
           updateCompanionCallback: ({

--- a/examples/multi_package/server/lib/database.drift.dart
+++ b/examples/multi_package/server/lib/database.drift.dart
@@ -261,7 +261,7 @@ class $$ActiveSessionsTableTableManager extends i0.RootTableManager<
     i3.$$ActiveSessionsTableOrderingComposer,
     $$ActiveSessionsTableCreateCompanionBuilder,
     $$ActiveSessionsTableUpdateCompanionBuilder,
-    $$ActiveSessionsTableWithReferences,
+    (i3.ActiveSession, $$ActiveSessionsTableWithReferences),
     i3.ActiveSession> {
   $$ActiveSessionsTableTableManager(
       i0.GeneratedDatabase db, i3.$ActiveSessionsTable table)
@@ -273,7 +273,7 @@ class $$ActiveSessionsTableTableManager extends i0.RootTableManager<
           orderingComposer: i3.$$ActiveSessionsTableOrderingComposer(
               i0.ComposerState(db, table)),
           withReferenceMapper: (p0) => p0
-              .map((e) => $$ActiveSessionsTableWithReferences(db, e))
+              .map((e) => (e, $$ActiveSessionsTableWithReferences(db, e)))
               .toList(),
           updateCompanionCallback: ({
             i0.Value<int> user = const i0.Value.absent(),
@@ -306,7 +306,7 @@ typedef $$ActiveSessionsTableProcessedTableManager = i0.ProcessedTableManager<
     i3.$$ActiveSessionsTableOrderingComposer,
     $$ActiveSessionsTableCreateCompanionBuilder,
     $$ActiveSessionsTableUpdateCompanionBuilder,
-    $$ActiveSessionsTableWithReferences,
+    (i3.ActiveSession, $$ActiveSessionsTableWithReferences),
     i3.ActiveSession>;
 
 class $$ActiveSessionsTableFilterComposer
@@ -364,6 +364,6 @@ class $$ActiveSessionsTableOrderingComposer
 class $$ActiveSessionsTableWithReferences {
   // ignore: unused_field
   final i0.GeneratedDatabase _db;
-  final i3.ActiveSession i3ActiveSession;
-  $$ActiveSessionsTableWithReferences(this._db, this.i3ActiveSession);
+  final i3.ActiveSession _item;
+  $$ActiveSessionsTableWithReferences(this._db, this._item);
 }

--- a/examples/multi_package/server/lib/database.drift.dart
+++ b/examples/multi_package/server/lib/database.drift.dart
@@ -253,62 +253,6 @@ typedef $$ActiveSessionsTableUpdateCompanionBuilder = i3.ActiveSessionsCompanion
   i0.Value<int> rowid,
 });
 
-class $$ActiveSessionsTableTableManager extends i0.RootTableManager<
-    i0.GeneratedDatabase,
-    i3.$ActiveSessionsTable,
-    i3.ActiveSession,
-    i3.$$ActiveSessionsTableFilterComposer,
-    i3.$$ActiveSessionsTableOrderingComposer,
-    $$ActiveSessionsTableCreateCompanionBuilder,
-    $$ActiveSessionsTableUpdateCompanionBuilder,
-    (i3.ActiveSession, $$ActiveSessionsTableWithReferences),
-    i3.ActiveSession> {
-  $$ActiveSessionsTableTableManager(
-      i0.GeneratedDatabase db, i3.$ActiveSessionsTable table)
-      : super(i0.TableManagerState(
-          db: db,
-          table: table,
-          filteringComposer: i3
-              .$$ActiveSessionsTableFilterComposer(i0.ComposerState(db, table)),
-          orderingComposer: i3.$$ActiveSessionsTableOrderingComposer(
-              i0.ComposerState(db, table)),
-          withReferenceMapper: (p0) => p0
-              .map((e) => (e, $$ActiveSessionsTableWithReferences(db, e)))
-              .toList(),
-          updateCompanionCallback: ({
-            i0.Value<int> user = const i0.Value.absent(),
-            i0.Value<String> bearerToken = const i0.Value.absent(),
-            i0.Value<int> rowid = const i0.Value.absent(),
-          }) =>
-              i3.ActiveSessionsCompanion(
-            user: user,
-            bearerToken: bearerToken,
-            rowid: rowid,
-          ),
-          createCompanionCallback: ({
-            required int user,
-            required String bearerToken,
-            i0.Value<int> rowid = const i0.Value.absent(),
-          }) =>
-              i3.ActiveSessionsCompanion.insert(
-            user: user,
-            bearerToken: bearerToken,
-            rowid: rowid,
-          ),
-        ));
-}
-
-typedef $$ActiveSessionsTableProcessedTableManager = i0.ProcessedTableManager<
-    i0.GeneratedDatabase,
-    i3.$ActiveSessionsTable,
-    i3.ActiveSession,
-    i3.$$ActiveSessionsTableFilterComposer,
-    i3.$$ActiveSessionsTableOrderingComposer,
-    $$ActiveSessionsTableCreateCompanionBuilder,
-    $$ActiveSessionsTableUpdateCompanionBuilder,
-    (i3.ActiveSession, $$ActiveSessionsTableWithReferences),
-    i3.ActiveSession>;
-
 class $$ActiveSessionsTableFilterComposer
     extends i0.FilterComposer<i0.GeneratedDatabase, i3.$ActiveSessionsTable> {
   $$ActiveSessionsTableFilterComposer(super.$state);
@@ -361,10 +305,63 @@ class $$ActiveSessionsTableOrderingComposer
   }
 }
 
-class $$ActiveSessionsTableWithReferences {
-  // ignore: unused_field
-  final i0.GeneratedDatabase _db;
-  // ignore: unused_field
-  final i3.ActiveSession _item;
-  $$ActiveSessionsTableWithReferences(this._db, this._item);
+class $$ActiveSessionsTableTableManager extends i0.RootTableManager<
+    i0.GeneratedDatabase,
+    i3.$ActiveSessionsTable,
+    i3.ActiveSession,
+    i3.$$ActiveSessionsTableFilterComposer,
+    i3.$$ActiveSessionsTableOrderingComposer,
+    $$ActiveSessionsTableCreateCompanionBuilder,
+    $$ActiveSessionsTableUpdateCompanionBuilder,
+    (
+      i3.ActiveSession,
+      i0.BaseWithReferences<i0.GeneratedDatabase, i3.ActiveSession>
+    ),
+    i3.ActiveSession> {
+  $$ActiveSessionsTableTableManager(
+      i0.GeneratedDatabase db, i3.$ActiveSessionsTable table)
+      : super(i0.TableManagerState(
+          db: db,
+          table: table,
+          filteringComposer: i3
+              .$$ActiveSessionsTableFilterComposer(i0.ComposerState(db, table)),
+          orderingComposer: i3.$$ActiveSessionsTableOrderingComposer(
+              i0.ComposerState(db, table)),
+          withReferenceMapper: (p0) =>
+              p0.map((e) => (e, i0.BaseWithReferences(db, e))).toList(),
+          updateCompanionCallback: ({
+            i0.Value<int> user = const i0.Value.absent(),
+            i0.Value<String> bearerToken = const i0.Value.absent(),
+            i0.Value<int> rowid = const i0.Value.absent(),
+          }) =>
+              i3.ActiveSessionsCompanion(
+            user: user,
+            bearerToken: bearerToken,
+            rowid: rowid,
+          ),
+          createCompanionCallback: ({
+            required int user,
+            required String bearerToken,
+            i0.Value<int> rowid = const i0.Value.absent(),
+          }) =>
+              i3.ActiveSessionsCompanion.insert(
+            user: user,
+            bearerToken: bearerToken,
+            rowid: rowid,
+          ),
+        ));
 }
+
+typedef $$ActiveSessionsTableProcessedTableManager = i0.ProcessedTableManager<
+    i0.GeneratedDatabase,
+    i3.$ActiveSessionsTable,
+    i3.ActiveSession,
+    i3.$$ActiveSessionsTableFilterComposer,
+    i3.$$ActiveSessionsTableOrderingComposer,
+    $$ActiveSessionsTableCreateCompanionBuilder,
+    $$ActiveSessionsTableUpdateCompanionBuilder,
+    (
+      i3.ActiveSession,
+      i0.BaseWithReferences<i0.GeneratedDatabase, i3.ActiveSession>
+    ),
+    i3.ActiveSession>;

--- a/examples/multi_package/server/lib/database.drift.dart
+++ b/examples/multi_package/server/lib/database.drift.dart
@@ -260,7 +260,9 @@ class $$ActiveSessionsTableTableManager extends i0.RootTableManager<
     i3.$$ActiveSessionsTableFilterComposer,
     i3.$$ActiveSessionsTableOrderingComposer,
     $$ActiveSessionsTableCreateCompanionBuilder,
-    $$ActiveSessionsTableUpdateCompanionBuilder> {
+    $$ActiveSessionsTableUpdateCompanionBuilder,
+    $$ActiveSessionsTableWithReferences,
+    i3.ActiveSession> {
   $$ActiveSessionsTableTableManager(
       i0.GeneratedDatabase db, i3.$ActiveSessionsTable table)
       : super(i0.TableManagerState(
@@ -270,6 +272,9 @@ class $$ActiveSessionsTableTableManager extends i0.RootTableManager<
               .$$ActiveSessionsTableFilterComposer(i0.ComposerState(db, table)),
           orderingComposer: i3.$$ActiveSessionsTableOrderingComposer(
               i0.ComposerState(db, table)),
+          dataclassMapper: (p0) async => p0
+              .map((e) => $$ActiveSessionsTableWithReferences(db, e))
+              .toList(),
           updateCompanionCallback: ({
             i0.Value<int> user = const i0.Value.absent(),
             i0.Value<String> bearerToken = const i0.Value.absent(),
@@ -292,6 +297,17 @@ class $$ActiveSessionsTableTableManager extends i0.RootTableManager<
           ),
         ));
 }
+
+typedef $$ActiveSessionsTableProcessedTableManager = i0.ProcessedTableManager<
+    i0.GeneratedDatabase,
+    i3.$ActiveSessionsTable,
+    i3.ActiveSession,
+    i3.$$ActiveSessionsTableFilterComposer,
+    i3.$$ActiveSessionsTableOrderingComposer,
+    $$ActiveSessionsTableCreateCompanionBuilder,
+    $$ActiveSessionsTableUpdateCompanionBuilder,
+    $$ActiveSessionsTableWithReferences,
+    i3.ActiveSession>;
 
 class $$ActiveSessionsTableFilterComposer
     extends i0.FilterComposer<i0.GeneratedDatabase, i3.$ActiveSessionsTable> {
@@ -343,4 +359,11 @@ class $$ActiveSessionsTableOrderingComposer
                 parentComposers)));
     return composer;
   }
+}
+
+class $$ActiveSessionsTableWithReferences {
+  // ignore: unused_field
+  final i0.GeneratedDatabase _db;
+  final i3.ActiveSession i3ActiveSession;
+  $$ActiveSessionsTableWithReferences(this._db, this.i3ActiveSession);
 }

--- a/examples/multi_package/shared/lib/shared.drift.dart
+++ b/examples/multi_package/shared/lib/shared.drift.dart
@@ -28,8 +28,10 @@ class SharedDrift extends i1.ModularAccessor {
         ));
   }
 
-  i2.Posts get posts => this.resultSet<i2.Posts>('posts');
-  i3.$UsersTable get users => this.resultSet<i3.$UsersTable>('users');
+  i2.Posts get posts =>
+      i1.ReadDatabaseContainer(attachedDatabase).resultSet<i2.Posts>('posts');
+  i3.$UsersTable get users => i1.ReadDatabaseContainer(attachedDatabase)
+      .resultSet<i3.$UsersTable>('users');
 }
 
 class AllPostsResult {

--- a/examples/multi_package/shared/lib/src/posts.drift.dart
+++ b/examples/multi_package/shared/lib/src/posts.drift.dart
@@ -234,7 +234,7 @@ class $PostsTableManager extends i0.RootTableManager<
               i1.$PostsFilterComposer(i0.ComposerState(db, table)),
           orderingComposer:
               i1.$PostsOrderingComposer(i0.ComposerState(db, table)),
-          dataclassMapper: (p0) async =>
+          withReferenceMapper: (p0) =>
               p0.map((e) => $PostsWithReferences(db, e)).toList(),
           updateCompanionCallback: ({
             i0.Value<int> author = const i0.Value.absent(),

--- a/examples/multi_package/shared/lib/src/posts.drift.dart
+++ b/examples/multi_package/shared/lib/src/posts.drift.dart
@@ -216,60 +216,6 @@ typedef $PostsUpdateCompanionBuilder = i1.PostsCompanion Function({
   i0.Value<int> rowid,
 });
 
-class $PostsTableManager extends i0.RootTableManager<
-    i0.GeneratedDatabase,
-    i1.Posts,
-    i1.Post,
-    i1.$PostsFilterComposer,
-    i1.$PostsOrderingComposer,
-    $PostsCreateCompanionBuilder,
-    $PostsUpdateCompanionBuilder,
-    (i1.Post, $PostsWithReferences),
-    i1.Post> {
-  $PostsTableManager(i0.GeneratedDatabase db, i1.Posts table)
-      : super(i0.TableManagerState(
-          db: db,
-          table: table,
-          filteringComposer:
-              i1.$PostsFilterComposer(i0.ComposerState(db, table)),
-          orderingComposer:
-              i1.$PostsOrderingComposer(i0.ComposerState(db, table)),
-          withReferenceMapper: (p0) =>
-              p0.map((e) => (e, $PostsWithReferences(db, e))).toList(),
-          updateCompanionCallback: ({
-            i0.Value<int> author = const i0.Value.absent(),
-            i0.Value<String?> content = const i0.Value.absent(),
-            i0.Value<int> rowid = const i0.Value.absent(),
-          }) =>
-              i1.PostsCompanion(
-            author: author,
-            content: content,
-            rowid: rowid,
-          ),
-          createCompanionCallback: ({
-            required int author,
-            i0.Value<String?> content = const i0.Value.absent(),
-            i0.Value<int> rowid = const i0.Value.absent(),
-          }) =>
-              i1.PostsCompanion.insert(
-            author: author,
-            content: content,
-            rowid: rowid,
-          ),
-        ));
-}
-
-typedef $PostsProcessedTableManager = i0.ProcessedTableManager<
-    i0.GeneratedDatabase,
-    i1.Posts,
-    i1.Post,
-    i1.$PostsFilterComposer,
-    i1.$PostsOrderingComposer,
-    $PostsCreateCompanionBuilder,
-    $PostsUpdateCompanionBuilder,
-    (i1.Post, $PostsWithReferences),
-    i1.Post>;
-
 class $PostsFilterComposer
     extends i0.FilterComposer<i0.GeneratedDatabase, i1.Posts> {
   $PostsFilterComposer(super.$state);
@@ -322,10 +268,56 @@ class $PostsOrderingComposer
   }
 }
 
-class $PostsWithReferences {
-  // ignore: unused_field
-  final i0.GeneratedDatabase _db;
-  // ignore: unused_field
-  final i1.Post _item;
-  $PostsWithReferences(this._db, this._item);
+class $PostsTableManager extends i0.RootTableManager<
+    i0.GeneratedDatabase,
+    i1.Posts,
+    i1.Post,
+    i1.$PostsFilterComposer,
+    i1.$PostsOrderingComposer,
+    $PostsCreateCompanionBuilder,
+    $PostsUpdateCompanionBuilder,
+    (i1.Post, i0.BaseWithReferences<i0.GeneratedDatabase, i1.Post>),
+    i1.Post> {
+  $PostsTableManager(i0.GeneratedDatabase db, i1.Posts table)
+      : super(i0.TableManagerState(
+          db: db,
+          table: table,
+          filteringComposer:
+              i1.$PostsFilterComposer(i0.ComposerState(db, table)),
+          orderingComposer:
+              i1.$PostsOrderingComposer(i0.ComposerState(db, table)),
+          withReferenceMapper: (p0) =>
+              p0.map((e) => (e, i0.BaseWithReferences(db, e))).toList(),
+          updateCompanionCallback: ({
+            i0.Value<int> author = const i0.Value.absent(),
+            i0.Value<String?> content = const i0.Value.absent(),
+            i0.Value<int> rowid = const i0.Value.absent(),
+          }) =>
+              i1.PostsCompanion(
+            author: author,
+            content: content,
+            rowid: rowid,
+          ),
+          createCompanionCallback: ({
+            required int author,
+            i0.Value<String?> content = const i0.Value.absent(),
+            i0.Value<int> rowid = const i0.Value.absent(),
+          }) =>
+              i1.PostsCompanion.insert(
+            author: author,
+            content: content,
+            rowid: rowid,
+          ),
+        ));
 }
+
+typedef $PostsProcessedTableManager = i0.ProcessedTableManager<
+    i0.GeneratedDatabase,
+    i1.Posts,
+    i1.Post,
+    i1.$PostsFilterComposer,
+    i1.$PostsOrderingComposer,
+    $PostsCreateCompanionBuilder,
+    $PostsUpdateCompanionBuilder,
+    (i1.Post, i0.BaseWithReferences<i0.GeneratedDatabase, i1.Post>),
+    i1.Post>;

--- a/examples/multi_package/shared/lib/src/posts.drift.dart
+++ b/examples/multi_package/shared/lib/src/posts.drift.dart
@@ -224,7 +224,7 @@ class $PostsTableManager extends i0.RootTableManager<
     i1.$PostsOrderingComposer,
     $PostsCreateCompanionBuilder,
     $PostsUpdateCompanionBuilder,
-    $PostsWithReferences,
+    (i1.Post, $PostsWithReferences),
     i1.Post> {
   $PostsTableManager(i0.GeneratedDatabase db, i1.Posts table)
       : super(i0.TableManagerState(
@@ -235,7 +235,7 @@ class $PostsTableManager extends i0.RootTableManager<
           orderingComposer:
               i1.$PostsOrderingComposer(i0.ComposerState(db, table)),
           withReferenceMapper: (p0) =>
-              p0.map((e) => $PostsWithReferences(db, e)).toList(),
+              p0.map((e) => (e, $PostsWithReferences(db, e))).toList(),
           updateCompanionCallback: ({
             i0.Value<int> author = const i0.Value.absent(),
             i0.Value<String?> content = const i0.Value.absent(),
@@ -267,7 +267,7 @@ typedef $PostsProcessedTableManager = i0.ProcessedTableManager<
     i1.$PostsOrderingComposer,
     $PostsCreateCompanionBuilder,
     $PostsUpdateCompanionBuilder,
-    $PostsWithReferences,
+    (i1.Post, $PostsWithReferences),
     i1.Post>;
 
 class $PostsFilterComposer
@@ -325,6 +325,6 @@ class $PostsOrderingComposer
 class $PostsWithReferences {
   // ignore: unused_field
   final i0.GeneratedDatabase _db;
-  final i1.Post i1Post;
-  $PostsWithReferences(this._db, this.i1Post);
+  final i1.Post _item;
+  $PostsWithReferences(this._db, this._item);
 }

--- a/examples/multi_package/shared/lib/src/posts.drift.dart
+++ b/examples/multi_package/shared/lib/src/posts.drift.dart
@@ -325,6 +325,7 @@ class $PostsOrderingComposer
 class $PostsWithReferences {
   // ignore: unused_field
   final i0.GeneratedDatabase _db;
+  // ignore: unused_field
   final i1.Post _item;
   $PostsWithReferences(this._db, this._item);
 }

--- a/examples/multi_package/shared/lib/src/posts.drift.dart
+++ b/examples/multi_package/shared/lib/src/posts.drift.dart
@@ -223,7 +223,9 @@ class $PostsTableManager extends i0.RootTableManager<
     i1.$PostsFilterComposer,
     i1.$PostsOrderingComposer,
     $PostsCreateCompanionBuilder,
-    $PostsUpdateCompanionBuilder> {
+    $PostsUpdateCompanionBuilder,
+    $PostsWithReferences,
+    i1.Post> {
   $PostsTableManager(i0.GeneratedDatabase db, i1.Posts table)
       : super(i0.TableManagerState(
           db: db,
@@ -232,6 +234,8 @@ class $PostsTableManager extends i0.RootTableManager<
               i1.$PostsFilterComposer(i0.ComposerState(db, table)),
           orderingComposer:
               i1.$PostsOrderingComposer(i0.ComposerState(db, table)),
+          dataclassMapper: (p0) async =>
+              p0.map((e) => $PostsWithReferences(db, e)).toList(),
           updateCompanionCallback: ({
             i0.Value<int> author = const i0.Value.absent(),
             i0.Value<String?> content = const i0.Value.absent(),
@@ -254,6 +258,17 @@ class $PostsTableManager extends i0.RootTableManager<
           ),
         ));
 }
+
+typedef $PostsProcessedTableManager = i0.ProcessedTableManager<
+    i0.GeneratedDatabase,
+    i1.Posts,
+    i1.Post,
+    i1.$PostsFilterComposer,
+    i1.$PostsOrderingComposer,
+    $PostsCreateCompanionBuilder,
+    $PostsUpdateCompanionBuilder,
+    $PostsWithReferences,
+    i1.Post>;
 
 class $PostsFilterComposer
     extends i0.FilterComposer<i0.GeneratedDatabase, i1.Posts> {
@@ -305,4 +320,11 @@ class $PostsOrderingComposer
                 parentComposers)));
     return composer;
   }
+}
+
+class $PostsWithReferences {
+  // ignore: unused_field
+  final i0.GeneratedDatabase _db;
+  final i1.Post i1Post;
+  $PostsWithReferences(this._db, this.i1Post);
 }

--- a/examples/multi_package/shared/lib/src/users.drift.dart
+++ b/examples/multi_package/shared/lib/src/users.drift.dart
@@ -270,6 +270,7 @@ class $$UsersTableOrderingComposer
 class $$UsersTableWithReferences {
   // ignore: unused_field
   final i0.GeneratedDatabase _db;
+  // ignore: unused_field
   final i1.User _item;
   $$UsersTableWithReferences(this._db, this._item);
 }

--- a/examples/multi_package/shared/lib/src/users.drift.dart
+++ b/examples/multi_package/shared/lib/src/users.drift.dart
@@ -207,7 +207,7 @@ class $$UsersTableTableManager extends i0.RootTableManager<
               i1.$$UsersTableFilterComposer(i0.ComposerState(db, table)),
           orderingComposer:
               i1.$$UsersTableOrderingComposer(i0.ComposerState(db, table)),
-          dataclassMapper: (p0) async =>
+          withReferenceMapper: (p0) =>
               p0.map((e) => $$UsersTableWithReferences(db, e)).toList(),
           updateCompanionCallback: ({
             i0.Value<int> id = const i0.Value.absent(),

--- a/examples/multi_package/shared/lib/src/users.drift.dart
+++ b/examples/multi_package/shared/lib/src/users.drift.dart
@@ -196,7 +196,9 @@ class $$UsersTableTableManager extends i0.RootTableManager<
     i1.$$UsersTableFilterComposer,
     i1.$$UsersTableOrderingComposer,
     $$UsersTableCreateCompanionBuilder,
-    $$UsersTableUpdateCompanionBuilder> {
+    $$UsersTableUpdateCompanionBuilder,
+    $$UsersTableWithReferences,
+    i1.User> {
   $$UsersTableTableManager(i0.GeneratedDatabase db, i1.$UsersTable table)
       : super(i0.TableManagerState(
           db: db,
@@ -205,6 +207,8 @@ class $$UsersTableTableManager extends i0.RootTableManager<
               i1.$$UsersTableFilterComposer(i0.ComposerState(db, table)),
           orderingComposer:
               i1.$$UsersTableOrderingComposer(i0.ComposerState(db, table)),
+          dataclassMapper: (p0) async =>
+              p0.map((e) => $$UsersTableWithReferences(db, e)).toList(),
           updateCompanionCallback: ({
             i0.Value<int> id = const i0.Value.absent(),
             i0.Value<String> name = const i0.Value.absent(),
@@ -223,6 +227,17 @@ class $$UsersTableTableManager extends i0.RootTableManager<
           ),
         ));
 }
+
+typedef $$UsersTableProcessedTableManager = i0.ProcessedTableManager<
+    i0.GeneratedDatabase,
+    i1.$UsersTable,
+    i1.User,
+    i1.$$UsersTableFilterComposer,
+    i1.$$UsersTableOrderingComposer,
+    $$UsersTableCreateCompanionBuilder,
+    $$UsersTableUpdateCompanionBuilder,
+    $$UsersTableWithReferences,
+    i1.User>;
 
 class $$UsersTableFilterComposer
     extends i0.FilterComposer<i0.GeneratedDatabase, i1.$UsersTable> {
@@ -250,4 +265,11 @@ class $$UsersTableOrderingComposer
       column: $state.table.name,
       builder: (column, joinBuilders) =>
           i0.ColumnOrderings(column, joinBuilders: joinBuilders));
+}
+
+class $$UsersTableWithReferences {
+  // ignore: unused_field
+  final i0.GeneratedDatabase _db;
+  final i1.User i1User;
+  $$UsersTableWithReferences(this._db, this.i1User);
 }

--- a/examples/multi_package/shared/lib/src/users.drift.dart
+++ b/examples/multi_package/shared/lib/src/users.drift.dart
@@ -197,7 +197,7 @@ class $$UsersTableTableManager extends i0.RootTableManager<
     i1.$$UsersTableOrderingComposer,
     $$UsersTableCreateCompanionBuilder,
     $$UsersTableUpdateCompanionBuilder,
-    $$UsersTableWithReferences,
+    (i1.User, $$UsersTableWithReferences),
     i1.User> {
   $$UsersTableTableManager(i0.GeneratedDatabase db, i1.$UsersTable table)
       : super(i0.TableManagerState(
@@ -208,7 +208,7 @@ class $$UsersTableTableManager extends i0.RootTableManager<
           orderingComposer:
               i1.$$UsersTableOrderingComposer(i0.ComposerState(db, table)),
           withReferenceMapper: (p0) =>
-              p0.map((e) => $$UsersTableWithReferences(db, e)).toList(),
+              p0.map((e) => (e, $$UsersTableWithReferences(db, e))).toList(),
           updateCompanionCallback: ({
             i0.Value<int> id = const i0.Value.absent(),
             i0.Value<String> name = const i0.Value.absent(),
@@ -236,7 +236,7 @@ typedef $$UsersTableProcessedTableManager = i0.ProcessedTableManager<
     i1.$$UsersTableOrderingComposer,
     $$UsersTableCreateCompanionBuilder,
     $$UsersTableUpdateCompanionBuilder,
-    $$UsersTableWithReferences,
+    (i1.User, $$UsersTableWithReferences),
     i1.User>;
 
 class $$UsersTableFilterComposer
@@ -270,6 +270,6 @@ class $$UsersTableOrderingComposer
 class $$UsersTableWithReferences {
   // ignore: unused_field
   final i0.GeneratedDatabase _db;
-  final i1.User i1User;
-  $$UsersTableWithReferences(this._db, this.i1User);
+  final i1.User _item;
+  $$UsersTableWithReferences(this._db, this._item);
 }

--- a/examples/multi_package/shared/lib/src/users.drift.dart
+++ b/examples/multi_package/shared/lib/src/users.drift.dart
@@ -189,56 +189,6 @@ typedef $$UsersTableUpdateCompanionBuilder = i1.UsersCompanion Function({
   i0.Value<String> name,
 });
 
-class $$UsersTableTableManager extends i0.RootTableManager<
-    i0.GeneratedDatabase,
-    i1.$UsersTable,
-    i1.User,
-    i1.$$UsersTableFilterComposer,
-    i1.$$UsersTableOrderingComposer,
-    $$UsersTableCreateCompanionBuilder,
-    $$UsersTableUpdateCompanionBuilder,
-    (i1.User, $$UsersTableWithReferences),
-    i1.User> {
-  $$UsersTableTableManager(i0.GeneratedDatabase db, i1.$UsersTable table)
-      : super(i0.TableManagerState(
-          db: db,
-          table: table,
-          filteringComposer:
-              i1.$$UsersTableFilterComposer(i0.ComposerState(db, table)),
-          orderingComposer:
-              i1.$$UsersTableOrderingComposer(i0.ComposerState(db, table)),
-          withReferenceMapper: (p0) =>
-              p0.map((e) => (e, $$UsersTableWithReferences(db, e))).toList(),
-          updateCompanionCallback: ({
-            i0.Value<int> id = const i0.Value.absent(),
-            i0.Value<String> name = const i0.Value.absent(),
-          }) =>
-              i1.UsersCompanion(
-            id: id,
-            name: name,
-          ),
-          createCompanionCallback: ({
-            i0.Value<int> id = const i0.Value.absent(),
-            required String name,
-          }) =>
-              i1.UsersCompanion.insert(
-            id: id,
-            name: name,
-          ),
-        ));
-}
-
-typedef $$UsersTableProcessedTableManager = i0.ProcessedTableManager<
-    i0.GeneratedDatabase,
-    i1.$UsersTable,
-    i1.User,
-    i1.$$UsersTableFilterComposer,
-    i1.$$UsersTableOrderingComposer,
-    $$UsersTableCreateCompanionBuilder,
-    $$UsersTableUpdateCompanionBuilder,
-    (i1.User, $$UsersTableWithReferences),
-    i1.User>;
-
 class $$UsersTableFilterComposer
     extends i0.FilterComposer<i0.GeneratedDatabase, i1.$UsersTable> {
   $$UsersTableFilterComposer(super.$state);
@@ -267,10 +217,52 @@ class $$UsersTableOrderingComposer
           i0.ColumnOrderings(column, joinBuilders: joinBuilders));
 }
 
-class $$UsersTableWithReferences {
-  // ignore: unused_field
-  final i0.GeneratedDatabase _db;
-  // ignore: unused_field
-  final i1.User _item;
-  $$UsersTableWithReferences(this._db, this._item);
+class $$UsersTableTableManager extends i0.RootTableManager<
+    i0.GeneratedDatabase,
+    i1.$UsersTable,
+    i1.User,
+    i1.$$UsersTableFilterComposer,
+    i1.$$UsersTableOrderingComposer,
+    $$UsersTableCreateCompanionBuilder,
+    $$UsersTableUpdateCompanionBuilder,
+    (i1.User, i0.BaseWithReferences<i0.GeneratedDatabase, i1.User>),
+    i1.User> {
+  $$UsersTableTableManager(i0.GeneratedDatabase db, i1.$UsersTable table)
+      : super(i0.TableManagerState(
+          db: db,
+          table: table,
+          filteringComposer:
+              i1.$$UsersTableFilterComposer(i0.ComposerState(db, table)),
+          orderingComposer:
+              i1.$$UsersTableOrderingComposer(i0.ComposerState(db, table)),
+          withReferenceMapper: (p0) =>
+              p0.map((e) => (e, i0.BaseWithReferences(db, e))).toList(),
+          updateCompanionCallback: ({
+            i0.Value<int> id = const i0.Value.absent(),
+            i0.Value<String> name = const i0.Value.absent(),
+          }) =>
+              i1.UsersCompanion(
+            id: id,
+            name: name,
+          ),
+          createCompanionCallback: ({
+            i0.Value<int> id = const i0.Value.absent(),
+            required String name,
+          }) =>
+              i1.UsersCompanion.insert(
+            id: id,
+            name: name,
+          ),
+        ));
 }
+
+typedef $$UsersTableProcessedTableManager = i0.ProcessedTableManager<
+    i0.GeneratedDatabase,
+    i1.$UsersTable,
+    i1.User,
+    i1.$$UsersTableFilterComposer,
+    i1.$$UsersTableOrderingComposer,
+    $$UsersTableCreateCompanionBuilder,
+    $$UsersTableUpdateCompanionBuilder,
+    (i1.User, i0.BaseWithReferences<i0.GeneratedDatabase, i1.User>),
+    i1.User>;

--- a/examples/with_built_value/lib/tables.drift.dart
+++ b/examples/with_built_value/lib/tables.drift.dart
@@ -190,56 +190,6 @@ typedef $UsersUpdateCompanionBuilder = i1.UsersCompanion Function({
   i0.Value<String> name,
 });
 
-class $UsersTableManager extends i0.RootTableManager<
-    i0.GeneratedDatabase,
-    i1.Users,
-    i1.User,
-    i1.$UsersFilterComposer,
-    i1.$UsersOrderingComposer,
-    $UsersCreateCompanionBuilder,
-    $UsersUpdateCompanionBuilder,
-    (i1.User, $UsersWithReferences),
-    i1.User> {
-  $UsersTableManager(i0.GeneratedDatabase db, i1.Users table)
-      : super(i0.TableManagerState(
-          db: db,
-          table: table,
-          filteringComposer:
-              i1.$UsersFilterComposer(i0.ComposerState(db, table)),
-          orderingComposer:
-              i1.$UsersOrderingComposer(i0.ComposerState(db, table)),
-          withReferenceMapper: (p0) =>
-              p0.map((e) => (e, $UsersWithReferences(db, e))).toList(),
-          updateCompanionCallback: ({
-            i0.Value<int> id = const i0.Value.absent(),
-            i0.Value<String> name = const i0.Value.absent(),
-          }) =>
-              i1.UsersCompanion(
-            id: id,
-            name: name,
-          ),
-          createCompanionCallback: ({
-            i0.Value<int> id = const i0.Value.absent(),
-            required String name,
-          }) =>
-              i1.UsersCompanion.insert(
-            id: id,
-            name: name,
-          ),
-        ));
-}
-
-typedef $UsersProcessedTableManager = i0.ProcessedTableManager<
-    i0.GeneratedDatabase,
-    i1.Users,
-    i1.User,
-    i1.$UsersFilterComposer,
-    i1.$UsersOrderingComposer,
-    $UsersCreateCompanionBuilder,
-    $UsersUpdateCompanionBuilder,
-    (i1.User, $UsersWithReferences),
-    i1.User>;
-
 class $UsersFilterComposer
     extends i0.FilterComposer<i0.GeneratedDatabase, i1.Users> {
   $UsersFilterComposer(super.$state);
@@ -268,10 +218,52 @@ class $UsersOrderingComposer
           i0.ColumnOrderings(column, joinBuilders: joinBuilders));
 }
 
-class $UsersWithReferences {
-  // ignore: unused_field
-  final i0.GeneratedDatabase _db;
-  // ignore: unused_field
-  final i1.User _item;
-  $UsersWithReferences(this._db, this._item);
+class $UsersTableManager extends i0.RootTableManager<
+    i0.GeneratedDatabase,
+    i1.Users,
+    i1.User,
+    i1.$UsersFilterComposer,
+    i1.$UsersOrderingComposer,
+    $UsersCreateCompanionBuilder,
+    $UsersUpdateCompanionBuilder,
+    (i1.User, i0.BaseWithReferences<i0.GeneratedDatabase, i1.User>),
+    i1.User> {
+  $UsersTableManager(i0.GeneratedDatabase db, i1.Users table)
+      : super(i0.TableManagerState(
+          db: db,
+          table: table,
+          filteringComposer:
+              i1.$UsersFilterComposer(i0.ComposerState(db, table)),
+          orderingComposer:
+              i1.$UsersOrderingComposer(i0.ComposerState(db, table)),
+          withReferenceMapper: (p0) =>
+              p0.map((e) => (e, i0.BaseWithReferences(db, e))).toList(),
+          updateCompanionCallback: ({
+            i0.Value<int> id = const i0.Value.absent(),
+            i0.Value<String> name = const i0.Value.absent(),
+          }) =>
+              i1.UsersCompanion(
+            id: id,
+            name: name,
+          ),
+          createCompanionCallback: ({
+            i0.Value<int> id = const i0.Value.absent(),
+            required String name,
+          }) =>
+              i1.UsersCompanion.insert(
+            id: id,
+            name: name,
+          ),
+        ));
 }
+
+typedef $UsersProcessedTableManager = i0.ProcessedTableManager<
+    i0.GeneratedDatabase,
+    i1.Users,
+    i1.User,
+    i1.$UsersFilterComposer,
+    i1.$UsersOrderingComposer,
+    $UsersCreateCompanionBuilder,
+    $UsersUpdateCompanionBuilder,
+    (i1.User, i0.BaseWithReferences<i0.GeneratedDatabase, i1.User>),
+    i1.User>;

--- a/examples/with_built_value/lib/tables.drift.dart
+++ b/examples/with_built_value/lib/tables.drift.dart
@@ -208,7 +208,7 @@ class $UsersTableManager extends i0.RootTableManager<
               i1.$UsersFilterComposer(i0.ComposerState(db, table)),
           orderingComposer:
               i1.$UsersOrderingComposer(i0.ComposerState(db, table)),
-          dataclassMapper: (p0) async =>
+          withReferenceMapper: (p0) =>
               p0.map((e) => $UsersWithReferences(db, e)).toList(),
           updateCompanionCallback: ({
             i0.Value<int> id = const i0.Value.absent(),

--- a/examples/with_built_value/lib/tables.drift.dart
+++ b/examples/with_built_value/lib/tables.drift.dart
@@ -197,7 +197,9 @@ class $UsersTableManager extends i0.RootTableManager<
     i1.$UsersFilterComposer,
     i1.$UsersOrderingComposer,
     $UsersCreateCompanionBuilder,
-    $UsersUpdateCompanionBuilder> {
+    $UsersUpdateCompanionBuilder,
+    $UsersWithReferences,
+    i1.User> {
   $UsersTableManager(i0.GeneratedDatabase db, i1.Users table)
       : super(i0.TableManagerState(
           db: db,
@@ -206,6 +208,8 @@ class $UsersTableManager extends i0.RootTableManager<
               i1.$UsersFilterComposer(i0.ComposerState(db, table)),
           orderingComposer:
               i1.$UsersOrderingComposer(i0.ComposerState(db, table)),
+          dataclassMapper: (p0) async =>
+              p0.map((e) => $UsersWithReferences(db, e)).toList(),
           updateCompanionCallback: ({
             i0.Value<int> id = const i0.Value.absent(),
             i0.Value<String> name = const i0.Value.absent(),
@@ -224,6 +228,17 @@ class $UsersTableManager extends i0.RootTableManager<
           ),
         ));
 }
+
+typedef $UsersProcessedTableManager = i0.ProcessedTableManager<
+    i0.GeneratedDatabase,
+    i1.Users,
+    i1.User,
+    i1.$UsersFilterComposer,
+    i1.$UsersOrderingComposer,
+    $UsersCreateCompanionBuilder,
+    $UsersUpdateCompanionBuilder,
+    $UsersWithReferences,
+    i1.User>;
 
 class $UsersFilterComposer
     extends i0.FilterComposer<i0.GeneratedDatabase, i1.Users> {
@@ -251,4 +266,11 @@ class $UsersOrderingComposer
       column: $state.table.name,
       builder: (column, joinBuilders) =>
           i0.ColumnOrderings(column, joinBuilders: joinBuilders));
+}
+
+class $UsersWithReferences {
+  // ignore: unused_field
+  final i0.GeneratedDatabase _db;
+  final i1.User i1User;
+  $UsersWithReferences(this._db, this.i1User);
 }

--- a/examples/with_built_value/lib/tables.drift.dart
+++ b/examples/with_built_value/lib/tables.drift.dart
@@ -271,6 +271,7 @@ class $UsersOrderingComposer
 class $UsersWithReferences {
   // ignore: unused_field
   final i0.GeneratedDatabase _db;
+  // ignore: unused_field
   final i1.User _item;
   $UsersWithReferences(this._db, this._item);
 }

--- a/examples/with_built_value/lib/tables.drift.dart
+++ b/examples/with_built_value/lib/tables.drift.dart
@@ -198,7 +198,7 @@ class $UsersTableManager extends i0.RootTableManager<
     i1.$UsersOrderingComposer,
     $UsersCreateCompanionBuilder,
     $UsersUpdateCompanionBuilder,
-    $UsersWithReferences,
+    (i1.User, $UsersWithReferences),
     i1.User> {
   $UsersTableManager(i0.GeneratedDatabase db, i1.Users table)
       : super(i0.TableManagerState(
@@ -209,7 +209,7 @@ class $UsersTableManager extends i0.RootTableManager<
           orderingComposer:
               i1.$UsersOrderingComposer(i0.ComposerState(db, table)),
           withReferenceMapper: (p0) =>
-              p0.map((e) => $UsersWithReferences(db, e)).toList(),
+              p0.map((e) => (e, $UsersWithReferences(db, e))).toList(),
           updateCompanionCallback: ({
             i0.Value<int> id = const i0.Value.absent(),
             i0.Value<String> name = const i0.Value.absent(),
@@ -237,7 +237,7 @@ typedef $UsersProcessedTableManager = i0.ProcessedTableManager<
     i1.$UsersOrderingComposer,
     $UsersCreateCompanionBuilder,
     $UsersUpdateCompanionBuilder,
-    $UsersWithReferences,
+    (i1.User, $UsersWithReferences),
     i1.User>;
 
 class $UsersFilterComposer
@@ -271,6 +271,6 @@ class $UsersOrderingComposer
 class $UsersWithReferences {
   // ignore: unused_field
   final i0.GeneratedDatabase _db;
-  final i1.User i1User;
-  $UsersWithReferences(this._db, this.i1User);
+  final i1.User _item;
+  $UsersWithReferences(this._db, this._item);
 }

--- a/extras/drift_postgres/example/main.g.dart
+++ b/extras/drift_postgres/example/main.g.dart
@@ -296,6 +296,7 @@ class $$UsersTableOrderingComposer
 class $$UsersTableWithReferences {
   // ignore: unused_field
   final _$DriftPostgresDatabase _db;
+  // ignore: unused_field
   final User _item;
   $$UsersTableWithReferences(this._db, this._item);
 }

--- a/extras/drift_postgres/example/main.g.dart
+++ b/extras/drift_postgres/example/main.g.dart
@@ -211,6 +211,34 @@ typedef $$UsersTableUpdateCompanionBuilder = UsersCompanion Function({
   Value<int> rowid,
 });
 
+class $$UsersTableFilterComposer
+    extends FilterComposer<_$DriftPostgresDatabase, $UsersTable> {
+  $$UsersTableFilterComposer(super.$state);
+  ColumnFilters<UuidValue> get id => $state.composableBuilder(
+      column: $state.table.id,
+      builder: (column, joinBuilders) =>
+          ColumnFilters(column, joinBuilders: joinBuilders));
+
+  ColumnFilters<String> get name => $state.composableBuilder(
+      column: $state.table.name,
+      builder: (column, joinBuilders) =>
+          ColumnFilters(column, joinBuilders: joinBuilders));
+}
+
+class $$UsersTableOrderingComposer
+    extends OrderingComposer<_$DriftPostgresDatabase, $UsersTable> {
+  $$UsersTableOrderingComposer(super.$state);
+  ColumnOrderings<UuidValue> get id => $state.composableBuilder(
+      column: $state.table.id,
+      builder: (column, joinBuilders) =>
+          ColumnOrderings(column, joinBuilders: joinBuilders));
+
+  ColumnOrderings<String> get name => $state.composableBuilder(
+      column: $state.table.name,
+      builder: (column, joinBuilders) =>
+          ColumnOrderings(column, joinBuilders: joinBuilders));
+}
+
 class $$UsersTableTableManager extends RootTableManager<
     _$DriftPostgresDatabase,
     $UsersTable,
@@ -219,7 +247,7 @@ class $$UsersTableTableManager extends RootTableManager<
     $$UsersTableOrderingComposer,
     $$UsersTableCreateCompanionBuilder,
     $$UsersTableUpdateCompanionBuilder,
-    (User, $$UsersTableWithReferences),
+    (User, BaseWithReferences<_$DriftPostgresDatabase, User>),
     User> {
   $$UsersTableTableManager(_$DriftPostgresDatabase db, $UsersTable table)
       : super(TableManagerState(
@@ -230,7 +258,7 @@ class $$UsersTableTableManager extends RootTableManager<
           orderingComposer:
               $$UsersTableOrderingComposer(ComposerState(db, table)),
           withReferenceMapper: (p0) =>
-              p0.map((e) => (e, $$UsersTableWithReferences(db, e))).toList(),
+              p0.map((e) => (e, BaseWithReferences(db, e))).toList(),
           updateCompanionCallback: ({
             Value<UuidValue> id = const Value.absent(),
             Value<String> name = const Value.absent(),
@@ -262,44 +290,8 @@ typedef $$UsersTableProcessedTableManager = ProcessedTableManager<
     $$UsersTableOrderingComposer,
     $$UsersTableCreateCompanionBuilder,
     $$UsersTableUpdateCompanionBuilder,
-    (User, $$UsersTableWithReferences),
+    (User, BaseWithReferences<_$DriftPostgresDatabase, User>),
     User>;
-
-class $$UsersTableFilterComposer
-    extends FilterComposer<_$DriftPostgresDatabase, $UsersTable> {
-  $$UsersTableFilterComposer(super.$state);
-  ColumnFilters<UuidValue> get id => $state.composableBuilder(
-      column: $state.table.id,
-      builder: (column, joinBuilders) =>
-          ColumnFilters(column, joinBuilders: joinBuilders));
-
-  ColumnFilters<String> get name => $state.composableBuilder(
-      column: $state.table.name,
-      builder: (column, joinBuilders) =>
-          ColumnFilters(column, joinBuilders: joinBuilders));
-}
-
-class $$UsersTableOrderingComposer
-    extends OrderingComposer<_$DriftPostgresDatabase, $UsersTable> {
-  $$UsersTableOrderingComposer(super.$state);
-  ColumnOrderings<UuidValue> get id => $state.composableBuilder(
-      column: $state.table.id,
-      builder: (column, joinBuilders) =>
-          ColumnOrderings(column, joinBuilders: joinBuilders));
-
-  ColumnOrderings<String> get name => $state.composableBuilder(
-      column: $state.table.name,
-      builder: (column, joinBuilders) =>
-          ColumnOrderings(column, joinBuilders: joinBuilders));
-}
-
-class $$UsersTableWithReferences {
-  // ignore: unused_field
-  final _$DriftPostgresDatabase _db;
-  // ignore: unused_field
-  final User _item;
-  $$UsersTableWithReferences(this._db, this._item);
-}
 
 class $DriftPostgresDatabaseManager {
   final _$DriftPostgresDatabase _db;

--- a/extras/drift_postgres/example/main.g.dart
+++ b/extras/drift_postgres/example/main.g.dart
@@ -219,7 +219,7 @@ class $$UsersTableTableManager extends RootTableManager<
     $$UsersTableOrderingComposer,
     $$UsersTableCreateCompanionBuilder,
     $$UsersTableUpdateCompanionBuilder,
-    $$UsersTableWithReferences,
+    (User, $$UsersTableWithReferences),
     User> {
   $$UsersTableTableManager(_$DriftPostgresDatabase db, $UsersTable table)
       : super(TableManagerState(
@@ -230,7 +230,7 @@ class $$UsersTableTableManager extends RootTableManager<
           orderingComposer:
               $$UsersTableOrderingComposer(ComposerState(db, table)),
           withReferenceMapper: (p0) =>
-              p0.map((e) => $$UsersTableWithReferences(db, e)).toList(),
+              p0.map((e) => (e, $$UsersTableWithReferences(db, e))).toList(),
           updateCompanionCallback: ({
             Value<UuidValue> id = const Value.absent(),
             Value<String> name = const Value.absent(),
@@ -262,7 +262,7 @@ typedef $$UsersTableProcessedTableManager = ProcessedTableManager<
     $$UsersTableOrderingComposer,
     $$UsersTableCreateCompanionBuilder,
     $$UsersTableUpdateCompanionBuilder,
-    $$UsersTableWithReferences,
+    (User, $$UsersTableWithReferences),
     User>;
 
 class $$UsersTableFilterComposer
@@ -296,8 +296,8 @@ class $$UsersTableOrderingComposer
 class $$UsersTableWithReferences {
   // ignore: unused_field
   final _$DriftPostgresDatabase _db;
-  final User user;
-  $$UsersTableWithReferences(this._db, this.user);
+  final User _item;
+  $$UsersTableWithReferences(this._db, this._item);
 }
 
 class $DriftPostgresDatabaseManager {

--- a/extras/drift_postgres/example/main.g.dart
+++ b/extras/drift_postgres/example/main.g.dart
@@ -229,7 +229,7 @@ class $$UsersTableTableManager extends RootTableManager<
               $$UsersTableFilterComposer(ComposerState(db, table)),
           orderingComposer:
               $$UsersTableOrderingComposer(ComposerState(db, table)),
-          dataclassMapper: (p0) async =>
+          withReferenceMapper: (p0) =>
               p0.map((e) => $$UsersTableWithReferences(db, e)).toList(),
           updateCompanionCallback: ({
             Value<UuidValue> id = const Value.absent(),

--- a/extras/drift_postgres/example/main.g.dart
+++ b/extras/drift_postgres/example/main.g.dart
@@ -218,7 +218,9 @@ class $$UsersTableTableManager extends RootTableManager<
     $$UsersTableFilterComposer,
     $$UsersTableOrderingComposer,
     $$UsersTableCreateCompanionBuilder,
-    $$UsersTableUpdateCompanionBuilder> {
+    $$UsersTableUpdateCompanionBuilder,
+    $$UsersTableWithReferences,
+    User> {
   $$UsersTableTableManager(_$DriftPostgresDatabase db, $UsersTable table)
       : super(TableManagerState(
           db: db,
@@ -227,6 +229,8 @@ class $$UsersTableTableManager extends RootTableManager<
               $$UsersTableFilterComposer(ComposerState(db, table)),
           orderingComposer:
               $$UsersTableOrderingComposer(ComposerState(db, table)),
+          dataclassMapper: (p0) async =>
+              p0.map((e) => $$UsersTableWithReferences(db, e)).toList(),
           updateCompanionCallback: ({
             Value<UuidValue> id = const Value.absent(),
             Value<String> name = const Value.absent(),
@@ -249,6 +253,17 @@ class $$UsersTableTableManager extends RootTableManager<
           ),
         ));
 }
+
+typedef $$UsersTableProcessedTableManager = ProcessedTableManager<
+    _$DriftPostgresDatabase,
+    $UsersTable,
+    User,
+    $$UsersTableFilterComposer,
+    $$UsersTableOrderingComposer,
+    $$UsersTableCreateCompanionBuilder,
+    $$UsersTableUpdateCompanionBuilder,
+    $$UsersTableWithReferences,
+    User>;
 
 class $$UsersTableFilterComposer
     extends FilterComposer<_$DriftPostgresDatabase, $UsersTable> {
@@ -276,6 +291,13 @@ class $$UsersTableOrderingComposer
       column: $state.table.name,
       builder: (column, joinBuilders) =>
           ColumnOrderings(column, joinBuilders: joinBuilders));
+}
+
+class $$UsersTableWithReferences {
+  // ignore: unused_field
+  final _$DriftPostgresDatabase _db;
+  final User user;
+  $$UsersTableWithReferences(this._db, this.user);
 }
 
 class $DriftPostgresDatabaseManager {

--- a/extras/integration_tests/drift_testcases/lib/database/database.g.dart
+++ b/extras/integration_tests/drift_testcases/lib/database/database.g.dart
@@ -741,7 +741,7 @@ class $$UsersTableTableManager extends RootTableManager<
     $$UsersTableOrderingComposer,
     $$UsersTableCreateCompanionBuilder,
     $$UsersTableUpdateCompanionBuilder,
-    $$UsersTableWithReferences,
+    (User, $$UsersTableWithReferences),
     User> {
   $$UsersTableTableManager(_$Database db, $UsersTable table)
       : super(TableManagerState(
@@ -752,7 +752,7 @@ class $$UsersTableTableManager extends RootTableManager<
           orderingComposer:
               $$UsersTableOrderingComposer(ComposerState(db, table)),
           withReferenceMapper: (p0) =>
-              p0.map((e) => $$UsersTableWithReferences(db, e)).toList(),
+              p0.map((e) => (e, $$UsersTableWithReferences(db, e))).toList(),
           updateCompanionCallback: ({
             Value<int> id = const Value.absent(),
             Value<String> name = const Value.absent(),
@@ -792,7 +792,7 @@ typedef $$UsersTableProcessedTableManager = ProcessedTableManager<
     $$UsersTableOrderingComposer,
     $$UsersTableCreateCompanionBuilder,
     $$UsersTableUpdateCompanionBuilder,
-    $$UsersTableWithReferences,
+    (User, $$UsersTableWithReferences),
     User>;
 
 class $$UsersTableFilterComposer
@@ -858,8 +858,8 @@ class $$UsersTableOrderingComposer
 class $$UsersTableWithReferences {
   // ignore: unused_field
   final _$Database _db;
-  final User user;
-  $$UsersTableWithReferences(this._db, this.user);
+  final User _item;
+  $$UsersTableWithReferences(this._db, this._item);
 }
 
 typedef $$FriendshipsTableCreateCompanionBuilder = FriendshipsCompanion
@@ -885,7 +885,7 @@ class $$FriendshipsTableTableManager extends RootTableManager<
     $$FriendshipsTableOrderingComposer,
     $$FriendshipsTableCreateCompanionBuilder,
     $$FriendshipsTableUpdateCompanionBuilder,
-    $$FriendshipsTableWithReferences,
+    (Friendship, $$FriendshipsTableWithReferences),
     Friendship> {
   $$FriendshipsTableTableManager(_$Database db, $FriendshipsTable table)
       : super(TableManagerState(
@@ -895,8 +895,9 @@ class $$FriendshipsTableTableManager extends RootTableManager<
               $$FriendshipsTableFilterComposer(ComposerState(db, table)),
           orderingComposer:
               $$FriendshipsTableOrderingComposer(ComposerState(db, table)),
-          withReferenceMapper: (p0) =>
-              p0.map((e) => $$FriendshipsTableWithReferences(db, e)).toList(),
+          withReferenceMapper: (p0) => p0
+              .map((e) => (e, $$FriendshipsTableWithReferences(db, e)))
+              .toList(),
           updateCompanionCallback: ({
             Value<int> firstUser = const Value.absent(),
             Value<int> secondUser = const Value.absent(),
@@ -932,7 +933,7 @@ typedef $$FriendshipsTableProcessedTableManager = ProcessedTableManager<
     $$FriendshipsTableOrderingComposer,
     $$FriendshipsTableCreateCompanionBuilder,
     $$FriendshipsTableUpdateCompanionBuilder,
-    $$FriendshipsTableWithReferences,
+    (Friendship, $$FriendshipsTableWithReferences),
     Friendship>;
 
 class $$FriendshipsTableFilterComposer
@@ -976,8 +977,8 @@ class $$FriendshipsTableOrderingComposer
 class $$FriendshipsTableWithReferences {
   // ignore: unused_field
   final _$Database _db;
-  final Friendship friendship;
-  $$FriendshipsTableWithReferences(this._db, this.friendship);
+  final Friendship _item;
+  $$FriendshipsTableWithReferences(this._db, this._item);
 }
 
 class $DatabaseManager {

--- a/extras/integration_tests/drift_testcases/lib/database/database.g.dart
+++ b/extras/integration_tests/drift_testcases/lib/database/database.g.dart
@@ -733,68 +733,6 @@ typedef $$UsersTableUpdateCompanionBuilder = UsersCompanion Function({
   Value<Preferences?> preferences,
 });
 
-class $$UsersTableTableManager extends RootTableManager<
-    _$Database,
-    $UsersTable,
-    User,
-    $$UsersTableFilterComposer,
-    $$UsersTableOrderingComposer,
-    $$UsersTableCreateCompanionBuilder,
-    $$UsersTableUpdateCompanionBuilder,
-    (User, $$UsersTableWithReferences),
-    User> {
-  $$UsersTableTableManager(_$Database db, $UsersTable table)
-      : super(TableManagerState(
-          db: db,
-          table: table,
-          filteringComposer:
-              $$UsersTableFilterComposer(ComposerState(db, table)),
-          orderingComposer:
-              $$UsersTableOrderingComposer(ComposerState(db, table)),
-          withReferenceMapper: (p0) =>
-              p0.map((e) => (e, $$UsersTableWithReferences(db, e))).toList(),
-          updateCompanionCallback: ({
-            Value<int> id = const Value.absent(),
-            Value<String> name = const Value.absent(),
-            Value<DateTime> birthDate = const Value.absent(),
-            Value<Uint8List?> profilePicture = const Value.absent(),
-            Value<Preferences?> preferences = const Value.absent(),
-          }) =>
-              UsersCompanion(
-            id: id,
-            name: name,
-            birthDate: birthDate,
-            profilePicture: profilePicture,
-            preferences: preferences,
-          ),
-          createCompanionCallback: ({
-            Value<int> id = const Value.absent(),
-            required String name,
-            required DateTime birthDate,
-            Value<Uint8List?> profilePicture = const Value.absent(),
-            Value<Preferences?> preferences = const Value.absent(),
-          }) =>
-              UsersCompanion.insert(
-            id: id,
-            name: name,
-            birthDate: birthDate,
-            profilePicture: profilePicture,
-            preferences: preferences,
-          ),
-        ));
-}
-
-typedef $$UsersTableProcessedTableManager = ProcessedTableManager<
-    _$Database,
-    $UsersTable,
-    User,
-    $$UsersTableFilterComposer,
-    $$UsersTableOrderingComposer,
-    $$UsersTableCreateCompanionBuilder,
-    $$UsersTableUpdateCompanionBuilder,
-    (User, $$UsersTableWithReferences),
-    User>;
-
 class $$UsersTableFilterComposer
     extends FilterComposer<_$Database, $UsersTable> {
   $$UsersTableFilterComposer(super.$state);
@@ -855,14 +793,67 @@ class $$UsersTableOrderingComposer
           ColumnOrderings(column, joinBuilders: joinBuilders));
 }
 
-class $$UsersTableWithReferences {
-  // ignore: unused_field
-  final _$Database _db;
-  // ignore: unused_field
-  final User _item;
-  $$UsersTableWithReferences(this._db, this._item);
+class $$UsersTableTableManager extends RootTableManager<
+    _$Database,
+    $UsersTable,
+    User,
+    $$UsersTableFilterComposer,
+    $$UsersTableOrderingComposer,
+    $$UsersTableCreateCompanionBuilder,
+    $$UsersTableUpdateCompanionBuilder,
+    (User, BaseWithReferences<_$Database, User>),
+    User> {
+  $$UsersTableTableManager(_$Database db, $UsersTable table)
+      : super(TableManagerState(
+          db: db,
+          table: table,
+          filteringComposer:
+              $$UsersTableFilterComposer(ComposerState(db, table)),
+          orderingComposer:
+              $$UsersTableOrderingComposer(ComposerState(db, table)),
+          withReferenceMapper: (p0) =>
+              p0.map((e) => (e, BaseWithReferences(db, e))).toList(),
+          updateCompanionCallback: ({
+            Value<int> id = const Value.absent(),
+            Value<String> name = const Value.absent(),
+            Value<DateTime> birthDate = const Value.absent(),
+            Value<Uint8List?> profilePicture = const Value.absent(),
+            Value<Preferences?> preferences = const Value.absent(),
+          }) =>
+              UsersCompanion(
+            id: id,
+            name: name,
+            birthDate: birthDate,
+            profilePicture: profilePicture,
+            preferences: preferences,
+          ),
+          createCompanionCallback: ({
+            Value<int> id = const Value.absent(),
+            required String name,
+            required DateTime birthDate,
+            Value<Uint8List?> profilePicture = const Value.absent(),
+            Value<Preferences?> preferences = const Value.absent(),
+          }) =>
+              UsersCompanion.insert(
+            id: id,
+            name: name,
+            birthDate: birthDate,
+            profilePicture: profilePicture,
+            preferences: preferences,
+          ),
+        ));
 }
 
+typedef $$UsersTableProcessedTableManager = ProcessedTableManager<
+    _$Database,
+    $UsersTable,
+    User,
+    $$UsersTableFilterComposer,
+    $$UsersTableOrderingComposer,
+    $$UsersTableCreateCompanionBuilder,
+    $$UsersTableUpdateCompanionBuilder,
+    (User, BaseWithReferences<_$Database, User>),
+    User>;
 typedef $$FriendshipsTableCreateCompanionBuilder = FriendshipsCompanion
     Function({
   required int firstUser,
@@ -877,65 +868,6 @@ typedef $$FriendshipsTableUpdateCompanionBuilder = FriendshipsCompanion
   Value<bool> reallyGoodFriends,
   Value<int> rowid,
 });
-
-class $$FriendshipsTableTableManager extends RootTableManager<
-    _$Database,
-    $FriendshipsTable,
-    Friendship,
-    $$FriendshipsTableFilterComposer,
-    $$FriendshipsTableOrderingComposer,
-    $$FriendshipsTableCreateCompanionBuilder,
-    $$FriendshipsTableUpdateCompanionBuilder,
-    (Friendship, $$FriendshipsTableWithReferences),
-    Friendship> {
-  $$FriendshipsTableTableManager(_$Database db, $FriendshipsTable table)
-      : super(TableManagerState(
-          db: db,
-          table: table,
-          filteringComposer:
-              $$FriendshipsTableFilterComposer(ComposerState(db, table)),
-          orderingComposer:
-              $$FriendshipsTableOrderingComposer(ComposerState(db, table)),
-          withReferenceMapper: (p0) => p0
-              .map((e) => (e, $$FriendshipsTableWithReferences(db, e)))
-              .toList(),
-          updateCompanionCallback: ({
-            Value<int> firstUser = const Value.absent(),
-            Value<int> secondUser = const Value.absent(),
-            Value<bool> reallyGoodFriends = const Value.absent(),
-            Value<int> rowid = const Value.absent(),
-          }) =>
-              FriendshipsCompanion(
-            firstUser: firstUser,
-            secondUser: secondUser,
-            reallyGoodFriends: reallyGoodFriends,
-            rowid: rowid,
-          ),
-          createCompanionCallback: ({
-            required int firstUser,
-            required int secondUser,
-            Value<bool> reallyGoodFriends = const Value.absent(),
-            Value<int> rowid = const Value.absent(),
-          }) =>
-              FriendshipsCompanion.insert(
-            firstUser: firstUser,
-            secondUser: secondUser,
-            reallyGoodFriends: reallyGoodFriends,
-            rowid: rowid,
-          ),
-        ));
-}
-
-typedef $$FriendshipsTableProcessedTableManager = ProcessedTableManager<
-    _$Database,
-    $FriendshipsTable,
-    Friendship,
-    $$FriendshipsTableFilterComposer,
-    $$FriendshipsTableOrderingComposer,
-    $$FriendshipsTableCreateCompanionBuilder,
-    $$FriendshipsTableUpdateCompanionBuilder,
-    (Friendship, $$FriendshipsTableWithReferences),
-    Friendship>;
 
 class $$FriendshipsTableFilterComposer
     extends FilterComposer<_$Database, $FriendshipsTable> {
@@ -975,13 +907,63 @@ class $$FriendshipsTableOrderingComposer
           ColumnOrderings(column, joinBuilders: joinBuilders));
 }
 
-class $$FriendshipsTableWithReferences {
-  // ignore: unused_field
-  final _$Database _db;
-  // ignore: unused_field
-  final Friendship _item;
-  $$FriendshipsTableWithReferences(this._db, this._item);
+class $$FriendshipsTableTableManager extends RootTableManager<
+    _$Database,
+    $FriendshipsTable,
+    Friendship,
+    $$FriendshipsTableFilterComposer,
+    $$FriendshipsTableOrderingComposer,
+    $$FriendshipsTableCreateCompanionBuilder,
+    $$FriendshipsTableUpdateCompanionBuilder,
+    (Friendship, BaseWithReferences<_$Database, Friendship>),
+    Friendship> {
+  $$FriendshipsTableTableManager(_$Database db, $FriendshipsTable table)
+      : super(TableManagerState(
+          db: db,
+          table: table,
+          filteringComposer:
+              $$FriendshipsTableFilterComposer(ComposerState(db, table)),
+          orderingComposer:
+              $$FriendshipsTableOrderingComposer(ComposerState(db, table)),
+          withReferenceMapper: (p0) =>
+              p0.map((e) => (e, BaseWithReferences(db, e))).toList(),
+          updateCompanionCallback: ({
+            Value<int> firstUser = const Value.absent(),
+            Value<int> secondUser = const Value.absent(),
+            Value<bool> reallyGoodFriends = const Value.absent(),
+            Value<int> rowid = const Value.absent(),
+          }) =>
+              FriendshipsCompanion(
+            firstUser: firstUser,
+            secondUser: secondUser,
+            reallyGoodFriends: reallyGoodFriends,
+            rowid: rowid,
+          ),
+          createCompanionCallback: ({
+            required int firstUser,
+            required int secondUser,
+            Value<bool> reallyGoodFriends = const Value.absent(),
+            Value<int> rowid = const Value.absent(),
+          }) =>
+              FriendshipsCompanion.insert(
+            firstUser: firstUser,
+            secondUser: secondUser,
+            reallyGoodFriends: reallyGoodFriends,
+            rowid: rowid,
+          ),
+        ));
 }
+
+typedef $$FriendshipsTableProcessedTableManager = ProcessedTableManager<
+    _$Database,
+    $FriendshipsTable,
+    Friendship,
+    $$FriendshipsTableFilterComposer,
+    $$FriendshipsTableOrderingComposer,
+    $$FriendshipsTableCreateCompanionBuilder,
+    $$FriendshipsTableUpdateCompanionBuilder,
+    (Friendship, BaseWithReferences<_$Database, Friendship>),
+    Friendship>;
 
 class $DatabaseManager {
   final _$Database _db;

--- a/extras/integration_tests/drift_testcases/lib/database/database.g.dart
+++ b/extras/integration_tests/drift_testcases/lib/database/database.g.dart
@@ -751,7 +751,7 @@ class $$UsersTableTableManager extends RootTableManager<
               $$UsersTableFilterComposer(ComposerState(db, table)),
           orderingComposer:
               $$UsersTableOrderingComposer(ComposerState(db, table)),
-          dataclassMapper: (p0) async =>
+          withReferenceMapper: (p0) =>
               p0.map((e) => $$UsersTableWithReferences(db, e)).toList(),
           updateCompanionCallback: ({
             Value<int> id = const Value.absent(),
@@ -895,7 +895,7 @@ class $$FriendshipsTableTableManager extends RootTableManager<
               $$FriendshipsTableFilterComposer(ComposerState(db, table)),
           orderingComposer:
               $$FriendshipsTableOrderingComposer(ComposerState(db, table)),
-          dataclassMapper: (p0) async =>
+          withReferenceMapper: (p0) =>
               p0.map((e) => $$FriendshipsTableWithReferences(db, e)).toList(),
           updateCompanionCallback: ({
             Value<int> firstUser = const Value.absent(),

--- a/extras/integration_tests/drift_testcases/lib/database/database.g.dart
+++ b/extras/integration_tests/drift_testcases/lib/database/database.g.dart
@@ -740,7 +740,9 @@ class $$UsersTableTableManager extends RootTableManager<
     $$UsersTableFilterComposer,
     $$UsersTableOrderingComposer,
     $$UsersTableCreateCompanionBuilder,
-    $$UsersTableUpdateCompanionBuilder> {
+    $$UsersTableUpdateCompanionBuilder,
+    $$UsersTableWithReferences,
+    User> {
   $$UsersTableTableManager(_$Database db, $UsersTable table)
       : super(TableManagerState(
           db: db,
@@ -749,6 +751,8 @@ class $$UsersTableTableManager extends RootTableManager<
               $$UsersTableFilterComposer(ComposerState(db, table)),
           orderingComposer:
               $$UsersTableOrderingComposer(ComposerState(db, table)),
+          dataclassMapper: (p0) async =>
+              p0.map((e) => $$UsersTableWithReferences(db, e)).toList(),
           updateCompanionCallback: ({
             Value<int> id = const Value.absent(),
             Value<String> name = const Value.absent(),
@@ -779,6 +783,17 @@ class $$UsersTableTableManager extends RootTableManager<
           ),
         ));
 }
+
+typedef $$UsersTableProcessedTableManager = ProcessedTableManager<
+    _$Database,
+    $UsersTable,
+    User,
+    $$UsersTableFilterComposer,
+    $$UsersTableOrderingComposer,
+    $$UsersTableCreateCompanionBuilder,
+    $$UsersTableUpdateCompanionBuilder,
+    $$UsersTableWithReferences,
+    User>;
 
 class $$UsersTableFilterComposer
     extends FilterComposer<_$Database, $UsersTable> {
@@ -840,6 +855,13 @@ class $$UsersTableOrderingComposer
           ColumnOrderings(column, joinBuilders: joinBuilders));
 }
 
+class $$UsersTableWithReferences {
+  // ignore: unused_field
+  final _$Database _db;
+  final User user;
+  $$UsersTableWithReferences(this._db, this.user);
+}
+
 typedef $$FriendshipsTableCreateCompanionBuilder = FriendshipsCompanion
     Function({
   required int firstUser,
@@ -862,7 +884,9 @@ class $$FriendshipsTableTableManager extends RootTableManager<
     $$FriendshipsTableFilterComposer,
     $$FriendshipsTableOrderingComposer,
     $$FriendshipsTableCreateCompanionBuilder,
-    $$FriendshipsTableUpdateCompanionBuilder> {
+    $$FriendshipsTableUpdateCompanionBuilder,
+    $$FriendshipsTableWithReferences,
+    Friendship> {
   $$FriendshipsTableTableManager(_$Database db, $FriendshipsTable table)
       : super(TableManagerState(
           db: db,
@@ -871,6 +895,8 @@ class $$FriendshipsTableTableManager extends RootTableManager<
               $$FriendshipsTableFilterComposer(ComposerState(db, table)),
           orderingComposer:
               $$FriendshipsTableOrderingComposer(ComposerState(db, table)),
+          dataclassMapper: (p0) async =>
+              p0.map((e) => $$FriendshipsTableWithReferences(db, e)).toList(),
           updateCompanionCallback: ({
             Value<int> firstUser = const Value.absent(),
             Value<int> secondUser = const Value.absent(),
@@ -897,6 +923,17 @@ class $$FriendshipsTableTableManager extends RootTableManager<
           ),
         ));
 }
+
+typedef $$FriendshipsTableProcessedTableManager = ProcessedTableManager<
+    _$Database,
+    $FriendshipsTable,
+    Friendship,
+    $$FriendshipsTableFilterComposer,
+    $$FriendshipsTableOrderingComposer,
+    $$FriendshipsTableCreateCompanionBuilder,
+    $$FriendshipsTableUpdateCompanionBuilder,
+    $$FriendshipsTableWithReferences,
+    Friendship>;
 
 class $$FriendshipsTableFilterComposer
     extends FilterComposer<_$Database, $FriendshipsTable> {
@@ -934,6 +971,13 @@ class $$FriendshipsTableOrderingComposer
       column: $state.table.reallyGoodFriends,
       builder: (column, joinBuilders) =>
           ColumnOrderings(column, joinBuilders: joinBuilders));
+}
+
+class $$FriendshipsTableWithReferences {
+  // ignore: unused_field
+  final _$Database _db;
+  final Friendship friendship;
+  $$FriendshipsTableWithReferences(this._db, this.friendship);
 }
 
 class $DatabaseManager {

--- a/extras/integration_tests/drift_testcases/lib/database/database.g.dart
+++ b/extras/integration_tests/drift_testcases/lib/database/database.g.dart
@@ -858,6 +858,7 @@ class $$UsersTableOrderingComposer
 class $$UsersTableWithReferences {
   // ignore: unused_field
   final _$Database _db;
+  // ignore: unused_field
   final User _item;
   $$UsersTableWithReferences(this._db, this._item);
 }
@@ -977,6 +978,7 @@ class $$FriendshipsTableOrderingComposer
 class $$FriendshipsTableWithReferences {
   // ignore: unused_field
   final _$Database _db;
+  // ignore: unused_field
   final Friendship _item;
   $$FriendshipsTableWithReferences(this._db, this._item);
 }

--- a/extras/integration_tests/web_wasm/lib/src/database.g.dart
+++ b/extras/integration_tests/web_wasm/lib/src/database.g.dart
@@ -203,57 +203,6 @@ typedef $$TestTableTableUpdateCompanionBuilder = TestTableCompanion Function({
   Value<String> content,
 });
 
-class $$TestTableTableTableManager extends RootTableManager<
-    _$TestDatabase,
-    $TestTableTable,
-    TestTableData,
-    $$TestTableTableFilterComposer,
-    $$TestTableTableOrderingComposer,
-    $$TestTableTableCreateCompanionBuilder,
-    $$TestTableTableUpdateCompanionBuilder,
-    (TestTableData, $$TestTableTableWithReferences),
-    TestTableData> {
-  $$TestTableTableTableManager(_$TestDatabase db, $TestTableTable table)
-      : super(TableManagerState(
-          db: db,
-          table: table,
-          filteringComposer:
-              $$TestTableTableFilterComposer(ComposerState(db, table)),
-          orderingComposer:
-              $$TestTableTableOrderingComposer(ComposerState(db, table)),
-          withReferenceMapper: (p0) => p0
-              .map((e) => (e, $$TestTableTableWithReferences(db, e)))
-              .toList(),
-          updateCompanionCallback: ({
-            Value<int> id = const Value.absent(),
-            Value<String> content = const Value.absent(),
-          }) =>
-              TestTableCompanion(
-            id: id,
-            content: content,
-          ),
-          createCompanionCallback: ({
-            Value<int> id = const Value.absent(),
-            required String content,
-          }) =>
-              TestTableCompanion.insert(
-            id: id,
-            content: content,
-          ),
-        ));
-}
-
-typedef $$TestTableTableProcessedTableManager = ProcessedTableManager<
-    _$TestDatabase,
-    $TestTableTable,
-    TestTableData,
-    $$TestTableTableFilterComposer,
-    $$TestTableTableOrderingComposer,
-    $$TestTableTableCreateCompanionBuilder,
-    $$TestTableTableUpdateCompanionBuilder,
-    (TestTableData, $$TestTableTableWithReferences),
-    TestTableData>;
-
 class $$TestTableTableFilterComposer
     extends FilterComposer<_$TestDatabase, $TestTableTable> {
   $$TestTableTableFilterComposer(super.$state);
@@ -282,13 +231,55 @@ class $$TestTableTableOrderingComposer
           ColumnOrderings(column, joinBuilders: joinBuilders));
 }
 
-class $$TestTableTableWithReferences {
-  // ignore: unused_field
-  final _$TestDatabase _db;
-  // ignore: unused_field
-  final TestTableData _item;
-  $$TestTableTableWithReferences(this._db, this._item);
+class $$TestTableTableTableManager extends RootTableManager<
+    _$TestDatabase,
+    $TestTableTable,
+    TestTableData,
+    $$TestTableTableFilterComposer,
+    $$TestTableTableOrderingComposer,
+    $$TestTableTableCreateCompanionBuilder,
+    $$TestTableTableUpdateCompanionBuilder,
+    (TestTableData, BaseWithReferences<_$TestDatabase, TestTableData>),
+    TestTableData> {
+  $$TestTableTableTableManager(_$TestDatabase db, $TestTableTable table)
+      : super(TableManagerState(
+          db: db,
+          table: table,
+          filteringComposer:
+              $$TestTableTableFilterComposer(ComposerState(db, table)),
+          orderingComposer:
+              $$TestTableTableOrderingComposer(ComposerState(db, table)),
+          withReferenceMapper: (p0) =>
+              p0.map((e) => (e, BaseWithReferences(db, e))).toList(),
+          updateCompanionCallback: ({
+            Value<int> id = const Value.absent(),
+            Value<String> content = const Value.absent(),
+          }) =>
+              TestTableCompanion(
+            id: id,
+            content: content,
+          ),
+          createCompanionCallback: ({
+            Value<int> id = const Value.absent(),
+            required String content,
+          }) =>
+              TestTableCompanion.insert(
+            id: id,
+            content: content,
+          ),
+        ));
 }
+
+typedef $$TestTableTableProcessedTableManager = ProcessedTableManager<
+    _$TestDatabase,
+    $TestTableTable,
+    TestTableData,
+    $$TestTableTableFilterComposer,
+    $$TestTableTableOrderingComposer,
+    $$TestTableTableCreateCompanionBuilder,
+    $$TestTableTableUpdateCompanionBuilder,
+    (TestTableData, BaseWithReferences<_$TestDatabase, TestTableData>),
+    TestTableData>;
 
 class $TestDatabaseManager {
   final _$TestDatabase _db;

--- a/extras/integration_tests/web_wasm/lib/src/database.g.dart
+++ b/extras/integration_tests/web_wasm/lib/src/database.g.dart
@@ -221,7 +221,7 @@ class $$TestTableTableTableManager extends RootTableManager<
               $$TestTableTableFilterComposer(ComposerState(db, table)),
           orderingComposer:
               $$TestTableTableOrderingComposer(ComposerState(db, table)),
-          dataclassMapper: (p0) async =>
+          withReferenceMapper: (p0) =>
               p0.map((e) => $$TestTableTableWithReferences(db, e)).toList(),
           updateCompanionCallback: ({
             Value<int> id = const Value.absent(),

--- a/extras/integration_tests/web_wasm/lib/src/database.g.dart
+++ b/extras/integration_tests/web_wasm/lib/src/database.g.dart
@@ -285,6 +285,7 @@ class $$TestTableTableOrderingComposer
 class $$TestTableTableWithReferences {
   // ignore: unused_field
   final _$TestDatabase _db;
+  // ignore: unused_field
   final TestTableData _item;
   $$TestTableTableWithReferences(this._db, this._item);
 }

--- a/extras/integration_tests/web_wasm/lib/src/database.g.dart
+++ b/extras/integration_tests/web_wasm/lib/src/database.g.dart
@@ -211,7 +211,7 @@ class $$TestTableTableTableManager extends RootTableManager<
     $$TestTableTableOrderingComposer,
     $$TestTableTableCreateCompanionBuilder,
     $$TestTableTableUpdateCompanionBuilder,
-    $$TestTableTableWithReferences,
+    (TestTableData, $$TestTableTableWithReferences),
     TestTableData> {
   $$TestTableTableTableManager(_$TestDatabase db, $TestTableTable table)
       : super(TableManagerState(
@@ -221,8 +221,9 @@ class $$TestTableTableTableManager extends RootTableManager<
               $$TestTableTableFilterComposer(ComposerState(db, table)),
           orderingComposer:
               $$TestTableTableOrderingComposer(ComposerState(db, table)),
-          withReferenceMapper: (p0) =>
-              p0.map((e) => $$TestTableTableWithReferences(db, e)).toList(),
+          withReferenceMapper: (p0) => p0
+              .map((e) => (e, $$TestTableTableWithReferences(db, e)))
+              .toList(),
           updateCompanionCallback: ({
             Value<int> id = const Value.absent(),
             Value<String> content = const Value.absent(),
@@ -250,7 +251,7 @@ typedef $$TestTableTableProcessedTableManager = ProcessedTableManager<
     $$TestTableTableOrderingComposer,
     $$TestTableTableCreateCompanionBuilder,
     $$TestTableTableUpdateCompanionBuilder,
-    $$TestTableTableWithReferences,
+    (TestTableData, $$TestTableTableWithReferences),
     TestTableData>;
 
 class $$TestTableTableFilterComposer
@@ -284,8 +285,8 @@ class $$TestTableTableOrderingComposer
 class $$TestTableTableWithReferences {
   // ignore: unused_field
   final _$TestDatabase _db;
-  final TestTableData testTableData;
-  $$TestTableTableWithReferences(this._db, this.testTableData);
+  final TestTableData _item;
+  $$TestTableTableWithReferences(this._db, this._item);
 }
 
 class $TestDatabaseManager {

--- a/extras/integration_tests/web_wasm/lib/src/database.g.dart
+++ b/extras/integration_tests/web_wasm/lib/src/database.g.dart
@@ -210,7 +210,9 @@ class $$TestTableTableTableManager extends RootTableManager<
     $$TestTableTableFilterComposer,
     $$TestTableTableOrderingComposer,
     $$TestTableTableCreateCompanionBuilder,
-    $$TestTableTableUpdateCompanionBuilder> {
+    $$TestTableTableUpdateCompanionBuilder,
+    $$TestTableTableWithReferences,
+    TestTableData> {
   $$TestTableTableTableManager(_$TestDatabase db, $TestTableTable table)
       : super(TableManagerState(
           db: db,
@@ -219,6 +221,8 @@ class $$TestTableTableTableManager extends RootTableManager<
               $$TestTableTableFilterComposer(ComposerState(db, table)),
           orderingComposer:
               $$TestTableTableOrderingComposer(ComposerState(db, table)),
+          dataclassMapper: (p0) async =>
+              p0.map((e) => $$TestTableTableWithReferences(db, e)).toList(),
           updateCompanionCallback: ({
             Value<int> id = const Value.absent(),
             Value<String> content = const Value.absent(),
@@ -237,6 +241,17 @@ class $$TestTableTableTableManager extends RootTableManager<
           ),
         ));
 }
+
+typedef $$TestTableTableProcessedTableManager = ProcessedTableManager<
+    _$TestDatabase,
+    $TestTableTable,
+    TestTableData,
+    $$TestTableTableFilterComposer,
+    $$TestTableTableOrderingComposer,
+    $$TestTableTableCreateCompanionBuilder,
+    $$TestTableTableUpdateCompanionBuilder,
+    $$TestTableTableWithReferences,
+    TestTableData>;
 
 class $$TestTableTableFilterComposer
     extends FilterComposer<_$TestDatabase, $TestTableTable> {
@@ -264,6 +279,13 @@ class $$TestTableTableOrderingComposer
       column: $state.table.content,
       builder: (column, joinBuilders) =>
           ColumnOrderings(column, joinBuilders: joinBuilders));
+}
+
+class $$TestTableTableWithReferences {
+  // ignore: unused_field
+  final _$TestDatabase _db;
+  final TestTableData testTableData;
+  $$TestTableTableWithReferences(this._db, this.testTableData);
 }
 
 class $TestDatabaseManager {


### PR DESCRIPTION
This PR adds the ability to do `withReferences` to get a manager that will return the row, along with pre-filtered managers for the related values.

This is how this feature work.

Every Manager has a Generic for holding the Dataclass for a row. 
It's called `$Dataclass`, and it refers to the original data class that Drift uses when working with the table. E.G `$User`

We now create another class called `<name>WithReferences` which contains the original dataclass, along with all the references. This new `$UserWithReferences` class is now ALSO a generic on the manager called `$MappedDataclass`

However, we need to keep track which data class will be returned.
For this we have a 3rd generic `$ActiveDataclass`, this is set to `$Dataclass` by default, but when `users.withReferences` is called, we return a Manager with `$MappedDataclass` as the `$ActiveDataclass`.

To actually perform the mapping, we have a callback on the manager that applies a mapping to each item in the database.

It's all getting very confusing. Let me know how If can help clarify anything.


---

This potentially has a breaking change if people have filters that utilize references with Type Converters that aren't symmetrical.
This causes a bug where needless joins are being created, so it's not a breaking change.

People may get warnings when re-generating, warnings that they've never seen before, which is jarring to them. I wonder what we should do alleviate that.

@simolus3 Ready for review