### PR TITLE
References with Prefetching

### DIFF
--- a/docs/lib/snippets/_shared/todo_tables.drift.dart
+++ b/docs/lib/snippets/_shared/todo_tables.drift.dart
@@ -424,7 +424,7 @@ class $$TodoItemsTableTableManager extends i0.RootTableManager<
       i0.BaseReferences<i0.GeneratedDatabase, i1.$TodoItemsTable, i1.TodoItem>
     ),
     i1.TodoItem,
-    i0.PrefetchHooks Function({bool category, bool inTransaction})> {
+    i0.PrefetchHooks Function({bool category})> {
   $$TodoItemsTableTableManager(
       i0.GeneratedDatabase db, i1.$TodoItemsTable table)
       : super(i0.TableManagerState(
@@ -482,7 +482,7 @@ typedef $$TodoItemsTableProcessedTableManager = i0.ProcessedTableManager<
       i0.BaseReferences<i0.GeneratedDatabase, i1.$TodoItemsTable, i1.TodoItem>
     ),
     i1.TodoItem,
-    i0.PrefetchHooks Function({bool category, bool inTransaction})>;
+    i0.PrefetchHooks Function({bool category})>;
 
 class $CategoriesTable extends i2.Categories
     with i0.TableInfo<$CategoriesTable, i1.Category> {

--- a/docs/lib/snippets/_shared/todo_tables.drift.dart
+++ b/docs/lib/snippets/_shared/todo_tables.drift.dart
@@ -424,7 +424,7 @@ class $$TodoItemsTableTableManager extends i0.RootTableManager<
       i0.BaseReferences<i0.GeneratedDatabase, i1.$TodoItemsTable, i1.TodoItem>
     ),
     i1.TodoItem,
-    i0.PrefetchHooks Function({bool category})> {
+    i0.PrefetchHooks Function({bool category, bool inTransaction})> {
   $$TodoItemsTableTableManager(
       i0.GeneratedDatabase db, i1.$TodoItemsTable table)
       : super(i0.TableManagerState(
@@ -482,7 +482,7 @@ typedef $$TodoItemsTableProcessedTableManager = i0.ProcessedTableManager<
       i0.BaseReferences<i0.GeneratedDatabase, i1.$TodoItemsTable, i1.TodoItem>
     ),
     i1.TodoItem,
-    i0.PrefetchHooks Function({bool category})>;
+    i0.PrefetchHooks Function({bool category, bool inTransaction})>;
 
 class $CategoriesTable extends i2.Categories
     with i0.TableInfo<$CategoriesTable, i1.Category> {

--- a/docs/lib/snippets/_shared/todo_tables.drift.dart
+++ b/docs/lib/snippets/_shared/todo_tables.drift.dart
@@ -328,54 +328,6 @@ typedef $$TodoItemsTableUpdateCompanionBuilder = i1.TodoItemsCompanion
   i0.Value<DateTime?> dueDate,
 });
 
-class $$TodoItemsTableTableManager extends i0.RootTableManager<
-    i0.GeneratedDatabase,
-    i1.$TodoItemsTable,
-    i1.TodoItem,
-    i1.$$TodoItemsTableFilterComposer,
-    i1.$$TodoItemsTableOrderingComposer,
-    $$TodoItemsTableCreateCompanionBuilder,
-    $$TodoItemsTableUpdateCompanionBuilder> {
-  $$TodoItemsTableTableManager(
-      i0.GeneratedDatabase db, i1.$TodoItemsTable table)
-      : super(i0.TableManagerState(
-          db: db,
-          table: table,
-          filteringComposer:
-              i1.$$TodoItemsTableFilterComposer(i0.ComposerState(db, table)),
-          orderingComposer:
-              i1.$$TodoItemsTableOrderingComposer(i0.ComposerState(db, table)),
-          updateCompanionCallback: ({
-            i0.Value<int> id = const i0.Value.absent(),
-            i0.Value<String> title = const i0.Value.absent(),
-            i0.Value<String> content = const i0.Value.absent(),
-            i0.Value<int?> category = const i0.Value.absent(),
-            i0.Value<DateTime?> dueDate = const i0.Value.absent(),
-          }) =>
-              i1.TodoItemsCompanion(
-            id: id,
-            title: title,
-            content: content,
-            category: category,
-            dueDate: dueDate,
-          ),
-          createCompanionCallback: ({
-            i0.Value<int> id = const i0.Value.absent(),
-            required String title,
-            required String content,
-            i0.Value<int?> category = const i0.Value.absent(),
-            i0.Value<DateTime?> dueDate = const i0.Value.absent(),
-          }) =>
-              i1.TodoItemsCompanion.insert(
-            id: id,
-            title: title,
-            content: content,
-            category: category,
-            dueDate: dueDate,
-          ),
-        ));
-}
-
 class $$TodoItemsTableFilterComposer
     extends i0.FilterComposer<i0.GeneratedDatabase, i1.$TodoItemsTable> {
   $$TodoItemsTableFilterComposer(super.$state);
@@ -458,6 +410,79 @@ class $$TodoItemsTableOrderingComposer
     return composer;
   }
 }
+
+class $$TodoItemsTableTableManager extends i0.RootTableManager<
+    i0.GeneratedDatabase,
+    i1.$TodoItemsTable,
+    i1.TodoItem,
+    i1.$$TodoItemsTableFilterComposer,
+    i1.$$TodoItemsTableOrderingComposer,
+    $$TodoItemsTableCreateCompanionBuilder,
+    $$TodoItemsTableUpdateCompanionBuilder,
+    (
+      i1.TodoItem,
+      i0.BaseReferences<i0.GeneratedDatabase, i1.$TodoItemsTable, i1.TodoItem>
+    ),
+    i1.TodoItem,
+    i0.PrefetchHooks Function({bool category})> {
+  $$TodoItemsTableTableManager(
+      i0.GeneratedDatabase db, i1.$TodoItemsTable table)
+      : super(i0.TableManagerState(
+          db: db,
+          table: table,
+          filteringComposer:
+              i1.$$TodoItemsTableFilterComposer(i0.ComposerState(db, table)),
+          orderingComposer:
+              i1.$$TodoItemsTableOrderingComposer(i0.ComposerState(db, table)),
+          updateCompanionCallback: ({
+            i0.Value<int> id = const i0.Value.absent(),
+            i0.Value<String> title = const i0.Value.absent(),
+            i0.Value<String> content = const i0.Value.absent(),
+            i0.Value<int?> category = const i0.Value.absent(),
+            i0.Value<DateTime?> dueDate = const i0.Value.absent(),
+          }) =>
+              i1.TodoItemsCompanion(
+            id: id,
+            title: title,
+            content: content,
+            category: category,
+            dueDate: dueDate,
+          ),
+          createCompanionCallback: ({
+            i0.Value<int> id = const i0.Value.absent(),
+            required String title,
+            required String content,
+            i0.Value<int?> category = const i0.Value.absent(),
+            i0.Value<DateTime?> dueDate = const i0.Value.absent(),
+          }) =>
+              i1.TodoItemsCompanion.insert(
+            id: id,
+            title: title,
+            content: content,
+            category: category,
+            dueDate: dueDate,
+          ),
+          withReferenceMapper: (p0) => p0
+              .map((e) => (e.readTable(table), i0.BaseReferences(db, table, e)))
+              .toList(),
+          prefetchHooksCallback: null,
+        ));
+}
+
+typedef $$TodoItemsTableProcessedTableManager = i0.ProcessedTableManager<
+    i0.GeneratedDatabase,
+    i1.$TodoItemsTable,
+    i1.TodoItem,
+    i1.$$TodoItemsTableFilterComposer,
+    i1.$$TodoItemsTableOrderingComposer,
+    $$TodoItemsTableCreateCompanionBuilder,
+    $$TodoItemsTableUpdateCompanionBuilder,
+    (
+      i1.TodoItem,
+      i0.BaseReferences<i0.GeneratedDatabase, i1.$TodoItemsTable, i1.TodoItem>
+    ),
+    i1.TodoItem,
+    i0.PrefetchHooks Function({bool category})>;
 
 class $CategoriesTable extends i2.Categories
     with i0.TableInfo<$CategoriesTable, i1.Category> {
@@ -648,42 +673,6 @@ typedef $$CategoriesTableUpdateCompanionBuilder = i1.CategoriesCompanion
   i0.Value<String> name,
 });
 
-class $$CategoriesTableTableManager extends i0.RootTableManager<
-    i0.GeneratedDatabase,
-    i1.$CategoriesTable,
-    i1.Category,
-    i1.$$CategoriesTableFilterComposer,
-    i1.$$CategoriesTableOrderingComposer,
-    $$CategoriesTableCreateCompanionBuilder,
-    $$CategoriesTableUpdateCompanionBuilder> {
-  $$CategoriesTableTableManager(
-      i0.GeneratedDatabase db, i1.$CategoriesTable table)
-      : super(i0.TableManagerState(
-          db: db,
-          table: table,
-          filteringComposer:
-              i1.$$CategoriesTableFilterComposer(i0.ComposerState(db, table)),
-          orderingComposer:
-              i1.$$CategoriesTableOrderingComposer(i0.ComposerState(db, table)),
-          updateCompanionCallback: ({
-            i0.Value<int> id = const i0.Value.absent(),
-            i0.Value<String> name = const i0.Value.absent(),
-          }) =>
-              i1.CategoriesCompanion(
-            id: id,
-            name: name,
-          ),
-          createCompanionCallback: ({
-            i0.Value<int> id = const i0.Value.absent(),
-            required String name,
-          }) =>
-              i1.CategoriesCompanion.insert(
-            id: id,
-            name: name,
-          ),
-        ));
-}
-
 class $$CategoriesTableFilterComposer
     extends i0.FilterComposer<i0.GeneratedDatabase, i1.$CategoriesTable> {
   $$CategoriesTableFilterComposer(super.$state);
@@ -711,6 +700,67 @@ class $$CategoriesTableOrderingComposer
       builder: (column, joinBuilders) =>
           i0.ColumnOrderings(column, joinBuilders: joinBuilders));
 }
+
+class $$CategoriesTableTableManager extends i0.RootTableManager<
+    i0.GeneratedDatabase,
+    i1.$CategoriesTable,
+    i1.Category,
+    i1.$$CategoriesTableFilterComposer,
+    i1.$$CategoriesTableOrderingComposer,
+    $$CategoriesTableCreateCompanionBuilder,
+    $$CategoriesTableUpdateCompanionBuilder,
+    (
+      i1.Category,
+      i0.BaseReferences<i0.GeneratedDatabase, i1.$CategoriesTable, i1.Category>
+    ),
+    i1.Category,
+    i0.PrefetchHooks Function()> {
+  $$CategoriesTableTableManager(
+      i0.GeneratedDatabase db, i1.$CategoriesTable table)
+      : super(i0.TableManagerState(
+          db: db,
+          table: table,
+          filteringComposer:
+              i1.$$CategoriesTableFilterComposer(i0.ComposerState(db, table)),
+          orderingComposer:
+              i1.$$CategoriesTableOrderingComposer(i0.ComposerState(db, table)),
+          updateCompanionCallback: ({
+            i0.Value<int> id = const i0.Value.absent(),
+            i0.Value<String> name = const i0.Value.absent(),
+          }) =>
+              i1.CategoriesCompanion(
+            id: id,
+            name: name,
+          ),
+          createCompanionCallback: ({
+            i0.Value<int> id = const i0.Value.absent(),
+            required String name,
+          }) =>
+              i1.CategoriesCompanion.insert(
+            id: id,
+            name: name,
+          ),
+          withReferenceMapper: (p0) => p0
+              .map((e) => (e.readTable(table), i0.BaseReferences(db, table, e)))
+              .toList(),
+          prefetchHooksCallback: null,
+        ));
+}
+
+typedef $$CategoriesTableProcessedTableManager = i0.ProcessedTableManager<
+    i0.GeneratedDatabase,
+    i1.$CategoriesTable,
+    i1.Category,
+    i1.$$CategoriesTableFilterComposer,
+    i1.$$CategoriesTableOrderingComposer,
+    $$CategoriesTableCreateCompanionBuilder,
+    $$CategoriesTableUpdateCompanionBuilder,
+    (
+      i1.Category,
+      i0.BaseReferences<i0.GeneratedDatabase, i1.$CategoriesTable, i1.Category>
+    ),
+    i1.Category,
+    i0.PrefetchHooks Function()>;
 
 class $UsersTable extends i2.Users with i0.TableInfo<$UsersTable, i1.User> {
   @override
@@ -901,41 +951,6 @@ typedef $$UsersTableUpdateCompanionBuilder = i1.UsersCompanion Function({
   i0.Value<DateTime> birthDate,
 });
 
-class $$UsersTableTableManager extends i0.RootTableManager<
-    i0.GeneratedDatabase,
-    i1.$UsersTable,
-    i1.User,
-    i1.$$UsersTableFilterComposer,
-    i1.$$UsersTableOrderingComposer,
-    $$UsersTableCreateCompanionBuilder,
-    $$UsersTableUpdateCompanionBuilder> {
-  $$UsersTableTableManager(i0.GeneratedDatabase db, i1.$UsersTable table)
-      : super(i0.TableManagerState(
-          db: db,
-          table: table,
-          filteringComposer:
-              i1.$$UsersTableFilterComposer(i0.ComposerState(db, table)),
-          orderingComposer:
-              i1.$$UsersTableOrderingComposer(i0.ComposerState(db, table)),
-          updateCompanionCallback: ({
-            i0.Value<int> id = const i0.Value.absent(),
-            i0.Value<DateTime> birthDate = const i0.Value.absent(),
-          }) =>
-              i1.UsersCompanion(
-            id: id,
-            birthDate: birthDate,
-          ),
-          createCompanionCallback: ({
-            i0.Value<int> id = const i0.Value.absent(),
-            required DateTime birthDate,
-          }) =>
-              i1.UsersCompanion.insert(
-            id: id,
-            birthDate: birthDate,
-          ),
-        ));
-}
-
 class $$UsersTableFilterComposer
     extends i0.FilterComposer<i0.GeneratedDatabase, i1.$UsersTable> {
   $$UsersTableFilterComposer(super.$state);
@@ -963,3 +978,57 @@ class $$UsersTableOrderingComposer
       builder: (column, joinBuilders) =>
           i0.ColumnOrderings(column, joinBuilders: joinBuilders));
 }
+
+class $$UsersTableTableManager extends i0.RootTableManager<
+    i0.GeneratedDatabase,
+    i1.$UsersTable,
+    i1.User,
+    i1.$$UsersTableFilterComposer,
+    i1.$$UsersTableOrderingComposer,
+    $$UsersTableCreateCompanionBuilder,
+    $$UsersTableUpdateCompanionBuilder,
+    (i1.User, i0.BaseReferences<i0.GeneratedDatabase, i1.$UsersTable, i1.User>),
+    i1.User,
+    i0.PrefetchHooks Function()> {
+  $$UsersTableTableManager(i0.GeneratedDatabase db, i1.$UsersTable table)
+      : super(i0.TableManagerState(
+          db: db,
+          table: table,
+          filteringComposer:
+              i1.$$UsersTableFilterComposer(i0.ComposerState(db, table)),
+          orderingComposer:
+              i1.$$UsersTableOrderingComposer(i0.ComposerState(db, table)),
+          updateCompanionCallback: ({
+            i0.Value<int> id = const i0.Value.absent(),
+            i0.Value<DateTime> birthDate = const i0.Value.absent(),
+          }) =>
+              i1.UsersCompanion(
+            id: id,
+            birthDate: birthDate,
+          ),
+          createCompanionCallback: ({
+            i0.Value<int> id = const i0.Value.absent(),
+            required DateTime birthDate,
+          }) =>
+              i1.UsersCompanion.insert(
+            id: id,
+            birthDate: birthDate,
+          ),
+          withReferenceMapper: (p0) => p0
+              .map((e) => (e.readTable(table), i0.BaseReferences(db, table, e)))
+              .toList(),
+          prefetchHooksCallback: null,
+        ));
+}
+
+typedef $$UsersTableProcessedTableManager = i0.ProcessedTableManager<
+    i0.GeneratedDatabase,
+    i1.$UsersTable,
+    i1.User,
+    i1.$$UsersTableFilterComposer,
+    i1.$$UsersTableOrderingComposer,
+    $$UsersTableCreateCompanionBuilder,
+    $$UsersTableUpdateCompanionBuilder,
+    (i1.User, i0.BaseReferences<i0.GeneratedDatabase, i1.$UsersTable, i1.User>),
+    i1.User,
+    i0.PrefetchHooks Function()>;

--- a/docs/lib/snippets/dart_api/manager.dart
+++ b/docs/lib/snippets/dart_api/manager.dart
@@ -1,4 +1,4 @@
-// ignore_for_file: invalid_use_of_internal_member
+// ignore_for_file: invalid_use_of_internal_member, unused_local_variable
 
 import 'package:drift/drift.dart';
 
@@ -209,6 +209,66 @@ extension ManagerExamples on AppDatabase {
     );
   }
 // #enddocregion manager_filter_custom_back_references
+
+// #docregion manager_references
+  Future references() async {
+    /// Get each todo, along with a its categories
+    final categoriesWithReferences =
+        await managers.todoItems.withReferences().get();
+    for (final (todo, refs) in categoriesWithReferences) {
+      final category = await refs.category?.getSingle();
+    }
+
+    /// This also works in the reverse
+    final todosWithRefs = await managers.todoCategory.withReferences().get();
+    for (final (category, refs) in todosWithRefs) {
+      final todos = await refs.todoItemsRefs.get();
+    }
+  }
+
+// #enddocregion manager_references
+// #docregion manager_prefetch_references
+  Future referencesPrefetch() async {
+    /// Get each todo, along with a its categories
+    final categoriesWithReferences = await managers.todoItems
+        .withReferences(
+          (prefetch) => prefetch(category: true),
+        )
+        .get();
+    for (final (todo, refs) in categoriesWithReferences) {
+      final category = refs.category?.prefetchedData?.firstOrNull;
+      // No longer needed
+      // final category = await refs.category?.getSingle();
+    }
+
+    /// This also works in the reverse
+    final todosWithRefs = await managers.todoCategory
+        .withReferences((prefetch) => prefetch(todoItemsRefs: true))
+        .get();
+    for (final (category, refs) in todosWithRefs) {
+      final todos = refs.todoItemsRefs.prefetchedData;
+      // No longer needed
+      //final todos = await refs.todoItemsRefs.get();
+    }
+  }
+// #enddocregion manager_prefetch_references
+
+  Future referencesPrefetchStream() async {
+// #docregion manager_prefetch_references_stream
+    /// Get each todo, along with a its categories
+    managers.todoItems
+        .withReferences((prefetch) => prefetch(category: true))
+        .watch()
+        .listen(
+      (todoWithRefs) {
+        for (final (todo, refs) in todoWithRefs) {
+          // Updates to this category won't trigger an update
+          final category = refs.category?.prefetchedData?.firstOrNull;
+        }
+      },
+    );
+// #enddocregion manager_prefetch_references_stream
+  }
 }
 
 // #docregion manager_filter_extensions

--- a/docs/lib/snippets/dart_api/manager.dart
+++ b/docs/lib/snippets/dart_api/manager.dart
@@ -16,10 +16,10 @@ class TodoItems extends Table {
 class TodoCategory extends Table {
   IntColumn get id => integer().autoIncrement()();
   TextColumn get description => text()();
+  IntColumn get user => integer().nullable().references(Users, #id)();
 }
 
 // #docregion user_group_tables
-
 class Users extends Table {
   IntColumn get id => integer().autoIncrement()();
   TextColumn get name => text()();
@@ -256,14 +256,17 @@ extension ManagerExamples on AppDatabase {
   Future referencesPrefetchStream() async {
 // #docregion manager_prefetch_references_stream
     /// Get each todo, along with a its categories
-    managers.todoItems
-        .withReferences((prefetch) => prefetch(category: true))
+    managers.todoCategory
+        .withReferences((prefetch) => prefetch(todoItemsRefs: true, user: true))
         .watch()
         .listen(
-      (todoWithRefs) {
-        for (final (todo, refs) in todoWithRefs) {
-          // Updates to this category won't trigger an update
-          final category = refs.category?.prefetchedData?.firstOrNull;
+      (catWithRefs) {
+        for (final (cat, refs) in catWithRefs) {
+          // Updates to the user table will trigger a query
+          final users = refs.user?.prefetchedData;
+
+          // However, updates to the TodoItems table will not trigger a query
+          final todos = refs.todoItemsRefs.prefetchedData;
         }
       },
     );

--- a/docs/lib/snippets/dart_api/manager.dart
+++ b/docs/lib/snippets/dart_api/manager.dart
@@ -130,7 +130,7 @@ extension ManagerExamples on AppDatabase {
   // #enddocregion manager_filter
 
   // #docregion manager_type_specific_filter
-  Future filterWithType() async {
+  Future<void> filterWithType() async {
     // Filter all items created since 7 days ago
     managers.todoItems.filter(
         (f) => f.createdAt.isAfter(DateTime.now().subtract(Duration(days: 7))));
@@ -141,7 +141,7 @@ extension ManagerExamples on AppDatabase {
 // #enddocregion manager_type_specific_filter
 
 // #docregion manager_ordering
-  Future orderWithType() async {
+  Future<void> orderWithType() async {
     // Order all items by their creation date in ascending order
     managers.todoItems.orderBy((o) => o.createdAt.asc());
 
@@ -151,7 +151,7 @@ extension ManagerExamples on AppDatabase {
 // #enddocregion manager_ordering
 
 // #docregion manager_count
-  Future count() async {
+  Future<void> count() async {
     // Count all items
     await managers.todoItems.count();
 
@@ -161,7 +161,7 @@ extension ManagerExamples on AppDatabase {
 // #enddocregion manager_count
 
 // #docregion manager_exists
-  Future exists() async {
+  Future<void> exists() async {
     // Check if any items exist
     await managers.todoItems.exists();
 
@@ -171,7 +171,7 @@ extension ManagerExamples on AppDatabase {
 // #enddocregion manager_exists
 
 // #docregion manager_filter_forward_references
-  Future relationalFilter() async {
+  Future<void> relationalFilter() async {
     // Get all items with a category description of "School"
     managers.todoItems.filter((f) => f.category.description("School"));
 
@@ -186,7 +186,7 @@ extension ManagerExamples on AppDatabase {
 // #enddocregion manager_filter_forward_references
 
 // #docregion manager_filter_back_references
-  Future reverseRelationalFilter() async {
+  Future<void> reverseRelationalFilter() async {
     // Get the category that has a todo item with an id of 1
     managers.todoCategory.filter((f) => f.todoItemsRefs((f) => f.id(1)));
 
@@ -199,7 +199,7 @@ extension ManagerExamples on AppDatabase {
 // #enddocregion manager_filter_back_references
 
 // #docregion manager_filter_custom_back_references
-  Future reverseNamedRelationalFilter() async {
+  Future<void> reverseNamedRelationalFilter() async {
     // Get all users who are administrators of a group with a name containing "Business"
     // or who own a group with an id of 1, 2, 4, or 5
     managers.users.filter(
@@ -211,24 +211,24 @@ extension ManagerExamples on AppDatabase {
 // #enddocregion manager_filter_custom_back_references
 
 // #docregion manager_references
-  Future references() async {
+  Future<void> references() async {
     /// Get each todo, along with a its categories
-    final categoriesWithReferences =
-        await managers.todoItems.withReferences().get();
-    for (final (todo, refs) in categoriesWithReferences) {
+    final todosWithRefs = await managers.todoItems.withReferences().get();
+    for (final (todo, refs) in todosWithRefs) {
       final category = await refs.category?.getSingle();
     }
 
     /// This also works in the reverse
-    final todosWithRefs = await managers.todoCategory.withReferences().get();
-    for (final (category, refs) in todosWithRefs) {
+    final categoriesWithRefs =
+        await managers.todoCategory.withReferences().get();
+    for (final (category, refs) in categoriesWithRefs) {
       final todos = await refs.todoItemsRefs.get();
     }
   }
 
 // #enddocregion manager_references
 // #docregion manager_prefetch_references
-  Future referencesPrefetch() async {
+  Future<void> referencesPrefetch() async {
     /// Get each todo, along with a its categories
     final categoriesWithReferences = await managers.todoItems
         .withReferences(
@@ -253,7 +253,7 @@ extension ManagerExamples on AppDatabase {
   }
 // #enddocregion manager_prefetch_references
 
-  Future referencesPrefetchStream() async {
+  Future<void> referencesPrefetchStream() async {
 // #docregion manager_prefetch_references_stream
     /// Get each todo, along with a its categories
     managers.todoCategory
@@ -287,7 +287,7 @@ extension After2000Filter on ColumnFilters<DateTime> {
       $composableFilter(column.unixepoch.equals(value));
 }
 
-Future filterWithExtension(AppDatabase db) async {
+Future<void> filterWithExtension(AppDatabase db) async {
   // Use the custom filters on any column that is of type DateTime
   db.managers.todoItems.filter((f) => f.createdAt.after2000orBefore1900());
 
@@ -302,7 +302,7 @@ extension After2000Ordering on ColumnOrderings<DateTime> {
   ComposableOrdering byUnixEpoch() => ColumnOrderings(column.unixepoch).asc();
 }
 
-Future orderingWithExtension(AppDatabase db) async {
+Future<void> orderingWithExtension(AppDatabase db) async {
   // Use the custom orderings on any column that is of type DateTime
   db.managers.todoItems.orderBy((f) => f.createdAt.byUnixEpoch());
 }
@@ -315,7 +315,7 @@ extension NoContentOrBefore2000FilterX on $$TodoItemsTableFilterComposer {
       (content.isNull() | createdAt.isBefore(DateTime(2000)));
 }
 
-Future customFilter(AppDatabase db) async {
+Future<void> customFilter(AppDatabase db) async {
   // Use the custom filter on the `TodoItems` table
   db.managers.todoItems.filter((f) => f.noContentOrBefore2000());
 }
@@ -327,7 +327,7 @@ extension ContentThenCreationDataX on $$TodoItemsTableOrderingComposer {
   ComposableOrdering contentThenCreatedAt() => content.asc() & createdAt.asc();
 }
 
-Future customOrdering(AppDatabase db) async {
+Future<void> customOrdering(AppDatabase db) async {
   // Use the custom ordering on the `TodoItems` table
   db.managers.todoItems.orderBy((f) => f.contentThenCreatedAt());
 }

--- a/docs/lib/snippets/modular/custom_types/drift_table.drift.dart
+++ b/docs/lib/snippets/modular/custom_types/drift_table.drift.dart
@@ -244,46 +244,6 @@ typedef $PeriodicRemindersUpdateCompanionBuilder = i1.PeriodicRemindersCompanion
   i0.Value<String> reminder,
 });
 
-class $PeriodicRemindersTableManager extends i0.RootTableManager<
-    i0.GeneratedDatabase,
-    i1.PeriodicReminders,
-    i1.PeriodicReminder,
-    i1.$PeriodicRemindersFilterComposer,
-    i1.$PeriodicRemindersOrderingComposer,
-    $PeriodicRemindersCreateCompanionBuilder,
-    $PeriodicRemindersUpdateCompanionBuilder> {
-  $PeriodicRemindersTableManager(
-      i0.GeneratedDatabase db, i1.PeriodicReminders table)
-      : super(i0.TableManagerState(
-          db: db,
-          table: table,
-          filteringComposer:
-              i1.$PeriodicRemindersFilterComposer(i0.ComposerState(db, table)),
-          orderingComposer: i1
-              .$PeriodicRemindersOrderingComposer(i0.ComposerState(db, table)),
-          updateCompanionCallback: ({
-            i0.Value<int> id = const i0.Value.absent(),
-            i0.Value<Duration> frequency = const i0.Value.absent(),
-            i0.Value<String> reminder = const i0.Value.absent(),
-          }) =>
-              i1.PeriodicRemindersCompanion(
-            id: id,
-            frequency: frequency,
-            reminder: reminder,
-          ),
-          createCompanionCallback: ({
-            i0.Value<int> id = const i0.Value.absent(),
-            required Duration frequency,
-            required String reminder,
-          }) =>
-              i1.PeriodicRemindersCompanion.insert(
-            id: id,
-            frequency: frequency,
-            reminder: reminder,
-          ),
-        ));
-}
-
 class $PeriodicRemindersFilterComposer
     extends i0.FilterComposer<i0.GeneratedDatabase, i1.PeriodicReminders> {
   $PeriodicRemindersFilterComposer(super.$state);
@@ -321,3 +281,70 @@ class $PeriodicRemindersOrderingComposer
       builder: (column, joinBuilders) =>
           i0.ColumnOrderings(column, joinBuilders: joinBuilders));
 }
+
+class $PeriodicRemindersTableManager extends i0.RootTableManager<
+    i0.GeneratedDatabase,
+    i1.PeriodicReminders,
+    i1.PeriodicReminder,
+    i1.$PeriodicRemindersFilterComposer,
+    i1.$PeriodicRemindersOrderingComposer,
+    $PeriodicRemindersCreateCompanionBuilder,
+    $PeriodicRemindersUpdateCompanionBuilder,
+    (
+      i1.PeriodicReminder,
+      i0.BaseReferences<i0.GeneratedDatabase, i1.PeriodicReminders,
+          i1.PeriodicReminder>
+    ),
+    i1.PeriodicReminder,
+    i0.PrefetchHooks Function()> {
+  $PeriodicRemindersTableManager(
+      i0.GeneratedDatabase db, i1.PeriodicReminders table)
+      : super(i0.TableManagerState(
+          db: db,
+          table: table,
+          filteringComposer:
+              i1.$PeriodicRemindersFilterComposer(i0.ComposerState(db, table)),
+          orderingComposer: i1
+              .$PeriodicRemindersOrderingComposer(i0.ComposerState(db, table)),
+          updateCompanionCallback: ({
+            i0.Value<int> id = const i0.Value.absent(),
+            i0.Value<Duration> frequency = const i0.Value.absent(),
+            i0.Value<String> reminder = const i0.Value.absent(),
+          }) =>
+              i1.PeriodicRemindersCompanion(
+            id: id,
+            frequency: frequency,
+            reminder: reminder,
+          ),
+          createCompanionCallback: ({
+            i0.Value<int> id = const i0.Value.absent(),
+            required Duration frequency,
+            required String reminder,
+          }) =>
+              i1.PeriodicRemindersCompanion.insert(
+            id: id,
+            frequency: frequency,
+            reminder: reminder,
+          ),
+          withReferenceMapper: (p0) => p0
+              .map((e) => (e.readTable(table), i0.BaseReferences(db, table, e)))
+              .toList(),
+          prefetchHooksCallback: null,
+        ));
+}
+
+typedef $PeriodicRemindersProcessedTableManager = i0.ProcessedTableManager<
+    i0.GeneratedDatabase,
+    i1.PeriodicReminders,
+    i1.PeriodicReminder,
+    i1.$PeriodicRemindersFilterComposer,
+    i1.$PeriodicRemindersOrderingComposer,
+    $PeriodicRemindersCreateCompanionBuilder,
+    $PeriodicRemindersUpdateCompanionBuilder,
+    (
+      i1.PeriodicReminder,
+      i0.BaseReferences<i0.GeneratedDatabase, i1.PeriodicReminders,
+          i1.PeriodicReminder>
+    ),
+    i1.PeriodicReminder,
+    i0.PrefetchHooks Function()>;

--- a/docs/lib/snippets/modular/custom_types/table.drift.dart
+++ b/docs/lib/snippets/modular/custom_types/table.drift.dart
@@ -242,46 +242,6 @@ typedef $$PeriodicRemindersTableUpdateCompanionBuilder
   i0.Value<String> reminder,
 });
 
-class $$PeriodicRemindersTableTableManager extends i0.RootTableManager<
-    i0.GeneratedDatabase,
-    i1.$PeriodicRemindersTable,
-    i1.PeriodicReminder,
-    i1.$$PeriodicRemindersTableFilterComposer,
-    i1.$$PeriodicRemindersTableOrderingComposer,
-    $$PeriodicRemindersTableCreateCompanionBuilder,
-    $$PeriodicRemindersTableUpdateCompanionBuilder> {
-  $$PeriodicRemindersTableTableManager(
-      i0.GeneratedDatabase db, i1.$PeriodicRemindersTable table)
-      : super(i0.TableManagerState(
-          db: db,
-          table: table,
-          filteringComposer: i1.$$PeriodicRemindersTableFilterComposer(
-              i0.ComposerState(db, table)),
-          orderingComposer: i1.$$PeriodicRemindersTableOrderingComposer(
-              i0.ComposerState(db, table)),
-          updateCompanionCallback: ({
-            i0.Value<int> id = const i0.Value.absent(),
-            i0.Value<Duration> frequency = const i0.Value.absent(),
-            i0.Value<String> reminder = const i0.Value.absent(),
-          }) =>
-              i1.PeriodicRemindersCompanion(
-            id: id,
-            frequency: frequency,
-            reminder: reminder,
-          ),
-          createCompanionCallback: ({
-            i0.Value<int> id = const i0.Value.absent(),
-            i0.Value<Duration> frequency = const i0.Value.absent(),
-            required String reminder,
-          }) =>
-              i1.PeriodicRemindersCompanion.insert(
-            id: id,
-            frequency: frequency,
-            reminder: reminder,
-          ),
-        ));
-}
-
 class $$PeriodicRemindersTableFilterComposer extends i0
     .FilterComposer<i0.GeneratedDatabase, i1.$PeriodicRemindersTable> {
   $$PeriodicRemindersTableFilterComposer(super.$state);
@@ -319,3 +279,71 @@ class $$PeriodicRemindersTableOrderingComposer extends i0
       builder: (column, joinBuilders) =>
           i0.ColumnOrderings(column, joinBuilders: joinBuilders));
 }
+
+class $$PeriodicRemindersTableTableManager extends i0.RootTableManager<
+    i0.GeneratedDatabase,
+    i1.$PeriodicRemindersTable,
+    i1.PeriodicReminder,
+    i1.$$PeriodicRemindersTableFilterComposer,
+    i1.$$PeriodicRemindersTableOrderingComposer,
+    $$PeriodicRemindersTableCreateCompanionBuilder,
+    $$PeriodicRemindersTableUpdateCompanionBuilder,
+    (
+      i1.PeriodicReminder,
+      i0.BaseReferences<i0.GeneratedDatabase, i1.$PeriodicRemindersTable,
+          i1.PeriodicReminder>
+    ),
+    i1.PeriodicReminder,
+    i0.PrefetchHooks Function()> {
+  $$PeriodicRemindersTableTableManager(
+      i0.GeneratedDatabase db, i1.$PeriodicRemindersTable table)
+      : super(i0.TableManagerState(
+          db: db,
+          table: table,
+          filteringComposer: i1.$$PeriodicRemindersTableFilterComposer(
+              i0.ComposerState(db, table)),
+          orderingComposer: i1.$$PeriodicRemindersTableOrderingComposer(
+              i0.ComposerState(db, table)),
+          updateCompanionCallback: ({
+            i0.Value<int> id = const i0.Value.absent(),
+            i0.Value<Duration> frequency = const i0.Value.absent(),
+            i0.Value<String> reminder = const i0.Value.absent(),
+          }) =>
+              i1.PeriodicRemindersCompanion(
+            id: id,
+            frequency: frequency,
+            reminder: reminder,
+          ),
+          createCompanionCallback: ({
+            i0.Value<int> id = const i0.Value.absent(),
+            i0.Value<Duration> frequency = const i0.Value.absent(),
+            required String reminder,
+          }) =>
+              i1.PeriodicRemindersCompanion.insert(
+            id: id,
+            frequency: frequency,
+            reminder: reminder,
+          ),
+          withReferenceMapper: (p0) => p0
+              .map((e) => (e.readTable(table), i0.BaseReferences(db, table, e)))
+              .toList(),
+          prefetchHooksCallback: null,
+        ));
+}
+
+typedef $$PeriodicRemindersTableProcessedTableManager
+    = i0.ProcessedTableManager<
+        i0.GeneratedDatabase,
+        i1.$PeriodicRemindersTable,
+        i1.PeriodicReminder,
+        i1.$$PeriodicRemindersTableFilterComposer,
+        i1.$$PeriodicRemindersTableOrderingComposer,
+        $$PeriodicRemindersTableCreateCompanionBuilder,
+        $$PeriodicRemindersTableUpdateCompanionBuilder,
+        (
+          i1.PeriodicReminder,
+          i0.BaseReferences<i0.GeneratedDatabase, i1.$PeriodicRemindersTable,
+              i1.PeriodicReminder>
+        ),
+        i1.PeriodicReminder,
+        i0.PrefetchHooks Function()>;

--- a/docs/lib/snippets/modular/drift/example.drift.dart
+++ b/docs/lib/snippets/modular/drift/example.drift.dart
@@ -363,7 +363,7 @@ class $TodosTableManager extends i0.RootTableManager<
     $TodosUpdateCompanionBuilder,
     (i1.Todo, i0.BaseReferences<i0.GeneratedDatabase, i1.Todos, i1.Todo>),
     i1.Todo,
-    i0.PrefetchHooks Function({bool category})> {
+    i0.PrefetchHooks Function({bool category, bool inTransaction})> {
   $TodosTableManager(i0.GeneratedDatabase db, i1.Todos table)
       : super(i0.TableManagerState(
           db: db,
@@ -413,7 +413,7 @@ typedef $TodosProcessedTableManager = i0.ProcessedTableManager<
     $TodosUpdateCompanionBuilder,
     (i1.Todo, i0.BaseReferences<i0.GeneratedDatabase, i1.Todos, i1.Todo>),
     i1.Todo,
-    i0.PrefetchHooks Function({bool category})>;
+    i0.PrefetchHooks Function({bool category, bool inTransaction})>;
 
 class Categories extends i0.Table with i0.TableInfo<Categories, i1.Category> {
   @override

--- a/docs/lib/snippets/modular/drift/example.drift.dart
+++ b/docs/lib/snippets/modular/drift/example.drift.dart
@@ -281,49 +281,6 @@ typedef $TodosUpdateCompanionBuilder = i1.TodosCompanion Function({
   i0.Value<int?> category,
 });
 
-class $TodosTableManager extends i0.RootTableManager<
-    i0.GeneratedDatabase,
-    i1.Todos,
-    i1.Todo,
-    i1.$TodosFilterComposer,
-    i1.$TodosOrderingComposer,
-    $TodosCreateCompanionBuilder,
-    $TodosUpdateCompanionBuilder> {
-  $TodosTableManager(i0.GeneratedDatabase db, i1.Todos table)
-      : super(i0.TableManagerState(
-          db: db,
-          table: table,
-          filteringComposer:
-              i1.$TodosFilterComposer(i0.ComposerState(db, table)),
-          orderingComposer:
-              i1.$TodosOrderingComposer(i0.ComposerState(db, table)),
-          updateCompanionCallback: ({
-            i0.Value<int> id = const i0.Value.absent(),
-            i0.Value<String> title = const i0.Value.absent(),
-            i0.Value<String> content = const i0.Value.absent(),
-            i0.Value<int?> category = const i0.Value.absent(),
-          }) =>
-              i1.TodosCompanion(
-            id: id,
-            title: title,
-            content: content,
-            category: category,
-          ),
-          createCompanionCallback: ({
-            i0.Value<int> id = const i0.Value.absent(),
-            required String title,
-            required String content,
-            i0.Value<int?> category = const i0.Value.absent(),
-          }) =>
-              i1.TodosCompanion.insert(
-            id: id,
-            title: title,
-            content: content,
-            category: category,
-          ),
-        ));
-}
-
 class $TodosFilterComposer
     extends i0.FilterComposer<i0.GeneratedDatabase, i1.Todos> {
   $TodosFilterComposer(super.$state);
@@ -395,6 +352,68 @@ class $TodosOrderingComposer
     return composer;
   }
 }
+
+class $TodosTableManager extends i0.RootTableManager<
+    i0.GeneratedDatabase,
+    i1.Todos,
+    i1.Todo,
+    i1.$TodosFilterComposer,
+    i1.$TodosOrderingComposer,
+    $TodosCreateCompanionBuilder,
+    $TodosUpdateCompanionBuilder,
+    (i1.Todo, i0.BaseReferences<i0.GeneratedDatabase, i1.Todos, i1.Todo>),
+    i1.Todo,
+    i0.PrefetchHooks Function({bool category})> {
+  $TodosTableManager(i0.GeneratedDatabase db, i1.Todos table)
+      : super(i0.TableManagerState(
+          db: db,
+          table: table,
+          filteringComposer:
+              i1.$TodosFilterComposer(i0.ComposerState(db, table)),
+          orderingComposer:
+              i1.$TodosOrderingComposer(i0.ComposerState(db, table)),
+          updateCompanionCallback: ({
+            i0.Value<int> id = const i0.Value.absent(),
+            i0.Value<String> title = const i0.Value.absent(),
+            i0.Value<String> content = const i0.Value.absent(),
+            i0.Value<int?> category = const i0.Value.absent(),
+          }) =>
+              i1.TodosCompanion(
+            id: id,
+            title: title,
+            content: content,
+            category: category,
+          ),
+          createCompanionCallback: ({
+            i0.Value<int> id = const i0.Value.absent(),
+            required String title,
+            required String content,
+            i0.Value<int?> category = const i0.Value.absent(),
+          }) =>
+              i1.TodosCompanion.insert(
+            id: id,
+            title: title,
+            content: content,
+            category: category,
+          ),
+          withReferenceMapper: (p0) => p0
+              .map((e) => (e.readTable(table), i0.BaseReferences(db, table, e)))
+              .toList(),
+          prefetchHooksCallback: null,
+        ));
+}
+
+typedef $TodosProcessedTableManager = i0.ProcessedTableManager<
+    i0.GeneratedDatabase,
+    i1.Todos,
+    i1.Todo,
+    i1.$TodosFilterComposer,
+    i1.$TodosOrderingComposer,
+    $TodosCreateCompanionBuilder,
+    $TodosUpdateCompanionBuilder,
+    (i1.Todo, i0.BaseReferences<i0.GeneratedDatabase, i1.Todos, i1.Todo>),
+    i1.Todo,
+    i0.PrefetchHooks Function({bool category})>;
 
 class Categories extends i0.Table with i0.TableInfo<Categories, i1.Category> {
   @override
@@ -590,41 +609,6 @@ typedef $CategoriesUpdateCompanionBuilder = i1.CategoriesCompanion Function({
   i0.Value<String> description,
 });
 
-class $CategoriesTableManager extends i0.RootTableManager<
-    i0.GeneratedDatabase,
-    i1.Categories,
-    i1.Category,
-    i1.$CategoriesFilterComposer,
-    i1.$CategoriesOrderingComposer,
-    $CategoriesCreateCompanionBuilder,
-    $CategoriesUpdateCompanionBuilder> {
-  $CategoriesTableManager(i0.GeneratedDatabase db, i1.Categories table)
-      : super(i0.TableManagerState(
-          db: db,
-          table: table,
-          filteringComposer:
-              i1.$CategoriesFilterComposer(i0.ComposerState(db, table)),
-          orderingComposer:
-              i1.$CategoriesOrderingComposer(i0.ComposerState(db, table)),
-          updateCompanionCallback: ({
-            i0.Value<int> id = const i0.Value.absent(),
-            i0.Value<String> description = const i0.Value.absent(),
-          }) =>
-              i1.CategoriesCompanion(
-            id: id,
-            description: description,
-          ),
-          createCompanionCallback: ({
-            i0.Value<int> id = const i0.Value.absent(),
-            required String description,
-          }) =>
-              i1.CategoriesCompanion.insert(
-            id: id,
-            description: description,
-          ),
-        ));
-}
-
 class $CategoriesFilterComposer
     extends i0.FilterComposer<i0.GeneratedDatabase, i1.Categories> {
   $CategoriesFilterComposer(super.$state);
@@ -652,6 +636,66 @@ class $CategoriesOrderingComposer
       builder: (column, joinBuilders) =>
           i0.ColumnOrderings(column, joinBuilders: joinBuilders));
 }
+
+class $CategoriesTableManager extends i0.RootTableManager<
+    i0.GeneratedDatabase,
+    i1.Categories,
+    i1.Category,
+    i1.$CategoriesFilterComposer,
+    i1.$CategoriesOrderingComposer,
+    $CategoriesCreateCompanionBuilder,
+    $CategoriesUpdateCompanionBuilder,
+    (
+      i1.Category,
+      i0.BaseReferences<i0.GeneratedDatabase, i1.Categories, i1.Category>
+    ),
+    i1.Category,
+    i0.PrefetchHooks Function()> {
+  $CategoriesTableManager(i0.GeneratedDatabase db, i1.Categories table)
+      : super(i0.TableManagerState(
+          db: db,
+          table: table,
+          filteringComposer:
+              i1.$CategoriesFilterComposer(i0.ComposerState(db, table)),
+          orderingComposer:
+              i1.$CategoriesOrderingComposer(i0.ComposerState(db, table)),
+          updateCompanionCallback: ({
+            i0.Value<int> id = const i0.Value.absent(),
+            i0.Value<String> description = const i0.Value.absent(),
+          }) =>
+              i1.CategoriesCompanion(
+            id: id,
+            description: description,
+          ),
+          createCompanionCallback: ({
+            i0.Value<int> id = const i0.Value.absent(),
+            required String description,
+          }) =>
+              i1.CategoriesCompanion.insert(
+            id: id,
+            description: description,
+          ),
+          withReferenceMapper: (p0) => p0
+              .map((e) => (e.readTable(table), i0.BaseReferences(db, table, e)))
+              .toList(),
+          prefetchHooksCallback: null,
+        ));
+}
+
+typedef $CategoriesProcessedTableManager = i0.ProcessedTableManager<
+    i0.GeneratedDatabase,
+    i1.Categories,
+    i1.Category,
+    i1.$CategoriesFilterComposer,
+    i1.$CategoriesOrderingComposer,
+    $CategoriesCreateCompanionBuilder,
+    $CategoriesUpdateCompanionBuilder,
+    (
+      i1.Category,
+      i0.BaseReferences<i0.GeneratedDatabase, i1.Categories, i1.Category>
+    ),
+    i1.Category,
+    i0.PrefetchHooks Function()>;
 
 class ExampleDrift extends i2.ModularAccessor {
   ExampleDrift(i0.GeneratedDatabase db) : super(db);

--- a/docs/lib/snippets/modular/drift/example.drift.dart
+++ b/docs/lib/snippets/modular/drift/example.drift.dart
@@ -363,7 +363,7 @@ class $TodosTableManager extends i0.RootTableManager<
     $TodosUpdateCompanionBuilder,
     (i1.Todo, i0.BaseReferences<i0.GeneratedDatabase, i1.Todos, i1.Todo>),
     i1.Todo,
-    i0.PrefetchHooks Function({bool category, bool inTransaction})> {
+    i0.PrefetchHooks Function({bool category})> {
   $TodosTableManager(i0.GeneratedDatabase db, i1.Todos table)
       : super(i0.TableManagerState(
           db: db,
@@ -413,7 +413,7 @@ typedef $TodosProcessedTableManager = i0.ProcessedTableManager<
     $TodosUpdateCompanionBuilder,
     (i1.Todo, i0.BaseReferences<i0.GeneratedDatabase, i1.Todos, i1.Todo>),
     i1.Todo,
-    i0.PrefetchHooks Function({bool category, bool inTransaction})>;
+    i0.PrefetchHooks Function({bool category})>;
 
 class Categories extends i0.Table with i0.TableInfo<Categories, i1.Category> {
   @override

--- a/docs/lib/snippets/modular/drift/with_existing.drift.dart
+++ b/docs/lib/snippets/modular/drift/with_existing.drift.dart
@@ -505,7 +505,7 @@ class $FriendsTableManager extends i0.RootTableManager<
     $FriendsUpdateCompanionBuilder,
     (i2.Friend, i0.BaseReferences<i0.GeneratedDatabase, i2.Friends, i2.Friend>),
     i2.Friend,
-    i0.PrefetchHooks Function({bool userA, bool userB})> {
+    i0.PrefetchHooks Function({bool userA, bool userB, bool inTransaction})> {
   $FriendsTableManager(i0.GeneratedDatabase db, i2.Friends table)
       : super(i0.TableManagerState(
           db: db,
@@ -551,7 +551,7 @@ typedef $FriendsProcessedTableManager = i0.ProcessedTableManager<
     $FriendsUpdateCompanionBuilder,
     (i2.Friend, i0.BaseReferences<i0.GeneratedDatabase, i2.Friends, i2.Friend>),
     i2.Friend,
-    i0.PrefetchHooks Function({bool userA, bool userB})>;
+    i0.PrefetchHooks Function({bool userA, bool userB, bool inTransaction})>;
 
 class WithExistingDrift extends i3.ModularAccessor {
   WithExistingDrift(i0.GeneratedDatabase db) : super(db);

--- a/docs/lib/snippets/modular/drift/with_existing.drift.dart
+++ b/docs/lib/snippets/modular/drift/with_existing.drift.dart
@@ -128,41 +128,6 @@ typedef $UsersUpdateCompanionBuilder = i2.UsersCompanion Function({
   i0.Value<String> name,
 });
 
-class $UsersTableManager extends i0.RootTableManager<
-    i0.GeneratedDatabase,
-    i2.Users,
-    i1.User,
-    i2.$UsersFilterComposer,
-    i2.$UsersOrderingComposer,
-    $UsersCreateCompanionBuilder,
-    $UsersUpdateCompanionBuilder> {
-  $UsersTableManager(i0.GeneratedDatabase db, i2.Users table)
-      : super(i0.TableManagerState(
-          db: db,
-          table: table,
-          filteringComposer:
-              i2.$UsersFilterComposer(i0.ComposerState(db, table)),
-          orderingComposer:
-              i2.$UsersOrderingComposer(i0.ComposerState(db, table)),
-          updateCompanionCallback: ({
-            i0.Value<int> id = const i0.Value.absent(),
-            i0.Value<String> name = const i0.Value.absent(),
-          }) =>
-              i2.UsersCompanion(
-            id: id,
-            name: name,
-          ),
-          createCompanionCallback: ({
-            i0.Value<int> id = const i0.Value.absent(),
-            required String name,
-          }) =>
-              i2.UsersCompanion.insert(
-            id: id,
-            name: name,
-          ),
-        ));
-}
-
 class $UsersFilterComposer
     extends i0.FilterComposer<i0.GeneratedDatabase, i2.Users> {
   $UsersFilterComposer(super.$state);
@@ -190,6 +155,60 @@ class $UsersOrderingComposer
       builder: (column, joinBuilders) =>
           i0.ColumnOrderings(column, joinBuilders: joinBuilders));
 }
+
+class $UsersTableManager extends i0.RootTableManager<
+    i0.GeneratedDatabase,
+    i2.Users,
+    i1.User,
+    i2.$UsersFilterComposer,
+    i2.$UsersOrderingComposer,
+    $UsersCreateCompanionBuilder,
+    $UsersUpdateCompanionBuilder,
+    (i1.User, i0.BaseReferences<i0.GeneratedDatabase, i2.Users, i1.User>),
+    i1.User,
+    i0.PrefetchHooks Function()> {
+  $UsersTableManager(i0.GeneratedDatabase db, i2.Users table)
+      : super(i0.TableManagerState(
+          db: db,
+          table: table,
+          filteringComposer:
+              i2.$UsersFilterComposer(i0.ComposerState(db, table)),
+          orderingComposer:
+              i2.$UsersOrderingComposer(i0.ComposerState(db, table)),
+          updateCompanionCallback: ({
+            i0.Value<int> id = const i0.Value.absent(),
+            i0.Value<String> name = const i0.Value.absent(),
+          }) =>
+              i2.UsersCompanion(
+            id: id,
+            name: name,
+          ),
+          createCompanionCallback: ({
+            i0.Value<int> id = const i0.Value.absent(),
+            required String name,
+          }) =>
+              i2.UsersCompanion.insert(
+            id: id,
+            name: name,
+          ),
+          withReferenceMapper: (p0) => p0
+              .map((e) => (e.readTable(table), i0.BaseReferences(db, table, e)))
+              .toList(),
+          prefetchHooksCallback: null,
+        ));
+}
+
+typedef $UsersProcessedTableManager = i0.ProcessedTableManager<
+    i0.GeneratedDatabase,
+    i2.Users,
+    i1.User,
+    i2.$UsersFilterComposer,
+    i2.$UsersOrderingComposer,
+    $UsersCreateCompanionBuilder,
+    $UsersUpdateCompanionBuilder,
+    (i1.User, i0.BaseReferences<i0.GeneratedDatabase, i2.Users, i1.User>),
+    i1.User,
+    i0.PrefetchHooks Function()>;
 
 class Friends extends i0.Table with i0.TableInfo<Friends, i2.Friend> {
   @override
@@ -400,45 +419,6 @@ typedef $FriendsUpdateCompanionBuilder = i2.FriendsCompanion Function({
   i0.Value<int> rowid,
 });
 
-class $FriendsTableManager extends i0.RootTableManager<
-    i0.GeneratedDatabase,
-    i2.Friends,
-    i2.Friend,
-    i2.$FriendsFilterComposer,
-    i2.$FriendsOrderingComposer,
-    $FriendsCreateCompanionBuilder,
-    $FriendsUpdateCompanionBuilder> {
-  $FriendsTableManager(i0.GeneratedDatabase db, i2.Friends table)
-      : super(i0.TableManagerState(
-          db: db,
-          table: table,
-          filteringComposer:
-              i2.$FriendsFilterComposer(i0.ComposerState(db, table)),
-          orderingComposer:
-              i2.$FriendsOrderingComposer(i0.ComposerState(db, table)),
-          updateCompanionCallback: ({
-            i0.Value<int> userA = const i0.Value.absent(),
-            i0.Value<int> userB = const i0.Value.absent(),
-            i0.Value<int> rowid = const i0.Value.absent(),
-          }) =>
-              i2.FriendsCompanion(
-            userA: userA,
-            userB: userB,
-            rowid: rowid,
-          ),
-          createCompanionCallback: ({
-            required int userA,
-            required int userB,
-            i0.Value<int> rowid = const i0.Value.absent(),
-          }) =>
-              i2.FriendsCompanion.insert(
-            userA: userA,
-            userB: userB,
-            rowid: rowid,
-          ),
-        ));
-}
-
 class $FriendsFilterComposer
     extends i0.FilterComposer<i0.GeneratedDatabase, i2.Friends> {
   $FriendsFilterComposer(super.$state);
@@ -514,6 +494,64 @@ class $FriendsOrderingComposer
     return composer;
   }
 }
+
+class $FriendsTableManager extends i0.RootTableManager<
+    i0.GeneratedDatabase,
+    i2.Friends,
+    i2.Friend,
+    i2.$FriendsFilterComposer,
+    i2.$FriendsOrderingComposer,
+    $FriendsCreateCompanionBuilder,
+    $FriendsUpdateCompanionBuilder,
+    (i2.Friend, i0.BaseReferences<i0.GeneratedDatabase, i2.Friends, i2.Friend>),
+    i2.Friend,
+    i0.PrefetchHooks Function({bool userA, bool userB})> {
+  $FriendsTableManager(i0.GeneratedDatabase db, i2.Friends table)
+      : super(i0.TableManagerState(
+          db: db,
+          table: table,
+          filteringComposer:
+              i2.$FriendsFilterComposer(i0.ComposerState(db, table)),
+          orderingComposer:
+              i2.$FriendsOrderingComposer(i0.ComposerState(db, table)),
+          updateCompanionCallback: ({
+            i0.Value<int> userA = const i0.Value.absent(),
+            i0.Value<int> userB = const i0.Value.absent(),
+            i0.Value<int> rowid = const i0.Value.absent(),
+          }) =>
+              i2.FriendsCompanion(
+            userA: userA,
+            userB: userB,
+            rowid: rowid,
+          ),
+          createCompanionCallback: ({
+            required int userA,
+            required int userB,
+            i0.Value<int> rowid = const i0.Value.absent(),
+          }) =>
+              i2.FriendsCompanion.insert(
+            userA: userA,
+            userB: userB,
+            rowid: rowid,
+          ),
+          withReferenceMapper: (p0) => p0
+              .map((e) => (e.readTable(table), i0.BaseReferences(db, table, e)))
+              .toList(),
+          prefetchHooksCallback: null,
+        ));
+}
+
+typedef $FriendsProcessedTableManager = i0.ProcessedTableManager<
+    i0.GeneratedDatabase,
+    i2.Friends,
+    i2.Friend,
+    i2.$FriendsFilterComposer,
+    i2.$FriendsOrderingComposer,
+    $FriendsCreateCompanionBuilder,
+    $FriendsUpdateCompanionBuilder,
+    (i2.Friend, i0.BaseReferences<i0.GeneratedDatabase, i2.Friends, i2.Friend>),
+    i2.Friend,
+    i0.PrefetchHooks Function({bool userA, bool userB})>;
 
 class WithExistingDrift extends i3.ModularAccessor {
   WithExistingDrift(i0.GeneratedDatabase db) : super(db);

--- a/docs/lib/snippets/modular/drift/with_existing.drift.dart
+++ b/docs/lib/snippets/modular/drift/with_existing.drift.dart
@@ -505,7 +505,7 @@ class $FriendsTableManager extends i0.RootTableManager<
     $FriendsUpdateCompanionBuilder,
     (i2.Friend, i0.BaseReferences<i0.GeneratedDatabase, i2.Friends, i2.Friend>),
     i2.Friend,
-    i0.PrefetchHooks Function({bool userA, bool userB, bool inTransaction})> {
+    i0.PrefetchHooks Function({bool userA, bool userB})> {
   $FriendsTableManager(i0.GeneratedDatabase db, i2.Friends table)
       : super(i0.TableManagerState(
           db: db,
@@ -551,7 +551,7 @@ typedef $FriendsProcessedTableManager = i0.ProcessedTableManager<
     $FriendsUpdateCompanionBuilder,
     (i2.Friend, i0.BaseReferences<i0.GeneratedDatabase, i2.Friends, i2.Friend>),
     i2.Friend,
-    i0.PrefetchHooks Function({bool userA, bool userB, bool inTransaction})>;
+    i0.PrefetchHooks Function({bool userA, bool userB})>;
 
 class WithExistingDrift extends i3.ModularAccessor {
   WithExistingDrift(i0.GeneratedDatabase db) : super(db);

--- a/docs/lib/snippets/modular/many_to_many/json.drift.dart
+++ b/docs/lib/snippets/modular/many_to_many/json.drift.dart
@@ -230,42 +230,6 @@ typedef $$ShoppingCartsTableUpdateCompanionBuilder = i2.ShoppingCartsCompanion
   i0.Value<i3.ShoppingCartEntries> entries,
 });
 
-class $$ShoppingCartsTableTableManager extends i0.RootTableManager<
-    i0.GeneratedDatabase,
-    i2.$ShoppingCartsTable,
-    i2.ShoppingCart,
-    i2.$$ShoppingCartsTableFilterComposer,
-    i2.$$ShoppingCartsTableOrderingComposer,
-    $$ShoppingCartsTableCreateCompanionBuilder,
-    $$ShoppingCartsTableUpdateCompanionBuilder> {
-  $$ShoppingCartsTableTableManager(
-      i0.GeneratedDatabase db, i2.$ShoppingCartsTable table)
-      : super(i0.TableManagerState(
-          db: db,
-          table: table,
-          filteringComposer: i2
-              .$$ShoppingCartsTableFilterComposer(i0.ComposerState(db, table)),
-          orderingComposer: i2.$$ShoppingCartsTableOrderingComposer(
-              i0.ComposerState(db, table)),
-          updateCompanionCallback: ({
-            i0.Value<int> id = const i0.Value.absent(),
-            i0.Value<i3.ShoppingCartEntries> entries = const i0.Value.absent(),
-          }) =>
-              i2.ShoppingCartsCompanion(
-            id: id,
-            entries: entries,
-          ),
-          createCompanionCallback: ({
-            i0.Value<int> id = const i0.Value.absent(),
-            required i3.ShoppingCartEntries entries,
-          }) =>
-              i2.ShoppingCartsCompanion.insert(
-            id: id,
-            entries: entries,
-          ),
-        ));
-}
-
 class $$ShoppingCartsTableFilterComposer
     extends i0.FilterComposer<i0.GeneratedDatabase, i2.$ShoppingCartsTable> {
   $$ShoppingCartsTableFilterComposer(super.$state);
@@ -296,3 +260,66 @@ class $$ShoppingCartsTableOrderingComposer
       builder: (column, joinBuilders) =>
           i0.ColumnOrderings(column, joinBuilders: joinBuilders));
 }
+
+class $$ShoppingCartsTableTableManager extends i0.RootTableManager<
+    i0.GeneratedDatabase,
+    i2.$ShoppingCartsTable,
+    i2.ShoppingCart,
+    i2.$$ShoppingCartsTableFilterComposer,
+    i2.$$ShoppingCartsTableOrderingComposer,
+    $$ShoppingCartsTableCreateCompanionBuilder,
+    $$ShoppingCartsTableUpdateCompanionBuilder,
+    (
+      i2.ShoppingCart,
+      i0.BaseReferences<i0.GeneratedDatabase, i2.$ShoppingCartsTable,
+          i2.ShoppingCart>
+    ),
+    i2.ShoppingCart,
+    i0.PrefetchHooks Function()> {
+  $$ShoppingCartsTableTableManager(
+      i0.GeneratedDatabase db, i2.$ShoppingCartsTable table)
+      : super(i0.TableManagerState(
+          db: db,
+          table: table,
+          filteringComposer: i2
+              .$$ShoppingCartsTableFilterComposer(i0.ComposerState(db, table)),
+          orderingComposer: i2.$$ShoppingCartsTableOrderingComposer(
+              i0.ComposerState(db, table)),
+          updateCompanionCallback: ({
+            i0.Value<int> id = const i0.Value.absent(),
+            i0.Value<i3.ShoppingCartEntries> entries = const i0.Value.absent(),
+          }) =>
+              i2.ShoppingCartsCompanion(
+            id: id,
+            entries: entries,
+          ),
+          createCompanionCallback: ({
+            i0.Value<int> id = const i0.Value.absent(),
+            required i3.ShoppingCartEntries entries,
+          }) =>
+              i2.ShoppingCartsCompanion.insert(
+            id: id,
+            entries: entries,
+          ),
+          withReferenceMapper: (p0) => p0
+              .map((e) => (e.readTable(table), i0.BaseReferences(db, table, e)))
+              .toList(),
+          prefetchHooksCallback: null,
+        ));
+}
+
+typedef $$ShoppingCartsTableProcessedTableManager = i0.ProcessedTableManager<
+    i0.GeneratedDatabase,
+    i2.$ShoppingCartsTable,
+    i2.ShoppingCart,
+    i2.$$ShoppingCartsTableFilterComposer,
+    i2.$$ShoppingCartsTableOrderingComposer,
+    $$ShoppingCartsTableCreateCompanionBuilder,
+    $$ShoppingCartsTableUpdateCompanionBuilder,
+    (
+      i2.ShoppingCart,
+      i0.BaseReferences<i0.GeneratedDatabase, i2.$ShoppingCartsTable,
+          i2.ShoppingCart>
+    ),
+    i2.ShoppingCart,
+    i0.PrefetchHooks Function()>;

--- a/docs/lib/snippets/modular/many_to_many/relational.drift.dart
+++ b/docs/lib/snippets/modular/many_to_many/relational.drift.dart
@@ -585,7 +585,8 @@ class $$ShoppingCartEntriesTableTableManager extends i0.RootTableManager<
           i2.ShoppingCartEntry>
     ),
     i2.ShoppingCartEntry,
-    i0.PrefetchHooks Function({bool shoppingCart, bool item})> {
+    i0.PrefetchHooks Function(
+        {bool shoppingCart, bool item, bool inTransaction})> {
   $$ShoppingCartEntriesTableTableManager(
       i0.GeneratedDatabase db, i2.$ShoppingCartEntriesTable table)
       : super(i0.TableManagerState(
@@ -637,4 +638,5 @@ typedef $$ShoppingCartEntriesTableProcessedTableManager
               i2.ShoppingCartEntry>
         ),
         i2.ShoppingCartEntry,
-        i0.PrefetchHooks Function({bool shoppingCart, bool item})>;
+        i0.PrefetchHooks Function(
+            {bool shoppingCart, bool item, bool inTransaction})>;

--- a/docs/lib/snippets/modular/many_to_many/relational.drift.dart
+++ b/docs/lib/snippets/modular/many_to_many/relational.drift.dart
@@ -585,8 +585,7 @@ class $$ShoppingCartEntriesTableTableManager extends i0.RootTableManager<
           i2.ShoppingCartEntry>
     ),
     i2.ShoppingCartEntry,
-    i0.PrefetchHooks Function(
-        {bool shoppingCart, bool item, bool inTransaction})> {
+    i0.PrefetchHooks Function({bool shoppingCart, bool item})> {
   $$ShoppingCartEntriesTableTableManager(
       i0.GeneratedDatabase db, i2.$ShoppingCartEntriesTable table)
       : super(i0.TableManagerState(
@@ -638,5 +637,4 @@ typedef $$ShoppingCartEntriesTableProcessedTableManager
               i2.ShoppingCartEntry>
         ),
         i2.ShoppingCartEntry,
-        i0.PrefetchHooks Function(
-            {bool shoppingCart, bool item, bool inTransaction})>;
+        i0.PrefetchHooks Function({bool shoppingCart, bool item})>;

--- a/docs/lib/snippets/modular/many_to_many/relational.drift.dart
+++ b/docs/lib/snippets/modular/many_to_many/relational.drift.dart
@@ -191,6 +191,24 @@ typedef $$ShoppingCartsTableUpdateCompanionBuilder = i2.ShoppingCartsCompanion
   i0.Value<int> id,
 });
 
+class $$ShoppingCartsTableFilterComposer
+    extends i0.FilterComposer<i0.GeneratedDatabase, i2.$ShoppingCartsTable> {
+  $$ShoppingCartsTableFilterComposer(super.$state);
+  i0.ColumnFilters<int> get id => $state.composableBuilder(
+      column: $state.table.id,
+      builder: (column, joinBuilders) =>
+          i0.ColumnFilters(column, joinBuilders: joinBuilders));
+}
+
+class $$ShoppingCartsTableOrderingComposer
+    extends i0.OrderingComposer<i0.GeneratedDatabase, i2.$ShoppingCartsTable> {
+  $$ShoppingCartsTableOrderingComposer(super.$state);
+  i0.ColumnOrderings<int> get id => $state.composableBuilder(
+      column: $state.table.id,
+      builder: (column, joinBuilders) =>
+          i0.ColumnOrderings(column, joinBuilders: joinBuilders));
+}
+
 class $$ShoppingCartsTableTableManager extends i0.RootTableManager<
     i0.GeneratedDatabase,
     i2.$ShoppingCartsTable,
@@ -198,7 +216,14 @@ class $$ShoppingCartsTableTableManager extends i0.RootTableManager<
     i2.$$ShoppingCartsTableFilterComposer,
     i2.$$ShoppingCartsTableOrderingComposer,
     $$ShoppingCartsTableCreateCompanionBuilder,
-    $$ShoppingCartsTableUpdateCompanionBuilder> {
+    $$ShoppingCartsTableUpdateCompanionBuilder,
+    (
+      i2.ShoppingCart,
+      i0.BaseReferences<i0.GeneratedDatabase, i2.$ShoppingCartsTable,
+          i2.ShoppingCart>
+    ),
+    i2.ShoppingCart,
+    i0.PrefetchHooks Function()> {
   $$ShoppingCartsTableTableManager(
       i0.GeneratedDatabase db, i2.$ShoppingCartsTable table)
       : super(i0.TableManagerState(
@@ -220,26 +245,28 @@ class $$ShoppingCartsTableTableManager extends i0.RootTableManager<
               i2.ShoppingCartsCompanion.insert(
             id: id,
           ),
+          withReferenceMapper: (p0) => p0
+              .map((e) => (e.readTable(table), i0.BaseReferences(db, table, e)))
+              .toList(),
+          prefetchHooksCallback: null,
         ));
 }
 
-class $$ShoppingCartsTableFilterComposer
-    extends i0.FilterComposer<i0.GeneratedDatabase, i2.$ShoppingCartsTable> {
-  $$ShoppingCartsTableFilterComposer(super.$state);
-  i0.ColumnFilters<int> get id => $state.composableBuilder(
-      column: $state.table.id,
-      builder: (column, joinBuilders) =>
-          i0.ColumnFilters(column, joinBuilders: joinBuilders));
-}
-
-class $$ShoppingCartsTableOrderingComposer
-    extends i0.OrderingComposer<i0.GeneratedDatabase, i2.$ShoppingCartsTable> {
-  $$ShoppingCartsTableOrderingComposer(super.$state);
-  i0.ColumnOrderings<int> get id => $state.composableBuilder(
-      column: $state.table.id,
-      builder: (column, joinBuilders) =>
-          i0.ColumnOrderings(column, joinBuilders: joinBuilders));
-}
+typedef $$ShoppingCartsTableProcessedTableManager = i0.ProcessedTableManager<
+    i0.GeneratedDatabase,
+    i2.$ShoppingCartsTable,
+    i2.ShoppingCart,
+    i2.$$ShoppingCartsTableFilterComposer,
+    i2.$$ShoppingCartsTableOrderingComposer,
+    $$ShoppingCartsTableCreateCompanionBuilder,
+    $$ShoppingCartsTableUpdateCompanionBuilder,
+    (
+      i2.ShoppingCart,
+      i0.BaseReferences<i0.GeneratedDatabase, i2.$ShoppingCartsTable,
+          i2.ShoppingCart>
+    ),
+    i2.ShoppingCart,
+    i0.PrefetchHooks Function()>;
 
 class $ShoppingCartEntriesTable extends i3.ShoppingCartEntries
     with i0.TableInfo<$ShoppingCartEntriesTable, i2.ShoppingCartEntry> {
@@ -462,46 +489,6 @@ typedef $$ShoppingCartEntriesTableUpdateCompanionBuilder
   i0.Value<int> rowid,
 });
 
-class $$ShoppingCartEntriesTableTableManager extends i0.RootTableManager<
-    i0.GeneratedDatabase,
-    i2.$ShoppingCartEntriesTable,
-    i2.ShoppingCartEntry,
-    i2.$$ShoppingCartEntriesTableFilterComposer,
-    i2.$$ShoppingCartEntriesTableOrderingComposer,
-    $$ShoppingCartEntriesTableCreateCompanionBuilder,
-    $$ShoppingCartEntriesTableUpdateCompanionBuilder> {
-  $$ShoppingCartEntriesTableTableManager(
-      i0.GeneratedDatabase db, i2.$ShoppingCartEntriesTable table)
-      : super(i0.TableManagerState(
-          db: db,
-          table: table,
-          filteringComposer: i2.$$ShoppingCartEntriesTableFilterComposer(
-              i0.ComposerState(db, table)),
-          orderingComposer: i2.$$ShoppingCartEntriesTableOrderingComposer(
-              i0.ComposerState(db, table)),
-          updateCompanionCallback: ({
-            i0.Value<int> shoppingCart = const i0.Value.absent(),
-            i0.Value<int> item = const i0.Value.absent(),
-            i0.Value<int> rowid = const i0.Value.absent(),
-          }) =>
-              i2.ShoppingCartEntriesCompanion(
-            shoppingCart: shoppingCart,
-            item: item,
-            rowid: rowid,
-          ),
-          createCompanionCallback: ({
-            required int shoppingCart,
-            required int item,
-            i0.Value<int> rowid = const i0.Value.absent(),
-          }) =>
-              i2.ShoppingCartEntriesCompanion.insert(
-            shoppingCart: shoppingCart,
-            item: item,
-            rowid: rowid,
-          ),
-        ));
-}
-
 class $$ShoppingCartEntriesTableFilterComposer extends i0
     .FilterComposer<i0.GeneratedDatabase, i2.$ShoppingCartEntriesTable> {
   $$ShoppingCartEntriesTableFilterComposer(super.$state);
@@ -583,3 +570,71 @@ class $$ShoppingCartEntriesTableOrderingComposer extends i0
     return composer;
   }
 }
+
+class $$ShoppingCartEntriesTableTableManager extends i0.RootTableManager<
+    i0.GeneratedDatabase,
+    i2.$ShoppingCartEntriesTable,
+    i2.ShoppingCartEntry,
+    i2.$$ShoppingCartEntriesTableFilterComposer,
+    i2.$$ShoppingCartEntriesTableOrderingComposer,
+    $$ShoppingCartEntriesTableCreateCompanionBuilder,
+    $$ShoppingCartEntriesTableUpdateCompanionBuilder,
+    (
+      i2.ShoppingCartEntry,
+      i0.BaseReferences<i0.GeneratedDatabase, i2.$ShoppingCartEntriesTable,
+          i2.ShoppingCartEntry>
+    ),
+    i2.ShoppingCartEntry,
+    i0.PrefetchHooks Function({bool shoppingCart, bool item})> {
+  $$ShoppingCartEntriesTableTableManager(
+      i0.GeneratedDatabase db, i2.$ShoppingCartEntriesTable table)
+      : super(i0.TableManagerState(
+          db: db,
+          table: table,
+          filteringComposer: i2.$$ShoppingCartEntriesTableFilterComposer(
+              i0.ComposerState(db, table)),
+          orderingComposer: i2.$$ShoppingCartEntriesTableOrderingComposer(
+              i0.ComposerState(db, table)),
+          updateCompanionCallback: ({
+            i0.Value<int> shoppingCart = const i0.Value.absent(),
+            i0.Value<int> item = const i0.Value.absent(),
+            i0.Value<int> rowid = const i0.Value.absent(),
+          }) =>
+              i2.ShoppingCartEntriesCompanion(
+            shoppingCart: shoppingCart,
+            item: item,
+            rowid: rowid,
+          ),
+          createCompanionCallback: ({
+            required int shoppingCart,
+            required int item,
+            i0.Value<int> rowid = const i0.Value.absent(),
+          }) =>
+              i2.ShoppingCartEntriesCompanion.insert(
+            shoppingCart: shoppingCart,
+            item: item,
+            rowid: rowid,
+          ),
+          withReferenceMapper: (p0) => p0
+              .map((e) => (e.readTable(table), i0.BaseReferences(db, table, e)))
+              .toList(),
+          prefetchHooksCallback: null,
+        ));
+}
+
+typedef $$ShoppingCartEntriesTableProcessedTableManager
+    = i0.ProcessedTableManager<
+        i0.GeneratedDatabase,
+        i2.$ShoppingCartEntriesTable,
+        i2.ShoppingCartEntry,
+        i2.$$ShoppingCartEntriesTableFilterComposer,
+        i2.$$ShoppingCartEntriesTableOrderingComposer,
+        $$ShoppingCartEntriesTableCreateCompanionBuilder,
+        $$ShoppingCartEntriesTableUpdateCompanionBuilder,
+        (
+          i2.ShoppingCartEntry,
+          i0.BaseReferences<i0.GeneratedDatabase, i2.$ShoppingCartEntriesTable,
+              i2.ShoppingCartEntry>
+        ),
+        i2.ShoppingCartEntry,
+        i0.PrefetchHooks Function({bool shoppingCart, bool item})>;

--- a/docs/lib/snippets/modular/many_to_many/shared.drift.dart
+++ b/docs/lib/snippets/modular/many_to_many/shared.drift.dart
@@ -241,46 +241,6 @@ typedef $$BuyableItemsTableUpdateCompanionBuilder = i1.BuyableItemsCompanion
   i0.Value<int> price,
 });
 
-class $$BuyableItemsTableTableManager extends i0.RootTableManager<
-    i0.GeneratedDatabase,
-    i1.$BuyableItemsTable,
-    i1.BuyableItem,
-    i1.$$BuyableItemsTableFilterComposer,
-    i1.$$BuyableItemsTableOrderingComposer,
-    $$BuyableItemsTableCreateCompanionBuilder,
-    $$BuyableItemsTableUpdateCompanionBuilder> {
-  $$BuyableItemsTableTableManager(
-      i0.GeneratedDatabase db, i1.$BuyableItemsTable table)
-      : super(i0.TableManagerState(
-          db: db,
-          table: table,
-          filteringComposer:
-              i1.$$BuyableItemsTableFilterComposer(i0.ComposerState(db, table)),
-          orderingComposer: i1
-              .$$BuyableItemsTableOrderingComposer(i0.ComposerState(db, table)),
-          updateCompanionCallback: ({
-            i0.Value<int> id = const i0.Value.absent(),
-            i0.Value<String> description = const i0.Value.absent(),
-            i0.Value<int> price = const i0.Value.absent(),
-          }) =>
-              i1.BuyableItemsCompanion(
-            id: id,
-            description: description,
-            price: price,
-          ),
-          createCompanionCallback: ({
-            i0.Value<int> id = const i0.Value.absent(),
-            required String description,
-            required int price,
-          }) =>
-              i1.BuyableItemsCompanion.insert(
-            id: id,
-            description: description,
-            price: price,
-          ),
-        ));
-}
-
 class $$BuyableItemsTableFilterComposer
     extends i0.FilterComposer<i0.GeneratedDatabase, i1.$BuyableItemsTable> {
   $$BuyableItemsTableFilterComposer(super.$state);
@@ -318,3 +278,70 @@ class $$BuyableItemsTableOrderingComposer
       builder: (column, joinBuilders) =>
           i0.ColumnOrderings(column, joinBuilders: joinBuilders));
 }
+
+class $$BuyableItemsTableTableManager extends i0.RootTableManager<
+    i0.GeneratedDatabase,
+    i1.$BuyableItemsTable,
+    i1.BuyableItem,
+    i1.$$BuyableItemsTableFilterComposer,
+    i1.$$BuyableItemsTableOrderingComposer,
+    $$BuyableItemsTableCreateCompanionBuilder,
+    $$BuyableItemsTableUpdateCompanionBuilder,
+    (
+      i1.BuyableItem,
+      i0.BaseReferences<i0.GeneratedDatabase, i1.$BuyableItemsTable,
+          i1.BuyableItem>
+    ),
+    i1.BuyableItem,
+    i0.PrefetchHooks Function()> {
+  $$BuyableItemsTableTableManager(
+      i0.GeneratedDatabase db, i1.$BuyableItemsTable table)
+      : super(i0.TableManagerState(
+          db: db,
+          table: table,
+          filteringComposer:
+              i1.$$BuyableItemsTableFilterComposer(i0.ComposerState(db, table)),
+          orderingComposer: i1
+              .$$BuyableItemsTableOrderingComposer(i0.ComposerState(db, table)),
+          updateCompanionCallback: ({
+            i0.Value<int> id = const i0.Value.absent(),
+            i0.Value<String> description = const i0.Value.absent(),
+            i0.Value<int> price = const i0.Value.absent(),
+          }) =>
+              i1.BuyableItemsCompanion(
+            id: id,
+            description: description,
+            price: price,
+          ),
+          createCompanionCallback: ({
+            i0.Value<int> id = const i0.Value.absent(),
+            required String description,
+            required int price,
+          }) =>
+              i1.BuyableItemsCompanion.insert(
+            id: id,
+            description: description,
+            price: price,
+          ),
+          withReferenceMapper: (p0) => p0
+              .map((e) => (e.readTable(table), i0.BaseReferences(db, table, e)))
+              .toList(),
+          prefetchHooksCallback: null,
+        ));
+}
+
+typedef $$BuyableItemsTableProcessedTableManager = i0.ProcessedTableManager<
+    i0.GeneratedDatabase,
+    i1.$BuyableItemsTable,
+    i1.BuyableItem,
+    i1.$$BuyableItemsTableFilterComposer,
+    i1.$$BuyableItemsTableOrderingComposer,
+    $$BuyableItemsTableCreateCompanionBuilder,
+    $$BuyableItemsTableUpdateCompanionBuilder,
+    (
+      i1.BuyableItem,
+      i0.BaseReferences<i0.GeneratedDatabase, i1.$BuyableItemsTable,
+          i1.BuyableItem>
+    ),
+    i1.BuyableItem,
+    i0.PrefetchHooks Function()>;

--- a/docs/lib/snippets/modular/upserts.drift.dart
+++ b/docs/lib/snippets/modular/upserts.drift.dart
@@ -205,6 +205,34 @@ typedef $$WordsTableUpdateCompanionBuilder = i1.WordsCompanion Function({
   i0.Value<int> rowid,
 });
 
+class $$WordsTableFilterComposer
+    extends i0.FilterComposer<i0.GeneratedDatabase, i1.$WordsTable> {
+  $$WordsTableFilterComposer(super.$state);
+  i0.ColumnFilters<String> get word => $state.composableBuilder(
+      column: $state.table.word,
+      builder: (column, joinBuilders) =>
+          i0.ColumnFilters(column, joinBuilders: joinBuilders));
+
+  i0.ColumnFilters<int> get usages => $state.composableBuilder(
+      column: $state.table.usages,
+      builder: (column, joinBuilders) =>
+          i0.ColumnFilters(column, joinBuilders: joinBuilders));
+}
+
+class $$WordsTableOrderingComposer
+    extends i0.OrderingComposer<i0.GeneratedDatabase, i1.$WordsTable> {
+  $$WordsTableOrderingComposer(super.$state);
+  i0.ColumnOrderings<String> get word => $state.composableBuilder(
+      column: $state.table.word,
+      builder: (column, joinBuilders) =>
+          i0.ColumnOrderings(column, joinBuilders: joinBuilders));
+
+  i0.ColumnOrderings<int> get usages => $state.composableBuilder(
+      column: $state.table.usages,
+      builder: (column, joinBuilders) =>
+          i0.ColumnOrderings(column, joinBuilders: joinBuilders));
+}
+
 class $$WordsTableTableManager extends i0.RootTableManager<
     i0.GeneratedDatabase,
     i1.$WordsTable,
@@ -212,7 +240,10 @@ class $$WordsTableTableManager extends i0.RootTableManager<
     i1.$$WordsTableFilterComposer,
     i1.$$WordsTableOrderingComposer,
     $$WordsTableCreateCompanionBuilder,
-    $$WordsTableUpdateCompanionBuilder> {
+    $$WordsTableUpdateCompanionBuilder,
+    (i1.Word, i0.BaseReferences<i0.GeneratedDatabase, i1.$WordsTable, i1.Word>),
+    i1.Word,
+    i0.PrefetchHooks Function()> {
   $$WordsTableTableManager(i0.GeneratedDatabase db, i1.$WordsTable table)
       : super(i0.TableManagerState(
           db: db,
@@ -241,36 +272,24 @@ class $$WordsTableTableManager extends i0.RootTableManager<
             usages: usages,
             rowid: rowid,
           ),
+          withReferenceMapper: (p0) => p0
+              .map((e) => (e.readTable(table), i0.BaseReferences(db, table, e)))
+              .toList(),
+          prefetchHooksCallback: null,
         ));
 }
 
-class $$WordsTableFilterComposer
-    extends i0.FilterComposer<i0.GeneratedDatabase, i1.$WordsTable> {
-  $$WordsTableFilterComposer(super.$state);
-  i0.ColumnFilters<String> get word => $state.composableBuilder(
-      column: $state.table.word,
-      builder: (column, joinBuilders) =>
-          i0.ColumnFilters(column, joinBuilders: joinBuilders));
-
-  i0.ColumnFilters<int> get usages => $state.composableBuilder(
-      column: $state.table.usages,
-      builder: (column, joinBuilders) =>
-          i0.ColumnFilters(column, joinBuilders: joinBuilders));
-}
-
-class $$WordsTableOrderingComposer
-    extends i0.OrderingComposer<i0.GeneratedDatabase, i1.$WordsTable> {
-  $$WordsTableOrderingComposer(super.$state);
-  i0.ColumnOrderings<String> get word => $state.composableBuilder(
-      column: $state.table.word,
-      builder: (column, joinBuilders) =>
-          i0.ColumnOrderings(column, joinBuilders: joinBuilders));
-
-  i0.ColumnOrderings<int> get usages => $state.composableBuilder(
-      column: $state.table.usages,
-      builder: (column, joinBuilders) =>
-          i0.ColumnOrderings(column, joinBuilders: joinBuilders));
-}
+typedef $$WordsTableProcessedTableManager = i0.ProcessedTableManager<
+    i0.GeneratedDatabase,
+    i1.$WordsTable,
+    i1.Word,
+    i1.$$WordsTableFilterComposer,
+    i1.$$WordsTableOrderingComposer,
+    $$WordsTableCreateCompanionBuilder,
+    $$WordsTableUpdateCompanionBuilder,
+    (i1.Word, i0.BaseReferences<i0.GeneratedDatabase, i1.$WordsTable, i1.Word>),
+    i1.Word,
+    i0.PrefetchHooks Function()>;
 
 class $MatchResultsTable extends i2.MatchResults
     with i0.TableInfo<$MatchResultsTable, i1.MatchResult> {
@@ -554,50 +573,6 @@ typedef $$MatchResultsTableUpdateCompanionBuilder = i1.MatchResultsCompanion
   i0.Value<bool> teamAWon,
 });
 
-class $$MatchResultsTableTableManager extends i0.RootTableManager<
-    i0.GeneratedDatabase,
-    i1.$MatchResultsTable,
-    i1.MatchResult,
-    i1.$$MatchResultsTableFilterComposer,
-    i1.$$MatchResultsTableOrderingComposer,
-    $$MatchResultsTableCreateCompanionBuilder,
-    $$MatchResultsTableUpdateCompanionBuilder> {
-  $$MatchResultsTableTableManager(
-      i0.GeneratedDatabase db, i1.$MatchResultsTable table)
-      : super(i0.TableManagerState(
-          db: db,
-          table: table,
-          filteringComposer:
-              i1.$$MatchResultsTableFilterComposer(i0.ComposerState(db, table)),
-          orderingComposer: i1
-              .$$MatchResultsTableOrderingComposer(i0.ComposerState(db, table)),
-          updateCompanionCallback: ({
-            i0.Value<int> id = const i0.Value.absent(),
-            i0.Value<String> teamA = const i0.Value.absent(),
-            i0.Value<String> teamB = const i0.Value.absent(),
-            i0.Value<bool> teamAWon = const i0.Value.absent(),
-          }) =>
-              i1.MatchResultsCompanion(
-            id: id,
-            teamA: teamA,
-            teamB: teamB,
-            teamAWon: teamAWon,
-          ),
-          createCompanionCallback: ({
-            i0.Value<int> id = const i0.Value.absent(),
-            required String teamA,
-            required String teamB,
-            required bool teamAWon,
-          }) =>
-              i1.MatchResultsCompanion.insert(
-            id: id,
-            teamA: teamA,
-            teamB: teamB,
-            teamAWon: teamAWon,
-          ),
-        ));
-}
-
 class $$MatchResultsTableFilterComposer
     extends i0.FilterComposer<i0.GeneratedDatabase, i1.$MatchResultsTable> {
   $$MatchResultsTableFilterComposer(super.$state);
@@ -645,3 +620,74 @@ class $$MatchResultsTableOrderingComposer
       builder: (column, joinBuilders) =>
           i0.ColumnOrderings(column, joinBuilders: joinBuilders));
 }
+
+class $$MatchResultsTableTableManager extends i0.RootTableManager<
+    i0.GeneratedDatabase,
+    i1.$MatchResultsTable,
+    i1.MatchResult,
+    i1.$$MatchResultsTableFilterComposer,
+    i1.$$MatchResultsTableOrderingComposer,
+    $$MatchResultsTableCreateCompanionBuilder,
+    $$MatchResultsTableUpdateCompanionBuilder,
+    (
+      i1.MatchResult,
+      i0.BaseReferences<i0.GeneratedDatabase, i1.$MatchResultsTable,
+          i1.MatchResult>
+    ),
+    i1.MatchResult,
+    i0.PrefetchHooks Function()> {
+  $$MatchResultsTableTableManager(
+      i0.GeneratedDatabase db, i1.$MatchResultsTable table)
+      : super(i0.TableManagerState(
+          db: db,
+          table: table,
+          filteringComposer:
+              i1.$$MatchResultsTableFilterComposer(i0.ComposerState(db, table)),
+          orderingComposer: i1
+              .$$MatchResultsTableOrderingComposer(i0.ComposerState(db, table)),
+          updateCompanionCallback: ({
+            i0.Value<int> id = const i0.Value.absent(),
+            i0.Value<String> teamA = const i0.Value.absent(),
+            i0.Value<String> teamB = const i0.Value.absent(),
+            i0.Value<bool> teamAWon = const i0.Value.absent(),
+          }) =>
+              i1.MatchResultsCompanion(
+            id: id,
+            teamA: teamA,
+            teamB: teamB,
+            teamAWon: teamAWon,
+          ),
+          createCompanionCallback: ({
+            i0.Value<int> id = const i0.Value.absent(),
+            required String teamA,
+            required String teamB,
+            required bool teamAWon,
+          }) =>
+              i1.MatchResultsCompanion.insert(
+            id: id,
+            teamA: teamA,
+            teamB: teamB,
+            teamAWon: teamAWon,
+          ),
+          withReferenceMapper: (p0) => p0
+              .map((e) => (e.readTable(table), i0.BaseReferences(db, table, e)))
+              .toList(),
+          prefetchHooksCallback: null,
+        ));
+}
+
+typedef $$MatchResultsTableProcessedTableManager = i0.ProcessedTableManager<
+    i0.GeneratedDatabase,
+    i1.$MatchResultsTable,
+    i1.MatchResult,
+    i1.$$MatchResultsTableFilterComposer,
+    i1.$$MatchResultsTableOrderingComposer,
+    $$MatchResultsTableCreateCompanionBuilder,
+    $$MatchResultsTableUpdateCompanionBuilder,
+    (
+      i1.MatchResult,
+      i0.BaseReferences<i0.GeneratedDatabase, i1.$MatchResultsTable,
+          i1.MatchResult>
+    ),
+    i1.MatchResult,
+    i0.PrefetchHooks Function()>;

--- a/docs/pages/docs/Dart API/manager.md
+++ b/docs/pages/docs/Dart API/manager.md
@@ -49,9 +49,12 @@ This will return a record with the entity and a `refs` object which contains the
 The problem with the above approach is that it will issue a separate query for each row in the result set. This can be very inefficient if you have a large number of rows. If there were 1000 todos, this would issue 1000 queries to fetch the category for each todo.
 
 {% block "blocks/alert" title="Watching with Prefetches" color="info" %}
-Prefetching references works when streaming data, however updates wont be triggered when the referenced data changes.
+If you are using `watch` you can use the `withPrefetches` method to prefetch references in a single query.
+However changes to the referenced table will not trigger a re-query of the parent table.
 
 {% include "blocks/snippet" snippets = snippets name = 'manager_prefetch_references_stream' %}
+
+This is because that when single references (e.g a category has a single user) are prefetched, they are included in the same query as the parent table. Therefore, when the user table changes, the query will be re-run and the parent table will be updated. However, when multiple references are prefetched, they are included in a separate query. Therefore, changes to the referenced table will not trigger a re-query of the parent table.
 
 {% endblock %}
 

--- a/docs/pages/docs/Dart API/manager.md
+++ b/docs/pages/docs/Dart API/manager.md
@@ -46,17 +46,8 @@ This will return a record with the entity and a `refs` object which contains the
 
 {% include "blocks/snippet" snippets = snippets name = 'manager_references' %}
 
-The problem with the above approach is that it will issue a separate query for each row in the result set. This can be very inefficient if you have a large number of rows. If there were 1000 todos, this would issue 1000 queries to fetch the category for each todo.
-
-{% block "blocks/alert" title="Watching with Prefetches" color="info" %}
-If you are using `watch` you can use the `withPrefetches` method to prefetch references in a single query.
-However changes to the referenced table will not trigger a re-query of the parent table.
-
-{% include "blocks/snippet" snippets = snippets name = 'manager_prefetch_references_stream' %}
-
-This is because that when single references (e.g a category has a single user) are prefetched, they are included in the same query as the parent table. Therefore, when the user table changes, the query will be re-run and the parent table will be updated. However, when multiple references are prefetched, they are included in a separate query. Therefore, changes to the referenced table will not trigger a re-query of the parent table.
-
-{% endblock %}
+The problem with the above approach is that it will issue a separate query for each row in the result set. This can be very inefficient if you have a large number of rows.  
+If there were 1000 todos, this would issue 1000 queries to fetch the category for each todo.
 
 #### Prefetching references
 

--- a/docs/pages/docs/Dart API/manager.md
+++ b/docs/pages/docs/Dart API/manager.md
@@ -39,6 +39,28 @@ Type specific filters for `int`, `double`, `Int64`, `DateTime` and `String` are 
 {% include "blocks/snippet" snippets = snippets name = 'manager_type_specific_filter' %}
 
 
+### Referencing other tables
+
+The manager also makes it easy to query an entities referenced fields by using the `withReferences` method.
+This will return a record with the entity and a `refs` object which contains the referenced fields.
+
+{% include "blocks/snippet" snippets = snippets name = 'manager_references' %}
+
+The problem with the above approach is that it will issue a separate query for each row in the result set. This can be very inefficient if you have a large number of rows. If there were 1000 todos, this would issue 1000 queries to fetch the category for each todo.
+
+{% block "blocks/alert" title="Watching with Prefetches" color="info" %}
+Prefetching references works when streaming data, however updates wont be triggered when the referenced data changes.
+
+{% include "blocks/snippet" snippets = snippets name = 'manager_prefetch_references_stream' %}
+
+{% endblock %}
+
+#### Prefetching references
+
+Drift provides a way to prefetch references in a single query to avoid inefficient queries. This is done by using the callback in the `withReferences` method. The referenced item will then be available in the referenced managers `prefetchedData` field.
+
+{% include "blocks/snippet" snippets = snippets name = 'manager_prefetch_references' %}
+
 ### Filtering across tables
 You can filter across references to other tables by using the generated reference filters. You can nest these as deep as you'd like and the manager will take care of adding the aliased joins behind the scenes.
 

--- a/docs/pubspec.yaml
+++ b/docs/pubspec.yaml
@@ -3,7 +3,7 @@ description: Documentation website for the drift project.
 publish_to: none
 
 environment:
-  sdk: '>=3.0.0 <4.0.0'
+  sdk: ">=3.0.0 <4.0.0"
 
 dependencies:
   drift:
@@ -21,13 +21,9 @@ dependencies:
   sqlite3: ^2.0.0
   # Fake flutter packages for snippets
   path_provider:
-    path: assets/path_provider
   sqlite3_flutter_libs:
-    path: assets/sqlite3_flutter_libs
   sqlcipher_flutter_libs:
-    path: assets/sqlcipher_flutter_libs
   drift_flutter:
-    path: assets/drift_flutter
   # Used in examples
   rxdart: ^0.27.3
   yaml: ^3.1.1
@@ -56,12 +52,19 @@ dev_dependencies:
   zap_dev: ^0.2.3+1
 
 dependency_overrides:
-  # todo: Remove after https://github.com/dart-lang/mime/pull/43
-  mime:
-    git:
-      url: https://github.com/simolus3/mime.git
-      ref: woff2
-  # This override is necessary to fool melos, we need the fake
-  # package because we don't have Flutter here.
+  path_provider:
+    path: assets/path_provider
+  sqlite3_flutter_libs:
+    path: assets/sqlite3_flutter_libs
+  sqlcipher_flutter_libs:
+    path: assets/sqlcipher_flutter_libs
   drift_flutter:
     path: assets/drift_flutter
+  drift:
+    path: ../drift
+  drift_dev:
+    path: ../drift_dev
+  drift_postgres:
+    path: ../extras/drift_postgres
+  sqlparser:
+    path: ../sqlparser

--- a/drift/example/main.g.dart
+++ b/drift/example/main.g.dart
@@ -797,7 +797,7 @@ class $$TodoCategoriesTableTableManager extends RootTableManager<
     $$TodoCategoriesTableUpdateCompanionBuilder,
     (TodoCategory, $$TodoCategoriesTableReferences),
     TodoCategory,
-    PrefetchHooks Function({bool todoItemsRefs})> {
+    PrefetchHooks Function({bool todoItemsRefs, bool inTransaction})> {
   $$TodoCategoriesTableTableManager(_$Database db, $TodoCategoriesTable table)
       : super(TableManagerState(
           db: db,
@@ -828,8 +828,12 @@ class $$TodoCategoriesTableTableManager extends RootTableManager<
                     $$TodoCategoriesTableReferences(db, table, e)
                   ))
               .toList(),
-          prefetchHooksCallback: ({todoItemsRefs = false}) {
+          prefetchHooksCallback: (
+              {todoItemsRefs = false, bool inTransaction = true}) {
             return PrefetchHooks(
+              db: db,
+              inTransaction: inTransaction,
+              explicitlyWatchedTables: [if (todoItemsRefs) db.todoItems],
               addJoins: null,
               prefetchedDataStreamsCallback: (items, {required bool watch}) {
                 return [
@@ -863,7 +867,7 @@ typedef $$TodoCategoriesTableProcessedTableManager = ProcessedTableManager<
     $$TodoCategoriesTableUpdateCompanionBuilder,
     (TodoCategory, $$TodoCategoriesTableReferences),
     TodoCategory,
-    PrefetchHooks Function({bool todoItemsRefs})>;
+    PrefetchHooks Function({bool todoItemsRefs, bool inTransaction})>;
 typedef $$TodoItemsTableCreateCompanionBuilder = TodoItemsCompanion Function({
   Value<int> id,
   required String title,
@@ -979,7 +983,7 @@ class $$TodoItemsTableTableManager extends RootTableManager<
     $$TodoItemsTableUpdateCompanionBuilder,
     (TodoItem, $$TodoItemsTableReferences),
     TodoItem,
-    PrefetchHooks Function({bool categoryId})> {
+    PrefetchHooks Function({bool categoryId, bool inTransaction})> {
   $$TodoItemsTableTableManager(_$Database db, $TodoItemsTable table)
       : super(TableManagerState(
           db: db,
@@ -1018,8 +1022,12 @@ class $$TodoItemsTableTableManager extends RootTableManager<
                     $$TodoItemsTableReferences(db, table, e)
                   ))
               .toList(),
-          prefetchHooksCallback: ({categoryId = false}) {
+          prefetchHooksCallback: (
+              {categoryId = false, bool inTransaction = true}) {
             return PrefetchHooks(
+              db: db,
+              inTransaction: inTransaction,
+              explicitlyWatchedTables: [],
               addJoins: <
                   T extends TableManagerState<
                       dynamic,
@@ -1063,7 +1071,7 @@ typedef $$TodoItemsTableProcessedTableManager = ProcessedTableManager<
     $$TodoItemsTableUpdateCompanionBuilder,
     (TodoItem, $$TodoItemsTableReferences),
     TodoItem,
-    PrefetchHooks Function({bool categoryId})>;
+    PrefetchHooks Function({bool categoryId, bool inTransaction})>;
 
 class $DatabaseManager {
   final _$Database _db;

--- a/drift/example/main.g.dart
+++ b/drift/example/main.g.dart
@@ -797,7 +797,7 @@ class $$TodoCategoriesTableTableManager extends RootTableManager<
     $$TodoCategoriesTableUpdateCompanionBuilder,
     (TodoCategory, $$TodoCategoriesTableReferences),
     TodoCategory,
-    PrefetchHooks Function({bool todoItemsRefs, bool inTransaction})> {
+    PrefetchHooks Function({bool todoItemsRefs})> {
   $$TodoCategoriesTableTableManager(_$Database db, $TodoCategoriesTable table)
       : super(TableManagerState(
           db: db,
@@ -828,11 +828,9 @@ class $$TodoCategoriesTableTableManager extends RootTableManager<
                     $$TodoCategoriesTableReferences(db, table, e)
                   ))
               .toList(),
-          prefetchHooksCallback: (
-              {todoItemsRefs = false, bool inTransaction = true}) {
+          prefetchHooksCallback: ({todoItemsRefs = false}) {
             return PrefetchHooks(
               db: db,
-              inTransaction: inTransaction,
               explicitlyWatchedTables: [if (todoItemsRefs) db.todoItems],
               addJoins: null,
               prefetchedDataStreamsCallback: (items, {required bool watch}) {
@@ -867,7 +865,7 @@ typedef $$TodoCategoriesTableProcessedTableManager = ProcessedTableManager<
     $$TodoCategoriesTableUpdateCompanionBuilder,
     (TodoCategory, $$TodoCategoriesTableReferences),
     TodoCategory,
-    PrefetchHooks Function({bool todoItemsRefs, bool inTransaction})>;
+    PrefetchHooks Function({bool todoItemsRefs})>;
 typedef $$TodoItemsTableCreateCompanionBuilder = TodoItemsCompanion Function({
   Value<int> id,
   required String title,
@@ -983,7 +981,7 @@ class $$TodoItemsTableTableManager extends RootTableManager<
     $$TodoItemsTableUpdateCompanionBuilder,
     (TodoItem, $$TodoItemsTableReferences),
     TodoItem,
-    PrefetchHooks Function({bool categoryId, bool inTransaction})> {
+    PrefetchHooks Function({bool categoryId})> {
   $$TodoItemsTableTableManager(_$Database db, $TodoItemsTable table)
       : super(TableManagerState(
           db: db,
@@ -1022,11 +1020,9 @@ class $$TodoItemsTableTableManager extends RootTableManager<
                     $$TodoItemsTableReferences(db, table, e)
                   ))
               .toList(),
-          prefetchHooksCallback: (
-              {categoryId = false, bool inTransaction = true}) {
+          prefetchHooksCallback: ({categoryId = false}) {
             return PrefetchHooks(
               db: db,
-              inTransaction: inTransaction,
               explicitlyWatchedTables: [],
               addJoins: <
                   T extends TableManagerState<
@@ -1071,7 +1067,7 @@ typedef $$TodoItemsTableProcessedTableManager = ProcessedTableManager<
     $$TodoItemsTableUpdateCompanionBuilder,
     (TodoItem, $$TodoItemsTableReferences),
     TodoItem,
-    PrefetchHooks Function({bool categoryId, bool inTransaction})>;
+    PrefetchHooks Function({bool categoryId})>;
 
 class $DatabaseManager {
   final _$Database _db;

--- a/drift/example/main.g.dart
+++ b/drift/example/main.g.dart
@@ -831,20 +831,22 @@ class $$TodoCategoriesTableTableManager extends RootTableManager<
           prefetchHooksCallback: ({todoItemsRefs = false}) {
             return PrefetchHooks(
               addJoins: null,
-              withPrefetches: (items) async {
-                items = await typedResultsWithPrefetched(
-                    doPrefetch: todoItemsRefs,
-                    currentTable: table,
-                    referencedTable:
-                        $$TodoCategoriesTableReferences._todoItemsRefsTable(db),
-                    managerFromTypedResult: (p0) =>
-                        $$TodoCategoriesTableReferences(db, table, p0)
-                            .todoItemsRefs,
-                    referencedItemsForCurrentItem: (item, referencedItems) =>
-                        referencedItems.where((e) => e.categoryId == item.id),
-                    typedResults: items);
-
-                return items;
+              prefetchedDataStreamsCallback: (items, {required bool watch}) {
+                return [
+                  if (todoItemsRefs)
+                    $_streamPrefetched(
+                        watch: watch,
+                        currentTable: table,
+                        referencedTable: $$TodoCategoriesTableReferences
+                            ._todoItemsRefsTable(db),
+                        managerFromTypedResult: (p0) =>
+                            $$TodoCategoriesTableReferences(db, table, p0)
+                                .todoItemsRefs,
+                        referencedItemsForCurrentItem:
+                            (item, referencedItems) => referencedItems
+                                .where((e) => e.categoryId == item.id),
+                        typedResults: items)
+                ];
               },
             );
           },
@@ -1043,8 +1045,8 @@ class $$TodoItemsTableTableManager extends RootTableManager<
 
                 return state;
               },
-              withPrefetches: (items) async {
-                return items;
+              prefetchedDataStreamsCallback: (items, {required bool watch}) {
+                return [];
               },
             );
           },

--- a/drift/example/main.g.dart
+++ b/drift/example/main.g.dart
@@ -833,11 +833,10 @@ class $$TodoCategoriesTableTableManager extends RootTableManager<
               db: db,
               explicitlyWatchedTables: [if (todoItemsRefs) db.todoItems],
               addJoins: null,
-              prefetchedDataStreamsCallback: (items, {required bool watch}) {
+              getPrefetchedDataCallback: (items) async {
                 return [
                   if (todoItemsRefs)
-                    $_streamPrefetched(
-                        watch: watch,
+                    await $_getPrefetchedData(
                         currentTable: table,
                         referencedTable: $$TodoCategoriesTableReferences
                             ._todoItemsRefsTable(db),
@@ -1049,7 +1048,7 @@ class $$TodoItemsTableTableManager extends RootTableManager<
 
                 return state;
               },
-              prefetchedDataStreamsCallback: (items, {required bool watch}) {
+              getPrefetchedDataCallback: (items) async {
                 return [];
               },
             );

--- a/drift/example/main.g.dart
+++ b/drift/example/main.g.dart
@@ -725,7 +725,7 @@ typedef $$TodoCategoriesTableUpdateCompanionBuilder = TodoCategoriesCompanion
   Value<String> name,
 });
 
-class $$TodoCategoriesTableReferences
+final class $$TodoCategoriesTableReferences
     extends BaseReferences<_$Database, $TodoCategoriesTable, TodoCategory> {
   $$TodoCategoriesTableReferences(
       super.$_db, super.$_table, super.$_typedResult);
@@ -875,7 +875,7 @@ typedef $$TodoItemsTableUpdateCompanionBuilder = TodoItemsCompanion Function({
   Value<int> categoryId,
 });
 
-class $$TodoItemsTableReferences
+final class $$TodoItemsTableReferences
     extends BaseReferences<_$Database, $TodoItemsTable, TodoItem> {
   $$TodoItemsTableReferences(super.$_db, super.$_table, super.$_typedResult);
 

--- a/drift/example/main.g.dart
+++ b/drift/example/main.g.dart
@@ -725,39 +725,24 @@ typedef $$TodoCategoriesTableUpdateCompanionBuilder = TodoCategoriesCompanion
   Value<String> name,
 });
 
-class $$TodoCategoriesTableTableManager extends RootTableManager<
-    _$Database,
-    $TodoCategoriesTable,
-    TodoCategory,
-    $$TodoCategoriesTableFilterComposer,
-    $$TodoCategoriesTableOrderingComposer,
-    $$TodoCategoriesTableCreateCompanionBuilder,
-    $$TodoCategoriesTableUpdateCompanionBuilder> {
-  $$TodoCategoriesTableTableManager(_$Database db, $TodoCategoriesTable table)
-      : super(TableManagerState(
-          db: db,
-          table: table,
-          filteringComposer:
-              $$TodoCategoriesTableFilterComposer(ComposerState(db, table)),
-          orderingComposer:
-              $$TodoCategoriesTableOrderingComposer(ComposerState(db, table)),
-          updateCompanionCallback: ({
-            Value<int> id = const Value.absent(),
-            Value<String> name = const Value.absent(),
-          }) =>
-              TodoCategoriesCompanion(
-            id: id,
-            name: name,
-          ),
-          createCompanionCallback: ({
-            Value<int> id = const Value.absent(),
-            required String name,
-          }) =>
-              TodoCategoriesCompanion.insert(
-            id: id,
-            name: name,
-          ),
-        ));
+class $$TodoCategoriesTableReferences
+    extends BaseReferences<_$Database, $TodoCategoriesTable, TodoCategory> {
+  $$TodoCategoriesTableReferences(
+      super.$_db, super.$_table, super.$_typedResult);
+
+  static MultiTypedResultKey<$TodoItemsTable, List<TodoItem>>
+      _todoItemsRefsTable(_$Database db) =>
+          MultiTypedResultKey.fromTable(db.todoItems,
+              aliasName: "todoItemsRefs__eyteWISGIb");
+
+  $$TodoItemsTableProcessedTableManager get todoItemsRefs {
+    final manager = $$TodoItemsTableTableManager($_db, $_db.todoItems)
+        .filter((f) => f.categoryId.id($_item.id));
+
+    final cache = $_typedResult.readTableOrNull(_todoItemsRefsTable($_db));
+    return ProcessedTableManager(
+        manager.$state.copyWith(prefetchedData: cache));
+  }
 }
 
 class $$TodoCategoriesTableFilterComposer
@@ -801,6 +786,81 @@ class $$TodoCategoriesTableOrderingComposer
           ColumnOrderings(column, joinBuilders: joinBuilders));
 }
 
+class $$TodoCategoriesTableTableManager extends RootTableManager<
+    _$Database,
+    $TodoCategoriesTable,
+    TodoCategory,
+    $$TodoCategoriesTableFilterComposer,
+    $$TodoCategoriesTableOrderingComposer,
+    $$TodoCategoriesTableCreateCompanionBuilder,
+    $$TodoCategoriesTableUpdateCompanionBuilder,
+    (TodoCategory, $$TodoCategoriesTableReferences),
+    TodoCategory,
+    PrefetchHooks Function({bool todoItemsRefs})> {
+  $$TodoCategoriesTableTableManager(_$Database db, $TodoCategoriesTable table)
+      : super(TableManagerState(
+          db: db,
+          table: table,
+          filteringComposer:
+              $$TodoCategoriesTableFilterComposer(ComposerState(db, table)),
+          orderingComposer:
+              $$TodoCategoriesTableOrderingComposer(ComposerState(db, table)),
+          updateCompanionCallback: ({
+            Value<int> id = const Value.absent(),
+            Value<String> name = const Value.absent(),
+          }) =>
+              TodoCategoriesCompanion(
+            id: id,
+            name: name,
+          ),
+          createCompanionCallback: ({
+            Value<int> id = const Value.absent(),
+            required String name,
+          }) =>
+              TodoCategoriesCompanion.insert(
+            id: id,
+            name: name,
+          ),
+          withReferenceMapper: (p0) => p0
+              .map((e) => (
+                    e.readTable(table),
+                    $$TodoCategoriesTableReferences(db, table, e)
+                  ))
+              .toList(),
+          prefetchHooksCallback: ({todoItemsRefs = false}) {
+            return PrefetchHooks(
+              addJoins: null,
+              withPrefetches: (items) async {
+                items = await typedResultsWithPrefetched(
+                    doPrefetch: todoItemsRefs,
+                    currentTable: table,
+                    referencedTable:
+                        $$TodoCategoriesTableReferences._todoItemsRefsTable(db),
+                    managerFromTypedResult: (p0) =>
+                        $$TodoCategoriesTableReferences(db, table, p0)
+                            .todoItemsRefs,
+                    referencedItemsForCurrentItem: (item, referencedItems) =>
+                        referencedItems.where((e) => e.categoryId == item.id),
+                    typedResults: items);
+
+                return items;
+              },
+            );
+          },
+        ));
+}
+
+typedef $$TodoCategoriesTableProcessedTableManager = ProcessedTableManager<
+    _$Database,
+    $TodoCategoriesTable,
+    TodoCategory,
+    $$TodoCategoriesTableFilterComposer,
+    $$TodoCategoriesTableOrderingComposer,
+    $$TodoCategoriesTableCreateCompanionBuilder,
+    $$TodoCategoriesTableUpdateCompanionBuilder,
+    (TodoCategory, $$TodoCategoriesTableReferences),
+    TodoCategory,
+    PrefetchHooks Function({bool todoItemsRefs})>;
 typedef $$TodoItemsTableCreateCompanionBuilder = TodoItemsCompanion Function({
   Value<int> id,
   required String title,
@@ -814,47 +874,23 @@ typedef $$TodoItemsTableUpdateCompanionBuilder = TodoItemsCompanion Function({
   Value<int> categoryId,
 });
 
-class $$TodoItemsTableTableManager extends RootTableManager<
-    _$Database,
-    $TodoItemsTable,
-    TodoItem,
-    $$TodoItemsTableFilterComposer,
-    $$TodoItemsTableOrderingComposer,
-    $$TodoItemsTableCreateCompanionBuilder,
-    $$TodoItemsTableUpdateCompanionBuilder> {
-  $$TodoItemsTableTableManager(_$Database db, $TodoItemsTable table)
-      : super(TableManagerState(
-          db: db,
-          table: table,
-          filteringComposer:
-              $$TodoItemsTableFilterComposer(ComposerState(db, table)),
-          orderingComposer:
-              $$TodoItemsTableOrderingComposer(ComposerState(db, table)),
-          updateCompanionCallback: ({
-            Value<int> id = const Value.absent(),
-            Value<String> title = const Value.absent(),
-            Value<String?> content = const Value.absent(),
-            Value<int> categoryId = const Value.absent(),
-          }) =>
-              TodoItemsCompanion(
-            id: id,
-            title: title,
-            content: content,
-            categoryId: categoryId,
-          ),
-          createCompanionCallback: ({
-            Value<int> id = const Value.absent(),
-            required String title,
-            Value<String?> content = const Value.absent(),
-            required int categoryId,
-          }) =>
-              TodoItemsCompanion.insert(
-            id: id,
-            title: title,
-            content: content,
-            categoryId: categoryId,
-          ),
-        ));
+class $$TodoItemsTableReferences
+    extends BaseReferences<_$Database, $TodoItemsTable, TodoItem> {
+  $$TodoItemsTableReferences(super.$_db, super.$_table, super.$_typedResult);
+
+  static $TodoCategoriesTable _categoryIdTable(_$Database db) =>
+      db.todoCategories.createAlias(
+          $_aliasNameGenerator(db.todoItems.categoryId, db.todoCategories.id));
+
+  $$TodoCategoriesTableProcessedTableManager? get categoryId {
+    if ($_item.categoryId == null) return null;
+    final manager = $$TodoCategoriesTableTableManager($_db, $_db.todoCategories)
+        .filter((f) => f.id($_item.categoryId!));
+    final item = $_typedResult.readTableOrNull(_categoryIdTable($_db));
+    if (item == null) return manager;
+    return ProcessedTableManager(
+        manager.$state.copyWith(prefetchedData: [item]));
+  }
 }
 
 class $$TodoItemsTableFilterComposer
@@ -929,6 +965,102 @@ class $$TodoItemsTableOrderingComposer
     return composer;
   }
 }
+
+class $$TodoItemsTableTableManager extends RootTableManager<
+    _$Database,
+    $TodoItemsTable,
+    TodoItem,
+    $$TodoItemsTableFilterComposer,
+    $$TodoItemsTableOrderingComposer,
+    $$TodoItemsTableCreateCompanionBuilder,
+    $$TodoItemsTableUpdateCompanionBuilder,
+    (TodoItem, $$TodoItemsTableReferences),
+    TodoItem,
+    PrefetchHooks Function({bool categoryId})> {
+  $$TodoItemsTableTableManager(_$Database db, $TodoItemsTable table)
+      : super(TableManagerState(
+          db: db,
+          table: table,
+          filteringComposer:
+              $$TodoItemsTableFilterComposer(ComposerState(db, table)),
+          orderingComposer:
+              $$TodoItemsTableOrderingComposer(ComposerState(db, table)),
+          updateCompanionCallback: ({
+            Value<int> id = const Value.absent(),
+            Value<String> title = const Value.absent(),
+            Value<String?> content = const Value.absent(),
+            Value<int> categoryId = const Value.absent(),
+          }) =>
+              TodoItemsCompanion(
+            id: id,
+            title: title,
+            content: content,
+            categoryId: categoryId,
+          ),
+          createCompanionCallback: ({
+            Value<int> id = const Value.absent(),
+            required String title,
+            Value<String?> content = const Value.absent(),
+            required int categoryId,
+          }) =>
+              TodoItemsCompanion.insert(
+            id: id,
+            title: title,
+            content: content,
+            categoryId: categoryId,
+          ),
+          withReferenceMapper: (p0) => p0
+              .map((e) => (
+                    e.readTable(table),
+                    $$TodoItemsTableReferences(db, table, e)
+                  ))
+              .toList(),
+          prefetchHooksCallback: ({categoryId = false}) {
+            return PrefetchHooks(
+              addJoins: <
+                  T extends TableManagerState<
+                      dynamic,
+                      dynamic,
+                      dynamic,
+                      dynamic,
+                      dynamic,
+                      dynamic,
+                      dynamic,
+                      dynamic,
+                      dynamic,
+                      dynamic>>(state) {
+                if (categoryId) {
+                  state = state.withJoin(
+                    currentTable: table,
+                    currentColumn: table.categoryId,
+                    referencedTable:
+                        $$TodoItemsTableReferences._categoryIdTable(db),
+                    referencedColumn:
+                        $$TodoItemsTableReferences._categoryIdTable(db).id,
+                  ) as T;
+                }
+
+                return state;
+              },
+              withPrefetches: (items) async {
+                return items;
+              },
+            );
+          },
+        ));
+}
+
+typedef $$TodoItemsTableProcessedTableManager = ProcessedTableManager<
+    _$Database,
+    $TodoItemsTable,
+    TodoItem,
+    $$TodoItemsTableFilterComposer,
+    $$TodoItemsTableOrderingComposer,
+    $$TodoItemsTableCreateCompanionBuilder,
+    $$TodoItemsTableUpdateCompanionBuilder,
+    (TodoItem, $$TodoItemsTableReferences),
+    TodoItem,
+    PrefetchHooks Function({bool categoryId})>;
 
 class $DatabaseManager {
   final _$Database _db;

--- a/drift/example/main.g.dart
+++ b/drift/example/main.g.dart
@@ -733,7 +733,8 @@ class $$TodoCategoriesTableReferences
   static MultiTypedResultKey<$TodoItemsTable, List<TodoItem>>
       _todoItemsRefsTable(_$Database db) =>
           MultiTypedResultKey.fromTable(db.todoItems,
-              aliasName: "todoItemsRefs__eyteWISGIb");
+              aliasName: $_aliasNameGenerator(
+                  db.todoCategories.id, db.todoItems.categoryId));
 
   $$TodoItemsTableProcessedTableManager get todoItemsRefs {
     final manager = $$TodoItemsTableTableManager($_db, $_db.todoItems)

--- a/drift/lib/drift.dart
+++ b/drift/lib/drift.dart
@@ -18,6 +18,7 @@ export 'src/runtime/executor/executor.dart';
 export 'src/runtime/executor/interceptor.dart';
 export 'src/runtime/query_builder/query_builder.dart'
     hide
+        JoinedSelectStatementAdditionalTablesX,
         CaseWhenExpressionWithBase,
         BaseCaseWhenExpression,
         SelectWithoutTables,

--- a/drift/lib/drift.dart
+++ b/drift/lib/drift.dart
@@ -18,7 +18,7 @@ export 'src/runtime/executor/executor.dart';
 export 'src/runtime/executor/interceptor.dart';
 export 'src/runtime/query_builder/query_builder.dart'
     hide
-        JoinedSelectStatementAdditionalTablesX,
+        JoinedSelectStatementAdditionalTables,
         CaseWhenExpressionWithBase,
         BaseCaseWhenExpression,
         SelectWithoutTables,

--- a/drift/lib/drift.dart
+++ b/drift/lib/drift.dart
@@ -20,7 +20,8 @@ export 'src/runtime/query_builder/query_builder.dart'
     hide
         CaseWhenExpressionWithBase,
         BaseCaseWhenExpression,
-        SelectWithoutTables;
+        SelectWithoutTables,
+        EditTypedResultExtension;
 export 'src/runtime/types/converters.dart';
 export 'src/runtime/types/mapping.dart' hide BaseSqlType, UserDefinedSqlType;
 export 'src/runtime/manager/manager.dart';

--- a/drift/lib/src/runtime/api/connection_user.dart
+++ b/drift/lib/src/runtime/api/connection_user.dart
@@ -63,7 +63,7 @@ abstract class DatabaseConnectionUser {
 
   /// Creates and auto-updating stream from the given select statement. This
   /// method should not be used directly.
-  Stream<List<Map<String, Object?>>> createStream(QueryStreamFetcher stmt) =>
+  Stream<T> createStream<T>(QueryStreamFetcher<T> stmt) =>
       resolvedEngine.streamQueries.registerStream(stmt, this);
 
   /// Creates a copy of the table with an alias so that it can be used in the

--- a/drift/lib/src/runtime/api/connection_user.dart
+++ b/drift/lib/src/runtime/api/connection_user.dart
@@ -63,7 +63,7 @@ abstract class DatabaseConnectionUser {
 
   /// Creates and auto-updating stream from the given select statement. This
   /// method should not be used directly.
-  Stream<T> createStream<T>(QueryStreamFetcher<T> stmt) =>
+  Stream<T> createStream<T extends Object>(QueryStreamFetcher<T> stmt) =>
       resolvedEngine.streamQueries.registerStream(stmt, this);
 
   /// Creates a copy of the table with an alias so that it can be used in the

--- a/drift/lib/src/runtime/cancellation_zone.dart
+++ b/drift/lib/src/runtime/cancellation_zone.dart
@@ -50,8 +50,7 @@ class CancellationToken<T> {
 
 /// Extensions that can be used on cancellable operations if they return a non-
 /// nullable value.
-extension NonNullableCancellationExtension<T extends Object>
-    on CancellationToken<T> {
+extension NonNullableCancellationExtension<T> on CancellationToken<T> {
   /// Wait for the result, or return `null` if the operation was cancelled.
   ///
   /// To avoid situations where `null` could be a valid result from an async

--- a/drift/lib/src/runtime/cancellation_zone.dart
+++ b/drift/lib/src/runtime/cancellation_zone.dart
@@ -50,7 +50,8 @@ class CancellationToken<T> {
 
 /// Extensions that can be used on cancellable operations if they return a non-
 /// nullable value.
-extension NonNullableCancellationExtension<T> on CancellationToken<T> {
+extension NonNullableCancellationExtension<T extends Object>
+    on CancellationToken<T> {
   /// Wait for the result, or return `null` if the operation was cancelled.
   ///
   /// To avoid situations where `null` could be a valid result from an async

--- a/drift/lib/src/runtime/executor/delayed_stream_queries.dart
+++ b/drift/lib/src/runtime/executor/delayed_stream_queries.dart
@@ -58,7 +58,7 @@ class DelayedStreamQueryStore implements StreamQueryStore {
   }
 
   @override
-  Stream<T> registerStream<T>(
+  Stream<T> registerStream<T extends Object>(
       QueryStreamFetcher<T> fetcher, DatabaseConnectionUser database) {
     return _delegateStream((store) => store.registerStream(fetcher, database));
   }

--- a/drift/lib/src/runtime/executor/delayed_stream_queries.dart
+++ b/drift/lib/src/runtime/executor/delayed_stream_queries.dart
@@ -58,8 +58,8 @@ class DelayedStreamQueryStore implements StreamQueryStore {
   }
 
   @override
-  Stream<List<Map<String, Object?>>> registerStream(
-      QueryStreamFetcher fetcher, DatabaseConnectionUser database) {
+  Stream<T> registerStream<T>(
+      QueryStreamFetcher<T> fetcher, DatabaseConnectionUser database) {
     return _delegateStream((store) => store.registerStream(fetcher, database));
   }
 

--- a/drift/lib/src/runtime/executor/stream_queries.dart
+++ b/drift/lib/src/runtime/executor/stream_queries.dart
@@ -16,7 +16,7 @@ const _listEquality = ListEquality<Object?>();
 /// Representation of a select statement that knows from which tables the
 /// statement is reading its data and how to execute the query.
 @internal
-class QueryStreamFetcher<Rows> {
+class QueryStreamFetcher<Rows extends Object> {
   /// Table updates that will affect this stream.
   ///
   /// If any of these tables changes, the stream must fetch its data again.
@@ -89,7 +89,7 @@ class StreamQueryStore {
       StreamController.broadcast(sync: true);
 
   /// Creates a new stream from the select statement.
-  Stream<T> registerStream<T>(
+  Stream<T> registerStream<T extends Object>(
       QueryStreamFetcher<T> fetcher, DatabaseConnectionUser database) {
     final key = fetcher.key;
 
@@ -182,7 +182,7 @@ class StreamQueryStore {
   }
 }
 
-class QueryStream<Rows> {
+class QueryStream<Rows extends Object> {
   final QueryStreamFetcher _fetcher;
   final StreamQueryStore _store;
   final DatabaseConnectionUser _database;

--- a/drift/lib/src/runtime/executor/stream_queries.dart
+++ b/drift/lib/src/runtime/executor/stream_queries.dart
@@ -237,7 +237,7 @@ class QueryStream<Rows> {
 
   StreamSubscription? _tablesChangedSubscription;
 
-  List<Map<String, Object?>>? _lastData;
+  Rows? _lastData;
   final List<CancellationToken> _runningOperations = [];
   bool _isClosed = false;
 
@@ -314,7 +314,7 @@ class QueryStream<Rows> {
   }
 
   Future<void> fetchAndEmitData() async {
-    final operation = CancellationToken<List<Map<String, dynamic>>>();
+    final operation = CancellationToken<Rows>();
     _runningOperations.add(operation);
 
     try {

--- a/drift/lib/src/runtime/manager/composable.dart
+++ b/drift/lib/src/runtime/manager/composable.dart
@@ -14,6 +14,9 @@ class JoinBuilder {
   /// The column of the [referencedTable] which will be use to create the join
   final GeneratedColumn referencedColumn;
 
+  /// Whether this join should be used to read columns from the referenced table
+  final bool useColumns;
+
   /// Class that describes how a ordering that is being
   /// applied to a referenced table
   /// should be joined to the current table
@@ -22,7 +25,8 @@ class JoinBuilder {
       {required this.currentTable,
       required this.referencedTable,
       required this.currentColumn,
-      required this.referencedColumn});
+      required this.referencedColumn,
+      this.useColumns = false});
 
   /// The name of the alias that this join will use
   String get aliasedName {
@@ -34,7 +38,8 @@ class JoinBuilder {
     if (identical(this, other)) return true;
     if (other is JoinBuilder) {
       return other.currentColumn == currentColumn &&
-          other.referencedColumn == referencedColumn;
+          other.referencedColumn == referencedColumn &&
+          other.useColumns == useColumns;
     } else {
       return false;
     }
@@ -54,7 +59,7 @@ class JoinBuilder {
   Join buildJoin() {
     return leftOuterJoin(
         referencedTable, currentColumn.equalsExp(referencedColumn),
-        useColumns: false);
+        useColumns: useColumns);
   }
 }
 

--- a/drift/lib/src/runtime/manager/composer.dart
+++ b/drift/lib/src/runtime/manager/composer.dart
@@ -83,8 +83,7 @@ class ComposerState<Database extends GeneratedDatabase,
 
     // Use the provided callbacks to create a join builder
     final referencedColumn = getReferencedColumn(referencedTable);
-    final aliasName =
-        '${aliasedColumn.tableName}__${aliasedColumn.name}__${referencedColumn.tableName}__${referencedColumn.name}';
+    final aliasName = $_aliasNameGenerator(aliasedColumn, referencedColumn);
     final aliasedReferencedTable =
         db.alias(referencedTable as TableInfo, aliasName);
     final aliasedReferencedColumn =

--- a/drift/lib/src/runtime/manager/filter.dart
+++ b/drift/lib/src/runtime/manager/filter.dart
@@ -143,7 +143,7 @@ extension StringFilters<T extends String> on ColumnFilters<String> {
   ///    to perform a case sensitive search, they can pass `caseInsensitive = false` manually
   ///
   /// We are using the default of {bool caseInsensitive = true}, so that users who haven't set
-  /// the database to be case sensitive wont be confues why their like expressions are case insensitive
+  /// the database to be case sensitive wont be confused why their like expressions are case insensitive
   Expression<bool> _buildExpression(
       _StringFilterTypes type, String value, bool caseInsensitive) {
     final Expression<String> column;

--- a/drift/lib/src/runtime/manager/manager.dart
+++ b/drift/lib/src/runtime/manager/manager.dart
@@ -706,16 +706,11 @@ abstract class BaseTableManager<
   @override
   Future<$ActiveDataclass?> getSingleOrNull({bool distinct = true}) async {
     final list = await get(distinct: distinct);
-    final iterator = list.iterator;
-
-    if (!iterator.moveNext()) {
+    if (list.isEmpty) {
       return null;
+    } else {
+      return list.single;
     }
-    final element = iterator.current;
-    if (iterator.moveNext()) {
-      throw StateError('Expected exactly one result, but found more than one!');
-    }
-    return element;
   }
 
   /// Creates an auto-updating stream of this statement, similar to

--- a/drift/lib/src/runtime/manager/manager.dart
+++ b/drift/lib/src/runtime/manager/manager.dart
@@ -473,6 +473,19 @@ abstract class BaseTableManager<
   /// ```
   ///
   /// Note that `prefetchedData` will be null if the reference was not prefetched.
+  ///
+  /// ### Transactions
+  /// By default references which are fetched as a separate query will be ran in a single transaction.
+  /// When streaming data, this can be inefficient. Any changes to any of the referenced tables will cause all the queries to be ran again.
+  ///
+  /// This can be disabled by setting `inTransaction: false` in the `prefetch` constructor.
+  /// ```dart
+  /// groups.withReferences((prefetch) => prefetch(users: true, inTransaction: false)).watch()
+  /// ````
+  /// In the above example, if the user table is updated, the query will only be ran for the user table, not the group table.
+  /// The downside of this is that the data may be inconsistent.
+  ///
+  /// For example, if a group is deleted between queries, you will have a reference to a group that doesn't exist.
   ProcessedTableManager<
           $Database,
           $Table,

--- a/drift/lib/src/runtime/manager/manager.dart
+++ b/drift/lib/src/runtime/manager/manager.dart
@@ -26,6 +26,7 @@ part 'references.dart';
 /// E.G Instead of `CategoriesCompanion.insert(name: "School")` you would use `(f) => f(name: "School")`
 ///
 /// The [$CreatePrefetchHooksCallback] refers to the function which the user will use to create a [PrefetchHooks] in `withReferences`
+/// See the [BaseReferences] class for more information on how this is used.
 ///
 /// E.G.
 /// ```dart
@@ -88,7 +89,7 @@ class TableManagerState<
   final $UpdateCompanionCallback _updateCompanionCallback;
 
   /// This function is used internally to convert a simple [$Dataclass] into one which has its references attached [$DataclassWithReferences].
-  /// This is used internaly by [toActiveDataclass] and should not be used outside of this class.
+  /// This is used internally by [toActiveDataclass] and should not be used outside of this class.
   final List<$DataclassWithReferences> Function(List<TypedResult>)
       _withReferenceMapper;
 
@@ -104,7 +105,7 @@ class TableManagerState<
     }
   }
 
-  /// If this field has references, this field will contain the function that the user will use to create a [PrefetchHooks]
+  /// If this table has references, this field will contain the function that the user will use to create a [PrefetchHooks]
   ///
   /// E.G.
   /// If the prefetch function would look like
@@ -119,8 +120,7 @@ class TableManagerState<
   /// ```
   final $CreatePrefetchHooksCallback? _prefetchHooksCallback;
 
-  /// If this manager was created with prefetched data, this field will contain the prefetched data
-  /// otherwise it will be null
+  /// Prefetched data, if references with prefetching enabled were added to this manager
   ///
   /// E.G.
   /// ```dart
@@ -143,7 +143,7 @@ class TableManagerState<
 
   /// Defines a class which holds the state for a table manager
   /// It contains the database instance, the table instance, and any filters/orderings that will be applied to the query
-  /// This is held in a seperate class than the [BaseTableManager] so that the state can be passed down from the root manager to the lower level managers
+  /// This is held in a separate class than the [BaseTableManager] so that the state can be passed down from the root manager to the lower level managers
   ///
   /// This class is used internally by the [BaseTableManager] and should not be used directly
   TableManagerState(
@@ -412,7 +412,7 @@ class TableManagerState<
 }
 
 /// Base class for all table managers
-/// Most of this classes functionality is kept in a seperate [TableManagerState] class
+/// Most of this classes functionality is kept in a separate [TableManagerState] class
 /// This is so that the state can be passed down to lower level managers
 @immutable
 abstract class BaseTableManager<
@@ -459,7 +459,7 @@ abstract class BaseTableManager<
   /// ```
   /// ### Prefetching
   ///
-  /// The keen among you may notice that the above code is extremly inefficient, as it will run a query for each group to get the users in that group.
+  /// The keen among you may notice that the above code is extremely inefficient, as it will run a query for each group to get the users in that group.
   /// This could mean hundreds of queries for a single page of data, grinding your application to a halt.
   ///
   /// The solution to this is to use prefetching, which will run a single query to get all the data you need.
@@ -773,8 +773,8 @@ class ProcessedTableManager<
   @internal
   ProcessedTableManager(super.$state);
 
-  /// The prefetched data for this manager
-  /// This will be null if the manager was not created with prefetched data
+  /// Prefetched data, if references with prefetching enabled were added to this manager
+  ///
   /// E.G.
   /// ```dart
   /// final (group,refs) = await groups.withReferences((prefetch) => prefetch(users: true)).getSingle();

--- a/drift/lib/src/runtime/manager/manager.dart
+++ b/drift/lib/src/runtime/manager/manager.dart
@@ -445,6 +445,34 @@ abstract class BaseTableManager<
   /// {@macro manager_internal_use_only}
   BaseTableManager(this.$state);
 
+  /// This function with return a new manager which will return each item in the database with its references
+  ///
+  /// The references are returned as a prefiltered manager, which will only return the items which are related to the item
+  ///
+  /// For example:
+  /// ```dart
+  /// for (final (group,refs) in await groups.withReferences().get()) {
+  ///   final usersInGroup = await refs.users.get();
+  ///   /// Is identical to:
+  ///   final usersInGroup = await users.filter((f) => f.group.id(group.id)).get();
+  /// }
+  /// ```
+  /// ### Prefetching
+  ///
+  /// The keen among you may notice that the above code is extremly inefficient, as it will run a query for each group to get the users in that group.
+  /// This could mean hundreds of queries for a single page of data, grinding your application to a halt.
+  ///
+  /// The solution to this is to use prefetching, which will run a single query to get all the data you need.
+  ///
+  /// For example:
+  /// ```dart
+  /// for (final (group,refs) in await groups.withReferences((prefetch) => prefetch(users: true)).get()) {
+  ///   final usersInGroup = refs.users.prefetchedData;
+  /// }
+  /// ```
+  ///
+  /// Note that `prefetchedData` will be null if the reference was not prefetched.
+  ///
   ProcessedTableManager<
           $Database,
           $Table,

--- a/drift/lib/src/runtime/manager/manager.dart
+++ b/drift/lib/src/runtime/manager/manager.dart
@@ -3,7 +3,6 @@ import 'dart:async';
 import 'package:collection/collection.dart';
 import 'package:drift/drift.dart';
 import 'package:drift/src/runtime/query_builder/query_builder.dart';
-import 'package:drift/src/utils/async.dart';
 import 'package:drift/src/utils/single_transformer.dart';
 import 'package:meta/meta.dart';
 
@@ -687,9 +686,8 @@ abstract class BaseTableManager<
         .withJoins($state)
         .copyWith(distinct: distinct, limit: limit, offset: offset)
         .buildSelectStatement()
-
-        /// The prefetch queries don't watch the database
-        /// We need to explicitly watch the tables that are used in the prefetch queries
+        // The prefetch queries don't watch the database
+        // We need to explicitly watch the tables that are used in the prefetch queries
         .watchWithAdditionalTables(
             $state.prefetchHooks.explicitlyWatchedTables);
 

--- a/drift/lib/src/runtime/manager/manager.dart
+++ b/drift/lib/src/runtime/manager/manager.dart
@@ -252,10 +252,9 @@ class TableManagerState<
     );
   }
 
-  /// When a user calls `withReferences` on a manager, we return a copy which is
-  /// set to return a `$DataclassWithReferences` instead of just a `$Dataclass`
+  /// This method creates a copy of this manager state with a join added to the query.
   ///
-  /// This function is used to make that copy.
+  /// If the join already exists in the [joinBuilders], but has `useColumns: false`, we update the JoinBuilder.
   TableManagerState<
           $Database,
           $Table,
@@ -744,7 +743,7 @@ abstract class BaseTableManager<
 /// By introducing a separate interface for managers with filters applied to
 /// them, the API doesn't allow combining incompatible clauses and operations.
 ///
-// As of now this is identical to [BaseTableManager] but it's kept seperate for
+// As of now this is identical to [BaseTableManager] but it's kept separate for
 // future extensibility.
 @immutable
 class ProcessedTableManager<

--- a/drift/lib/src/runtime/manager/manager.dart
+++ b/drift/lib/src/runtime/manager/manager.dart
@@ -139,7 +139,7 @@ class TableManagerState<
   final List<TypedResult>? _prefetchedData;
 
   /// Once `withReferences` is called, this field will be set to the function that will be used to get the prefetched data
-  late final PrefetchHooks _prefetchHooks;
+  late final PrefetchHooks prefetchHooks;
 
   /// Defines a class which holds the state for a table manager
   /// It contains the database instance, the table instance, and any filters/orderings that will be applied to the query
@@ -164,7 +164,7 @@ class TableManagerState<
       this.offset,
       this.orderingBuilders = const {},
       this.joinBuilders = const {}})
-      : _prefetchHooks = prefetchHooks ?? PrefetchHooks(),
+      : prefetchHooks = prefetchHooks ?? PrefetchHooks(),
         _prefetchedData = prefetchedData,
         _prefetchHooksCallback = prefetchHooksCallback,
         _withReferenceMapper = withReferenceMapper,
@@ -208,7 +208,7 @@ class TableManagerState<
       withReferenceMapper: _withReferenceMapper,
       prefetchHooksCallback: _prefetchHooksCallback,
       prefetchedData: prefetchedDataAsTypedResult ?? this._prefetchedData,
-      prefetchHooks: prefetchHooks ?? this._prefetchHooks,
+      prefetchHooks: prefetchHooks ?? this.prefetchHooks,
       filter: filter ?? this.filter,
       joinBuilders: joinBuilders ?? this.joinBuilders,
       orderingBuilders: orderingBuilders ?? this.orderingBuilders,
@@ -631,14 +631,14 @@ abstract class BaseTableManager<
   Future<List<$ActiveDataclass>> get(
       {bool distinct = false, int? limit, int? offset}) async {
     /// Fetch the items from the database with the prefetch hooks
-    var items = await $state._prefetchHooks
+    var items = await $state.prefetchHooks
         .withJoins($state)
         .copyWith(distinct: distinct, limit: limit, offset: offset)
         .buildSelectStatement()
         .get();
 
     /// Apply the prefetch hooks to the items
-    items = await $state._prefetchHooks.withPrefetches(items);
+    items = await $state.prefetchHooks.withPrefetches(items);
     return $state.toActiveDataclass(items);
   }
 
@@ -654,7 +654,7 @@ abstract class BaseTableManager<
   Stream<List<$ActiveDataclass>> watch(
       {bool distinct = false, int? limit, int? offset}) {
     /// Fetch the items from the database with the prefetch hooks
-    var itemStream = $state._prefetchHooks
+    var itemStream = $state.prefetchHooks
         .withJoins($state)
         .copyWith(distinct: distinct, limit: limit, offset: offset)
         .buildSelectStatement()
@@ -662,7 +662,7 @@ abstract class BaseTableManager<
 
     /// Return the stream with the prefetch hooks applied
     return itemStream.asyncMap((event) async {
-      event = await $state._prefetchHooks.withPrefetches(event);
+      event = await $state.prefetchHooks.withPrefetches(event);
       return $state.toActiveDataclass(event);
     });
   }

--- a/drift/lib/src/runtime/manager/references.dart
+++ b/drift/lib/src/runtime/manager/references.dart
@@ -301,14 +301,14 @@ class PrefetchHooks {
 
   /// A function which will return list of references for each prefetch data source.
   final Future<List<List<MultiTypedResultEntry>>> Function(List<TypedResult>)?
-      prefetchedDataCallback;
+      getPrefetchedDataCallback;
 
   /// Create a [PrefetchHooks] object
   PrefetchHooks(
       {required this.db,
       StateTransformer? addJoins,
       this.explicitlyWatchedTables = const [],
-      this.prefetchedDataCallback}) {
+      this.getPrefetchedDataCallback}) {
     withJoins = addJoins ?? _defaultStateTransformer;
   }
 
@@ -316,12 +316,12 @@ class PrefetchHooks {
   Stream<List<TypedResult>> _addPrefetchedDataToStream(
       Stream<List<TypedResult>> itemStream) {
     /// If this table contains no reverse references, we can just return the stream as is.
-    if (prefetchedDataCallback == null) {
+    if (getPrefetchedDataCallback == null) {
       return itemStream;
     }
 
     return itemStream.asyncMap((rows) async {
-      final prefetchedData = await prefetchedDataCallback!(rows);
+      final prefetchedData = await getPrefetchedDataCallback!(rows);
       return await db.transaction(
         () async {
           return _addPrefetchedDataToRows(rows, prefetchedData);
@@ -493,7 +493,7 @@ class MultiTypedResultEntry<T> {
 ///
 /// This function is used by the generated code and should not be used directly.
 // ignore: non_constant_identifier_names
-Future<List<MultiTypedResultEntry<$ReferencedDataclass>>> $_prefetchedReference<
+Future<List<MultiTypedResultEntry<$ReferencedDataclass>>> $_getPrefetchedData<
         $CurrentDataclass, $CurrentTable extends Table, $ReferencedDataclass>(
     {required ProcessedTableManager<
                 dynamic,

--- a/drift/lib/src/runtime/manager/references.dart
+++ b/drift/lib/src/runtime/manager/references.dart
@@ -174,6 +174,8 @@ class MultiTypedResultKey<$Table extends Table, $Dataclass>
   }
 }
 
+/// This function is used to prefetch referenced data for a list of TypedResults.
+/// And then insert the prefetched data into the TypedResult object using the [MultiTypedResultKey] as a key.
 Future<List<TypedResult>> typedResultsWithPrefetched<
         $CurrentDataclass,
         $CurrentTable extends Table,
@@ -202,7 +204,6 @@ Future<List<TypedResult>> typedResultsWithPrefetched<
   if (!doPrefetch || typedResults.isEmpty) {
     return typedResults;
   } else {
-    print(referencedTable.hashCode);
     final managers = typedResults.map(managerFromTypedResult);
     // Combine all the referenced managers into 1 large query which will return all the
     // referenced items in one go.

--- a/drift/lib/src/runtime/manager/references.dart
+++ b/drift/lib/src/runtime/manager/references.dart
@@ -71,7 +71,7 @@ String $_aliasNameGenerator(
 ///
 /// ### Manager API
 ///
-/// This is quite verbose, and the manager api seeks to solve this for you.
+/// This is quite verbose, and the manager api seeks to solve this for drift users.
 /// The API looks like this:
 /// ```dart
 /// products.withReferences((prefetch) => prefetch(department: true)).get()

--- a/drift/lib/src/runtime/manager/references.dart
+++ b/drift/lib/src/runtime/manager/references.dart
@@ -160,6 +160,18 @@ class MultiTypedResultKey<$Table extends Table, $Dataclass>
       },
     );
   }
+
+  /// Only use the entity name as the hashcode
+  @override
+  int get hashCode => entityName.hashCode;
+
+  @override
+  bool operator ==(Object other) {
+    if (other is MultiTypedResultKey<$Table, $Dataclass>) {
+      return other.entityName == entityName;
+    }
+    return false;
+  }
 }
 
 Future<List<TypedResult>> typedResultsWithPrefetched<
@@ -190,6 +202,7 @@ Future<List<TypedResult>> typedResultsWithPrefetched<
   if (!doPrefetch || typedResults.isEmpty) {
     return typedResults;
   } else {
+    print(referencedTable.hashCode);
     final managers = typedResults.map(managerFromTypedResult);
     // Combine all the referenced managers into 1 large query which will return all the
     // referenced items in one go.
@@ -201,7 +214,8 @@ Future<List<TypedResult>> typedResultsWithPrefetched<
     // Put each of these referenced items into the typed results
     return typedResults.map((e) {
       final item = e.readTable(currentTable);
-      final refs = referencedItemsForCurrentItem(item, referencedItems);
+      final refs =
+          referencedItemsForCurrentItem(item, referencedItems).toList();
       e.addData(referencedTable, refs);
       return e;
     }).toList();

--- a/drift/lib/src/runtime/manager/references.dart
+++ b/drift/lib/src/runtime/manager/references.dart
@@ -1,0 +1,209 @@
+part of 'manager.dart';
+
+/// A simple function for generating aliases for referenced columns
+///
+/// This function is used internally by generated code and should not be used directly.
+// ignore: non_constant_identifier_names
+String $_aliasNameGenerator(
+    GeneratedColumn currentColumn, GeneratedColumn referencedColumn) {
+  return '${currentColumn.tableName}__${currentColumn.name}__${referencedColumn.tableName}__${referencedColumn.name}';
+}
+
+/// Base class for the "WithReference" classes
+///
+/// When a user calls `withReferences` on a manager, the item is returned, along with an instance of this
+/// class which contains getters for the referenced tables manager which are pre-filtered to the item.
+/// So the following:
+/// ```dart
+/// final (group,refs) = await groups.filter((f) => f.id(5)).withReferences().getSingle()
+/// final usersInGroup = refs.users.get() // filter((f) => f.group(group.id)) is already applied
+/// ```
+/// is short for:
+/// ```dart
+/// final group = await groups.filter((f) => f.id(5)).getSingle()
+/// final usersInGroup = await users.filter((f) => f.group(group.id)).get()
+/// ```
+/// {@macro manager_internal_use_only}
+class BaseReferences<$Database extends GeneratedDatabase, $Table extends Table,
+    $Dataclass> {
+  /// The database instance
+  // ignore: non_constant_identifier_names
+  final $Database $_db;
+
+  /// The table of this item
+  // ignore: non_constant_identifier_names
+  final TableInfo<$Table, $Dataclass> $_table;
+
+  /// The raw [TypedResult] for this item
+  // ignore: non_constant_identifier_names
+  final TypedResult $_typedResult;
+
+  // The item these references are for
+  // ignore: public_member_api_docs, non_constant_identifier_names
+  late final $Dataclass $_item = $_typedResult.readTable($_table);
+
+  /// Create a [BaseReferences] class
+  // ignore: non_constant_identifier_names
+  BaseReferences(this.$_db, this.$_table, this.$_typedResult);
+}
+
+/// Type definition for a function that transforms the state of a manager
+typedef StateTransformer = T Function<
+    T extends TableManagerState<dynamic, dynamic, dynamic, dynamic, dynamic,
+        dynamic, dynamic, dynamic, dynamic, dynamic>>(T $state);
+
+T _defaultStateTransformer<
+    T extends TableManagerState<dynamic, dynamic, dynamic, dynamic, dynamic,
+        dynamic, dynamic, dynamic, dynamic, dynamic>>(T $state) {
+  return $state;
+}
+
+/// Type definition for a function which transforms a List of TypedResults
+typedef TypedResultTransformer = Future<List<TypedResult>> Function(
+    List<TypedResult> results);
+
+/// When a user requests that certain fields are prefetched, we create a [PrefetchHooks] class for the manager.
+/// This class has hooks for adding joins to the query before the query is executed, and for running prefetches after the query is executed.
+/// {@macro manager_internal_use_only}
+class PrefetchHooks {
+  /// This callback is used to add joins to the query before it is executed.
+  late final StateTransformer withJoins;
+
+  /// This callback is used to prefetch referenced data and insert it into the TypedResult object.
+  late final TypedResultTransformer withPrefetches;
+
+  /// Create a [PrefetchHooks] object
+  PrefetchHooks(
+      {StateTransformer? addJoins, TypedResultTransformer? withPrefetches}) {
+    withJoins = addJoins ?? _defaultStateTransformer;
+    this.withPrefetches = withPrefetches ?? (results) async => results;
+  }
+}
+
+/// This class is used to convert a table which expects a single dataclass per row into a table that can contain a multiple dataclasses per row.
+/// However when we prefetch multiple references, we need to store them in a list, which isn't supported by the referenced table class.
+/// For single references, we use original referenced table as a key in the TypedResult._parsedData object.
+/// {@macro manager_internal_use_only}
+class MultiTypedResultKey<$Table extends Table, $Dataclass>
+    implements ResultSetImplementation<$Table, $Dataclass> {
+  @override
+  final List<GeneratedColumn<Object>> $columns;
+
+  @override
+  final $Table asDslTable;
+
+  @override
+  final DatabaseConnectionUser attachedDatabase;
+
+  @override
+  final Map<String, GeneratedColumn<Object>> columnsByName;
+
+  @override
+  final String entityName;
+
+  @override
+  FutureOr<$Dataclass> map(Map<String, dynamic> data, {String? tablePrefix}) =>
+      _mapFunction(data, tablePrefix: tablePrefix);
+
+  final FutureOr<$Dataclass> Function(Map<String, dynamic> data,
+      {String? tablePrefix}) _mapFunction;
+
+  @override
+  String get aliasedName => entityName;
+
+  @override
+  MultiTypedResultKey<$Table, $Dataclass> createAlias(String alias) {
+    return MultiTypedResultKey._(
+      $columns: $columns,
+      asDslTable: asDslTable,
+      attachedDatabase: attachedDatabase,
+      columnsByName: columnsByName,
+      entityName: alias,
+      mapFunction: _mapFunction,
+    );
+  }
+
+  const MultiTypedResultKey._(
+      {required this.$columns,
+      required this.asDslTable,
+      required this.attachedDatabase,
+      required this.columnsByName,
+      required this.entityName,
+      required FutureOr<$Dataclass> Function(Map<String, dynamic>,
+              {String? tablePrefix})
+          mapFunction})
+      : _mapFunction = mapFunction;
+
+  /// Create a [MultiTypedResultKey] from a table
+  static MultiTypedResultKey<$Table, List<$Dataclass>>
+      fromTable<$Table extends Table, $Dataclass>(
+          TableInfo<$Table, $Dataclass> table,
+          {required String aliasName}) {
+    return MultiTypedResultKey<$Table, List<$Dataclass>>._(
+      $columns: table.$columns,
+      asDslTable: table.asDslTable,
+      attachedDatabase: table.attachedDatabase,
+      columnsByName: table.columnsByName,
+      entityName: aliasName,
+
+      /// This table is used a key for a map and should never be used to read data
+      /// However, in case it is, we will map a single item to a list of items
+      mapFunction: (Map<String, dynamic> data, {String? tablePrefix}) {
+        final singleResult = table.map(data, tablePrefix: tablePrefix);
+        if (singleResult is $Dataclass) {
+          return [singleResult];
+        } else {
+          return singleResult.then(
+            (value) => [value],
+          );
+        }
+      },
+    );
+  }
+}
+
+Future<List<TypedResult>> typedResultsWithPrefetched<
+        $CurrentDataclass,
+        $CurrentTable extends Table,
+        $ReferencedDataclass,
+        $ReferencedTable extends Table>(
+    {required bool doPrefetch,
+    required ProcessedTableManager<
+                dynamic,
+                dynamic,
+                $ReferencedDataclass,
+                dynamic,
+                dynamic,
+                dynamic,
+                dynamic,
+                dynamic,
+                $ReferencedDataclass,
+                dynamic>
+            Function(TypedResult)
+        managerFromTypedResult,
+    required List<TypedResult> typedResults,
+    required TableInfo<$CurrentTable, $CurrentDataclass> currentTable,
+    required MultiTypedResultKey referencedTable,
+    required Iterable<$ReferencedDataclass> Function(
+            $CurrentDataclass item, List<$ReferencedDataclass> referencedItems)
+        referencedItemsForCurrentItem}) async {
+  if (!doPrefetch || typedResults.isEmpty) {
+    return typedResults;
+  } else {
+    final managers = typedResults.map(managerFromTypedResult);
+    // Combine all the referenced managers into 1 large query which will return all the
+    // referenced items in one go.
+    final manager = managers.reduce((value, element) => value._filter(
+        (_) => ComposableFilter._(element.$state.filter, {}),
+        _BooleanOperator.or));
+    final referencedItems = await manager.get(distinct: true);
+
+    // Put each of these referenced items into the typed results
+    return typedResults.map((e) {
+      final item = e.readTable(currentTable);
+      final refs = referencedItemsForCurrentItem(item, referencedItems);
+      e.addData(referencedTable, refs);
+      return e;
+    }).toList();
+  }
+}

--- a/drift/lib/src/runtime/manager/references.dart
+++ b/drift/lib/src/runtime/manager/references.dart
@@ -375,10 +375,8 @@ class MultiTypedResultKey<$Table extends Table, $Dataclass>
 
   @override
   FutureOr<$Dataclass> map(Map<String, dynamic> data, {String? tablePrefix}) =>
-      _mapFunction(data, tablePrefix: tablePrefix);
-
-  final FutureOr<$Dataclass> Function(Map<String, dynamic> data,
-      {String? tablePrefix}) _mapFunction;
+      throw UnsupportedError(
+          "A MultiTypedResultKey cannot be used to parse the raw data from a SQL query");
 
   @override
   String get aliasedName => entityName;
@@ -391,7 +389,6 @@ class MultiTypedResultKey<$Table extends Table, $Dataclass>
       attachedDatabase: attachedDatabase,
       columnsByName: columnsByName,
       entityName: alias,
-      mapFunction: _mapFunction,
     );
   }
 
@@ -400,11 +397,7 @@ class MultiTypedResultKey<$Table extends Table, $Dataclass>
       required this.asDslTable,
       required this.attachedDatabase,
       required this.columnsByName,
-      required this.entityName,
-      required FutureOr<$Dataclass> Function(Map<String, dynamic>,
-              {String? tablePrefix})
-          mapFunction})
-      : _mapFunction = mapFunction;
+      required this.entityName});
 
   /// Create a [MultiTypedResultKey] from a table
   static MultiTypedResultKey<$Table, List<$Dataclass>>
@@ -417,19 +410,6 @@ class MultiTypedResultKey<$Table extends Table, $Dataclass>
       attachedDatabase: table.attachedDatabase,
       columnsByName: table.columnsByName,
       entityName: aliasName,
-
-      /// This table is used a key for a map and should never be used to read data
-      /// However, in case it is, we will map a single item to a list of items
-      mapFunction: (Map<String, dynamic> data, {String? tablePrefix}) {
-        final singleResult = table.map(data, tablePrefix: tablePrefix);
-        if (singleResult is $Dataclass) {
-          return [singleResult];
-        } else {
-          return singleResult.then(
-            (value) => [value],
-          );
-        }
-      },
     );
   }
 

--- a/drift/lib/src/runtime/manager/references.dart
+++ b/drift/lib/src/runtime/manager/references.dart
@@ -319,6 +319,12 @@ class PrefetchHooks {
       /// Build a list of stream which contain the prefetched data for each reverse reference (e.g. users and todos for a group)
       final streams = prefetchedDataStreamsCallback!(rows, watch: watch);
 
+      /// CombineLatestStream won't trigger any events if it's passed an empty list of streams.
+      /// In this case, we can just return the original stream.
+      if (streams.isEmpty) {
+        return Stream.value(rows);
+      }
+
       /// Combine all the streams of prefetched data with the stream of the original data into a single stream
       return CombineLatestStream(streams, (prefetches) {
         final results = <TypedResult>[];

--- a/drift/lib/src/runtime/query_builder/statements/query.dart
+++ b/drift/lib/src/runtime/query_builder/statements/query.dart
@@ -238,17 +238,11 @@ abstract mixin class Selectable<T>
   @override
   Future<T?> getSingleOrNull() async {
     final list = await get();
-    final iterator = list.iterator;
-
-    if (!iterator.moveNext()) {
+    if (list.isEmpty) {
       return null;
+    } else {
+      return list.single;
     }
-    final element = iterator.current;
-    if (iterator.moveNext()) {
-      throw StateError('Expected exactly one result, but found more than one!');
-    }
-
-    return element;
   }
 
   @override

--- a/drift/lib/src/runtime/query_builder/statements/select/custom_select.dart
+++ b/drift/lib/src/runtime/query_builder/statements/select/custom_select.dart
@@ -22,7 +22,7 @@ class CustomSelectStatement with Selectable<QueryRow> {
 
   /// Constructs a fetcher for this query. The fetcher is responsible for
   /// updating a stream at the right moment.
-  QueryStreamFetcher _constructFetcher() {
+  QueryStreamFetcher<List<Map<String, Object?>>> _constructFetcher() {
     final args = _mapArgs();
 
     return QueryStreamFetcher(

--- a/drift/lib/src/runtime/query_builder/statements/select/select.dart
+++ b/drift/lib/src/runtime/query_builder/statements/select/select.dart
@@ -300,3 +300,12 @@ class TypedResult {
         column.converter, read<S>(column));
   }
 }
+
+/// This extension is used to add custom data to a [TypedResult] row outside of this library.
+@internal
+extension EditTypedResultExtension on TypedResult {
+  /// Adds a new expression to this result row.
+  void addData(ResultSetImplementation table, dynamic data) {
+    _parsedData[table] = data;
+  }
+}

--- a/drift/lib/src/runtime/query_builder/statements/select/select_with_join.dart
+++ b/drift/lib/src/runtime/query_builder/statements/select/select_with_join.dart
@@ -395,7 +395,7 @@ class _ResultStructure {
 }
 
 @internal
-extension JoinedSelectStatementAdditionalTablesX on JoinedSelectStatement {
+extension JoinedSelectStatementAdditionalTables on JoinedSelectStatement {
   Stream<List<TypedResult>> watchWithAdditionalTables(
           [Iterable<ResultSetImplementation<dynamic, dynamic>> tables =
               const []]) =>

--- a/drift/lib/src/runtime/query_builder/statements/select/select_with_join.dart
+++ b/drift/lib/src/runtime/query_builder/statements/select/select_with_join.dart
@@ -239,11 +239,15 @@ class JoinedSelectStatement<FirstT extends HasResultSet, FirstD>
     _groupBy = GroupBy._(expressions.toList(), having);
   }
 
-  @override
-  Stream<List<TypedResult>> watch() {
+  /// Builds a query which which will emit a new result whenever any of the
+  /// tables this query depends on changes.
+  /// You can pass additional tables to watch to this method.
+  Stream<List<TypedResult>> _watchWithAdditionalTables(
+      [Iterable<ResultSetImplementation<dynamic, dynamic>> tables = const []]) {
     final ctx = constructQuery();
     final fetcher = QueryStreamFetcher(
-      readsFrom: TableUpdateQuery.onAllTables(ctx.watchedTables),
+      readsFrom:
+          TableUpdateQuery.onAllTables(ctx.watchedTables.followedBy(tables)),
       fetchData: () => _getRaw(ctx),
       key: StreamKey(ctx.sql, ctx.boundVariables),
     );
@@ -251,6 +255,11 @@ class JoinedSelectStatement<FirstT extends HasResultSet, FirstD>
     return database
         .createStream(fetcher)
         .asyncMapPerSubscription((rows) => _mapResponse(rows));
+  }
+
+  @override
+  Stream<List<TypedResult>> watch() {
+    return _watchWithAdditionalTables();
   }
 
   @override
@@ -383,4 +392,12 @@ class _ResultStructure {
   final List<ResultSetImplementation> queriedTables;
 
   _ResultStructure({required this.columnAliases, required this.queriedTables});
+}
+
+@internal
+extension JoinedSelectStatementAdditionalTablesX on JoinedSelectStatement {
+  Stream<List<TypedResult>> watchWithAdditionalTables(
+          [Iterable<ResultSetImplementation<dynamic, dynamic>> tables =
+              const []]) =>
+      _watchWithAdditionalTables(tables);
 }

--- a/drift/pubspec.yaml
+++ b/drift/pubspec.yaml
@@ -26,6 +26,7 @@ dependencies:
   path: ^1.8.0
   stack_trace: ^1.11.1
   web: ^0.5.0
+  rxdart: ">=0.24.0 <=0.29.0"
 
 dev_dependencies:
   archive: ^3.3.1
@@ -43,7 +44,6 @@ dev_dependencies:
   build_runner: ^2.0.0
   test: ^1.17.0
   mockito: ^5.4.3
-  rxdart: ^0.27.0
   shelf: ^1.3.0
   test_descriptor: ^2.0.1
   vm_service: ^14.0.0

--- a/drift/pubspec.yaml
+++ b/drift/pubspec.yaml
@@ -26,7 +26,6 @@ dependencies:
   path: ^1.8.0
   stack_trace: ^1.11.1
   web: ^0.5.0
-  rxdart: ">=0.24.0 <=0.29.0"
 
 dev_dependencies:
   archive: ^3.3.1
@@ -47,3 +46,4 @@ dev_dependencies:
   shelf: ^1.3.0
   test_descriptor: ^2.0.1
   vm_service: ^14.0.0
+  rxdart: ^0.28.0

--- a/drift/test/database/data_class_test.dart
+++ b/drift/test/database/data_class_test.dart
@@ -39,7 +39,7 @@ void main() {
         id: RowId(13),
         title: 'Title',
         content: 'Content',
-        category: 3,
+        category: RowId(3),
         targetDate: DateTime.now(),
       );
       expect(

--- a/drift/test/database/statements/join_test.dart
+++ b/drift/test/database/statements/join_test.dart
@@ -85,7 +85,7 @@ void main() {
           title: 'title',
           content: 'content',
           targetDate: date,
-          category: 3,
+          category: RowId(3),
           status: TodoStatus.workInProgress,
         ));
 

--- a/drift/test/database/statements/select_test.dart
+++ b/drift/test/database/statements/select_test.dart
@@ -19,7 +19,7 @@ const _todoEntry = TodoEntry(
   id: RowId(10),
   title: 'A todo title',
   content: 'Content',
-  category: 3,
+  category: RowId(3),
 );
 
 void main() {

--- a/drift/test/database/statements/update_test.dart
+++ b/drift/test/database/statements/update_test.dart
@@ -24,7 +24,7 @@ void main() {
     test('for entire table', () async {
       await db.update(db.todosTable).write(const TodosTableCompanion(
             title: Value('Updated title'),
-            category: Value(3),
+            category: Value(RowId(3)),
           ));
 
       verify(executor.runUpdate(

--- a/drift/test/extensions/geopoly_integration_test.g.dart
+++ b/drift/test/extensions/geopoly_integration_test.g.dart
@@ -245,6 +245,34 @@ typedef $GeopolyTestUpdateCompanionBuilder = GeopolyTestCompanion Function({
   Value<int> rowid,
 });
 
+class $GeopolyTestFilterComposer
+    extends FilterComposer<_$_GeopolyTestDatabase, GeopolyTest> {
+  $GeopolyTestFilterComposer(super.$state);
+  ColumnFilters<GeopolyPolygon> get shape => $state.composableBuilder(
+      column: $state.table.shape,
+      builder: (column, joinBuilders) =>
+          ColumnFilters(column, joinBuilders: joinBuilders));
+
+  ColumnFilters<DriftAny> get a => $state.composableBuilder(
+      column: $state.table.a,
+      builder: (column, joinBuilders) =>
+          ColumnFilters(column, joinBuilders: joinBuilders));
+}
+
+class $GeopolyTestOrderingComposer
+    extends OrderingComposer<_$_GeopolyTestDatabase, GeopolyTest> {
+  $GeopolyTestOrderingComposer(super.$state);
+  ColumnOrderings<GeopolyPolygon> get shape => $state.composableBuilder(
+      column: $state.table.shape,
+      builder: (column, joinBuilders) =>
+          ColumnOrderings(column, joinBuilders: joinBuilders));
+
+  ColumnOrderings<DriftAny> get a => $state.composableBuilder(
+      column: $state.table.a,
+      builder: (column, joinBuilders) =>
+          ColumnOrderings(column, joinBuilders: joinBuilders));
+}
+
 class $GeopolyTestTableManager extends RootTableManager<
     _$_GeopolyTestDatabase,
     GeopolyTest,
@@ -252,7 +280,13 @@ class $GeopolyTestTableManager extends RootTableManager<
     $GeopolyTestFilterComposer,
     $GeopolyTestOrderingComposer,
     $GeopolyTestCreateCompanionBuilder,
-    $GeopolyTestUpdateCompanionBuilder> {
+    $GeopolyTestUpdateCompanionBuilder,
+    (
+      GeopolyTestData,
+      BaseReferences<_$_GeopolyTestDatabase, GeopolyTest, GeopolyTestData>
+    ),
+    GeopolyTestData,
+    PrefetchHooks Function()> {
   $GeopolyTestTableManager(_$_GeopolyTestDatabase db, GeopolyTest table)
       : super(TableManagerState(
           db: db,
@@ -281,36 +315,27 @@ class $GeopolyTestTableManager extends RootTableManager<
             a: a,
             rowid: rowid,
           ),
+          withReferenceMapper: (p0) => p0
+              .map((e) => (e.readTable(table), BaseReferences(db, table, e)))
+              .toList(),
+          prefetchHooksCallback: null,
         ));
 }
 
-class $GeopolyTestFilterComposer
-    extends FilterComposer<_$_GeopolyTestDatabase, GeopolyTest> {
-  $GeopolyTestFilterComposer(super.$state);
-  ColumnFilters<GeopolyPolygon> get shape => $state.composableBuilder(
-      column: $state.table.shape,
-      builder: (column, joinBuilders) =>
-          ColumnFilters(column, joinBuilders: joinBuilders));
-
-  ColumnFilters<DriftAny> get a => $state.composableBuilder(
-      column: $state.table.a,
-      builder: (column, joinBuilders) =>
-          ColumnFilters(column, joinBuilders: joinBuilders));
-}
-
-class $GeopolyTestOrderingComposer
-    extends OrderingComposer<_$_GeopolyTestDatabase, GeopolyTest> {
-  $GeopolyTestOrderingComposer(super.$state);
-  ColumnOrderings<GeopolyPolygon> get shape => $state.composableBuilder(
-      column: $state.table.shape,
-      builder: (column, joinBuilders) =>
-          ColumnOrderings(column, joinBuilders: joinBuilders));
-
-  ColumnOrderings<DriftAny> get a => $state.composableBuilder(
-      column: $state.table.a,
-      builder: (column, joinBuilders) =>
-          ColumnOrderings(column, joinBuilders: joinBuilders));
-}
+typedef $GeopolyTestProcessedTableManager = ProcessedTableManager<
+    _$_GeopolyTestDatabase,
+    GeopolyTest,
+    GeopolyTestData,
+    $GeopolyTestFilterComposer,
+    $GeopolyTestOrderingComposer,
+    $GeopolyTestCreateCompanionBuilder,
+    $GeopolyTestUpdateCompanionBuilder,
+    (
+      GeopolyTestData,
+      BaseReferences<_$_GeopolyTestDatabase, GeopolyTest, GeopolyTestData>
+    ),
+    GeopolyTestData,
+    PrefetchHooks Function()>;
 
 class $_GeopolyTestDatabaseManager {
   final _$_GeopolyTestDatabase _db;

--- a/drift/test/extensions/json1_integration_test.dart
+++ b/drift/test/extensions/json1_integration_test.dart
@@ -85,12 +85,12 @@ void main() {
             TodosTableCompanion.insert(
                 title: Value('first title'),
                 content: 'entry in category',
-                category: Value(1)),
+                category: Value(RowId(1))),
             TodosTableCompanion.insert(content: 'not in category'),
             TodosTableCompanion.insert(
                 title: Value('second title'),
                 content: 'another in category',
-                category: Value(1))
+                category: Value(RowId(1)))
           ]);
       });
     });

--- a/drift/test/generated/custom_tables.g.dart
+++ b/drift/test/generated/custom_tables.g.dart
@@ -2031,6 +2031,22 @@ typedef $NoIdsUpdateCompanionBuilder = NoIdsCompanion Function({
   Value<Uint8List> payload,
 });
 
+class $NoIdsFilterComposer extends FilterComposer<_$CustomTablesDb, NoIds> {
+  $NoIdsFilterComposer(super.$state);
+  ColumnFilters<Uint8List> get payload => $state.composableBuilder(
+      column: $state.table.payload,
+      builder: (column, joinBuilders) =>
+          ColumnFilters(column, joinBuilders: joinBuilders));
+}
+
+class $NoIdsOrderingComposer extends OrderingComposer<_$CustomTablesDb, NoIds> {
+  $NoIdsOrderingComposer(super.$state);
+  ColumnOrderings<Uint8List> get payload => $state.composableBuilder(
+      column: $state.table.payload,
+      builder: (column, joinBuilders) =>
+          ColumnOrderings(column, joinBuilders: joinBuilders));
+}
+
 class $NoIdsTableManager extends RootTableManager<
     _$CustomTablesDb,
     NoIds,
@@ -2038,7 +2054,10 @@ class $NoIdsTableManager extends RootTableManager<
     $NoIdsFilterComposer,
     $NoIdsOrderingComposer,
     $NoIdsCreateCompanionBuilder,
-    $NoIdsUpdateCompanionBuilder> {
+    $NoIdsUpdateCompanionBuilder,
+    (NoIdRow, BaseReferences<_$CustomTablesDb, NoIds, NoIdRow>),
+    NoIdRow,
+    PrefetchHooks Function()> {
   $NoIdsTableManager(_$CustomTablesDb db, NoIds table)
       : super(TableManagerState(
           db: db,
@@ -2057,25 +2076,24 @@ class $NoIdsTableManager extends RootTableManager<
               NoIdsCompanion.insert(
             payload: payload,
           ),
+          withReferenceMapper: (p0) => p0
+              .map((e) => (e.readTable(table), BaseReferences(db, table, e)))
+              .toList(),
+          prefetchHooksCallback: null,
         ));
 }
 
-class $NoIdsFilterComposer extends FilterComposer<_$CustomTablesDb, NoIds> {
-  $NoIdsFilterComposer(super.$state);
-  ColumnFilters<Uint8List> get payload => $state.composableBuilder(
-      column: $state.table.payload,
-      builder: (column, joinBuilders) =>
-          ColumnFilters(column, joinBuilders: joinBuilders));
-}
-
-class $NoIdsOrderingComposer extends OrderingComposer<_$CustomTablesDb, NoIds> {
-  $NoIdsOrderingComposer(super.$state);
-  ColumnOrderings<Uint8List> get payload => $state.composableBuilder(
-      column: $state.table.payload,
-      builder: (column, joinBuilders) =>
-          ColumnOrderings(column, joinBuilders: joinBuilders));
-}
-
+typedef $NoIdsProcessedTableManager = ProcessedTableManager<
+    _$CustomTablesDb,
+    NoIds,
+    NoIdRow,
+    $NoIdsFilterComposer,
+    $NoIdsOrderingComposer,
+    $NoIdsCreateCompanionBuilder,
+    $NoIdsUpdateCompanionBuilder,
+    (NoIdRow, BaseReferences<_$CustomTablesDb, NoIds, NoIdRow>),
+    NoIdRow,
+    PrefetchHooks Function()>;
 typedef $WithDefaultsCreateCompanionBuilder = WithDefaultsCompanion Function({
   Value<String?> a,
   Value<int?> b,
@@ -2086,45 +2104,6 @@ typedef $WithDefaultsUpdateCompanionBuilder = WithDefaultsCompanion Function({
   Value<int?> b,
   Value<int> rowid,
 });
-
-class $WithDefaultsTableManager extends RootTableManager<
-    _$CustomTablesDb,
-    WithDefaults,
-    WithDefault,
-    $WithDefaultsFilterComposer,
-    $WithDefaultsOrderingComposer,
-    $WithDefaultsCreateCompanionBuilder,
-    $WithDefaultsUpdateCompanionBuilder> {
-  $WithDefaultsTableManager(_$CustomTablesDb db, WithDefaults table)
-      : super(TableManagerState(
-          db: db,
-          table: table,
-          filteringComposer:
-              $WithDefaultsFilterComposer(ComposerState(db, table)),
-          orderingComposer:
-              $WithDefaultsOrderingComposer(ComposerState(db, table)),
-          updateCompanionCallback: ({
-            Value<String?> a = const Value.absent(),
-            Value<int?> b = const Value.absent(),
-            Value<int> rowid = const Value.absent(),
-          }) =>
-              WithDefaultsCompanion(
-            a: a,
-            b: b,
-            rowid: rowid,
-          ),
-          createCompanionCallback: ({
-            Value<String?> a = const Value.absent(),
-            Value<int?> b = const Value.absent(),
-            Value<int> rowid = const Value.absent(),
-          }) =>
-              WithDefaultsCompanion.insert(
-            a: a,
-            b: b,
-            rowid: rowid,
-          ),
-        ));
-}
 
 class $WithDefaultsFilterComposer
     extends FilterComposer<_$CustomTablesDb, WithDefaults> {
@@ -2154,6 +2133,63 @@ class $WithDefaultsOrderingComposer
           ColumnOrderings(column, joinBuilders: joinBuilders));
 }
 
+class $WithDefaultsTableManager extends RootTableManager<
+    _$CustomTablesDb,
+    WithDefaults,
+    WithDefault,
+    $WithDefaultsFilterComposer,
+    $WithDefaultsOrderingComposer,
+    $WithDefaultsCreateCompanionBuilder,
+    $WithDefaultsUpdateCompanionBuilder,
+    (WithDefault, BaseReferences<_$CustomTablesDb, WithDefaults, WithDefault>),
+    WithDefault,
+    PrefetchHooks Function()> {
+  $WithDefaultsTableManager(_$CustomTablesDb db, WithDefaults table)
+      : super(TableManagerState(
+          db: db,
+          table: table,
+          filteringComposer:
+              $WithDefaultsFilterComposer(ComposerState(db, table)),
+          orderingComposer:
+              $WithDefaultsOrderingComposer(ComposerState(db, table)),
+          updateCompanionCallback: ({
+            Value<String?> a = const Value.absent(),
+            Value<int?> b = const Value.absent(),
+            Value<int> rowid = const Value.absent(),
+          }) =>
+              WithDefaultsCompanion(
+            a: a,
+            b: b,
+            rowid: rowid,
+          ),
+          createCompanionCallback: ({
+            Value<String?> a = const Value.absent(),
+            Value<int?> b = const Value.absent(),
+            Value<int> rowid = const Value.absent(),
+          }) =>
+              WithDefaultsCompanion.insert(
+            a: a,
+            b: b,
+            rowid: rowid,
+          ),
+          withReferenceMapper: (p0) => p0
+              .map((e) => (e.readTable(table), BaseReferences(db, table, e)))
+              .toList(),
+          prefetchHooksCallback: null,
+        ));
+}
+
+typedef $WithDefaultsProcessedTableManager = ProcessedTableManager<
+    _$CustomTablesDb,
+    WithDefaults,
+    WithDefault,
+    $WithDefaultsFilterComposer,
+    $WithDefaultsOrderingComposer,
+    $WithDefaultsCreateCompanionBuilder,
+    $WithDefaultsUpdateCompanionBuilder,
+    (WithDefault, BaseReferences<_$CustomTablesDb, WithDefaults, WithDefault>),
+    WithDefault,
+    PrefetchHooks Function()>;
 typedef $WithConstraintsCreateCompanionBuilder = WithConstraintsCompanion
     Function({
   Value<String?> a,
@@ -2168,49 +2204,6 @@ typedef $WithConstraintsUpdateCompanionBuilder = WithConstraintsCompanion
   Value<double?> c,
   Value<int> rowid,
 });
-
-class $WithConstraintsTableManager extends RootTableManager<
-    _$CustomTablesDb,
-    WithConstraints,
-    WithConstraint,
-    $WithConstraintsFilterComposer,
-    $WithConstraintsOrderingComposer,
-    $WithConstraintsCreateCompanionBuilder,
-    $WithConstraintsUpdateCompanionBuilder> {
-  $WithConstraintsTableManager(_$CustomTablesDb db, WithConstraints table)
-      : super(TableManagerState(
-          db: db,
-          table: table,
-          filteringComposer:
-              $WithConstraintsFilterComposer(ComposerState(db, table)),
-          orderingComposer:
-              $WithConstraintsOrderingComposer(ComposerState(db, table)),
-          updateCompanionCallback: ({
-            Value<String?> a = const Value.absent(),
-            Value<int> b = const Value.absent(),
-            Value<double?> c = const Value.absent(),
-            Value<int> rowid = const Value.absent(),
-          }) =>
-              WithConstraintsCompanion(
-            a: a,
-            b: b,
-            c: c,
-            rowid: rowid,
-          ),
-          createCompanionCallback: ({
-            Value<String?> a = const Value.absent(),
-            required int b,
-            Value<double?> c = const Value.absent(),
-            Value<int> rowid = const Value.absent(),
-          }) =>
-              WithConstraintsCompanion.insert(
-            a: a,
-            b: b,
-            c: c,
-            rowid: rowid,
-          ),
-        ));
-}
 
 class $WithConstraintsFilterComposer
     extends FilterComposer<_$CustomTablesDb, WithConstraints> {
@@ -2250,6 +2243,73 @@ class $WithConstraintsOrderingComposer
           ColumnOrderings(column, joinBuilders: joinBuilders));
 }
 
+class $WithConstraintsTableManager extends RootTableManager<
+    _$CustomTablesDb,
+    WithConstraints,
+    WithConstraint,
+    $WithConstraintsFilterComposer,
+    $WithConstraintsOrderingComposer,
+    $WithConstraintsCreateCompanionBuilder,
+    $WithConstraintsUpdateCompanionBuilder,
+    (
+      WithConstraint,
+      BaseReferences<_$CustomTablesDb, WithConstraints, WithConstraint>
+    ),
+    WithConstraint,
+    PrefetchHooks Function()> {
+  $WithConstraintsTableManager(_$CustomTablesDb db, WithConstraints table)
+      : super(TableManagerState(
+          db: db,
+          table: table,
+          filteringComposer:
+              $WithConstraintsFilterComposer(ComposerState(db, table)),
+          orderingComposer:
+              $WithConstraintsOrderingComposer(ComposerState(db, table)),
+          updateCompanionCallback: ({
+            Value<String?> a = const Value.absent(),
+            Value<int> b = const Value.absent(),
+            Value<double?> c = const Value.absent(),
+            Value<int> rowid = const Value.absent(),
+          }) =>
+              WithConstraintsCompanion(
+            a: a,
+            b: b,
+            c: c,
+            rowid: rowid,
+          ),
+          createCompanionCallback: ({
+            Value<String?> a = const Value.absent(),
+            required int b,
+            Value<double?> c = const Value.absent(),
+            Value<int> rowid = const Value.absent(),
+          }) =>
+              WithConstraintsCompanion.insert(
+            a: a,
+            b: b,
+            c: c,
+            rowid: rowid,
+          ),
+          withReferenceMapper: (p0) => p0
+              .map((e) => (e.readTable(table), BaseReferences(db, table, e)))
+              .toList(),
+          prefetchHooksCallback: null,
+        ));
+}
+
+typedef $WithConstraintsProcessedTableManager = ProcessedTableManager<
+    _$CustomTablesDb,
+    WithConstraints,
+    WithConstraint,
+    $WithConstraintsFilterComposer,
+    $WithConstraintsOrderingComposer,
+    $WithConstraintsCreateCompanionBuilder,
+    $WithConstraintsUpdateCompanionBuilder,
+    (
+      WithConstraint,
+      BaseReferences<_$CustomTablesDb, WithConstraints, WithConstraint>
+    ),
+    WithConstraint,
+    PrefetchHooks Function()>;
 typedef $ConfigTableCreateCompanionBuilder = ConfigCompanion Function({
   required String configKey,
   Value<DriftAny?> configValue,
@@ -2264,53 +2324,6 @@ typedef $ConfigTableUpdateCompanionBuilder = ConfigCompanion Function({
   Value<SyncType?> syncStateImplicit,
   Value<int> rowid,
 });
-
-class $ConfigTableTableManager extends RootTableManager<
-    _$CustomTablesDb,
-    ConfigTable,
-    Config,
-    $ConfigTableFilterComposer,
-    $ConfigTableOrderingComposer,
-    $ConfigTableCreateCompanionBuilder,
-    $ConfigTableUpdateCompanionBuilder> {
-  $ConfigTableTableManager(_$CustomTablesDb db, ConfigTable table)
-      : super(TableManagerState(
-          db: db,
-          table: table,
-          filteringComposer:
-              $ConfigTableFilterComposer(ComposerState(db, table)),
-          orderingComposer:
-              $ConfigTableOrderingComposer(ComposerState(db, table)),
-          updateCompanionCallback: ({
-            Value<String> configKey = const Value.absent(),
-            Value<DriftAny?> configValue = const Value.absent(),
-            Value<SyncType?> syncState = const Value.absent(),
-            Value<SyncType?> syncStateImplicit = const Value.absent(),
-            Value<int> rowid = const Value.absent(),
-          }) =>
-              ConfigCompanion(
-            configKey: configKey,
-            configValue: configValue,
-            syncState: syncState,
-            syncStateImplicit: syncStateImplicit,
-            rowid: rowid,
-          ),
-          createCompanionCallback: ({
-            required String configKey,
-            Value<DriftAny?> configValue = const Value.absent(),
-            Value<SyncType?> syncState = const Value.absent(),
-            Value<SyncType?> syncStateImplicit = const Value.absent(),
-            Value<int> rowid = const Value.absent(),
-          }) =>
-              ConfigCompanion.insert(
-            configKey: configKey,
-            configValue: configValue,
-            syncState: syncState,
-            syncStateImplicit: syncStateImplicit,
-            rowid: rowid,
-          ),
-        ));
-}
 
 class $ConfigTableFilterComposer
     extends FilterComposer<_$CustomTablesDb, ConfigTable> {
@@ -2364,6 +2377,71 @@ class $ConfigTableOrderingComposer
           ColumnOrderings(column, joinBuilders: joinBuilders));
 }
 
+class $ConfigTableTableManager extends RootTableManager<
+    _$CustomTablesDb,
+    ConfigTable,
+    Config,
+    $ConfigTableFilterComposer,
+    $ConfigTableOrderingComposer,
+    $ConfigTableCreateCompanionBuilder,
+    $ConfigTableUpdateCompanionBuilder,
+    (Config, BaseReferences<_$CustomTablesDb, ConfigTable, Config>),
+    Config,
+    PrefetchHooks Function()> {
+  $ConfigTableTableManager(_$CustomTablesDb db, ConfigTable table)
+      : super(TableManagerState(
+          db: db,
+          table: table,
+          filteringComposer:
+              $ConfigTableFilterComposer(ComposerState(db, table)),
+          orderingComposer:
+              $ConfigTableOrderingComposer(ComposerState(db, table)),
+          updateCompanionCallback: ({
+            Value<String> configKey = const Value.absent(),
+            Value<DriftAny?> configValue = const Value.absent(),
+            Value<SyncType?> syncState = const Value.absent(),
+            Value<SyncType?> syncStateImplicit = const Value.absent(),
+            Value<int> rowid = const Value.absent(),
+          }) =>
+              ConfigCompanion(
+            configKey: configKey,
+            configValue: configValue,
+            syncState: syncState,
+            syncStateImplicit: syncStateImplicit,
+            rowid: rowid,
+          ),
+          createCompanionCallback: ({
+            required String configKey,
+            Value<DriftAny?> configValue = const Value.absent(),
+            Value<SyncType?> syncState = const Value.absent(),
+            Value<SyncType?> syncStateImplicit = const Value.absent(),
+            Value<int> rowid = const Value.absent(),
+          }) =>
+              ConfigCompanion.insert(
+            configKey: configKey,
+            configValue: configValue,
+            syncState: syncState,
+            syncStateImplicit: syncStateImplicit,
+            rowid: rowid,
+          ),
+          withReferenceMapper: (p0) => p0
+              .map((e) => (e.readTable(table), BaseReferences(db, table, e)))
+              .toList(),
+          prefetchHooksCallback: null,
+        ));
+}
+
+typedef $ConfigTableProcessedTableManager = ProcessedTableManager<
+    _$CustomTablesDb,
+    ConfigTable,
+    Config,
+    $ConfigTableFilterComposer,
+    $ConfigTableOrderingComposer,
+    $ConfigTableCreateCompanionBuilder,
+    $ConfigTableUpdateCompanionBuilder,
+    (Config, BaseReferences<_$CustomTablesDb, ConfigTable, Config>),
+    Config,
+    PrefetchHooks Function()>;
 typedef $MytableCreateCompanionBuilder = MytableCompanion Function({
   Value<int> someid,
   Value<String?> sometext,
@@ -2376,47 +2454,6 @@ typedef $MytableUpdateCompanionBuilder = MytableCompanion Function({
   Value<bool?> isInserting,
   Value<DateTime?> somedate,
 });
-
-class $MytableTableManager extends RootTableManager<
-    _$CustomTablesDb,
-    Mytable,
-    MytableData,
-    $MytableFilterComposer,
-    $MytableOrderingComposer,
-    $MytableCreateCompanionBuilder,
-    $MytableUpdateCompanionBuilder> {
-  $MytableTableManager(_$CustomTablesDb db, Mytable table)
-      : super(TableManagerState(
-          db: db,
-          table: table,
-          filteringComposer: $MytableFilterComposer(ComposerState(db, table)),
-          orderingComposer: $MytableOrderingComposer(ComposerState(db, table)),
-          updateCompanionCallback: ({
-            Value<int> someid = const Value.absent(),
-            Value<String?> sometext = const Value.absent(),
-            Value<bool?> isInserting = const Value.absent(),
-            Value<DateTime?> somedate = const Value.absent(),
-          }) =>
-              MytableCompanion(
-            someid: someid,
-            sometext: sometext,
-            isInserting: isInserting,
-            somedate: somedate,
-          ),
-          createCompanionCallback: ({
-            Value<int> someid = const Value.absent(),
-            Value<String?> sometext = const Value.absent(),
-            Value<bool?> isInserting = const Value.absent(),
-            Value<DateTime?> somedate = const Value.absent(),
-          }) =>
-              MytableCompanion.insert(
-            someid: someid,
-            sometext: sometext,
-            isInserting: isInserting,
-            somedate: somedate,
-          ),
-        ));
-}
 
 class $MytableFilterComposer extends FilterComposer<_$CustomTablesDb, Mytable> {
   $MytableFilterComposer(super.$state);
@@ -2465,6 +2502,65 @@ class $MytableOrderingComposer
           ColumnOrderings(column, joinBuilders: joinBuilders));
 }
 
+class $MytableTableManager extends RootTableManager<
+    _$CustomTablesDb,
+    Mytable,
+    MytableData,
+    $MytableFilterComposer,
+    $MytableOrderingComposer,
+    $MytableCreateCompanionBuilder,
+    $MytableUpdateCompanionBuilder,
+    (MytableData, BaseReferences<_$CustomTablesDb, Mytable, MytableData>),
+    MytableData,
+    PrefetchHooks Function()> {
+  $MytableTableManager(_$CustomTablesDb db, Mytable table)
+      : super(TableManagerState(
+          db: db,
+          table: table,
+          filteringComposer: $MytableFilterComposer(ComposerState(db, table)),
+          orderingComposer: $MytableOrderingComposer(ComposerState(db, table)),
+          updateCompanionCallback: ({
+            Value<int> someid = const Value.absent(),
+            Value<String?> sometext = const Value.absent(),
+            Value<bool?> isInserting = const Value.absent(),
+            Value<DateTime?> somedate = const Value.absent(),
+          }) =>
+              MytableCompanion(
+            someid: someid,
+            sometext: sometext,
+            isInserting: isInserting,
+            somedate: somedate,
+          ),
+          createCompanionCallback: ({
+            Value<int> someid = const Value.absent(),
+            Value<String?> sometext = const Value.absent(),
+            Value<bool?> isInserting = const Value.absent(),
+            Value<DateTime?> somedate = const Value.absent(),
+          }) =>
+              MytableCompanion.insert(
+            someid: someid,
+            sometext: sometext,
+            isInserting: isInserting,
+            somedate: somedate,
+          ),
+          withReferenceMapper: (p0) => p0
+              .map((e) => (e.readTable(table), BaseReferences(db, table, e)))
+              .toList(),
+          prefetchHooksCallback: null,
+        ));
+}
+
+typedef $MytableProcessedTableManager = ProcessedTableManager<
+    _$CustomTablesDb,
+    Mytable,
+    MytableData,
+    $MytableFilterComposer,
+    $MytableOrderingComposer,
+    $MytableCreateCompanionBuilder,
+    $MytableUpdateCompanionBuilder,
+    (MytableData, BaseReferences<_$CustomTablesDb, Mytable, MytableData>),
+    MytableData,
+    PrefetchHooks Function()>;
 typedef $EmailCreateCompanionBuilder = EmailCompanion Function({
   required String sender,
   required String title,
@@ -2477,47 +2573,6 @@ typedef $EmailUpdateCompanionBuilder = EmailCompanion Function({
   Value<String> body,
   Value<int> rowid,
 });
-
-class $EmailTableManager extends RootTableManager<
-    _$CustomTablesDb,
-    Email,
-    EMail,
-    $EmailFilterComposer,
-    $EmailOrderingComposer,
-    $EmailCreateCompanionBuilder,
-    $EmailUpdateCompanionBuilder> {
-  $EmailTableManager(_$CustomTablesDb db, Email table)
-      : super(TableManagerState(
-          db: db,
-          table: table,
-          filteringComposer: $EmailFilterComposer(ComposerState(db, table)),
-          orderingComposer: $EmailOrderingComposer(ComposerState(db, table)),
-          updateCompanionCallback: ({
-            Value<String> sender = const Value.absent(),
-            Value<String> title = const Value.absent(),
-            Value<String> body = const Value.absent(),
-            Value<int> rowid = const Value.absent(),
-          }) =>
-              EmailCompanion(
-            sender: sender,
-            title: title,
-            body: body,
-            rowid: rowid,
-          ),
-          createCompanionCallback: ({
-            required String sender,
-            required String title,
-            required String body,
-            Value<int> rowid = const Value.absent(),
-          }) =>
-              EmailCompanion.insert(
-            sender: sender,
-            title: title,
-            body: body,
-            rowid: rowid,
-          ),
-        ));
-}
 
 class $EmailFilterComposer extends FilterComposer<_$CustomTablesDb, Email> {
   $EmailFilterComposer(super.$state);
@@ -2555,6 +2610,65 @@ class $EmailOrderingComposer extends OrderingComposer<_$CustomTablesDb, Email> {
           ColumnOrderings(column, joinBuilders: joinBuilders));
 }
 
+class $EmailTableManager extends RootTableManager<
+    _$CustomTablesDb,
+    Email,
+    EMail,
+    $EmailFilterComposer,
+    $EmailOrderingComposer,
+    $EmailCreateCompanionBuilder,
+    $EmailUpdateCompanionBuilder,
+    (EMail, BaseReferences<_$CustomTablesDb, Email, EMail>),
+    EMail,
+    PrefetchHooks Function()> {
+  $EmailTableManager(_$CustomTablesDb db, Email table)
+      : super(TableManagerState(
+          db: db,
+          table: table,
+          filteringComposer: $EmailFilterComposer(ComposerState(db, table)),
+          orderingComposer: $EmailOrderingComposer(ComposerState(db, table)),
+          updateCompanionCallback: ({
+            Value<String> sender = const Value.absent(),
+            Value<String> title = const Value.absent(),
+            Value<String> body = const Value.absent(),
+            Value<int> rowid = const Value.absent(),
+          }) =>
+              EmailCompanion(
+            sender: sender,
+            title: title,
+            body: body,
+            rowid: rowid,
+          ),
+          createCompanionCallback: ({
+            required String sender,
+            required String title,
+            required String body,
+            Value<int> rowid = const Value.absent(),
+          }) =>
+              EmailCompanion.insert(
+            sender: sender,
+            title: title,
+            body: body,
+            rowid: rowid,
+          ),
+          withReferenceMapper: (p0) => p0
+              .map((e) => (e.readTable(table), BaseReferences(db, table, e)))
+              .toList(),
+          prefetchHooksCallback: null,
+        ));
+}
+
+typedef $EmailProcessedTableManager = ProcessedTableManager<
+    _$CustomTablesDb,
+    Email,
+    EMail,
+    $EmailFilterComposer,
+    $EmailOrderingComposer,
+    $EmailCreateCompanionBuilder,
+    $EmailUpdateCompanionBuilder,
+    (EMail, BaseReferences<_$CustomTablesDb, Email, EMail>),
+    EMail,
+    PrefetchHooks Function()>;
 typedef $WeirdTableCreateCompanionBuilder = WeirdTableCompanion Function({
   required int sqlClass,
   required String textColumn,
@@ -2565,45 +2679,6 @@ typedef $WeirdTableUpdateCompanionBuilder = WeirdTableCompanion Function({
   Value<String> textColumn,
   Value<int> rowid,
 });
-
-class $WeirdTableTableManager extends RootTableManager<
-    _$CustomTablesDb,
-    WeirdTable,
-    WeirdData,
-    $WeirdTableFilterComposer,
-    $WeirdTableOrderingComposer,
-    $WeirdTableCreateCompanionBuilder,
-    $WeirdTableUpdateCompanionBuilder> {
-  $WeirdTableTableManager(_$CustomTablesDb db, WeirdTable table)
-      : super(TableManagerState(
-          db: db,
-          table: table,
-          filteringComposer:
-              $WeirdTableFilterComposer(ComposerState(db, table)),
-          orderingComposer:
-              $WeirdTableOrderingComposer(ComposerState(db, table)),
-          updateCompanionCallback: ({
-            Value<int> sqlClass = const Value.absent(),
-            Value<String> textColumn = const Value.absent(),
-            Value<int> rowid = const Value.absent(),
-          }) =>
-              WeirdTableCompanion(
-            sqlClass: sqlClass,
-            textColumn: textColumn,
-            rowid: rowid,
-          ),
-          createCompanionCallback: ({
-            required int sqlClass,
-            required String textColumn,
-            Value<int> rowid = const Value.absent(),
-          }) =>
-              WeirdTableCompanion.insert(
-            sqlClass: sqlClass,
-            textColumn: textColumn,
-            rowid: rowid,
-          ),
-        ));
-}
 
 class $WeirdTableFilterComposer
     extends FilterComposer<_$CustomTablesDb, WeirdTable> {
@@ -2632,6 +2707,64 @@ class $WeirdTableOrderingComposer
       builder: (column, joinBuilders) =>
           ColumnOrderings(column, joinBuilders: joinBuilders));
 }
+
+class $WeirdTableTableManager extends RootTableManager<
+    _$CustomTablesDb,
+    WeirdTable,
+    WeirdData,
+    $WeirdTableFilterComposer,
+    $WeirdTableOrderingComposer,
+    $WeirdTableCreateCompanionBuilder,
+    $WeirdTableUpdateCompanionBuilder,
+    (WeirdData, BaseReferences<_$CustomTablesDb, WeirdTable, WeirdData>),
+    WeirdData,
+    PrefetchHooks Function()> {
+  $WeirdTableTableManager(_$CustomTablesDb db, WeirdTable table)
+      : super(TableManagerState(
+          db: db,
+          table: table,
+          filteringComposer:
+              $WeirdTableFilterComposer(ComposerState(db, table)),
+          orderingComposer:
+              $WeirdTableOrderingComposer(ComposerState(db, table)),
+          updateCompanionCallback: ({
+            Value<int> sqlClass = const Value.absent(),
+            Value<String> textColumn = const Value.absent(),
+            Value<int> rowid = const Value.absent(),
+          }) =>
+              WeirdTableCompanion(
+            sqlClass: sqlClass,
+            textColumn: textColumn,
+            rowid: rowid,
+          ),
+          createCompanionCallback: ({
+            required int sqlClass,
+            required String textColumn,
+            Value<int> rowid = const Value.absent(),
+          }) =>
+              WeirdTableCompanion.insert(
+            sqlClass: sqlClass,
+            textColumn: textColumn,
+            rowid: rowid,
+          ),
+          withReferenceMapper: (p0) => p0
+              .map((e) => (e.readTable(table), BaseReferences(db, table, e)))
+              .toList(),
+          prefetchHooksCallback: null,
+        ));
+}
+
+typedef $WeirdTableProcessedTableManager = ProcessedTableManager<
+    _$CustomTablesDb,
+    WeirdTable,
+    WeirdData,
+    $WeirdTableFilterComposer,
+    $WeirdTableOrderingComposer,
+    $WeirdTableCreateCompanionBuilder,
+    $WeirdTableUpdateCompanionBuilder,
+    (WeirdData, BaseReferences<_$CustomTablesDb, WeirdTable, WeirdData>),
+    WeirdData,
+    PrefetchHooks Function()>;
 
 class $CustomTablesDbManager {
   final _$CustomTablesDb _db;

--- a/drift/test/generated/todos.dart
+++ b/drift/test/generated/todos.dart
@@ -1,4 +1,5 @@
 import 'package:drift/drift.dart';
+import 'package:drift/isolate.dart';
 import 'package:mockito/annotations.dart';
 import 'package:uuid/uuid.dart';
 
@@ -31,6 +32,7 @@ class TodosTable extends Table with AutoIncrement {
   @ReferenceName("todos")
   IntColumn get category => integer()
       .references(Categories, #id, initiallyDeferred: true)
+      .map(TypeConverter.extensionType<RowId, int>())
       .nullable()();
 
   TextColumn get status => textEnum<TodoStatus>().nullable()();

--- a/drift/test/generated/todos.dart
+++ b/drift/test/generated/todos.dart
@@ -1,5 +1,4 @@
 import 'package:drift/drift.dart';
-import 'package:drift/isolate.dart';
 import 'package:mockito/annotations.dart';
 import 'package:uuid/uuid.dart';
 

--- a/drift/test/generated/todos.g.dart
+++ b/drift/test/generated/todos.g.dart
@@ -3589,19 +3589,21 @@ class $$CategoriesTableTableManager extends RootTableManager<
           prefetchHooksCallback: ({todos = false}) {
             return PrefetchHooks(
               addJoins: null,
-              withPrefetches: (items) async {
-                items = await typedResultsWithPrefetched(
-                    doPrefetch: todos,
-                    currentTable: table,
-                    referencedTable:
-                        $$CategoriesTableReferences._todosTable(db),
-                    managerFromTypedResult: (p0) =>
-                        $$CategoriesTableReferences(db, table, p0).todos,
-                    referencedItemsForCurrentItem: (item, referencedItems) =>
-                        referencedItems.where((e) => e.category == item.id),
-                    typedResults: items);
-
-                return items;
+              prefetchedDataStreamsCallback: (items, {required bool watch}) {
+                return [
+                  if (todos)
+                    $_streamPrefetched(
+                        watch: watch,
+                        currentTable: table,
+                        referencedTable:
+                            $$CategoriesTableReferences._todosTable(db),
+                        managerFromTypedResult: (p0) =>
+                            $$CategoriesTableReferences(db, table, p0).todos,
+                        referencedItemsForCurrentItem: (item,
+                                referencedItems) =>
+                            referencedItems.where((e) => e.category == item.id),
+                        typedResults: items)
+                ];
               },
             );
           },
@@ -3825,8 +3827,8 @@ class $$TodosTableTableTableManager extends RootTableManager<
 
                 return state;
               },
-              withPrefetches: (items) async {
-                return items;
+              prefetchedDataStreamsCallback: (items, {required bool watch}) {
+                return [];
               },
             );
           },
@@ -4741,19 +4743,22 @@ class $$DepartmentTableTableManager extends RootTableManager<
           prefetchHooksCallback: ({productRefs = false}) {
             return PrefetchHooks(
               addJoins: null,
-              withPrefetches: (items) async {
-                items = await typedResultsWithPrefetched(
-                    doPrefetch: productRefs,
-                    currentTable: table,
-                    referencedTable:
-                        $$DepartmentTableReferences._productRefsTable(db),
-                    managerFromTypedResult: (p0) =>
-                        $$DepartmentTableReferences(db, table, p0).productRefs,
-                    referencedItemsForCurrentItem: (item, referencedItems) =>
-                        referencedItems.where((e) => e.department == item.id),
-                    typedResults: items);
-
-                return items;
+              prefetchedDataStreamsCallback: (items, {required bool watch}) {
+                return [
+                  if (productRefs)
+                    $_streamPrefetched(
+                        watch: watch,
+                        currentTable: table,
+                        referencedTable:
+                            $$DepartmentTableReferences._productRefsTable(db),
+                        managerFromTypedResult: (p0) =>
+                            $$DepartmentTableReferences(db, table, p0)
+                                .productRefs,
+                        referencedItemsForCurrentItem:
+                            (item, referencedItems) => referencedItems
+                                .where((e) => e.department == item.id),
+                        typedResults: items)
+                ];
               },
             );
           },
@@ -4950,19 +4955,21 @@ class $$ProductTableTableManager extends RootTableManager<
 
                 return state;
               },
-              withPrefetches: (items) async {
-                items = await typedResultsWithPrefetched(
-                    doPrefetch: listings,
-                    currentTable: table,
-                    referencedTable:
-                        $$ProductTableReferences._listingsTable(db),
-                    managerFromTypedResult: (p0) =>
-                        $$ProductTableReferences(db, table, p0).listings,
-                    referencedItemsForCurrentItem: (item, referencedItems) =>
-                        referencedItems.where((e) => e.product == item.id),
-                    typedResults: items);
-
-                return items;
+              prefetchedDataStreamsCallback: (items, {required bool watch}) {
+                return [
+                  if (listings)
+                    $_streamPrefetched(
+                        watch: watch,
+                        currentTable: table,
+                        referencedTable:
+                            $$ProductTableReferences._listingsTable(db),
+                        managerFromTypedResult: (p0) =>
+                            $$ProductTableReferences(db, table, p0).listings,
+                        referencedItemsForCurrentItem: (item,
+                                referencedItems) =>
+                            referencedItems.where((e) => e.product == item.id),
+                        typedResults: items)
+                ];
               },
             );
           },
@@ -5090,18 +5097,21 @@ class $$StoreTableTableManager extends RootTableManager<
           prefetchHooksCallback: ({listings = false}) {
             return PrefetchHooks(
               addJoins: null,
-              withPrefetches: (items) async {
-                items = await typedResultsWithPrefetched(
-                    doPrefetch: listings,
-                    currentTable: table,
-                    referencedTable: $$StoreTableReferences._listingsTable(db),
-                    managerFromTypedResult: (p0) =>
-                        $$StoreTableReferences(db, table, p0).listings,
-                    referencedItemsForCurrentItem: (item, referencedItems) =>
-                        referencedItems.where((e) => e.store == item.id),
-                    typedResults: items);
-
-                return items;
+              prefetchedDataStreamsCallback: (items, {required bool watch}) {
+                return [
+                  if (listings)
+                    $_streamPrefetched(
+                        watch: watch,
+                        currentTable: table,
+                        referencedTable:
+                            $$StoreTableReferences._listingsTable(db),
+                        managerFromTypedResult: (p0) =>
+                            $$StoreTableReferences(db, table, p0).listings,
+                        referencedItemsForCurrentItem: (item,
+                                referencedItems) =>
+                            referencedItems.where((e) => e.store == item.id),
+                        typedResults: items)
+                ];
               },
             );
           },
@@ -5321,8 +5331,8 @@ class $$ListingTableTableManager extends RootTableManager<
 
                 return state;
               },
-              withPrefetches: (items) async {
-                return items;
+              prefetchedDataStreamsCallback: (items, {required bool watch}) {
+                return [];
               },
             );
           },

--- a/drift/test/generated/todos.g.dart
+++ b/drift/test/generated/todos.g.dart
@@ -3462,7 +3462,8 @@ class $$CategoriesTableReferences
   static MultiTypedResultKey<$TodosTableTable, List<TodoEntry>> _todosTable(
           _$TodoDb db) =>
       MultiTypedResultKey.fromTable(db.todosTable,
-          aliasName: "todos__PAQghpCEKc");
+          aliasName:
+              $_aliasNameGenerator(db.categories.id, db.todosTable.category));
 
   $$TodosTableTableProcessedTableManager get todos {
     final manager = $$TodosTableTableTableManager($_db, $_db.todosTable)
@@ -4640,9 +4641,10 @@ class $$DepartmentTableReferences
   $$DepartmentTableReferences(super.$_db, super.$_table, super.$_typedResult);
 
   static MultiTypedResultKey<$ProductTable, List<ProductData>>
-      _productRefsTable(_$TodoDb db) =>
-          MultiTypedResultKey.fromTable(db.product,
-              aliasName: "productRefs__YnLqMtvQxi");
+      _productRefsTable(_$TodoDb db) => MultiTypedResultKey.fromTable(
+          db.product,
+          aliasName:
+              $_aliasNameGenerator(db.department.id, db.product.department));
 
   $$ProductTableProcessedTableManager get productRefs {
     final manager = $$ProductTableTableManager($_db, $_db.product)
@@ -4801,7 +4803,7 @@ class $$ProductTableReferences
   static MultiTypedResultKey<$ListingTable, List<ListingData>> _listingsTable(
           _$TodoDb db) =>
       MultiTypedResultKey.fromTable(db.listing,
-          aliasName: "listings__KEmAGPfGKG");
+          aliasName: $_aliasNameGenerator(db.product.id, db.listing.product));
 
   $$ListingTableProcessedTableManager get listings {
     final manager = $$ListingTableTableManager($_db, $_db.listing)
@@ -4994,11 +4996,12 @@ class $$StoreTableReferences
   static MultiTypedResultKey<$ListingTable, List<ListingData>> _listingsTable(
           _$TodoDb db) =>
       MultiTypedResultKey.fromTable(db.listing,
-          aliasName: "listings__nJkbMhCzXE");
+          aliasName: $_aliasNameGenerator(db.store.id, db.listing.store));
 
   $$ListingTableProcessedTableManager get listings {
     final manager = $$ListingTableTableManager($_db, $_db.listing)
         .filter((f) => f.store.id($_item.id));
+
     final cache = $_typedResult.readTableOrNull(_listingsTable($_db));
     return ProcessedTableManager(
         manager.$state.copyWith(prefetchedData: cache));

--- a/drift/test/generated/todos.g.dart
+++ b/drift/test/generated/todos.g.dart
@@ -3551,7 +3551,7 @@ class $$CategoriesTableTableManager extends RootTableManager<
     $$CategoriesTableUpdateCompanionBuilder,
     (Category, $$CategoriesTableReferences),
     Category,
-    PrefetchHooks Function({bool todos})> {
+    PrefetchHooks Function({bool todos, bool inTransaction})> {
   $$CategoriesTableTableManager(_$TodoDb db, $CategoriesTable table)
       : super(TableManagerState(
           db: db,
@@ -3586,8 +3586,11 @@ class $$CategoriesTableTableManager extends RootTableManager<
                     $$CategoriesTableReferences(db, table, e)
                   ))
               .toList(),
-          prefetchHooksCallback: ({todos = false}) {
+          prefetchHooksCallback: ({todos = false, bool inTransaction = true}) {
             return PrefetchHooks(
+              db: db,
+              inTransaction: inTransaction,
+              explicitlyWatchedTables: [if (todos) db.todosTable],
               addJoins: null,
               prefetchedDataStreamsCallback: (items, {required bool watch}) {
                 return [
@@ -3620,7 +3623,7 @@ typedef $$CategoriesTableProcessedTableManager = ProcessedTableManager<
     $$CategoriesTableUpdateCompanionBuilder,
     (Category, $$CategoriesTableReferences),
     Category,
-    PrefetchHooks Function({bool todos})>;
+    PrefetchHooks Function({bool todos, bool inTransaction})>;
 typedef $$TodosTableTableCreateCompanionBuilder = TodosTableCompanion Function({
   Value<RowId> id,
   Value<String?> title,
@@ -3753,7 +3756,7 @@ class $$TodosTableTableTableManager extends RootTableManager<
     $$TodosTableTableUpdateCompanionBuilder,
     (TodoEntry, $$TodosTableTableReferences),
     TodoEntry,
-    PrefetchHooks Function({bool category})> {
+    PrefetchHooks Function({bool category, bool inTransaction})> {
   $$TodosTableTableTableManager(_$TodoDb db, $TodosTableTable table)
       : super(TableManagerState(
           db: db,
@@ -3800,8 +3803,12 @@ class $$TodosTableTableTableManager extends RootTableManager<
                     $$TodosTableTableReferences(db, table, e)
                   ))
               .toList(),
-          prefetchHooksCallback: ({category = false}) {
+          prefetchHooksCallback: (
+              {category = false, bool inTransaction = true}) {
             return PrefetchHooks(
+              db: db,
+              inTransaction: inTransaction,
+              explicitlyWatchedTables: [],
               addJoins: <
                   T extends TableManagerState<
                       dynamic,
@@ -3845,7 +3852,7 @@ typedef $$TodosTableTableProcessedTableManager = ProcessedTableManager<
     $$TodosTableTableUpdateCompanionBuilder,
     (TodoEntry, $$TodosTableTableReferences),
     TodoEntry,
-    PrefetchHooks Function({bool category})>;
+    PrefetchHooks Function({bool category, bool inTransaction})>;
 typedef $$UsersTableCreateCompanionBuilder = UsersCompanion Function({
   Value<RowId> id,
   required String name,
@@ -4709,7 +4716,7 @@ class $$DepartmentTableTableManager extends RootTableManager<
     $$DepartmentTableUpdateCompanionBuilder,
     (DepartmentData, $$DepartmentTableReferences),
     DepartmentData,
-    PrefetchHooks Function({bool productRefs})> {
+    PrefetchHooks Function({bool productRefs, bool inTransaction})> {
   $$DepartmentTableTableManager(_$TodoDb db, $DepartmentTable table)
       : super(TableManagerState(
           db: db,
@@ -4740,8 +4747,12 @@ class $$DepartmentTableTableManager extends RootTableManager<
                     $$DepartmentTableReferences(db, table, e)
                   ))
               .toList(),
-          prefetchHooksCallback: ({productRefs = false}) {
+          prefetchHooksCallback: (
+              {productRefs = false, bool inTransaction = true}) {
             return PrefetchHooks(
+              db: db,
+              inTransaction: inTransaction,
+              explicitlyWatchedTables: [if (productRefs) db.product],
               addJoins: null,
               prefetchedDataStreamsCallback: (items, {required bool watch}) {
                 return [
@@ -4775,7 +4786,7 @@ typedef $$DepartmentTableProcessedTableManager = ProcessedTableManager<
     $$DepartmentTableUpdateCompanionBuilder,
     (DepartmentData, $$DepartmentTableReferences),
     DepartmentData,
-    PrefetchHooks Function({bool productRefs})>;
+    PrefetchHooks Function({bool productRefs, bool inTransaction})>;
 typedef $$ProductTableCreateCompanionBuilder = ProductCompanion Function({
   Value<int> id,
   Value<String?> name,
@@ -4895,7 +4906,8 @@ class $$ProductTableTableManager extends RootTableManager<
     $$ProductTableUpdateCompanionBuilder,
     (ProductData, $$ProductTableReferences),
     ProductData,
-    PrefetchHooks Function({bool department, bool listings})> {
+    PrefetchHooks Function(
+        {bool department, bool listings, bool inTransaction})> {
   $$ProductTableTableManager(_$TodoDb db, $ProductTable table)
       : super(TableManagerState(
           db: db,
@@ -4928,8 +4940,14 @@ class $$ProductTableTableManager extends RootTableManager<
               .map((e) =>
                   (e.readTable(table), $$ProductTableReferences(db, table, e)))
               .toList(),
-          prefetchHooksCallback: ({department = false, listings = false}) {
+          prefetchHooksCallback: (
+              {department = false,
+              listings = false,
+              bool inTransaction = true}) {
             return PrefetchHooks(
+              db: db,
+              inTransaction: inTransaction,
+              explicitlyWatchedTables: [if (listings) db.listing],
               addJoins: <
                   T extends TableManagerState<
                       dynamic,
@@ -4986,7 +5004,8 @@ typedef $$ProductTableProcessedTableManager = ProcessedTableManager<
     $$ProductTableUpdateCompanionBuilder,
     (ProductData, $$ProductTableReferences),
     ProductData,
-    PrefetchHooks Function({bool department, bool listings})>;
+    PrefetchHooks Function(
+        {bool department, bool listings, bool inTransaction})>;
 typedef $$StoreTableCreateCompanionBuilder = StoreCompanion Function({
   Value<int> id,
   Value<String?> name,
@@ -5065,7 +5084,7 @@ class $$StoreTableTableManager extends RootTableManager<
     $$StoreTableUpdateCompanionBuilder,
     (StoreData, $$StoreTableReferences),
     StoreData,
-    PrefetchHooks Function({bool listings})> {
+    PrefetchHooks Function({bool listings, bool inTransaction})> {
   $$StoreTableTableManager(_$TodoDb db, $StoreTable table)
       : super(TableManagerState(
           db: db,
@@ -5094,8 +5113,12 @@ class $$StoreTableTableManager extends RootTableManager<
               .map((e) =>
                   (e.readTable(table), $$StoreTableReferences(db, table, e)))
               .toList(),
-          prefetchHooksCallback: ({listings = false}) {
+          prefetchHooksCallback: (
+              {listings = false, bool inTransaction = true}) {
             return PrefetchHooks(
+              db: db,
+              inTransaction: inTransaction,
+              explicitlyWatchedTables: [if (listings) db.listing],
               addJoins: null,
               prefetchedDataStreamsCallback: (items, {required bool watch}) {
                 return [
@@ -5128,7 +5151,7 @@ typedef $$StoreTableProcessedTableManager = ProcessedTableManager<
     $$StoreTableUpdateCompanionBuilder,
     (StoreData, $$StoreTableReferences),
     StoreData,
-    PrefetchHooks Function({bool listings})>;
+    PrefetchHooks Function({bool listings, bool inTransaction})>;
 typedef $$ListingTableCreateCompanionBuilder = ListingCompanion Function({
   Value<int> id,
   Value<int?> product,
@@ -5259,7 +5282,7 @@ class $$ListingTableTableManager extends RootTableManager<
     $$ListingTableUpdateCompanionBuilder,
     (ListingData, $$ListingTableReferences),
     ListingData,
-    PrefetchHooks Function({bool product, bool store})> {
+    PrefetchHooks Function({bool product, bool store, bool inTransaction})> {
   $$ListingTableTableManager(_$TodoDb db, $ListingTable table)
       : super(TableManagerState(
           db: db,
@@ -5296,8 +5319,12 @@ class $$ListingTableTableManager extends RootTableManager<
               .map((e) =>
                   (e.readTable(table), $$ListingTableReferences(db, table, e)))
               .toList(),
-          prefetchHooksCallback: ({product = false, store = false}) {
+          prefetchHooksCallback: (
+              {product = false, store = false, bool inTransaction = true}) {
             return PrefetchHooks(
+              db: db,
+              inTransaction: inTransaction,
+              explicitlyWatchedTables: [],
               addJoins: <
                   T extends TableManagerState<
                       dynamic,
@@ -5349,7 +5376,7 @@ typedef $$ListingTableProcessedTableManager = ProcessedTableManager<
     $$ListingTableUpdateCompanionBuilder,
     (ListingData, $$ListingTableReferences),
     ListingData,
-    PrefetchHooks Function({bool product, bool store})>;
+    PrefetchHooks Function({bool product, bool store, bool inTransaction})>;
 
 class $TodoDbManager {
   final _$TodoDb _db;

--- a/drift/test/generated/todos.g.dart
+++ b/drift/test/generated/todos.g.dart
@@ -3551,7 +3551,7 @@ class $$CategoriesTableTableManager extends RootTableManager<
     $$CategoriesTableUpdateCompanionBuilder,
     (Category, $$CategoriesTableReferences),
     Category,
-    PrefetchHooks Function({bool todos, bool inTransaction})> {
+    PrefetchHooks Function({bool todos})> {
   $$CategoriesTableTableManager(_$TodoDb db, $CategoriesTable table)
       : super(TableManagerState(
           db: db,
@@ -3586,10 +3586,9 @@ class $$CategoriesTableTableManager extends RootTableManager<
                     $$CategoriesTableReferences(db, table, e)
                   ))
               .toList(),
-          prefetchHooksCallback: ({todos = false, bool inTransaction = true}) {
+          prefetchHooksCallback: ({todos = false}) {
             return PrefetchHooks(
               db: db,
-              inTransaction: inTransaction,
               explicitlyWatchedTables: [if (todos) db.todosTable],
               addJoins: null,
               prefetchedDataStreamsCallback: (items, {required bool watch}) {
@@ -3623,7 +3622,7 @@ typedef $$CategoriesTableProcessedTableManager = ProcessedTableManager<
     $$CategoriesTableUpdateCompanionBuilder,
     (Category, $$CategoriesTableReferences),
     Category,
-    PrefetchHooks Function({bool todos, bool inTransaction})>;
+    PrefetchHooks Function({bool todos})>;
 typedef $$TodosTableTableCreateCompanionBuilder = TodosTableCompanion Function({
   Value<RowId> id,
   Value<String?> title,
@@ -3756,7 +3755,7 @@ class $$TodosTableTableTableManager extends RootTableManager<
     $$TodosTableTableUpdateCompanionBuilder,
     (TodoEntry, $$TodosTableTableReferences),
     TodoEntry,
-    PrefetchHooks Function({bool category, bool inTransaction})> {
+    PrefetchHooks Function({bool category})> {
   $$TodosTableTableTableManager(_$TodoDb db, $TodosTableTable table)
       : super(TableManagerState(
           db: db,
@@ -3803,11 +3802,9 @@ class $$TodosTableTableTableManager extends RootTableManager<
                     $$TodosTableTableReferences(db, table, e)
                   ))
               .toList(),
-          prefetchHooksCallback: (
-              {category = false, bool inTransaction = true}) {
+          prefetchHooksCallback: ({category = false}) {
             return PrefetchHooks(
               db: db,
-              inTransaction: inTransaction,
               explicitlyWatchedTables: [],
               addJoins: <
                   T extends TableManagerState<
@@ -3852,7 +3849,7 @@ typedef $$TodosTableTableProcessedTableManager = ProcessedTableManager<
     $$TodosTableTableUpdateCompanionBuilder,
     (TodoEntry, $$TodosTableTableReferences),
     TodoEntry,
-    PrefetchHooks Function({bool category, bool inTransaction})>;
+    PrefetchHooks Function({bool category})>;
 typedef $$UsersTableCreateCompanionBuilder = UsersCompanion Function({
   Value<RowId> id,
   required String name,
@@ -4716,7 +4713,7 @@ class $$DepartmentTableTableManager extends RootTableManager<
     $$DepartmentTableUpdateCompanionBuilder,
     (DepartmentData, $$DepartmentTableReferences),
     DepartmentData,
-    PrefetchHooks Function({bool productRefs, bool inTransaction})> {
+    PrefetchHooks Function({bool productRefs})> {
   $$DepartmentTableTableManager(_$TodoDb db, $DepartmentTable table)
       : super(TableManagerState(
           db: db,
@@ -4747,11 +4744,9 @@ class $$DepartmentTableTableManager extends RootTableManager<
                     $$DepartmentTableReferences(db, table, e)
                   ))
               .toList(),
-          prefetchHooksCallback: (
-              {productRefs = false, bool inTransaction = true}) {
+          prefetchHooksCallback: ({productRefs = false}) {
             return PrefetchHooks(
               db: db,
-              inTransaction: inTransaction,
               explicitlyWatchedTables: [if (productRefs) db.product],
               addJoins: null,
               prefetchedDataStreamsCallback: (items, {required bool watch}) {
@@ -4786,7 +4781,7 @@ typedef $$DepartmentTableProcessedTableManager = ProcessedTableManager<
     $$DepartmentTableUpdateCompanionBuilder,
     (DepartmentData, $$DepartmentTableReferences),
     DepartmentData,
-    PrefetchHooks Function({bool productRefs, bool inTransaction})>;
+    PrefetchHooks Function({bool productRefs})>;
 typedef $$ProductTableCreateCompanionBuilder = ProductCompanion Function({
   Value<int> id,
   Value<String?> name,
@@ -4906,8 +4901,7 @@ class $$ProductTableTableManager extends RootTableManager<
     $$ProductTableUpdateCompanionBuilder,
     (ProductData, $$ProductTableReferences),
     ProductData,
-    PrefetchHooks Function(
-        {bool department, bool listings, bool inTransaction})> {
+    PrefetchHooks Function({bool department, bool listings})> {
   $$ProductTableTableManager(_$TodoDb db, $ProductTable table)
       : super(TableManagerState(
           db: db,
@@ -4940,13 +4934,9 @@ class $$ProductTableTableManager extends RootTableManager<
               .map((e) =>
                   (e.readTable(table), $$ProductTableReferences(db, table, e)))
               .toList(),
-          prefetchHooksCallback: (
-              {department = false,
-              listings = false,
-              bool inTransaction = true}) {
+          prefetchHooksCallback: ({department = false, listings = false}) {
             return PrefetchHooks(
               db: db,
-              inTransaction: inTransaction,
               explicitlyWatchedTables: [if (listings) db.listing],
               addJoins: <
                   T extends TableManagerState<
@@ -5004,8 +4994,7 @@ typedef $$ProductTableProcessedTableManager = ProcessedTableManager<
     $$ProductTableUpdateCompanionBuilder,
     (ProductData, $$ProductTableReferences),
     ProductData,
-    PrefetchHooks Function(
-        {bool department, bool listings, bool inTransaction})>;
+    PrefetchHooks Function({bool department, bool listings})>;
 typedef $$StoreTableCreateCompanionBuilder = StoreCompanion Function({
   Value<int> id,
   Value<String?> name,
@@ -5084,7 +5073,7 @@ class $$StoreTableTableManager extends RootTableManager<
     $$StoreTableUpdateCompanionBuilder,
     (StoreData, $$StoreTableReferences),
     StoreData,
-    PrefetchHooks Function({bool listings, bool inTransaction})> {
+    PrefetchHooks Function({bool listings})> {
   $$StoreTableTableManager(_$TodoDb db, $StoreTable table)
       : super(TableManagerState(
           db: db,
@@ -5113,11 +5102,9 @@ class $$StoreTableTableManager extends RootTableManager<
               .map((e) =>
                   (e.readTable(table), $$StoreTableReferences(db, table, e)))
               .toList(),
-          prefetchHooksCallback: (
-              {listings = false, bool inTransaction = true}) {
+          prefetchHooksCallback: ({listings = false}) {
             return PrefetchHooks(
               db: db,
-              inTransaction: inTransaction,
               explicitlyWatchedTables: [if (listings) db.listing],
               addJoins: null,
               prefetchedDataStreamsCallback: (items, {required bool watch}) {
@@ -5151,7 +5138,7 @@ typedef $$StoreTableProcessedTableManager = ProcessedTableManager<
     $$StoreTableUpdateCompanionBuilder,
     (StoreData, $$StoreTableReferences),
     StoreData,
-    PrefetchHooks Function({bool listings, bool inTransaction})>;
+    PrefetchHooks Function({bool listings})>;
 typedef $$ListingTableCreateCompanionBuilder = ListingCompanion Function({
   Value<int> id,
   Value<int?> product,
@@ -5282,7 +5269,7 @@ class $$ListingTableTableManager extends RootTableManager<
     $$ListingTableUpdateCompanionBuilder,
     (ListingData, $$ListingTableReferences),
     ListingData,
-    PrefetchHooks Function({bool product, bool store, bool inTransaction})> {
+    PrefetchHooks Function({bool product, bool store})> {
   $$ListingTableTableManager(_$TodoDb db, $ListingTable table)
       : super(TableManagerState(
           db: db,
@@ -5319,11 +5306,9 @@ class $$ListingTableTableManager extends RootTableManager<
               .map((e) =>
                   (e.readTable(table), $$ListingTableReferences(db, table, e)))
               .toList(),
-          prefetchHooksCallback: (
-              {product = false, store = false, bool inTransaction = true}) {
+          prefetchHooksCallback: ({product = false, store = false}) {
             return PrefetchHooks(
               db: db,
-              inTransaction: inTransaction,
               explicitlyWatchedTables: [],
               addJoins: <
                   T extends TableManagerState<
@@ -5376,7 +5361,7 @@ typedef $$ListingTableProcessedTableManager = ProcessedTableManager<
     $$ListingTableUpdateCompanionBuilder,
     (ListingData, $$ListingTableReferences),
     ListingData,
-    PrefetchHooks Function({bool product, bool store, bool inTransaction})>;
+    PrefetchHooks Function({bool product, bool store})>;
 
 class $TodoDbManager {
   final _$TodoDb _db;

--- a/drift/test/generated/todos.g.dart
+++ b/drift/test/generated/todos.g.dart
@@ -309,12 +309,13 @@ class $TodosTableTable extends TodosTable
   static const VerificationMeta _categoryMeta =
       const VerificationMeta('category');
   @override
-  late final GeneratedColumn<int> category = GeneratedColumn<int>(
-      'category', aliasedName, true,
-      type: DriftSqlType.int,
-      requiredDuringInsert: false,
-      defaultConstraints: GeneratedColumn.constraintIsAlways(
-          'REFERENCES categories (id) DEFERRABLE INITIALLY DEFERRED'));
+  late final GeneratedColumnWithTypeConverter<RowId?, int> category =
+      GeneratedColumn<int>('category', aliasedName, true,
+              type: DriftSqlType.int,
+              requiredDuringInsert: false,
+              defaultConstraints: GeneratedColumn.constraintIsAlways(
+                  'REFERENCES categories (id) DEFERRABLE INITIALLY DEFERRED'))
+          .withConverter<RowId?>($TodosTableTable.$convertercategoryn);
   static const VerificationMeta _statusMeta = const VerificationMeta('status');
   @override
   late final GeneratedColumnWithTypeConverter<TodoStatus?, String> status =
@@ -351,10 +352,7 @@ class $TodosTableTable extends TodosTable
           targetDate.isAcceptableOrUnknown(
               data['target_date']!, _targetDateMeta));
     }
-    if (data.containsKey('category')) {
-      context.handle(_categoryMeta,
-          category.isAcceptableOrUnknown(data['category']!, _categoryMeta));
-    }
+    context.handle(_categoryMeta, const VerificationResult.success());
     context.handle(_statusMeta, const VerificationResult.success());
     return context;
   }
@@ -378,8 +376,9 @@ class $TodosTableTable extends TodosTable
           .read(DriftSqlType.string, data['${effectivePrefix}content'])!,
       targetDate: attachedDatabase.typeMapping
           .read(DriftSqlType.dateTime, data['${effectivePrefix}target_date']),
-      category: attachedDatabase.typeMapping
-          .read(DriftSqlType.int, data['${effectivePrefix}category']),
+      category: $TodosTableTable.$convertercategoryn.fromSql(attachedDatabase
+          .typeMapping
+          .read(DriftSqlType.int, data['${effectivePrefix}category'])),
       status: $TodosTableTable.$converterstatusn.fromSql(attachedDatabase
           .typeMapping
           .read(DriftSqlType.string, data['${effectivePrefix}status'])),
@@ -393,6 +392,10 @@ class $TodosTableTable extends TodosTable
 
   static JsonTypeConverter2<RowId, int, int> $converterid =
       TypeConverter.extensionType<RowId, int>();
+  static JsonTypeConverter2<RowId, int, int> $convertercategory =
+      TypeConverter.extensionType<RowId, int>();
+  static JsonTypeConverter2<RowId?, int?, int?> $convertercategoryn =
+      JsonTypeConverter2.asNullable($convertercategory);
   static JsonTypeConverter2<TodoStatus, String, String> $converterstatus =
       const EnumNameConverter<TodoStatus>(TodoStatus.values);
   static JsonTypeConverter2<TodoStatus?, String?, String?> $converterstatusn =
@@ -404,7 +407,7 @@ class TodoEntry extends DataClass implements Insertable<TodoEntry> {
   final String? title;
   final String content;
   final DateTime? targetDate;
-  final int? category;
+  final RowId? category;
   final TodoStatus? status;
   const TodoEntry(
       {required this.id,
@@ -427,7 +430,8 @@ class TodoEntry extends DataClass implements Insertable<TodoEntry> {
       map['target_date'] = Variable<DateTime>(targetDate);
     }
     if (!nullToAbsent || category != null) {
-      map['category'] = Variable<int>(category);
+      map['category'] =
+          Variable<int>($TodosTableTable.$convertercategoryn.toSql(category));
     }
     if (!nullToAbsent || status != null) {
       map['status'] =
@@ -462,7 +466,8 @@ class TodoEntry extends DataClass implements Insertable<TodoEntry> {
       title: serializer.fromJson<String?>(json['title']),
       content: serializer.fromJson<String>(json['content']),
       targetDate: serializer.fromJson<DateTime?>(json['target_date']),
-      category: serializer.fromJson<int?>(json['category']),
+      category: $TodosTableTable.$convertercategoryn
+          .fromJson(serializer.fromJson<int?>(json['category'])),
       status: $TodosTableTable.$converterstatusn
           .fromJson(serializer.fromJson<String?>(json['status'])),
     );
@@ -480,7 +485,8 @@ class TodoEntry extends DataClass implements Insertable<TodoEntry> {
       'title': serializer.toJson<String?>(title),
       'content': serializer.toJson<String>(content),
       'target_date': serializer.toJson<DateTime?>(targetDate),
-      'category': serializer.toJson<int?>(category),
+      'category': serializer
+          .toJson<int?>($TodosTableTable.$convertercategoryn.toJson(category)),
       'status': serializer
           .toJson<String?>($TodosTableTable.$converterstatusn.toJson(status)),
     };
@@ -491,7 +497,7 @@ class TodoEntry extends DataClass implements Insertable<TodoEntry> {
           Value<String?> title = const Value.absent(),
           String? content,
           Value<DateTime?> targetDate = const Value.absent(),
-          Value<int?> category = const Value.absent(),
+          Value<RowId?> category = const Value.absent(),
           Value<TodoStatus?> status = const Value.absent()}) =>
       TodoEntry(
         id: id ?? this.id,
@@ -546,7 +552,7 @@ class TodosTableCompanion extends UpdateCompanion<TodoEntry> {
   final Value<String?> title;
   final Value<String> content;
   final Value<DateTime?> targetDate;
-  final Value<int?> category;
+  final Value<RowId?> category;
   final Value<TodoStatus?> status;
   const TodosTableCompanion({
     this.id = const Value.absent(),
@@ -587,7 +593,7 @@ class TodosTableCompanion extends UpdateCompanion<TodoEntry> {
       Value<String?>? title,
       Value<String>? content,
       Value<DateTime?>? targetDate,
-      Value<int?>? category,
+      Value<RowId?>? category,
       Value<TodoStatus?>? status}) {
     return TodosTableCompanion(
       id: id ?? this.id,
@@ -615,7 +621,8 @@ class TodosTableCompanion extends UpdateCompanion<TodoEntry> {
       map['target_date'] = Variable<DateTime>(targetDate.value);
     }
     if (category.present) {
-      map['category'] = Variable<int>(category.value);
+      map['category'] = Variable<int>(
+          $TodosTableTable.$convertercategoryn.toSql(category.value));
     }
     if (status.present) {
       map['status'] = Variable<String>(
@@ -3357,7 +3364,9 @@ abstract class _$TodoDb extends GeneratedDatabase {
           title: row.readNullable<String>('title'),
           content: row.read<String>('content'),
           targetDate: row.readNullable<DateTime>('target_date'),
-          category: row.readNullable<int>('category'),
+          category: NullAwareTypeConverter.wrapFromSql(
+              $TodosTableTable.$convertercategory,
+              row.readNullable<int>('category')),
           status: NullAwareTypeConverter.wrapFromSql(
               $TodosTableTable.$converterstatus,
               row.readNullable<String>('status')),
@@ -3446,43 +3455,23 @@ typedef $$CategoriesTableUpdateCompanionBuilder = CategoriesCompanion Function({
   Value<CategoryPriority> priority,
 });
 
-class $$CategoriesTableTableManager extends RootTableManager<
-    _$TodoDb,
-    $CategoriesTable,
-    Category,
-    $$CategoriesTableFilterComposer,
-    $$CategoriesTableOrderingComposer,
-    $$CategoriesTableCreateCompanionBuilder,
-    $$CategoriesTableUpdateCompanionBuilder> {
-  $$CategoriesTableTableManager(_$TodoDb db, $CategoriesTable table)
-      : super(TableManagerState(
-          db: db,
-          table: table,
-          filteringComposer:
-              $$CategoriesTableFilterComposer(ComposerState(db, table)),
-          orderingComposer:
-              $$CategoriesTableOrderingComposer(ComposerState(db, table)),
-          updateCompanionCallback: ({
-            Value<RowId> id = const Value.absent(),
-            Value<String> description = const Value.absent(),
-            Value<CategoryPriority> priority = const Value.absent(),
-          }) =>
-              CategoriesCompanion(
-            id: id,
-            description: description,
-            priority: priority,
-          ),
-          createCompanionCallback: ({
-            Value<RowId> id = const Value.absent(),
-            required String description,
-            Value<CategoryPriority> priority = const Value.absent(),
-          }) =>
-              CategoriesCompanion.insert(
-            id: id,
-            description: description,
-            priority: priority,
-          ),
-        ));
+class $$CategoriesTableReferences
+    extends BaseReferences<_$TodoDb, $CategoriesTable, Category> {
+  $$CategoriesTableReferences(super.$_db, super.$_table, super.$_typedResult);
+
+  static MultiTypedResultKey<$TodosTableTable, List<TodoEntry>> _todosTable(
+          _$TodoDb db) =>
+      MultiTypedResultKey.fromTable(db.todosTable,
+          aliasName: "todos__PAQghpCEKc");
+
+  $$TodosTableTableProcessedTableManager get todos {
+    final manager = $$TodosTableTableTableManager($_db, $_db.todosTable)
+        .filter((f) => f.category.id($_item.id));
+
+    final cache = $_typedResult.readTableOrNull(_todosTable($_db));
+    return ProcessedTableManager(
+        manager.$state.copyWith(prefetchedData: cache));
+  }
 }
 
 class $$CategoriesTableFilterComposer
@@ -3551,12 +3540,90 @@ class $$CategoriesTableOrderingComposer
               ColumnOrderings(column, joinBuilders: joinBuilders));
 }
 
+class $$CategoriesTableTableManager extends RootTableManager<
+    _$TodoDb,
+    $CategoriesTable,
+    Category,
+    $$CategoriesTableFilterComposer,
+    $$CategoriesTableOrderingComposer,
+    $$CategoriesTableCreateCompanionBuilder,
+    $$CategoriesTableUpdateCompanionBuilder,
+    (Category, $$CategoriesTableReferences),
+    Category,
+    PrefetchHooks Function({bool todos})> {
+  $$CategoriesTableTableManager(_$TodoDb db, $CategoriesTable table)
+      : super(TableManagerState(
+          db: db,
+          table: table,
+          filteringComposer:
+              $$CategoriesTableFilterComposer(ComposerState(db, table)),
+          orderingComposer:
+              $$CategoriesTableOrderingComposer(ComposerState(db, table)),
+          updateCompanionCallback: ({
+            Value<RowId> id = const Value.absent(),
+            Value<String> description = const Value.absent(),
+            Value<CategoryPriority> priority = const Value.absent(),
+          }) =>
+              CategoriesCompanion(
+            id: id,
+            description: description,
+            priority: priority,
+          ),
+          createCompanionCallback: ({
+            Value<RowId> id = const Value.absent(),
+            required String description,
+            Value<CategoryPriority> priority = const Value.absent(),
+          }) =>
+              CategoriesCompanion.insert(
+            id: id,
+            description: description,
+            priority: priority,
+          ),
+          withReferenceMapper: (p0) => p0
+              .map((e) => (
+                    e.readTable(table),
+                    $$CategoriesTableReferences(db, table, e)
+                  ))
+              .toList(),
+          prefetchHooksCallback: ({todos = false}) {
+            return PrefetchHooks(
+              addJoins: null,
+              withPrefetches: (items) async {
+                items = await typedResultsWithPrefetched(
+                    doPrefetch: todos,
+                    currentTable: table,
+                    referencedTable:
+                        $$CategoriesTableReferences._todosTable(db),
+                    managerFromTypedResult: (p0) =>
+                        $$CategoriesTableReferences(db, table, p0).todos,
+                    referencedItemsForCurrentItem: (item, referencedItems) =>
+                        referencedItems.where((e) => e.category == item.id),
+                    typedResults: items);
+
+                return items;
+              },
+            );
+          },
+        ));
+}
+
+typedef $$CategoriesTableProcessedTableManager = ProcessedTableManager<
+    _$TodoDb,
+    $CategoriesTable,
+    Category,
+    $$CategoriesTableFilterComposer,
+    $$CategoriesTableOrderingComposer,
+    $$CategoriesTableCreateCompanionBuilder,
+    $$CategoriesTableUpdateCompanionBuilder,
+    (Category, $$CategoriesTableReferences),
+    Category,
+    PrefetchHooks Function({bool todos})>;
 typedef $$TodosTableTableCreateCompanionBuilder = TodosTableCompanion Function({
   Value<RowId> id,
   Value<String?> title,
   required String content,
   Value<DateTime?> targetDate,
-  Value<int?> category,
+  Value<RowId?> category,
   Value<TodoStatus?> status,
 });
 typedef $$TodosTableTableUpdateCompanionBuilder = TodosTableCompanion Function({
@@ -3564,59 +3631,27 @@ typedef $$TodosTableTableUpdateCompanionBuilder = TodosTableCompanion Function({
   Value<String?> title,
   Value<String> content,
   Value<DateTime?> targetDate,
-  Value<int?> category,
+  Value<RowId?> category,
   Value<TodoStatus?> status,
 });
 
-class $$TodosTableTableTableManager extends RootTableManager<
-    _$TodoDb,
-    $TodosTableTable,
-    TodoEntry,
-    $$TodosTableTableFilterComposer,
-    $$TodosTableTableOrderingComposer,
-    $$TodosTableTableCreateCompanionBuilder,
-    $$TodosTableTableUpdateCompanionBuilder> {
-  $$TodosTableTableTableManager(_$TodoDb db, $TodosTableTable table)
-      : super(TableManagerState(
-          db: db,
-          table: table,
-          filteringComposer:
-              $$TodosTableTableFilterComposer(ComposerState(db, table)),
-          orderingComposer:
-              $$TodosTableTableOrderingComposer(ComposerState(db, table)),
-          updateCompanionCallback: ({
-            Value<RowId> id = const Value.absent(),
-            Value<String?> title = const Value.absent(),
-            Value<String> content = const Value.absent(),
-            Value<DateTime?> targetDate = const Value.absent(),
-            Value<int?> category = const Value.absent(),
-            Value<TodoStatus?> status = const Value.absent(),
-          }) =>
-              TodosTableCompanion(
-            id: id,
-            title: title,
-            content: content,
-            targetDate: targetDate,
-            category: category,
-            status: status,
-          ),
-          createCompanionCallback: ({
-            Value<RowId> id = const Value.absent(),
-            Value<String?> title = const Value.absent(),
-            required String content,
-            Value<DateTime?> targetDate = const Value.absent(),
-            Value<int?> category = const Value.absent(),
-            Value<TodoStatus?> status = const Value.absent(),
-          }) =>
-              TodosTableCompanion.insert(
-            id: id,
-            title: title,
-            content: content,
-            targetDate: targetDate,
-            category: category,
-            status: status,
-          ),
-        ));
+class $$TodosTableTableReferences
+    extends BaseReferences<_$TodoDb, $TodosTableTable, TodoEntry> {
+  $$TodosTableTableReferences(super.$_db, super.$_table, super.$_typedResult);
+
+  static $CategoriesTable _categoryTable(_$TodoDb db) =>
+      db.categories.createAlias(
+          $_aliasNameGenerator(db.todosTable.category, db.categories.id));
+
+  $$CategoriesTableProcessedTableManager? get category {
+    if ($_item.category == null) return null;
+    final manager = $$CategoriesTableTableManager($_db, $_db.categories)
+        .filter((f) => f.id($_item.category!));
+    final item = $_typedResult.readTableOrNull(_categoryTable($_db));
+    if (item == null) return manager;
+    return ProcessedTableManager(
+        manager.$state.copyWith(prefetchedData: [item]));
+  }
 }
 
 class $$TodosTableTableFilterComposer
@@ -3705,6 +3740,109 @@ class $$TodosTableTableOrderingComposer
   }
 }
 
+class $$TodosTableTableTableManager extends RootTableManager<
+    _$TodoDb,
+    $TodosTableTable,
+    TodoEntry,
+    $$TodosTableTableFilterComposer,
+    $$TodosTableTableOrderingComposer,
+    $$TodosTableTableCreateCompanionBuilder,
+    $$TodosTableTableUpdateCompanionBuilder,
+    (TodoEntry, $$TodosTableTableReferences),
+    TodoEntry,
+    PrefetchHooks Function({bool category})> {
+  $$TodosTableTableTableManager(_$TodoDb db, $TodosTableTable table)
+      : super(TableManagerState(
+          db: db,
+          table: table,
+          filteringComposer:
+              $$TodosTableTableFilterComposer(ComposerState(db, table)),
+          orderingComposer:
+              $$TodosTableTableOrderingComposer(ComposerState(db, table)),
+          updateCompanionCallback: ({
+            Value<RowId> id = const Value.absent(),
+            Value<String?> title = const Value.absent(),
+            Value<String> content = const Value.absent(),
+            Value<DateTime?> targetDate = const Value.absent(),
+            Value<RowId?> category = const Value.absent(),
+            Value<TodoStatus?> status = const Value.absent(),
+          }) =>
+              TodosTableCompanion(
+            id: id,
+            title: title,
+            content: content,
+            targetDate: targetDate,
+            category: category,
+            status: status,
+          ),
+          createCompanionCallback: ({
+            Value<RowId> id = const Value.absent(),
+            Value<String?> title = const Value.absent(),
+            required String content,
+            Value<DateTime?> targetDate = const Value.absent(),
+            Value<RowId?> category = const Value.absent(),
+            Value<TodoStatus?> status = const Value.absent(),
+          }) =>
+              TodosTableCompanion.insert(
+            id: id,
+            title: title,
+            content: content,
+            targetDate: targetDate,
+            category: category,
+            status: status,
+          ),
+          withReferenceMapper: (p0) => p0
+              .map((e) => (
+                    e.readTable(table),
+                    $$TodosTableTableReferences(db, table, e)
+                  ))
+              .toList(),
+          prefetchHooksCallback: ({category = false}) {
+            return PrefetchHooks(
+              addJoins: <
+                  T extends TableManagerState<
+                      dynamic,
+                      dynamic,
+                      dynamic,
+                      dynamic,
+                      dynamic,
+                      dynamic,
+                      dynamic,
+                      dynamic,
+                      dynamic,
+                      dynamic>>(state) {
+                if (category) {
+                  state = state.withJoin(
+                    currentTable: table,
+                    currentColumn: table.category,
+                    referencedTable:
+                        $$TodosTableTableReferences._categoryTable(db),
+                    referencedColumn:
+                        $$TodosTableTableReferences._categoryTable(db).id,
+                  ) as T;
+                }
+
+                return state;
+              },
+              withPrefetches: (items) async {
+                return items;
+              },
+            );
+          },
+        ));
+}
+
+typedef $$TodosTableTableProcessedTableManager = ProcessedTableManager<
+    _$TodoDb,
+    $TodosTableTable,
+    TodoEntry,
+    $$TodosTableTableFilterComposer,
+    $$TodosTableTableOrderingComposer,
+    $$TodosTableTableCreateCompanionBuilder,
+    $$TodosTableTableUpdateCompanionBuilder,
+    (TodoEntry, $$TodosTableTableReferences),
+    TodoEntry,
+    PrefetchHooks Function({bool category})>;
 typedef $$UsersTableCreateCompanionBuilder = UsersCompanion Function({
   Value<RowId> id,
   required String name,
@@ -3719,53 +3857,6 @@ typedef $$UsersTableUpdateCompanionBuilder = UsersCompanion Function({
   Value<Uint8List> profilePicture,
   Value<DateTime> creationTime,
 });
-
-class $$UsersTableTableManager extends RootTableManager<
-    _$TodoDb,
-    $UsersTable,
-    User,
-    $$UsersTableFilterComposer,
-    $$UsersTableOrderingComposer,
-    $$UsersTableCreateCompanionBuilder,
-    $$UsersTableUpdateCompanionBuilder> {
-  $$UsersTableTableManager(_$TodoDb db, $UsersTable table)
-      : super(TableManagerState(
-          db: db,
-          table: table,
-          filteringComposer:
-              $$UsersTableFilterComposer(ComposerState(db, table)),
-          orderingComposer:
-              $$UsersTableOrderingComposer(ComposerState(db, table)),
-          updateCompanionCallback: ({
-            Value<RowId> id = const Value.absent(),
-            Value<String> name = const Value.absent(),
-            Value<bool> isAwesome = const Value.absent(),
-            Value<Uint8List> profilePicture = const Value.absent(),
-            Value<DateTime> creationTime = const Value.absent(),
-          }) =>
-              UsersCompanion(
-            id: id,
-            name: name,
-            isAwesome: isAwesome,
-            profilePicture: profilePicture,
-            creationTime: creationTime,
-          ),
-          createCompanionCallback: ({
-            Value<RowId> id = const Value.absent(),
-            required String name,
-            Value<bool> isAwesome = const Value.absent(),
-            required Uint8List profilePicture,
-            Value<DateTime> creationTime = const Value.absent(),
-          }) =>
-              UsersCompanion.insert(
-            id: id,
-            name: name,
-            isAwesome: isAwesome,
-            profilePicture: profilePicture,
-            creationTime: creationTime,
-          ),
-        ));
-}
 
 class $$UsersTableFilterComposer extends FilterComposer<_$TodoDb, $UsersTable> {
   $$UsersTableFilterComposer(super.$state);
@@ -3826,6 +3917,71 @@ class $$UsersTableOrderingComposer
           ColumnOrderings(column, joinBuilders: joinBuilders));
 }
 
+class $$UsersTableTableManager extends RootTableManager<
+    _$TodoDb,
+    $UsersTable,
+    User,
+    $$UsersTableFilterComposer,
+    $$UsersTableOrderingComposer,
+    $$UsersTableCreateCompanionBuilder,
+    $$UsersTableUpdateCompanionBuilder,
+    (User, BaseReferences<_$TodoDb, $UsersTable, User>),
+    User,
+    PrefetchHooks Function()> {
+  $$UsersTableTableManager(_$TodoDb db, $UsersTable table)
+      : super(TableManagerState(
+          db: db,
+          table: table,
+          filteringComposer:
+              $$UsersTableFilterComposer(ComposerState(db, table)),
+          orderingComposer:
+              $$UsersTableOrderingComposer(ComposerState(db, table)),
+          updateCompanionCallback: ({
+            Value<RowId> id = const Value.absent(),
+            Value<String> name = const Value.absent(),
+            Value<bool> isAwesome = const Value.absent(),
+            Value<Uint8List> profilePicture = const Value.absent(),
+            Value<DateTime> creationTime = const Value.absent(),
+          }) =>
+              UsersCompanion(
+            id: id,
+            name: name,
+            isAwesome: isAwesome,
+            profilePicture: profilePicture,
+            creationTime: creationTime,
+          ),
+          createCompanionCallback: ({
+            Value<RowId> id = const Value.absent(),
+            required String name,
+            Value<bool> isAwesome = const Value.absent(),
+            required Uint8List profilePicture,
+            Value<DateTime> creationTime = const Value.absent(),
+          }) =>
+              UsersCompanion.insert(
+            id: id,
+            name: name,
+            isAwesome: isAwesome,
+            profilePicture: profilePicture,
+            creationTime: creationTime,
+          ),
+          withReferenceMapper: (p0) => p0
+              .map((e) => (e.readTable(table), BaseReferences(db, table, e)))
+              .toList(),
+          prefetchHooksCallback: null,
+        ));
+}
+
+typedef $$UsersTableProcessedTableManager = ProcessedTableManager<
+    _$TodoDb,
+    $UsersTable,
+    User,
+    $$UsersTableFilterComposer,
+    $$UsersTableOrderingComposer,
+    $$UsersTableCreateCompanionBuilder,
+    $$UsersTableUpdateCompanionBuilder,
+    (User, BaseReferences<_$TodoDb, $UsersTable, User>),
+    User,
+    PrefetchHooks Function()>;
 typedef $$SharedTodosTableCreateCompanionBuilder = SharedTodosCompanion
     Function({
   required int todo,
@@ -3838,45 +3994,6 @@ typedef $$SharedTodosTableUpdateCompanionBuilder = SharedTodosCompanion
   Value<int> user,
   Value<int> rowid,
 });
-
-class $$SharedTodosTableTableManager extends RootTableManager<
-    _$TodoDb,
-    $SharedTodosTable,
-    SharedTodo,
-    $$SharedTodosTableFilterComposer,
-    $$SharedTodosTableOrderingComposer,
-    $$SharedTodosTableCreateCompanionBuilder,
-    $$SharedTodosTableUpdateCompanionBuilder> {
-  $$SharedTodosTableTableManager(_$TodoDb db, $SharedTodosTable table)
-      : super(TableManagerState(
-          db: db,
-          table: table,
-          filteringComposer:
-              $$SharedTodosTableFilterComposer(ComposerState(db, table)),
-          orderingComposer:
-              $$SharedTodosTableOrderingComposer(ComposerState(db, table)),
-          updateCompanionCallback: ({
-            Value<int> todo = const Value.absent(),
-            Value<int> user = const Value.absent(),
-            Value<int> rowid = const Value.absent(),
-          }) =>
-              SharedTodosCompanion(
-            todo: todo,
-            user: user,
-            rowid: rowid,
-          ),
-          createCompanionCallback: ({
-            required int todo,
-            required int user,
-            Value<int> rowid = const Value.absent(),
-          }) =>
-              SharedTodosCompanion.insert(
-            todo: todo,
-            user: user,
-            rowid: rowid,
-          ),
-        ));
-}
 
 class $$SharedTodosTableFilterComposer
     extends FilterComposer<_$TodoDb, $SharedTodosTable> {
@@ -3906,6 +4023,63 @@ class $$SharedTodosTableOrderingComposer
           ColumnOrderings(column, joinBuilders: joinBuilders));
 }
 
+class $$SharedTodosTableTableManager extends RootTableManager<
+    _$TodoDb,
+    $SharedTodosTable,
+    SharedTodo,
+    $$SharedTodosTableFilterComposer,
+    $$SharedTodosTableOrderingComposer,
+    $$SharedTodosTableCreateCompanionBuilder,
+    $$SharedTodosTableUpdateCompanionBuilder,
+    (SharedTodo, BaseReferences<_$TodoDb, $SharedTodosTable, SharedTodo>),
+    SharedTodo,
+    PrefetchHooks Function()> {
+  $$SharedTodosTableTableManager(_$TodoDb db, $SharedTodosTable table)
+      : super(TableManagerState(
+          db: db,
+          table: table,
+          filteringComposer:
+              $$SharedTodosTableFilterComposer(ComposerState(db, table)),
+          orderingComposer:
+              $$SharedTodosTableOrderingComposer(ComposerState(db, table)),
+          updateCompanionCallback: ({
+            Value<int> todo = const Value.absent(),
+            Value<int> user = const Value.absent(),
+            Value<int> rowid = const Value.absent(),
+          }) =>
+              SharedTodosCompanion(
+            todo: todo,
+            user: user,
+            rowid: rowid,
+          ),
+          createCompanionCallback: ({
+            required int todo,
+            required int user,
+            Value<int> rowid = const Value.absent(),
+          }) =>
+              SharedTodosCompanion.insert(
+            todo: todo,
+            user: user,
+            rowid: rowid,
+          ),
+          withReferenceMapper: (p0) => p0
+              .map((e) => (e.readTable(table), BaseReferences(db, table, e)))
+              .toList(),
+          prefetchHooksCallback: null,
+        ));
+}
+
+typedef $$SharedTodosTableProcessedTableManager = ProcessedTableManager<
+    _$TodoDb,
+    $SharedTodosTable,
+    SharedTodo,
+    $$SharedTodosTableFilterComposer,
+    $$SharedTodosTableOrderingComposer,
+    $$SharedTodosTableCreateCompanionBuilder,
+    $$SharedTodosTableUpdateCompanionBuilder,
+    (SharedTodo, BaseReferences<_$TodoDb, $SharedTodosTable, SharedTodo>),
+    SharedTodo,
+    PrefetchHooks Function()>;
 typedef $$TableWithoutPKTableCreateCompanionBuilder = TableWithoutPKCompanion
     Function({
   required int notReallyAnId,
@@ -3922,53 +4096,6 @@ typedef $$TableWithoutPKTableUpdateCompanionBuilder = TableWithoutPKCompanion
   Value<MyCustomObject> custom,
   Value<int> rowid,
 });
-
-class $$TableWithoutPKTableTableManager extends RootTableManager<
-    _$TodoDb,
-    $TableWithoutPKTable,
-    CustomRowClass,
-    $$TableWithoutPKTableFilterComposer,
-    $$TableWithoutPKTableOrderingComposer,
-    $$TableWithoutPKTableCreateCompanionBuilder,
-    $$TableWithoutPKTableUpdateCompanionBuilder> {
-  $$TableWithoutPKTableTableManager(_$TodoDb db, $TableWithoutPKTable table)
-      : super(TableManagerState(
-          db: db,
-          table: table,
-          filteringComposer:
-              $$TableWithoutPKTableFilterComposer(ComposerState(db, table)),
-          orderingComposer:
-              $$TableWithoutPKTableOrderingComposer(ComposerState(db, table)),
-          updateCompanionCallback: ({
-            Value<int> notReallyAnId = const Value.absent(),
-            Value<double> someFloat = const Value.absent(),
-            Value<BigInt?> webSafeInt = const Value.absent(),
-            Value<MyCustomObject> custom = const Value.absent(),
-            Value<int> rowid = const Value.absent(),
-          }) =>
-              TableWithoutPKCompanion(
-            notReallyAnId: notReallyAnId,
-            someFloat: someFloat,
-            webSafeInt: webSafeInt,
-            custom: custom,
-            rowid: rowid,
-          ),
-          createCompanionCallback: ({
-            required int notReallyAnId,
-            required double someFloat,
-            Value<BigInt?> webSafeInt = const Value.absent(),
-            Value<MyCustomObject> custom = const Value.absent(),
-            Value<int> rowid = const Value.absent(),
-          }) =>
-              TableWithoutPKCompanion.insert(
-            notReallyAnId: notReallyAnId,
-            someFloat: someFloat,
-            webSafeInt: webSafeInt,
-            custom: custom,
-            rowid: rowid,
-          ),
-        ));
-}
 
 class $$TableWithoutPKTableFilterComposer
     extends FilterComposer<_$TodoDb, $TableWithoutPKTable> {
@@ -4020,6 +4147,77 @@ class $$TableWithoutPKTableOrderingComposer
           ColumnOrderings(column, joinBuilders: joinBuilders));
 }
 
+class $$TableWithoutPKTableTableManager extends RootTableManager<
+    _$TodoDb,
+    $TableWithoutPKTable,
+    CustomRowClass,
+    $$TableWithoutPKTableFilterComposer,
+    $$TableWithoutPKTableOrderingComposer,
+    $$TableWithoutPKTableCreateCompanionBuilder,
+    $$TableWithoutPKTableUpdateCompanionBuilder,
+    (
+      CustomRowClass,
+      BaseReferences<_$TodoDb, $TableWithoutPKTable, CustomRowClass>
+    ),
+    CustomRowClass,
+    PrefetchHooks Function()> {
+  $$TableWithoutPKTableTableManager(_$TodoDb db, $TableWithoutPKTable table)
+      : super(TableManagerState(
+          db: db,
+          table: table,
+          filteringComposer:
+              $$TableWithoutPKTableFilterComposer(ComposerState(db, table)),
+          orderingComposer:
+              $$TableWithoutPKTableOrderingComposer(ComposerState(db, table)),
+          updateCompanionCallback: ({
+            Value<int> notReallyAnId = const Value.absent(),
+            Value<double> someFloat = const Value.absent(),
+            Value<BigInt?> webSafeInt = const Value.absent(),
+            Value<MyCustomObject> custom = const Value.absent(),
+            Value<int> rowid = const Value.absent(),
+          }) =>
+              TableWithoutPKCompanion(
+            notReallyAnId: notReallyAnId,
+            someFloat: someFloat,
+            webSafeInt: webSafeInt,
+            custom: custom,
+            rowid: rowid,
+          ),
+          createCompanionCallback: ({
+            required int notReallyAnId,
+            required double someFloat,
+            Value<BigInt?> webSafeInt = const Value.absent(),
+            Value<MyCustomObject> custom = const Value.absent(),
+            Value<int> rowid = const Value.absent(),
+          }) =>
+              TableWithoutPKCompanion.insert(
+            notReallyAnId: notReallyAnId,
+            someFloat: someFloat,
+            webSafeInt: webSafeInt,
+            custom: custom,
+            rowid: rowid,
+          ),
+          withReferenceMapper: (p0) => p0
+              .map((e) => (e.readTable(table), BaseReferences(db, table, e)))
+              .toList(),
+          prefetchHooksCallback: null,
+        ));
+}
+
+typedef $$TableWithoutPKTableProcessedTableManager = ProcessedTableManager<
+    _$TodoDb,
+    $TableWithoutPKTable,
+    CustomRowClass,
+    $$TableWithoutPKTableFilterComposer,
+    $$TableWithoutPKTableOrderingComposer,
+    $$TableWithoutPKTableCreateCompanionBuilder,
+    $$TableWithoutPKTableUpdateCompanionBuilder,
+    (
+      CustomRowClass,
+      BaseReferences<_$TodoDb, $TableWithoutPKTable, CustomRowClass>
+    ),
+    CustomRowClass,
+    PrefetchHooks Function()>;
 typedef $$PureDefaultsTableCreateCompanionBuilder = PureDefaultsCompanion
     Function({
   Value<MyCustomObject?> txt,
@@ -4031,6 +4229,26 @@ typedef $$PureDefaultsTableUpdateCompanionBuilder = PureDefaultsCompanion
   Value<int> rowid,
 });
 
+class $$PureDefaultsTableFilterComposer
+    extends FilterComposer<_$TodoDb, $PureDefaultsTable> {
+  $$PureDefaultsTableFilterComposer(super.$state);
+  ColumnWithTypeConverterFilters<MyCustomObject?, MyCustomObject, String>
+      get txt => $state.composableBuilder(
+          column: $state.table.txt,
+          builder: (column, joinBuilders) => ColumnWithTypeConverterFilters(
+              column,
+              joinBuilders: joinBuilders));
+}
+
+class $$PureDefaultsTableOrderingComposer
+    extends OrderingComposer<_$TodoDb, $PureDefaultsTable> {
+  $$PureDefaultsTableOrderingComposer(super.$state);
+  ColumnOrderings<String> get txt => $state.composableBuilder(
+      column: $state.table.txt,
+      builder: (column, joinBuilders) =>
+          ColumnOrderings(column, joinBuilders: joinBuilders));
+}
+
 class $$PureDefaultsTableTableManager extends RootTableManager<
     _$TodoDb,
     $PureDefaultsTable,
@@ -4038,7 +4256,10 @@ class $$PureDefaultsTableTableManager extends RootTableManager<
     $$PureDefaultsTableFilterComposer,
     $$PureDefaultsTableOrderingComposer,
     $$PureDefaultsTableCreateCompanionBuilder,
-    $$PureDefaultsTableUpdateCompanionBuilder> {
+    $$PureDefaultsTableUpdateCompanionBuilder,
+    (PureDefault, BaseReferences<_$TodoDb, $PureDefaultsTable, PureDefault>),
+    PureDefault,
+    PrefetchHooks Function()> {
   $$PureDefaultsTableTableManager(_$TodoDb db, $PureDefaultsTable table)
       : super(TableManagerState(
           db: db,
@@ -4063,29 +4284,24 @@ class $$PureDefaultsTableTableManager extends RootTableManager<
             txt: txt,
             rowid: rowid,
           ),
+          withReferenceMapper: (p0) => p0
+              .map((e) => (e.readTable(table), BaseReferences(db, table, e)))
+              .toList(),
+          prefetchHooksCallback: null,
         ));
 }
 
-class $$PureDefaultsTableFilterComposer
-    extends FilterComposer<_$TodoDb, $PureDefaultsTable> {
-  $$PureDefaultsTableFilterComposer(super.$state);
-  ColumnWithTypeConverterFilters<MyCustomObject?, MyCustomObject, String>
-      get txt => $state.composableBuilder(
-          column: $state.table.txt,
-          builder: (column, joinBuilders) => ColumnWithTypeConverterFilters(
-              column,
-              joinBuilders: joinBuilders));
-}
-
-class $$PureDefaultsTableOrderingComposer
-    extends OrderingComposer<_$TodoDb, $PureDefaultsTable> {
-  $$PureDefaultsTableOrderingComposer(super.$state);
-  ColumnOrderings<String> get txt => $state.composableBuilder(
-      column: $state.table.txt,
-      builder: (column, joinBuilders) =>
-          ColumnOrderings(column, joinBuilders: joinBuilders));
-}
-
+typedef $$PureDefaultsTableProcessedTableManager = ProcessedTableManager<
+    _$TodoDb,
+    $PureDefaultsTable,
+    PureDefault,
+    $$PureDefaultsTableFilterComposer,
+    $$PureDefaultsTableOrderingComposer,
+    $$PureDefaultsTableCreateCompanionBuilder,
+    $$PureDefaultsTableUpdateCompanionBuilder,
+    (PureDefault, BaseReferences<_$TodoDb, $PureDefaultsTable, PureDefault>),
+    PureDefault,
+    PrefetchHooks Function()>;
 typedef $$WithCustomTypeTableCreateCompanionBuilder = WithCustomTypeCompanion
     Function({
   required UuidValue id,
@@ -4097,6 +4313,24 @@ typedef $$WithCustomTypeTableUpdateCompanionBuilder = WithCustomTypeCompanion
   Value<int> rowid,
 });
 
+class $$WithCustomTypeTableFilterComposer
+    extends FilterComposer<_$TodoDb, $WithCustomTypeTable> {
+  $$WithCustomTypeTableFilterComposer(super.$state);
+  ColumnFilters<UuidValue> get id => $state.composableBuilder(
+      column: $state.table.id,
+      builder: (column, joinBuilders) =>
+          ColumnFilters(column, joinBuilders: joinBuilders));
+}
+
+class $$WithCustomTypeTableOrderingComposer
+    extends OrderingComposer<_$TodoDb, $WithCustomTypeTable> {
+  $$WithCustomTypeTableOrderingComposer(super.$state);
+  ColumnOrderings<UuidValue> get id => $state.composableBuilder(
+      column: $state.table.id,
+      builder: (column, joinBuilders) =>
+          ColumnOrderings(column, joinBuilders: joinBuilders));
+}
+
 class $$WithCustomTypeTableTableManager extends RootTableManager<
     _$TodoDb,
     $WithCustomTypeTable,
@@ -4104,7 +4338,13 @@ class $$WithCustomTypeTableTableManager extends RootTableManager<
     $$WithCustomTypeTableFilterComposer,
     $$WithCustomTypeTableOrderingComposer,
     $$WithCustomTypeTableCreateCompanionBuilder,
-    $$WithCustomTypeTableUpdateCompanionBuilder> {
+    $$WithCustomTypeTableUpdateCompanionBuilder,
+    (
+      WithCustomTypeData,
+      BaseReferences<_$TodoDb, $WithCustomTypeTable, WithCustomTypeData>
+    ),
+    WithCustomTypeData,
+    PrefetchHooks Function()> {
   $$WithCustomTypeTableTableManager(_$TodoDb db, $WithCustomTypeTable table)
       : super(TableManagerState(
           db: db,
@@ -4129,27 +4369,27 @@ class $$WithCustomTypeTableTableManager extends RootTableManager<
             id: id,
             rowid: rowid,
           ),
+          withReferenceMapper: (p0) => p0
+              .map((e) => (e.readTable(table), BaseReferences(db, table, e)))
+              .toList(),
+          prefetchHooksCallback: null,
         ));
 }
 
-class $$WithCustomTypeTableFilterComposer
-    extends FilterComposer<_$TodoDb, $WithCustomTypeTable> {
-  $$WithCustomTypeTableFilterComposer(super.$state);
-  ColumnFilters<UuidValue> get id => $state.composableBuilder(
-      column: $state.table.id,
-      builder: (column, joinBuilders) =>
-          ColumnFilters(column, joinBuilders: joinBuilders));
-}
-
-class $$WithCustomTypeTableOrderingComposer
-    extends OrderingComposer<_$TodoDb, $WithCustomTypeTable> {
-  $$WithCustomTypeTableOrderingComposer(super.$state);
-  ColumnOrderings<UuidValue> get id => $state.composableBuilder(
-      column: $state.table.id,
-      builder: (column, joinBuilders) =>
-          ColumnOrderings(column, joinBuilders: joinBuilders));
-}
-
+typedef $$WithCustomTypeTableProcessedTableManager = ProcessedTableManager<
+    _$TodoDb,
+    $WithCustomTypeTable,
+    WithCustomTypeData,
+    $$WithCustomTypeTableFilterComposer,
+    $$WithCustomTypeTableOrderingComposer,
+    $$WithCustomTypeTableCreateCompanionBuilder,
+    $$WithCustomTypeTableUpdateCompanionBuilder,
+    (
+      WithCustomTypeData,
+      BaseReferences<_$TodoDb, $WithCustomTypeTable, WithCustomTypeData>
+    ),
+    WithCustomTypeData,
+    PrefetchHooks Function()>;
 typedef $$TableWithEveryColumnTypeTableCreateCompanionBuilder
     = TableWithEveryColumnTypeCompanion Function({
   Value<RowId> id,
@@ -4176,74 +4416,6 @@ typedef $$TableWithEveryColumnTypeTableUpdateCompanionBuilder
   Value<TodoStatus?> anIntEnum,
   Value<MyCustomObject?> aTextWithConverter,
 });
-
-class $$TableWithEveryColumnTypeTableTableManager extends RootTableManager<
-    _$TodoDb,
-    $TableWithEveryColumnTypeTable,
-    TableWithEveryColumnTypeData,
-    $$TableWithEveryColumnTypeTableFilterComposer,
-    $$TableWithEveryColumnTypeTableOrderingComposer,
-    $$TableWithEveryColumnTypeTableCreateCompanionBuilder,
-    $$TableWithEveryColumnTypeTableUpdateCompanionBuilder> {
-  $$TableWithEveryColumnTypeTableTableManager(
-      _$TodoDb db, $TableWithEveryColumnTypeTable table)
-      : super(TableManagerState(
-          db: db,
-          table: table,
-          filteringComposer: $$TableWithEveryColumnTypeTableFilterComposer(
-              ComposerState(db, table)),
-          orderingComposer: $$TableWithEveryColumnTypeTableOrderingComposer(
-              ComposerState(db, table)),
-          updateCompanionCallback: ({
-            Value<RowId> id = const Value.absent(),
-            Value<bool?> aBool = const Value.absent(),
-            Value<DateTime?> aDateTime = const Value.absent(),
-            Value<String?> aText = const Value.absent(),
-            Value<int?> anInt = const Value.absent(),
-            Value<BigInt?> anInt64 = const Value.absent(),
-            Value<double?> aReal = const Value.absent(),
-            Value<Uint8List?> aBlob = const Value.absent(),
-            Value<TodoStatus?> anIntEnum = const Value.absent(),
-            Value<MyCustomObject?> aTextWithConverter = const Value.absent(),
-          }) =>
-              TableWithEveryColumnTypeCompanion(
-            id: id,
-            aBool: aBool,
-            aDateTime: aDateTime,
-            aText: aText,
-            anInt: anInt,
-            anInt64: anInt64,
-            aReal: aReal,
-            aBlob: aBlob,
-            anIntEnum: anIntEnum,
-            aTextWithConverter: aTextWithConverter,
-          ),
-          createCompanionCallback: ({
-            Value<RowId> id = const Value.absent(),
-            Value<bool?> aBool = const Value.absent(),
-            Value<DateTime?> aDateTime = const Value.absent(),
-            Value<String?> aText = const Value.absent(),
-            Value<int?> anInt = const Value.absent(),
-            Value<BigInt?> anInt64 = const Value.absent(),
-            Value<double?> aReal = const Value.absent(),
-            Value<Uint8List?> aBlob = const Value.absent(),
-            Value<TodoStatus?> anIntEnum = const Value.absent(),
-            Value<MyCustomObject?> aTextWithConverter = const Value.absent(),
-          }) =>
-              TableWithEveryColumnTypeCompanion.insert(
-            id: id,
-            aBool: aBool,
-            aDateTime: aDateTime,
-            aText: aText,
-            anInt: anInt,
-            anInt64: anInt64,
-            aReal: aReal,
-            aBlob: aBlob,
-            anIntEnum: anIntEnum,
-            aTextWithConverter: aTextWithConverter,
-          ),
-        ));
-}
 
 class $$TableWithEveryColumnTypeTableFilterComposer
     extends FilterComposer<_$TodoDb, $TableWithEveryColumnTypeTable> {
@@ -4359,6 +4531,101 @@ class $$TableWithEveryColumnTypeTableOrderingComposer
           ColumnOrderings(column, joinBuilders: joinBuilders));
 }
 
+class $$TableWithEveryColumnTypeTableTableManager extends RootTableManager<
+    _$TodoDb,
+    $TableWithEveryColumnTypeTable,
+    TableWithEveryColumnTypeData,
+    $$TableWithEveryColumnTypeTableFilterComposer,
+    $$TableWithEveryColumnTypeTableOrderingComposer,
+    $$TableWithEveryColumnTypeTableCreateCompanionBuilder,
+    $$TableWithEveryColumnTypeTableUpdateCompanionBuilder,
+    (
+      TableWithEveryColumnTypeData,
+      BaseReferences<_$TodoDb, $TableWithEveryColumnTypeTable,
+          TableWithEveryColumnTypeData>
+    ),
+    TableWithEveryColumnTypeData,
+    PrefetchHooks Function()> {
+  $$TableWithEveryColumnTypeTableTableManager(
+      _$TodoDb db, $TableWithEveryColumnTypeTable table)
+      : super(TableManagerState(
+          db: db,
+          table: table,
+          filteringComposer: $$TableWithEveryColumnTypeTableFilterComposer(
+              ComposerState(db, table)),
+          orderingComposer: $$TableWithEveryColumnTypeTableOrderingComposer(
+              ComposerState(db, table)),
+          updateCompanionCallback: ({
+            Value<RowId> id = const Value.absent(),
+            Value<bool?> aBool = const Value.absent(),
+            Value<DateTime?> aDateTime = const Value.absent(),
+            Value<String?> aText = const Value.absent(),
+            Value<int?> anInt = const Value.absent(),
+            Value<BigInt?> anInt64 = const Value.absent(),
+            Value<double?> aReal = const Value.absent(),
+            Value<Uint8List?> aBlob = const Value.absent(),
+            Value<TodoStatus?> anIntEnum = const Value.absent(),
+            Value<MyCustomObject?> aTextWithConverter = const Value.absent(),
+          }) =>
+              TableWithEveryColumnTypeCompanion(
+            id: id,
+            aBool: aBool,
+            aDateTime: aDateTime,
+            aText: aText,
+            anInt: anInt,
+            anInt64: anInt64,
+            aReal: aReal,
+            aBlob: aBlob,
+            anIntEnum: anIntEnum,
+            aTextWithConverter: aTextWithConverter,
+          ),
+          createCompanionCallback: ({
+            Value<RowId> id = const Value.absent(),
+            Value<bool?> aBool = const Value.absent(),
+            Value<DateTime?> aDateTime = const Value.absent(),
+            Value<String?> aText = const Value.absent(),
+            Value<int?> anInt = const Value.absent(),
+            Value<BigInt?> anInt64 = const Value.absent(),
+            Value<double?> aReal = const Value.absent(),
+            Value<Uint8List?> aBlob = const Value.absent(),
+            Value<TodoStatus?> anIntEnum = const Value.absent(),
+            Value<MyCustomObject?> aTextWithConverter = const Value.absent(),
+          }) =>
+              TableWithEveryColumnTypeCompanion.insert(
+            id: id,
+            aBool: aBool,
+            aDateTime: aDateTime,
+            aText: aText,
+            anInt: anInt,
+            anInt64: anInt64,
+            aReal: aReal,
+            aBlob: aBlob,
+            anIntEnum: anIntEnum,
+            aTextWithConverter: aTextWithConverter,
+          ),
+          withReferenceMapper: (p0) => p0
+              .map((e) => (e.readTable(table), BaseReferences(db, table, e)))
+              .toList(),
+          prefetchHooksCallback: null,
+        ));
+}
+
+typedef $$TableWithEveryColumnTypeTableProcessedTableManager
+    = ProcessedTableManager<
+        _$TodoDb,
+        $TableWithEveryColumnTypeTable,
+        TableWithEveryColumnTypeData,
+        $$TableWithEveryColumnTypeTableFilterComposer,
+        $$TableWithEveryColumnTypeTableOrderingComposer,
+        $$TableWithEveryColumnTypeTableCreateCompanionBuilder,
+        $$TableWithEveryColumnTypeTableUpdateCompanionBuilder,
+        (
+          TableWithEveryColumnTypeData,
+          BaseReferences<_$TodoDb, $TableWithEveryColumnTypeTable,
+              TableWithEveryColumnTypeData>
+        ),
+        TableWithEveryColumnTypeData,
+        PrefetchHooks Function()>;
 typedef $$DepartmentTableCreateCompanionBuilder = DepartmentCompanion Function({
   Value<int> id,
   Value<String?> name,
@@ -4368,39 +4635,23 @@ typedef $$DepartmentTableUpdateCompanionBuilder = DepartmentCompanion Function({
   Value<String?> name,
 });
 
-class $$DepartmentTableTableManager extends RootTableManager<
-    _$TodoDb,
-    $DepartmentTable,
-    DepartmentData,
-    $$DepartmentTableFilterComposer,
-    $$DepartmentTableOrderingComposer,
-    $$DepartmentTableCreateCompanionBuilder,
-    $$DepartmentTableUpdateCompanionBuilder> {
-  $$DepartmentTableTableManager(_$TodoDb db, $DepartmentTable table)
-      : super(TableManagerState(
-          db: db,
-          table: table,
-          filteringComposer:
-              $$DepartmentTableFilterComposer(ComposerState(db, table)),
-          orderingComposer:
-              $$DepartmentTableOrderingComposer(ComposerState(db, table)),
-          updateCompanionCallback: ({
-            Value<int> id = const Value.absent(),
-            Value<String?> name = const Value.absent(),
-          }) =>
-              DepartmentCompanion(
-            id: id,
-            name: name,
-          ),
-          createCompanionCallback: ({
-            Value<int> id = const Value.absent(),
-            Value<String?> name = const Value.absent(),
-          }) =>
-              DepartmentCompanion.insert(
-            id: id,
-            name: name,
-          ),
-        ));
+class $$DepartmentTableReferences
+    extends BaseReferences<_$TodoDb, $DepartmentTable, DepartmentData> {
+  $$DepartmentTableReferences(super.$_db, super.$_table, super.$_typedResult);
+
+  static MultiTypedResultKey<$ProductTable, List<ProductData>>
+      _productRefsTable(_$TodoDb db) =>
+          MultiTypedResultKey.fromTable(db.product,
+              aliasName: "productRefs__YnLqMtvQxi");
+
+  $$ProductTableProcessedTableManager get productRefs {
+    final manager = $$ProductTableTableManager($_db, $_db.product)
+        .filter((f) => f.department.id($_item.id));
+
+    final cache = $_typedResult.readTableOrNull(_productRefsTable($_db));
+    return ProcessedTableManager(
+        manager.$state.copyWith(prefetchedData: cache));
+  }
 }
 
 class $$DepartmentTableFilterComposer
@@ -4444,6 +4695,80 @@ class $$DepartmentTableOrderingComposer
           ColumnOrderings(column, joinBuilders: joinBuilders));
 }
 
+class $$DepartmentTableTableManager extends RootTableManager<
+    _$TodoDb,
+    $DepartmentTable,
+    DepartmentData,
+    $$DepartmentTableFilterComposer,
+    $$DepartmentTableOrderingComposer,
+    $$DepartmentTableCreateCompanionBuilder,
+    $$DepartmentTableUpdateCompanionBuilder,
+    (DepartmentData, $$DepartmentTableReferences),
+    DepartmentData,
+    PrefetchHooks Function({bool productRefs})> {
+  $$DepartmentTableTableManager(_$TodoDb db, $DepartmentTable table)
+      : super(TableManagerState(
+          db: db,
+          table: table,
+          filteringComposer:
+              $$DepartmentTableFilterComposer(ComposerState(db, table)),
+          orderingComposer:
+              $$DepartmentTableOrderingComposer(ComposerState(db, table)),
+          updateCompanionCallback: ({
+            Value<int> id = const Value.absent(),
+            Value<String?> name = const Value.absent(),
+          }) =>
+              DepartmentCompanion(
+            id: id,
+            name: name,
+          ),
+          createCompanionCallback: ({
+            Value<int> id = const Value.absent(),
+            Value<String?> name = const Value.absent(),
+          }) =>
+              DepartmentCompanion.insert(
+            id: id,
+            name: name,
+          ),
+          withReferenceMapper: (p0) => p0
+              .map((e) => (
+                    e.readTable(table),
+                    $$DepartmentTableReferences(db, table, e)
+                  ))
+              .toList(),
+          prefetchHooksCallback: ({productRefs = false}) {
+            return PrefetchHooks(
+              addJoins: null,
+              withPrefetches: (items) async {
+                items = await typedResultsWithPrefetched(
+                    doPrefetch: productRefs,
+                    currentTable: table,
+                    referencedTable:
+                        $$DepartmentTableReferences._productRefsTable(db),
+                    managerFromTypedResult: (p0) =>
+                        $$DepartmentTableReferences(db, table, p0).productRefs,
+                    referencedItemsForCurrentItem: (item, referencedItems) =>
+                        referencedItems.where((e) => e.department == item.id),
+                    typedResults: items);
+
+                return items;
+              },
+            );
+          },
+        ));
+}
+
+typedef $$DepartmentTableProcessedTableManager = ProcessedTableManager<
+    _$TodoDb,
+    $DepartmentTable,
+    DepartmentData,
+    $$DepartmentTableFilterComposer,
+    $$DepartmentTableOrderingComposer,
+    $$DepartmentTableCreateCompanionBuilder,
+    $$DepartmentTableUpdateCompanionBuilder,
+    (DepartmentData, $$DepartmentTableReferences),
+    DepartmentData,
+    PrefetchHooks Function({bool productRefs})>;
 typedef $$ProductTableCreateCompanionBuilder = ProductCompanion Function({
   Value<int> id,
   Value<String?> name,
@@ -4455,43 +4780,37 @@ typedef $$ProductTableUpdateCompanionBuilder = ProductCompanion Function({
   Value<int?> department,
 });
 
-class $$ProductTableTableManager extends RootTableManager<
-    _$TodoDb,
-    $ProductTable,
-    ProductData,
-    $$ProductTableFilterComposer,
-    $$ProductTableOrderingComposer,
-    $$ProductTableCreateCompanionBuilder,
-    $$ProductTableUpdateCompanionBuilder> {
-  $$ProductTableTableManager(_$TodoDb db, $ProductTable table)
-      : super(TableManagerState(
-          db: db,
-          table: table,
-          filteringComposer:
-              $$ProductTableFilterComposer(ComposerState(db, table)),
-          orderingComposer:
-              $$ProductTableOrderingComposer(ComposerState(db, table)),
-          updateCompanionCallback: ({
-            Value<int> id = const Value.absent(),
-            Value<String?> name = const Value.absent(),
-            Value<int?> department = const Value.absent(),
-          }) =>
-              ProductCompanion(
-            id: id,
-            name: name,
-            department: department,
-          ),
-          createCompanionCallback: ({
-            Value<int> id = const Value.absent(),
-            Value<String?> name = const Value.absent(),
-            Value<int?> department = const Value.absent(),
-          }) =>
-              ProductCompanion.insert(
-            id: id,
-            name: name,
-            department: department,
-          ),
-        ));
+class $$ProductTableReferences
+    extends BaseReferences<_$TodoDb, $ProductTable, ProductData> {
+  $$ProductTableReferences(super.$_db, super.$_table, super.$_typedResult);
+
+  static $DepartmentTable _departmentTable(_$TodoDb db) =>
+      db.department.createAlias(
+          $_aliasNameGenerator(db.product.department, db.department.id));
+
+  $$DepartmentTableProcessedTableManager? get department {
+    if ($_item.department == null) return null;
+    final manager = $$DepartmentTableTableManager($_db, $_db.department)
+        .filter((f) => f.id($_item.department!));
+    final item = $_typedResult.readTableOrNull(_departmentTable($_db));
+    if (item == null) return manager;
+    return ProcessedTableManager(
+        manager.$state.copyWith(prefetchedData: [item]));
+  }
+
+  static MultiTypedResultKey<$ListingTable, List<ListingData>> _listingsTable(
+          _$TodoDb db) =>
+      MultiTypedResultKey.fromTable(db.listing,
+          aliasName: "listings__KEmAGPfGKG");
+
+  $$ListingTableProcessedTableManager get listings {
+    final manager = $$ListingTableTableManager($_db, $_db.listing)
+        .filter((f) => f.product.id($_item.id));
+
+    final cache = $_typedResult.readTableOrNull(_listingsTable($_db));
+    return ProcessedTableManager(
+        manager.$state.copyWith(prefetchedData: cache));
+  }
 }
 
 class $$ProductTableFilterComposer
@@ -4559,6 +4878,106 @@ class $$ProductTableOrderingComposer
   }
 }
 
+class $$ProductTableTableManager extends RootTableManager<
+    _$TodoDb,
+    $ProductTable,
+    ProductData,
+    $$ProductTableFilterComposer,
+    $$ProductTableOrderingComposer,
+    $$ProductTableCreateCompanionBuilder,
+    $$ProductTableUpdateCompanionBuilder,
+    (ProductData, $$ProductTableReferences),
+    ProductData,
+    PrefetchHooks Function({bool department, bool listings})> {
+  $$ProductTableTableManager(_$TodoDb db, $ProductTable table)
+      : super(TableManagerState(
+          db: db,
+          table: table,
+          filteringComposer:
+              $$ProductTableFilterComposer(ComposerState(db, table)),
+          orderingComposer:
+              $$ProductTableOrderingComposer(ComposerState(db, table)),
+          updateCompanionCallback: ({
+            Value<int> id = const Value.absent(),
+            Value<String?> name = const Value.absent(),
+            Value<int?> department = const Value.absent(),
+          }) =>
+              ProductCompanion(
+            id: id,
+            name: name,
+            department: department,
+          ),
+          createCompanionCallback: ({
+            Value<int> id = const Value.absent(),
+            Value<String?> name = const Value.absent(),
+            Value<int?> department = const Value.absent(),
+          }) =>
+              ProductCompanion.insert(
+            id: id,
+            name: name,
+            department: department,
+          ),
+          withReferenceMapper: (p0) => p0
+              .map((e) =>
+                  (e.readTable(table), $$ProductTableReferences(db, table, e)))
+              .toList(),
+          prefetchHooksCallback: ({department = false, listings = false}) {
+            return PrefetchHooks(
+              addJoins: <
+                  T extends TableManagerState<
+                      dynamic,
+                      dynamic,
+                      dynamic,
+                      dynamic,
+                      dynamic,
+                      dynamic,
+                      dynamic,
+                      dynamic,
+                      dynamic,
+                      dynamic>>(state) {
+                if (department) {
+                  state = state.withJoin(
+                    currentTable: table,
+                    currentColumn: table.department,
+                    referencedTable:
+                        $$ProductTableReferences._departmentTable(db),
+                    referencedColumn:
+                        $$ProductTableReferences._departmentTable(db).id,
+                  ) as T;
+                }
+
+                return state;
+              },
+              withPrefetches: (items) async {
+                items = await typedResultsWithPrefetched(
+                    doPrefetch: listings,
+                    currentTable: table,
+                    referencedTable:
+                        $$ProductTableReferences._listingsTable(db),
+                    managerFromTypedResult: (p0) =>
+                        $$ProductTableReferences(db, table, p0).listings,
+                    referencedItemsForCurrentItem: (item, referencedItems) =>
+                        referencedItems.where((e) => e.product == item.id),
+                    typedResults: items);
+
+                return items;
+              },
+            );
+          },
+        ));
+}
+
+typedef $$ProductTableProcessedTableManager = ProcessedTableManager<
+    _$TodoDb,
+    $ProductTable,
+    ProductData,
+    $$ProductTableFilterComposer,
+    $$ProductTableOrderingComposer,
+    $$ProductTableCreateCompanionBuilder,
+    $$ProductTableUpdateCompanionBuilder,
+    (ProductData, $$ProductTableReferences),
+    ProductData,
+    PrefetchHooks Function({bool department, bool listings})>;
 typedef $$StoreTableCreateCompanionBuilder = StoreCompanion Function({
   Value<int> id,
   Value<String?> name,
@@ -4568,39 +4987,23 @@ typedef $$StoreTableUpdateCompanionBuilder = StoreCompanion Function({
   Value<String?> name,
 });
 
-class $$StoreTableTableManager extends RootTableManager<
-    _$TodoDb,
-    $StoreTable,
-    StoreData,
-    $$StoreTableFilterComposer,
-    $$StoreTableOrderingComposer,
-    $$StoreTableCreateCompanionBuilder,
-    $$StoreTableUpdateCompanionBuilder> {
-  $$StoreTableTableManager(_$TodoDb db, $StoreTable table)
-      : super(TableManagerState(
-          db: db,
-          table: table,
-          filteringComposer:
-              $$StoreTableFilterComposer(ComposerState(db, table)),
-          orderingComposer:
-              $$StoreTableOrderingComposer(ComposerState(db, table)),
-          updateCompanionCallback: ({
-            Value<int> id = const Value.absent(),
-            Value<String?> name = const Value.absent(),
-          }) =>
-              StoreCompanion(
-            id: id,
-            name: name,
-          ),
-          createCompanionCallback: ({
-            Value<int> id = const Value.absent(),
-            Value<String?> name = const Value.absent(),
-          }) =>
-              StoreCompanion.insert(
-            id: id,
-            name: name,
-          ),
-        ));
+class $$StoreTableReferences
+    extends BaseReferences<_$TodoDb, $StoreTable, StoreData> {
+  $$StoreTableReferences(super.$_db, super.$_table, super.$_typedResult);
+
+  static MultiTypedResultKey<$ListingTable, List<ListingData>> _listingsTable(
+          _$TodoDb db) =>
+      MultiTypedResultKey.fromTable(db.listing,
+          aliasName: "listings__nJkbMhCzXE");
+
+  $$ListingTableProcessedTableManager get listings {
+    final manager = $$ListingTableTableManager($_db, $_db.listing)
+        .filter((f) => f.store.id($_item.id));
+
+    final cache = $_typedResult.readTableOrNull(_listingsTable($_db));
+    return ProcessedTableManager(
+        manager.$state.copyWith(prefetchedData: cache));
+  }
 }
 
 class $$StoreTableFilterComposer extends FilterComposer<_$TodoDb, $StoreTable> {
@@ -4643,6 +5046,77 @@ class $$StoreTableOrderingComposer
           ColumnOrderings(column, joinBuilders: joinBuilders));
 }
 
+class $$StoreTableTableManager extends RootTableManager<
+    _$TodoDb,
+    $StoreTable,
+    StoreData,
+    $$StoreTableFilterComposer,
+    $$StoreTableOrderingComposer,
+    $$StoreTableCreateCompanionBuilder,
+    $$StoreTableUpdateCompanionBuilder,
+    (StoreData, $$StoreTableReferences),
+    StoreData,
+    PrefetchHooks Function({bool listings})> {
+  $$StoreTableTableManager(_$TodoDb db, $StoreTable table)
+      : super(TableManagerState(
+          db: db,
+          table: table,
+          filteringComposer:
+              $$StoreTableFilterComposer(ComposerState(db, table)),
+          orderingComposer:
+              $$StoreTableOrderingComposer(ComposerState(db, table)),
+          updateCompanionCallback: ({
+            Value<int> id = const Value.absent(),
+            Value<String?> name = const Value.absent(),
+          }) =>
+              StoreCompanion(
+            id: id,
+            name: name,
+          ),
+          createCompanionCallback: ({
+            Value<int> id = const Value.absent(),
+            Value<String?> name = const Value.absent(),
+          }) =>
+              StoreCompanion.insert(
+            id: id,
+            name: name,
+          ),
+          withReferenceMapper: (p0) => p0
+              .map((e) =>
+                  (e.readTable(table), $$StoreTableReferences(db, table, e)))
+              .toList(),
+          prefetchHooksCallback: ({listings = false}) {
+            return PrefetchHooks(
+              addJoins: null,
+              withPrefetches: (items) async {
+                items = await typedResultsWithPrefetched(
+                    doPrefetch: listings,
+                    currentTable: table,
+                    referencedTable: $$StoreTableReferences._listingsTable(db),
+                    managerFromTypedResult: (p0) =>
+                        $$StoreTableReferences(db, table, p0).listings,
+                    referencedItemsForCurrentItem: (item, referencedItems) =>
+                        referencedItems.where((e) => e.store == item.id),
+                    typedResults: items);
+
+                return items;
+              },
+            );
+          },
+        ));
+}
+
+typedef $$StoreTableProcessedTableManager = ProcessedTableManager<
+    _$TodoDb,
+    $StoreTable,
+    StoreData,
+    $$StoreTableFilterComposer,
+    $$StoreTableOrderingComposer,
+    $$StoreTableCreateCompanionBuilder,
+    $$StoreTableUpdateCompanionBuilder,
+    (StoreData, $$StoreTableReferences),
+    StoreData,
+    PrefetchHooks Function({bool listings})>;
 typedef $$ListingTableCreateCompanionBuilder = ListingCompanion Function({
   Value<int> id,
   Value<int?> product,
@@ -4656,47 +5130,35 @@ typedef $$ListingTableUpdateCompanionBuilder = ListingCompanion Function({
   Value<double?> price,
 });
 
-class $$ListingTableTableManager extends RootTableManager<
-    _$TodoDb,
-    $ListingTable,
-    ListingData,
-    $$ListingTableFilterComposer,
-    $$ListingTableOrderingComposer,
-    $$ListingTableCreateCompanionBuilder,
-    $$ListingTableUpdateCompanionBuilder> {
-  $$ListingTableTableManager(_$TodoDb db, $ListingTable table)
-      : super(TableManagerState(
-          db: db,
-          table: table,
-          filteringComposer:
-              $$ListingTableFilterComposer(ComposerState(db, table)),
-          orderingComposer:
-              $$ListingTableOrderingComposer(ComposerState(db, table)),
-          updateCompanionCallback: ({
-            Value<int> id = const Value.absent(),
-            Value<int?> product = const Value.absent(),
-            Value<int?> store = const Value.absent(),
-            Value<double?> price = const Value.absent(),
-          }) =>
-              ListingCompanion(
-            id: id,
-            product: product,
-            store: store,
-            price: price,
-          ),
-          createCompanionCallback: ({
-            Value<int> id = const Value.absent(),
-            Value<int?> product = const Value.absent(),
-            Value<int?> store = const Value.absent(),
-            Value<double?> price = const Value.absent(),
-          }) =>
-              ListingCompanion.insert(
-            id: id,
-            product: product,
-            store: store,
-            price: price,
-          ),
-        ));
+class $$ListingTableReferences
+    extends BaseReferences<_$TodoDb, $ListingTable, ListingData> {
+  $$ListingTableReferences(super.$_db, super.$_table, super.$_typedResult);
+
+  static $ProductTable _productTable(_$TodoDb db) => db.product
+      .createAlias($_aliasNameGenerator(db.listing.product, db.product.id));
+
+  $$ProductTableProcessedTableManager? get product {
+    if ($_item.product == null) return null;
+    final manager = $$ProductTableTableManager($_db, $_db.product)
+        .filter((f) => f.id($_item.product!));
+    final item = $_typedResult.readTableOrNull(_productTable($_db));
+    if (item == null) return manager;
+    return ProcessedTableManager(
+        manager.$state.copyWith(prefetchedData: [item]));
+  }
+
+  static $StoreTable _storeTable(_$TodoDb db) =>
+      db.store.createAlias($_aliasNameGenerator(db.listing.store, db.store.id));
+
+  $$StoreTableProcessedTableManager? get store {
+    if ($_item.store == null) return null;
+    final manager = $$StoreTableTableManager($_db, $_db.store)
+        .filter((f) => f.id($_item.store!));
+    final item = $_typedResult.readTableOrNull(_storeTable($_db));
+    if (item == null) return manager;
+    return ProcessedTableManager(
+        manager.$state.copyWith(prefetchedData: [item]));
+  }
 }
 
 class $$ListingTableFilterComposer
@@ -4775,6 +5237,108 @@ class $$ListingTableOrderingComposer
   }
 }
 
+class $$ListingTableTableManager extends RootTableManager<
+    _$TodoDb,
+    $ListingTable,
+    ListingData,
+    $$ListingTableFilterComposer,
+    $$ListingTableOrderingComposer,
+    $$ListingTableCreateCompanionBuilder,
+    $$ListingTableUpdateCompanionBuilder,
+    (ListingData, $$ListingTableReferences),
+    ListingData,
+    PrefetchHooks Function({bool product, bool store})> {
+  $$ListingTableTableManager(_$TodoDb db, $ListingTable table)
+      : super(TableManagerState(
+          db: db,
+          table: table,
+          filteringComposer:
+              $$ListingTableFilterComposer(ComposerState(db, table)),
+          orderingComposer:
+              $$ListingTableOrderingComposer(ComposerState(db, table)),
+          updateCompanionCallback: ({
+            Value<int> id = const Value.absent(),
+            Value<int?> product = const Value.absent(),
+            Value<int?> store = const Value.absent(),
+            Value<double?> price = const Value.absent(),
+          }) =>
+              ListingCompanion(
+            id: id,
+            product: product,
+            store: store,
+            price: price,
+          ),
+          createCompanionCallback: ({
+            Value<int> id = const Value.absent(),
+            Value<int?> product = const Value.absent(),
+            Value<int?> store = const Value.absent(),
+            Value<double?> price = const Value.absent(),
+          }) =>
+              ListingCompanion.insert(
+            id: id,
+            product: product,
+            store: store,
+            price: price,
+          ),
+          withReferenceMapper: (p0) => p0
+              .map((e) =>
+                  (e.readTable(table), $$ListingTableReferences(db, table, e)))
+              .toList(),
+          prefetchHooksCallback: ({product = false, store = false}) {
+            return PrefetchHooks(
+              addJoins: <
+                  T extends TableManagerState<
+                      dynamic,
+                      dynamic,
+                      dynamic,
+                      dynamic,
+                      dynamic,
+                      dynamic,
+                      dynamic,
+                      dynamic,
+                      dynamic,
+                      dynamic>>(state) {
+                if (product) {
+                  state = state.withJoin(
+                    currentTable: table,
+                    currentColumn: table.product,
+                    referencedTable: $$ListingTableReferences._productTable(db),
+                    referencedColumn:
+                        $$ListingTableReferences._productTable(db).id,
+                  ) as T;
+                }
+                if (store) {
+                  state = state.withJoin(
+                    currentTable: table,
+                    currentColumn: table.store,
+                    referencedTable: $$ListingTableReferences._storeTable(db),
+                    referencedColumn:
+                        $$ListingTableReferences._storeTable(db).id,
+                  ) as T;
+                }
+
+                return state;
+              },
+              withPrefetches: (items) async {
+                return items;
+              },
+            );
+          },
+        ));
+}
+
+typedef $$ListingTableProcessedTableManager = ProcessedTableManager<
+    _$TodoDb,
+    $ListingTable,
+    ListingData,
+    $$ListingTableFilterComposer,
+    $$ListingTableOrderingComposer,
+    $$ListingTableCreateCompanionBuilder,
+    $$ListingTableUpdateCompanionBuilder,
+    (ListingData, $$ListingTableReferences),
+    ListingData,
+    PrefetchHooks Function({bool product, bool store})>;
+
 class $TodoDbManager {
   final _$TodoDb _db;
   $TodoDbManager(this._db);
@@ -4810,7 +5374,7 @@ class AllTodosWithCategoryResult extends CustomResultSet {
   final String? title;
   final String content;
   final DateTime? targetDate;
-  final int? category;
+  final RowId? category;
   final TodoStatus? status;
   final RowId catId;
   final String catDesc;

--- a/drift/test/generated/todos.g.dart
+++ b/drift/test/generated/todos.g.dart
@@ -3591,11 +3591,10 @@ class $$CategoriesTableTableManager extends RootTableManager<
               db: db,
               explicitlyWatchedTables: [if (todos) db.todosTable],
               addJoins: null,
-              prefetchedDataStreamsCallback: (items, {required bool watch}) {
+              getPrefetchedDataCallback: (items) async {
                 return [
                   if (todos)
-                    $_streamPrefetched(
-                        watch: watch,
+                    await $_getPrefetchedData(
                         currentTable: table,
                         referencedTable:
                             $$CategoriesTableReferences._todosTable(db),
@@ -3831,7 +3830,7 @@ class $$TodosTableTableTableManager extends RootTableManager<
 
                 return state;
               },
-              prefetchedDataStreamsCallback: (items, {required bool watch}) {
+              getPrefetchedDataCallback: (items) async {
                 return [];
               },
             );
@@ -4749,11 +4748,10 @@ class $$DepartmentTableTableManager extends RootTableManager<
               db: db,
               explicitlyWatchedTables: [if (productRefs) db.product],
               addJoins: null,
-              prefetchedDataStreamsCallback: (items, {required bool watch}) {
+              getPrefetchedDataCallback: (items) async {
                 return [
                   if (productRefs)
-                    $_streamPrefetched(
-                        watch: watch,
+                    await $_getPrefetchedData(
                         currentTable: table,
                         referencedTable:
                             $$DepartmentTableReferences._productRefsTable(db),
@@ -4963,11 +4961,10 @@ class $$ProductTableTableManager extends RootTableManager<
 
                 return state;
               },
-              prefetchedDataStreamsCallback: (items, {required bool watch}) {
+              getPrefetchedDataCallback: (items) async {
                 return [
                   if (listings)
-                    $_streamPrefetched(
-                        watch: watch,
+                    await $_getPrefetchedData(
                         currentTable: table,
                         referencedTable:
                             $$ProductTableReferences._listingsTable(db),
@@ -5107,11 +5104,10 @@ class $$StoreTableTableManager extends RootTableManager<
               db: db,
               explicitlyWatchedTables: [if (listings) db.listing],
               addJoins: null,
-              prefetchedDataStreamsCallback: (items, {required bool watch}) {
+              getPrefetchedDataCallback: (items) async {
                 return [
                   if (listings)
-                    $_streamPrefetched(
-                        watch: watch,
+                    await $_getPrefetchedData(
                         currentTable: table,
                         referencedTable:
                             $$StoreTableReferences._listingsTable(db),
@@ -5343,7 +5339,7 @@ class $$ListingTableTableManager extends RootTableManager<
 
                 return state;
               },
-              prefetchedDataStreamsCallback: (items, {required bool watch}) {
+              getPrefetchedDataCallback: (items) async {
                 return [];
               },
             );

--- a/drift/test/generated/todos.g.dart
+++ b/drift/test/generated/todos.g.dart
@@ -4999,7 +4999,6 @@ class $$StoreTableReferences
   $$ListingTableProcessedTableManager get listings {
     final manager = $$ListingTableTableManager($_db, $_db.listing)
         .filter((f) => f.store.id($_item.id));
-
     final cache = $_typedResult.readTableOrNull(_listingsTable($_db));
     return ProcessedTableManager(
         manager.$state.copyWith(prefetchedData: cache));

--- a/drift/test/generated/todos.g.dart
+++ b/drift/test/generated/todos.g.dart
@@ -3455,7 +3455,7 @@ typedef $$CategoriesTableUpdateCompanionBuilder = CategoriesCompanion Function({
   Value<CategoryPriority> priority,
 });
 
-class $$CategoriesTableReferences
+final class $$CategoriesTableReferences
     extends BaseReferences<_$TodoDb, $CategoriesTable, Category> {
   $$CategoriesTableReferences(super.$_db, super.$_table, super.$_typedResult);
 
@@ -3636,7 +3636,7 @@ typedef $$TodosTableTableUpdateCompanionBuilder = TodosTableCompanion Function({
   Value<TodoStatus?> status,
 });
 
-class $$TodosTableTableReferences
+final class $$TodosTableTableReferences
     extends BaseReferences<_$TodoDb, $TodosTableTable, TodoEntry> {
   $$TodosTableTableReferences(super.$_db, super.$_table, super.$_typedResult);
 
@@ -4636,7 +4636,7 @@ typedef $$DepartmentTableUpdateCompanionBuilder = DepartmentCompanion Function({
   Value<String?> name,
 });
 
-class $$DepartmentTableReferences
+final class $$DepartmentTableReferences
     extends BaseReferences<_$TodoDb, $DepartmentTable, DepartmentData> {
   $$DepartmentTableReferences(super.$_db, super.$_table, super.$_typedResult);
 
@@ -4782,7 +4782,7 @@ typedef $$ProductTableUpdateCompanionBuilder = ProductCompanion Function({
   Value<int?> department,
 });
 
-class $$ProductTableReferences
+final class $$ProductTableReferences
     extends BaseReferences<_$TodoDb, $ProductTable, ProductData> {
   $$ProductTableReferences(super.$_db, super.$_table, super.$_typedResult);
 
@@ -4989,7 +4989,7 @@ typedef $$StoreTableUpdateCompanionBuilder = StoreCompanion Function({
   Value<String?> name,
 });
 
-class $$StoreTableReferences
+final class $$StoreTableReferences
     extends BaseReferences<_$TodoDb, $StoreTable, StoreData> {
   $$StoreTableReferences(super.$_db, super.$_table, super.$_typedResult);
 
@@ -5132,7 +5132,7 @@ typedef $$ListingTableUpdateCompanionBuilder = ListingCompanion Function({
   Value<double?> price,
 });
 
-class $$ListingTableReferences
+final class $$ListingTableReferences
     extends BaseReferences<_$TodoDb, $ListingTable, ListingData> {
   $$ListingTableReferences(super.$_db, super.$_table, super.$_typedResult);
 

--- a/drift/test/generated/todos.mocks.dart
+++ b/drift/test/generated/todos.mocks.dart
@@ -930,7 +930,8 @@ class MockTodoDb extends _i1.Mock implements _i3.TodoDb {
       ) as _i5.Future<void>);
 
   @override
-  _i5.Stream<T> createStream<T>(_i4.QueryStreamFetcher<T>? stmt) =>
+  _i5.Stream<T> createStream<T extends Object>(
+          _i4.QueryStreamFetcher<T>? stmt) =>
       (super.noSuchMethod(
         Invocation.method(
           #createStream,

--- a/drift/test/generated/todos.mocks.dart
+++ b/drift/test/generated/todos.mocks.dart
@@ -930,17 +930,15 @@ class MockTodoDb extends _i1.Mock implements _i3.TodoDb {
       ) as _i5.Future<void>);
 
   @override
-  _i5.Stream<List<Map<String, Object?>>> createStream(
-          _i4.QueryStreamFetcher? stmt) =>
+  _i5.Stream<T> createStream<T>(_i4.QueryStreamFetcher<T>? stmt) =>
       (super.noSuchMethod(
         Invocation.method(
           #createStream,
           [stmt],
         ),
-        returnValue: _i5.Stream<List<Map<String, Object?>>>.empty(),
-        returnValueForMissingStub:
-            _i5.Stream<List<Map<String, Object?>>>.empty(),
-      ) as _i5.Stream<List<Map<String, Object?>>>);
+        returnValue: _i5.Stream<T>.empty(),
+        returnValueForMissingStub: _i5.Stream<T>.empty(),
+      ) as _i5.Stream<T>);
 
   @override
   T alias<T, D>(

--- a/drift/test/integration_tests/insert_integration_test.dart
+++ b/drift/test/integration_tests/insert_integration_test.dart
@@ -262,7 +262,7 @@ void main() {
       final id = await db.categories
           .insertOne(CategoriesCompanion.insert(description: 'with entry'));
       await db.todosTable.insertOne(TodosTableCompanion.insert(
-          content: 'my content', category: Value(id)));
+          content: 'my content', category: Value(RowId(id))));
 
       final amountOfTodos =
           db.todosTable.id.count(filter: db.todosTable.id.isNotNull());

--- a/drift/test/integration_tests/regress_1894_test.dart
+++ b/drift/test/integration_tests/regress_1894_test.dart
@@ -12,7 +12,7 @@ void main() {
     final nonEmptyId = await db.categories
         .insertOne(CategoriesCompanion.insert(description: 'category'));
     await db.todosTable.insertOne(TodosTableCompanion.insert(
-        content: 'entry', category: Value(nonEmptyId)));
+        content: 'entry', category: Value(RowId(nonEmptyId))));
 
     final emptyId = await db.categories.insertOne(
         CategoriesCompanion.insert(description: 'this category empty YEET'));

--- a/drift/test/integration_tests/regress_2166_test.g.dart
+++ b/drift/test/integration_tests/regress_2166_test.g.dart
@@ -209,41 +209,6 @@ typedef $$_SomeTableTableUpdateCompanionBuilder = _SomeTableCompanion Function({
   Value<String?> name,
 });
 
-class $$_SomeTableTableTableManager extends RootTableManager<
-    _$_SomeDb,
-    $_SomeTableTable,
-    _SomeTableData,
-    $$_SomeTableTableFilterComposer,
-    $$_SomeTableTableOrderingComposer,
-    $$_SomeTableTableCreateCompanionBuilder,
-    $$_SomeTableTableUpdateCompanionBuilder> {
-  $$_SomeTableTableTableManager(_$_SomeDb db, $_SomeTableTable table)
-      : super(TableManagerState(
-          db: db,
-          table: table,
-          filteringComposer:
-              $$_SomeTableTableFilterComposer(ComposerState(db, table)),
-          orderingComposer:
-              $$_SomeTableTableOrderingComposer(ComposerState(db, table)),
-          updateCompanionCallback: ({
-            Value<int> id = const Value.absent(),
-            Value<String?> name = const Value.absent(),
-          }) =>
-              _SomeTableCompanion(
-            id: id,
-            name: name,
-          ),
-          createCompanionCallback: ({
-            Value<int> id = const Value.absent(),
-            Value<String?> name = const Value.absent(),
-          }) =>
-              _SomeTableCompanion.insert(
-            id: id,
-            name: name,
-          ),
-        ));
-}
-
 class $$_SomeTableTableFilterComposer
     extends FilterComposer<_$_SomeDb, $_SomeTableTable> {
   $$_SomeTableTableFilterComposer(super.$state);
@@ -271,6 +236,66 @@ class $$_SomeTableTableOrderingComposer
       builder: (column, joinBuilders) =>
           ColumnOrderings(column, joinBuilders: joinBuilders));
 }
+
+class $$_SomeTableTableTableManager extends RootTableManager<
+    _$_SomeDb,
+    $_SomeTableTable,
+    _SomeTableData,
+    $$_SomeTableTableFilterComposer,
+    $$_SomeTableTableOrderingComposer,
+    $$_SomeTableTableCreateCompanionBuilder,
+    $$_SomeTableTableUpdateCompanionBuilder,
+    (
+      _SomeTableData,
+      BaseReferences<_$_SomeDb, $_SomeTableTable, _SomeTableData>
+    ),
+    _SomeTableData,
+    PrefetchHooks Function()> {
+  $$_SomeTableTableTableManager(_$_SomeDb db, $_SomeTableTable table)
+      : super(TableManagerState(
+          db: db,
+          table: table,
+          filteringComposer:
+              $$_SomeTableTableFilterComposer(ComposerState(db, table)),
+          orderingComposer:
+              $$_SomeTableTableOrderingComposer(ComposerState(db, table)),
+          updateCompanionCallback: ({
+            Value<int> id = const Value.absent(),
+            Value<String?> name = const Value.absent(),
+          }) =>
+              _SomeTableCompanion(
+            id: id,
+            name: name,
+          ),
+          createCompanionCallback: ({
+            Value<int> id = const Value.absent(),
+            Value<String?> name = const Value.absent(),
+          }) =>
+              _SomeTableCompanion.insert(
+            id: id,
+            name: name,
+          ),
+          withReferenceMapper: (p0) => p0
+              .map((e) => (e.readTable(table), BaseReferences(db, table, e)))
+              .toList(),
+          prefetchHooksCallback: null,
+        ));
+}
+
+typedef $$_SomeTableTableProcessedTableManager = ProcessedTableManager<
+    _$_SomeDb,
+    $_SomeTableTable,
+    _SomeTableData,
+    $$_SomeTableTableFilterComposer,
+    $$_SomeTableTableOrderingComposer,
+    $$_SomeTableTableCreateCompanionBuilder,
+    $$_SomeTableTableUpdateCompanionBuilder,
+    (
+      _SomeTableData,
+      BaseReferences<_$_SomeDb, $_SomeTableTable, _SomeTableData>
+    ),
+    _SomeTableData,
+    PrefetchHooks Function()>;
 
 class $_SomeDbManager {
   final _$_SomeDb _db;

--- a/drift/test/integration_tests/select_integration_test.dart
+++ b/drift/test/integration_tests/select_integration_test.dart
@@ -35,7 +35,7 @@ void main() {
     await db.todosTable.insertOne(TodosTableCompanion.insert(
         content: 'some content',
         title: const Value('title'),
-        category: Value(category.id.id)));
+        category: Value(category.id)));
 
     final result = await db.todoWithCategoryView.select().getSingle();
     expect(
@@ -61,9 +61,11 @@ void main() {
       batch.insertAll(
         db.todosTable,
         [
-          TodosTableCompanion.insert(content: 'aaaaa', category: Value(1)),
-          TodosTableCompanion.insert(content: 'aa', category: Value(1)),
-          TodosTableCompanion.insert(content: 'bbbbbb', category: Value(2)),
+          TodosTableCompanion.insert(
+              content: 'aaaaa', category: Value(RowId(1))),
+          TodosTableCompanion.insert(content: 'aa', category: Value(RowId(1))),
+          TodosTableCompanion.insert(
+              content: 'bbbbbb', category: Value(RowId(2))),
         ],
       );
     });

--- a/drift/test/manager/manager_filter_test.dart
+++ b/drift/test/manager/manager_filter_test.dart
@@ -33,49 +33,49 @@ void main() {
 
     // Equals
     expect(
-        db.managers.tableWithEveryColumnType
+        await db.managers.tableWithEveryColumnType
             .filter((f) => f.aReal.equals(5.0))
             .count(),
-        completion(1));
+        1);
     expect(
-        db.managers.tableWithEveryColumnType
+        await db.managers.tableWithEveryColumnType
             .filter((f) => f.aReal(3.0))
             .count(),
-        completion(1));
+        1);
 
     // Not Equals - Exclude null (Default behavior)
     expect(
-        db.managers.tableWithEveryColumnType
+        await db.managers.tableWithEveryColumnType
             .filter((f) => f.aReal.not.equals(5.0))
             .count(),
-        completion(1));
+        1);
 
     // In
     expect(
-        db.managers.tableWithEveryColumnType
+        await db.managers.tableWithEveryColumnType
             .filter((f) => f.aReal.isIn([3.0, 5.0]))
             .count(),
-        completion(2));
+        2);
 
     // Not In
     expect(
-        db.managers.tableWithEveryColumnType
+        await db.managers.tableWithEveryColumnType
             .filter((f) => f.aReal.not.isIn([3.0, 5.0]))
             .count(),
-        completion(0));
+        0);
 
     // Null check
     expect(
-        db.managers.tableWithEveryColumnType
+        await db.managers.tableWithEveryColumnType
             .filter((f) => f.aReal.isNull())
             .count(),
-        completion(1));
+        1);
 
     expect(
-        db.managers.tableWithEveryColumnType
+        await db.managers.tableWithEveryColumnType
             .filter((f) => f.aReal.not.isNull())
             .count(),
-        completion(2));
+        2);
   });
 
   test('manager - query number', () async {
@@ -96,39 +96,39 @@ void main() {
 
     // More than
     expect(
-        db.managers.tableWithEveryColumnType
+        await db.managers.tableWithEveryColumnType
             .filter((f) => f.aReal.isBiggerThan(3.0))
             .count(),
-        completion(1));
+        1);
     expect(
-        db.managers.tableWithEveryColumnType
+        await db.managers.tableWithEveryColumnType
             .filter((f) => f.aReal.isBiggerOrEqualTo(3.0))
             .count(),
-        completion(2));
+        2);
 
     // Less than
     expect(
-        db.managers.tableWithEveryColumnType
+        await db.managers.tableWithEveryColumnType
             .filter((f) => f.aReal.isSmallerThan(5.0))
             .count(),
-        completion(1));
+        1);
     expect(
-        db.managers.tableWithEveryColumnType
+        await db.managers.tableWithEveryColumnType
             .filter((f) => f.aReal.isSmallerOrEqualTo(5.0))
             .count(),
-        completion(2));
+        2);
 
     // Between
     expect(
-        db.managers.tableWithEveryColumnType
+        await db.managers.tableWithEveryColumnType
             .filter((f) => f.aReal.isBetween(3.0, 5.0))
             .count(),
-        completion(2));
+        2);
     expect(
-        db.managers.tableWithEveryColumnType
+        await db.managers.tableWithEveryColumnType
             .filter((f) => f.aReal.not.isBetween(3.0, 5.0))
             .count(),
-        completion(0));
+        0);
   });
 
   test('manager - query string', () async {
@@ -146,48 +146,48 @@ void main() {
 
     // StartsWith
     expect(
-        db.managers.tableWithEveryColumnType
+        await db.managers.tableWithEveryColumnType
             .filter((f) => f.aText.startsWith("that"))
             .count(),
-        completion(2));
+        2);
 
     // EndsWith
     expect(
-        db.managers.tableWithEveryColumnType
+        await db.managers.tableWithEveryColumnType
             .filter((f) => f.aText.endsWith("done"))
             .count(),
-        completion(2));
+        2);
 
     // Contains
     expect(
-        db.managers.tableWithEveryColumnType
+        await db.managers.tableWithEveryColumnType
             .filter((f) => f.aText.contains("math"))
             .count(),
-        completion(2));
+        2);
 
     // Make the database case sensitive
     await db.customStatement('PRAGMA case_sensitive_like = ON');
 
     // StartsWith
     expect(
-        db.managers.tableWithEveryColumnType
+        await db.managers.tableWithEveryColumnType
             .filter((f) => f.aText.startsWith("that", caseInsensitive: false))
             .count(),
-        completion(1));
+        1);
 
     // EndsWith
     expect(
-        db.managers.tableWithEveryColumnType
+        await db.managers.tableWithEveryColumnType
             .filter((f) => f.aText.endsWith("done", caseInsensitive: false))
             .count(),
-        completion(1));
+        1);
 
     // Contains
     expect(
-        db.managers.tableWithEveryColumnType
+        await db.managers.tableWithEveryColumnType
             .filter((f) => f.aText.contains("math", caseInsensitive: false))
             .count(),
-        completion(1));
+        1);
   });
 
   test('manager - query int64', () async {
@@ -208,41 +208,41 @@ void main() {
 
     // More than
     expect(
-        db.managers.tableWithEveryColumnType
+        await db.managers.tableWithEveryColumnType
             .filter((f) => f.anInt64.isBiggerThan(BigInt.from(3.0)))
             .count(),
-        completion(1));
+        1);
     expect(
-        db.managers.tableWithEveryColumnType
+        await db.managers.tableWithEveryColumnType
             .filter((f) => f.anInt64.isBiggerOrEqualTo(BigInt.from(3.0)))
             .count(),
-        completion(2));
+        2);
 
     // Less than
     expect(
-        db.managers.tableWithEveryColumnType
+        await db.managers.tableWithEveryColumnType
             .filter((f) => f.anInt64.isSmallerThan(BigInt.from(5.0)))
             .count(),
-        completion(1));
+        1);
     expect(
-        db.managers.tableWithEveryColumnType
+        await db.managers.tableWithEveryColumnType
             .filter((f) => f.anInt64.isSmallerOrEqualTo(BigInt.from(5.0)))
             .count(),
-        completion(2));
+        2);
 
     // Between
     expect(
-        db.managers.tableWithEveryColumnType
+        await db.managers.tableWithEveryColumnType
             .filter(
                 (f) => f.anInt64.isBetween(BigInt.from(3.0), BigInt.from(5.0)))
             .count(),
-        completion(2));
+        2);
     expect(
-        db.managers.tableWithEveryColumnType
+        await db.managers.tableWithEveryColumnType
             .filter((f) =>
                 f.anInt64.not.isBetween(BigInt.from(3.0), BigInt.from(5.0)))
             .count(),
-        completion(0));
+        0);
   });
 
   test('manager - query bool', () async {
@@ -263,11 +263,11 @@ void main() {
         creationTime: Value(DateTime.now().add(Duration(days: 2)))));
 
     // False
-    expect(db.managers.users.filter((f) => f.isAwesome.isFalse()).count(),
-        completion(1));
+    expect(await db.managers.users.filter((f) => f.isAwesome.isFalse()).count(),
+        1);
     // True
-    expect(db.managers.users.filter((f) => f.isAwesome.isTrue()).count(),
-        completion(2));
+    expect(
+        await db.managers.users.filter((f) => f.isAwesome.isTrue()).count(), 2);
   });
 
   test('manager - query datetime', () async {
@@ -291,39 +291,39 @@ void main() {
 
     // More than
     expect(
-        db.managers.tableWithEveryColumnType
+        await db.managers.tableWithEveryColumnType
             .filter((f) => f.aDateTime.isAfter(day2))
             .count(),
-        completion(1));
+        1);
     expect(
-        db.managers.tableWithEveryColumnType
+        await db.managers.tableWithEveryColumnType
             .filter((f) => f.aDateTime.isAfterOrOn(day2))
             .count(),
-        completion(2));
+        2);
 
     // Less than
     expect(
-        db.managers.tableWithEveryColumnType
+        await db.managers.tableWithEveryColumnType
             .filter((f) => f.aDateTime.isBefore(day2))
             .count(),
-        completion(1));
+        1);
     expect(
-        db.managers.tableWithEveryColumnType
+        await db.managers.tableWithEveryColumnType
             .filter((f) => f.aDateTime.isBeforeOrOn(day2))
             .count(),
-        completion(2));
+        2);
 
     // Between
     expect(
-        db.managers.tableWithEveryColumnType
+        await db.managers.tableWithEveryColumnType
             .filter((f) => f.aDateTime.isBetween(day1, day2))
             .count(),
-        completion(2));
+        2);
     expect(
-        db.managers.tableWithEveryColumnType
+        await db.managers.tableWithEveryColumnType
             .filter((f) => f.aDateTime.not.isBetween(day1, day2))
             .count(),
-        completion(1));
+        1);
   });
 
   test('manager - query custom column', () async {
@@ -344,44 +344,44 @@ void main() {
 
     // Equals
     expect(
-        db.managers.tableWithEveryColumnType
+        await db.managers.tableWithEveryColumnType
             .filter((f) => f.anIntEnum.equals(TodoStatus.open))
             .count(),
-        completion(2));
+        2);
     expect(
-        db.managers.tableWithEveryColumnType
+        await db.managers.tableWithEveryColumnType
             .filter((f) => f.anIntEnum(TodoStatus.open))
             .count(),
-        completion(2));
+        2);
 
     expect(
-        db.managers.tableWithEveryColumnType
+        await db.managers.tableWithEveryColumnType
             .filter((f) => f.anIntEnum.not(TodoStatus.open))
             .count(),
-        completion(2));
+        2);
 
     // Not Equals
     expect(
-        db.managers.tableWithEveryColumnType
+        await db.managers.tableWithEveryColumnType
             .filter((f) => f.anIntEnum.not.equals(TodoStatus.open))
             .count(),
-        completion(2));
+        2);
 
     // In
     expect(
-        db.managers.tableWithEveryColumnType
+        await db.managers.tableWithEveryColumnType
             .filter((f) =>
                 f.anIntEnum.isIn([TodoStatus.open, TodoStatus.workInProgress]))
             .count(),
-        completion(3));
+        3);
 
     // Not In
     expect(
-        db.managers.tableWithEveryColumnType
+        await db.managers.tableWithEveryColumnType
             .filter((f) => f.anIntEnum.not
                 .isIn([TodoStatus.open, TodoStatus.workInProgress]))
             .count(),
-        completion(1));
+        1);
   });
 
   test('manager - multiple filters', () async {
@@ -402,10 +402,10 @@ void main() {
 
     // By default, all filters are AND
     expect(
-        db.managers.tableWithEveryColumnType
+        await db.managers.tableWithEveryColumnType
             .filter((f) => f.aText("person"))
             .filter((f) => f.aReal(5.0))
             .count(),
-        completion(1));
+        1);
   });
 }

--- a/drift/test/manager/manager_order_test.dart
+++ b/drift/test/manager/manager_order_test.dart
@@ -55,14 +55,14 @@ void main() {
         id: Value(RowId(1)),
         content: "Get that english homework done",
         title: Value("English Homework"),
-        category: Value(workCategoryId),
+        category: Value(RowId(workCategoryId)),
         status: Value(TodoStatus.open),
         targetDate: Value(DateTime.now().add(Duration(days: 1, seconds: 15)))));
     await db.managers.todosTable.create((o) => o(
         id: Value(RowId(2)),
         content: "Finish that Book report",
         title: Value("Book Report"),
-        category: Value(workCategoryId),
+        category: Value(RowId(workCategoryId)),
         status: Value(TodoStatus.done),
         targetDate:
             Value(DateTime.now().subtract(Duration(days: 2, seconds: 15)))));
@@ -70,14 +70,14 @@ void main() {
         id: Value(RowId(3)),
         content: "Get that math homework done",
         title: Value("Math Homework"),
-        category: Value(schoolCategoryId),
+        category: Value(RowId(schoolCategoryId)),
         status: Value(TodoStatus.open),
         targetDate: Value(DateTime.now().add(Duration(days: 1, seconds: 10)))));
     await db.managers.todosTable.create((o) => o(
         id: Value(RowId(4)),
         content: "Finish that report",
         title: Value("Report"),
-        category: Value(schoolCategoryId),
+        category: Value(RowId(schoolCategoryId)),
         status: Value(TodoStatus.workInProgress),
         targetDate: Value(DateTime.now().add(Duration(days: 2, seconds: 10)))));
     // Order by related

--- a/drift/test/manager/manager_order_test.dart
+++ b/drift/test/manager/manager_order_test.dart
@@ -32,17 +32,17 @@ void main() {
 
     // Equals
     expect(
-        db.managers.tableWithEveryColumnType
+        await db.managers.tableWithEveryColumnType
             .orderBy((o) => o.aDateTime.desc())
             .get()
             .then((value) => value[0].id),
-        completion(3));
+        3);
     expect(
-        db.managers.tableWithEveryColumnType
+        await db.managers.tableWithEveryColumnType
             .orderBy((o) => o.aDateTime.asc())
             .get()
             .then((value) => value[0].id),
-        completion(1));
+        1);
   });
 
   test('manager - order related', () async {
@@ -82,10 +82,10 @@ void main() {
         targetDate: Value(DateTime.now().add(Duration(days: 2, seconds: 10)))));
     // Order by related
     expect(
-        db.managers.todosTable
+        await db.managers.todosTable
             .orderBy((o) => o.category.id.asc())
             .get()
             .then((value) => value.map((e) => e.id).toList()),
-        completion([3, 4, 1, 2]));
+        [3, 4, 1, 2]);
   });
 }

--- a/drift/test/manager/manager_prefetch_test.dart
+++ b/drift/test/manager/manager_prefetch_test.dart
@@ -316,17 +316,6 @@ void main() {
     expect(await filteredListingWithStore.get(), hasLength(1));
 
     // When filters have joins and we select a referenced field with a join, they should be combined
-    final listingWithStoreAndProductQ = db.managers.listing
-        .filter((f) => f.store.name("Walmart"))
-        .withReferences((o) => o(store: true, inTransaction: false));
-    final stateWithJoinsQ = listingWithStoreAndProductQ.$state.prefetchHooks
-        .withJoins(listingWithStoreAndProductQ.$state);
-    expect(stateWithJoinsQ.joinBuilders, hasLength(1));
-    for (final (listing, refs) in await listingWithStoreAndProductQ.get()) {
-      expect(refs.store?.prefetchedData, isNotNull);
-    }
-
-    // When filters have joins and we select a referenced field with a join, they should be combined
     final listingWithStoreAndProduct = db.managers.listing
         .filter((f) => f.store.name("Walmart"))
         .withReferences((o) => o(store: true));
@@ -345,14 +334,9 @@ void main() {
     }
 
     final prductWuthListingsStream = db.managers.product
-        .withReferences((o) => o(listings: true, inTransaction: true))
+        .withReferences((o) => o(listings: true))
         .watch()
         .map((event) => event.map((e) => e.$2.listings));
     expect(prductWuthListingsStream, emitsInOrder([isNotEmpty]));
-    final prductWuthListingsStreamT = db.managers.product
-        .withReferences((o) => o(listings: true, inTransaction: false))
-        .watch()
-        .map((event) => event.map((e) => e.$2.listings));
-    expect(prductWuthListingsStreamT, emitsInOrder([isNotEmpty]));
   });
 }

--- a/drift/test/manager/manager_prefetch_test.dart
+++ b/drift/test/manager/manager_prefetch_test.dart
@@ -27,6 +27,11 @@ void main() {
         Value<String> title
       })> todoData;
 
+  test("manager - with references tests - foreign key", () async {
+    final storeWithListings =
+        db.managers.store.withReferences((o) => o(listings: true));
+  });
+
   setUp(() async {
     db = TodoDb(testInMemoryDatabase());
     stores = [

--- a/drift/test/manager/manager_prefetch_test.dart
+++ b/drift/test/manager/manager_prefetch_test.dart
@@ -1,0 +1,331 @@
+// ignore_for_file: unused_local_variable
+
+import 'package:drift/drift.dart' hide isNull, isNotNull;
+import 'package:test/test.dart';
+
+import '../generated/todos.dart';
+import '../test_utils/test_utils.dart';
+
+void main() {
+  late TodoDb db;
+  late List<StoreData> stores;
+  late List<DepartmentData> departments;
+  late List<ProductData> products;
+  late List<int> listings;
+  final categoryData = [
+    (description: "School", priority: Value(CategoryPriority.high)),
+    (description: "Work", priority: Value(CategoryPriority.low)),
+  ];
+  late int schoolCategoryId;
+  late int workCategoryId;
+  late List<
+      ({
+        Value<RowId> category,
+        String content,
+        Value<TodoStatus> status,
+        Value<DateTime> targetDate,
+        Value<String> title
+      })> todoData;
+
+  setUp(() async {
+    db = TodoDb(testInMemoryDatabase());
+    stores = [
+      await db.managers.store.createReturning((o) => o(name: Value("Walmart"))),
+      await db.managers.store.createReturning((o) => o(name: Value("Target"))),
+      await db.managers.store.createReturning((o) => o(name: Value("Costco")))
+    ];
+    departments = [
+      await db.managers.department
+          .createReturning((o) => o(name: Value("Electronics"))),
+      await db.managers.department
+          .createReturning((o) => o(name: Value("Grocery"))),
+      await db.managers.department
+          .createReturning((o) => o(name: Value("Clothing")))
+    ];
+    products = [
+      // Electronics
+      await db.managers.product.createReturning(
+          (o) => o(name: Value("TV"), department: Value(departments[0].id))),
+      await db.managers.product.createReturning((o) =>
+          o(name: Value("Cell Phone"), department: Value(departments[0].id))),
+      await db.managers.product.createReturning((o) =>
+          o(name: Value("Charger"), department: Value(departments[0].id))),
+      // Grocery
+      await db.managers.product.createReturning((o) =>
+          o(name: Value("Cereal"), department: Value(departments[1].id))),
+      await db.managers.product.createReturning(
+          (o) => o(name: Value("Meat"), department: Value(departments[1].id))),
+      // Clothing
+      await db.managers.product.createReturning(
+          (o) => o(name: Value("Shirt"), department: Value(departments[2].id))),
+      await db.managers.product.createReturning(
+          (o) => o(name: Value("Pants"), department: Value(departments[2].id))),
+      await db.managers.product.createReturning(
+          (o) => o(name: Value("Socks"), department: Value(departments[2].id))),
+      await db.managers.product.createReturning(
+          (o) => o(name: Value("Cap"), department: Value(departments[2].id)))
+    ];
+    listings = [
+      // Walmart - Electronics
+      await db.managers.listing.create((o) => o(
+          product: Value(products[0].id),
+          store: Value(stores[0].id),
+          price: Value(100.0))),
+      await db.managers.listing.create((o) => o(
+          product: Value(products[1].id),
+          store: Value(stores[0].id),
+          price: Value(200.0))),
+      await db.managers.listing.create((o) => o(
+          product: Value(products[2].id),
+          store: Value(stores[0].id),
+          price: Value(10.0))),
+
+      // Walmart - Grocery
+      await db.managers.listing.create((o) => o(
+          product: Value(products[3].id),
+          store: Value(stores[0].id),
+          price: Value(5.0))),
+      await db.managers.listing.create((o) => o(
+          product: Value(products[4].id),
+          store: Value(stores[0].id),
+          price: Value(15.0))),
+
+      // Walmart - Clothing
+      await db.managers.listing.create((o) => o(
+          product: Value(products[5].id),
+          store: Value(stores[0].id),
+          price: Value(20.0))),
+      await db.managers.listing.create((o) => o(
+          product: Value(products[6].id),
+          store: Value(stores[0].id),
+          price: Value(30.0))),
+      await db.managers.listing.create((o) => o(
+          product: Value(products[7].id),
+          store: Value(stores[0].id),
+          price: Value(5.0))),
+      await db.managers.listing.create((o) => o(
+          product: Value(products[8].id),
+          store: Value(stores[0].id),
+          price: Value(10.0))),
+
+      // Target - Electronics
+
+      // Target does not have any TVs
+      // But is otherwise cheaper on electronics
+      // await db.managers.listing.create((o) => o(
+      //     product: Value(products[0].id),
+      //     store: Value(stores[0].id),
+      //     price: Value(100.0))),
+      await db.managers.listing.create((o) => o(
+          product: Value(products[1].id),
+          store: Value(stores[1].id),
+          price: Value(150.0))),
+      await db.managers.listing.create((o) => o(
+          product: Value(products[2].id),
+          store: Value(stores[1].id),
+          price: Value(15.0))),
+
+      // Target - Grocery
+
+      // More expensive groceries
+      await db.managers.listing.create((o) => o(
+          product: Value(products[3].id),
+          store: Value(stores[1].id),
+          price: Value(10.0))),
+      await db.managers.listing.create((o) => o(
+          product: Value(products[4].id),
+          store: Value(stores[1].id),
+          price: Value(20.0))),
+
+      // Target - Clothing
+
+      // Does not have any shirts or pants
+      // await db.managers.listing.create((o) => o(
+      //     product: Value(products[5].id),
+      //     store: Value(stores[1].id),
+      //     price: Value(20.0))),
+      // await db.managers.listing.create((o) => o(
+      //     product: Value(products[6].id),
+      //     store: Value(stores[1].id),
+      //     price: Value(30.0))),
+      await db.managers.listing.create((o) => o(
+          product: Value(products[7].id),
+          store: Value(stores[1].id),
+          price: Value(5.0))),
+      await db.managers.listing.create((o) => o(
+          product: Value(products[8].id),
+          store: Value(stores[1].id),
+          price: Value(10.0))),
+
+      // Costco - Electronics
+      // Much cheaper electronics
+      await db.managers.listing.create((o) => o(
+          product: Value(products[0].id),
+          store: Value(stores[2].id),
+          price: Value(50.0))),
+      await db.managers.listing.create((o) => o(
+          product: Value(products[1].id),
+          store: Value(stores[2].id),
+          price: Value(100.0))),
+      await db.managers.listing.create((o) => o(
+          product: Value(products[2].id),
+          store: Value(stores[2].id),
+          price: Value(2.50))),
+
+      // Costco - Grocery
+
+      // More expensive groceries
+      await db.managers.listing.create((o) => o(
+          product: Value(products[3].id),
+          store: Value(stores[2].id),
+          price: Value(20.0))),
+      await db.managers.listing.create((o) => o(
+          product: Value(products[4].id),
+          store: Value(stores[2].id),
+          price: Value(900.0))),
+    ];
+    schoolCategoryId = await db.managers.categories.create((o) => o(
+        priority: categoryData[0].priority,
+        description: categoryData[0].description));
+    workCategoryId = await db.managers.categories.create((o) => o(
+        priority: categoryData[1].priority,
+        description: categoryData[1].description));
+
+    todoData = [
+      // School
+      (
+        content: "Get that math homework done",
+        title: Value("Math Homework"),
+        category: Value(RowId(schoolCategoryId)),
+        status: Value(TodoStatus.open),
+        targetDate: Value(DateTime.now().add(Duration(days: 1, seconds: 10)))
+      ),
+      (
+        content: "Finish that report",
+        title: Value("Report"),
+        category: Value(RowId(schoolCategoryId)),
+        status: Value(TodoStatus.workInProgress),
+        targetDate: Value(DateTime.now().add(Duration(days: 2, seconds: 10)))
+      ),
+      (
+        content: "Get that english homework done",
+        title: Value("English Homework"),
+        category: Value(RowId(schoolCategoryId)),
+        status: Value(TodoStatus.open),
+        targetDate: Value(DateTime.now().add(Duration(days: 1, seconds: 15)))
+      ),
+      (
+        content: "Finish that Book report",
+        title: Value("Book Report"),
+        category: Value(RowId(schoolCategoryId)),
+        status: Value(TodoStatus.done),
+        targetDate:
+            Value(DateTime.now().subtract(Duration(days: 2, seconds: 15)))
+      ),
+      // Work
+      (
+        content: "File those reports",
+        title: Value("File Reports"),
+        category: Value(RowId(workCategoryId)),
+        status: Value(TodoStatus.open),
+        targetDate: Value(DateTime.now().add(Duration(days: 1, seconds: 20)))
+      ),
+      (
+        content: "Clean the office",
+        title: Value("Clean Office"),
+        category: Value(RowId(workCategoryId)),
+        status: Value(TodoStatus.workInProgress),
+        targetDate: Value(DateTime.now().add(Duration(days: 2, seconds: 20)))
+      ),
+      (
+        content: "Nail that presentation",
+        title: Value("Presentation"),
+        category: Value(RowId(workCategoryId)),
+        status: Value(TodoStatus.open),
+        targetDate: Value(DateTime.now().add(Duration(days: 1, seconds: 25)))
+      ),
+      (
+        content: "Take a break",
+        title: Value("Break"),
+        category: Value(RowId(workCategoryId)),
+        status: Value(TodoStatus.done),
+        targetDate:
+            Value(DateTime.now().subtract(Duration(days: 2, seconds: 25)))
+      ),
+      // Items with no category
+      (
+        content: "Get Whiteboard",
+        title: Value("Whiteboard"),
+        status: Value(TodoStatus.open),
+        targetDate: Value(DateTime.now().add(Duration(days: 1, seconds: 50))),
+        category: Value.absent(),
+      ),
+      (
+        category: Value.absent(),
+        content: "Drink Water",
+        title: Value("Water"),
+        status: Value(TodoStatus.workInProgress),
+        targetDate: Value(DateTime.now().add(Duration(days: 2, seconds: 50)))
+      ),
+    ];
+    for (var i in todoData) {
+      await db.managers.todosTable.create((o) => o(
+          content: i.content,
+          title: i.title,
+          category: i.category,
+          status: i.status,
+          targetDate: i.targetDate));
+    }
+  });
+
+  tearDown(() => db.close());
+
+  test('manager - with references tests', () async {
+    // Get reverse references
+    final storeWithListings =
+        db.managers.store.withReferences((o) => o(listings: true));
+    for (final (store, refs) in await storeWithListings.get()) {
+      expect(refs.listings.prefetchedData, isNotEmpty);
+    }
+    final storeWithoutListings =
+        db.managers.store.withReferences((o) => o(listings: false));
+    for (final (store, refs) in await storeWithoutListings.get()) {
+      expect(refs.listings.prefetchedData, isNull);
+    }
+    // Get reverse references with filters
+    final filteredStoreWithListings = db.managers.store
+        .filter((f) => f.id(1))
+        .withReferences((o) => o(listings: true));
+    expect(await filteredStoreWithListings.get(), hasLength(1));
+
+    // Forwards references
+    final listingWithStore =
+        db.managers.listing.withReferences((o) => o(store: true));
+    for (final (listing, refs) in await listingWithStore.get()) {
+      expect(refs.store!.prefetchedData, hasLength(1));
+    }
+    final listingWithoutStore =
+        db.managers.listing.withReferences((o) => o(store: false));
+    for (final (listing, refs) in await listingWithoutStore.get()) {
+      expect(refs.store?.prefetchedData, isNull);
+    }
+    // Forwards references with filters
+    final filteredListingWithStore = db.managers.listing
+        .filter((f) => f.id(1))
+        .withReferences((o) => o(store: true));
+    expect(await filteredListingWithStore.get(), hasLength(1));
+
+    // When filters have joins and we select a referenced field with a join, they should be combined
+    final listingWithStoreAndProduct = db.managers.listing
+        .filter(
+          (f) => f.store.name("Walmart"),
+        )
+        .withReferences((o) => o(store: true));
+    final stateWithJoins = listingWithStoreAndProduct.$state.prefetchHooks
+        .withJoins(listingWithStoreAndProduct.$state);
+    expect(stateWithJoins.joinBuilders, hasLength(1));
+    for (final (listing, refs) in await listingWithStoreAndProduct.get()) {
+      expect(refs.store?.prefetchedData, isNotNull);
+    }
+  });
+}

--- a/drift/test/manager/manager_prefetch_test.dart
+++ b/drift/test/manager/manager_prefetch_test.dart
@@ -186,6 +186,74 @@ void main() {
     }
   });
 
+  test("manager - with references tests - watch ", () async {
+    final departmentsData = [
+      (name: "Electronics", id: 1),
+      (name: "Clothing", id: 2),
+      (name: "Books", id: 3)
+    ];
+    final productsData = [
+      (name: "TV", department: 1, id: 1),
+      (name: "Shirt", department: 2, id: 2),
+      (name: "Book", department: 3, id: 3),
+      (name: "Another Book", department: 3, id: 4),
+    ];
+    final listingsData = [
+      (product: 1, store: 1, price: 100.0),
+      (product: 2, store: 1, price: 50.0),
+      (product: 3, store: 2, price: 20.0),
+      (product: 4, store: 3, price: 10.0),
+    ];
+    final storesData = [
+      (name: "Walmart", id: 1),
+      (name: "Target", id: 2),
+      (name: "Costco", id: 3)
+    ];
+    await db.managers.product.bulkCreate(
+      (o) {
+        return productsData.map((e) => o(
+            name: Value(e.name),
+            department: Value(e.department),
+            id: Value(e.id)));
+      },
+    );
+    await db.managers.department.bulkCreate(
+      (o) {
+        return departmentsData
+            .map((e) => o(name: Value(e.name), id: Value(e.id)));
+      },
+    );
+    await db.managers.store.bulkCreate(
+      (o) {
+        return storesData.map((e) => o(name: Value(e.name), id: Value(e.id)));
+      },
+    );
+    await db.managers.listing.bulkCreate(
+      (o) {
+        return listingsData.map((e) => o(
+            product: Value(e.product),
+            store: Value(e.store),
+            price: Value(e.price)));
+      },
+    );
+
+    List<(ProductData, $$ProductTableReferences)>? products;
+    final stream = db.managers.product
+        .withReferences(
+            (prefetch) => prefetch(department: true, listings: true))
+        .watch()
+        .listen(
+          (event) {},
+        );
+    await Future.delayed(const Duration(milliseconds: 100));
+    // await pumpEventQueue(times: 1000);
+    // expect(products, isNotNull);
+    // for (final (product, refs) in products!) {
+    //   expect(refs.department?.prefetchedData, allOf(isNotEmpty, hasLength(1)));
+    //   expect(refs.listings.prefetchedData, allOf(isNotEmpty));
+    // }
+  });
+
   setUp(() async {
     db = TodoDb(testInMemoryDatabase());
   });

--- a/drift/test/manager/manager_prefetch_test.dart
+++ b/drift/test/manager/manager_prefetch_test.dart
@@ -316,6 +316,17 @@ void main() {
     expect(await filteredListingWithStore.get(), hasLength(1));
 
     // When filters have joins and we select a referenced field with a join, they should be combined
+    final listingWithStoreAndProductQ = db.managers.listing
+        .filter((f) => f.store.name("Walmart"))
+        .withReferences((o) => o(store: true, inTransaction: false));
+    final stateWithJoinsQ = listingWithStoreAndProductQ.$state.prefetchHooks
+        .withJoins(listingWithStoreAndProductQ.$state);
+    expect(stateWithJoinsQ.joinBuilders, hasLength(1));
+    for (final (listing, refs) in await listingWithStoreAndProductQ.get()) {
+      expect(refs.store?.prefetchedData, isNotNull);
+    }
+
+    // When filters have joins and we select a referenced field with a join, they should be combined
     final listingWithStoreAndProduct = db.managers.listing
         .filter((f) => f.store.name("Walmart"))
         .withReferences((o) => o(store: true));
@@ -334,9 +345,14 @@ void main() {
     }
 
     final prductWuthListingsStream = db.managers.product
-        .withReferences((o) => o(listings: true))
+        .withReferences((o) => o(listings: true, inTransaction: true))
         .watch()
         .map((event) => event.map((e) => e.$2.listings));
     expect(prductWuthListingsStream, emitsInOrder([isNotEmpty]));
+    final prductWuthListingsStreamT = db.managers.product
+        .withReferences((o) => o(listings: true, inTransaction: false))
+        .watch()
+        .map((event) => event.map((e) => e.$2.listings));
+    expect(prductWuthListingsStreamT, emitsInOrder([isNotEmpty]));
   });
 }

--- a/drift/test/manager/manager_prefetch_test.dart
+++ b/drift/test/manager/manager_prefetch_test.dart
@@ -317,9 +317,7 @@ void main() {
 
     // When filters have joins and we select a referenced field with a join, they should be combined
     final listingWithStoreAndProduct = db.managers.listing
-        .filter(
-          (f) => f.store.name("Walmart"),
-        )
+        .filter((f) => f.store.name("Walmart"))
         .withReferences((o) => o(store: true));
     final stateWithJoins = listingWithStoreAndProduct.$state.prefetchHooks
         .withJoins(listingWithStoreAndProduct.$state);
@@ -327,5 +325,18 @@ void main() {
     for (final (listing, refs) in await listingWithStoreAndProduct.get()) {
       expect(refs.store?.prefetchedData, isNotNull);
     }
+
+    final prductWuthListings = await db.managers.product
+        .withReferences((o) => o(listings: true))
+        .get();
+    for (final (product, refs) in prductWuthListings) {
+      expect(refs.listings.prefetchedData, isNotEmpty);
+    }
+
+    final prductWuthListingsStream = db.managers.product
+        .withReferences((o) => o(listings: true))
+        .watch()
+        .map((event) => event.map((e) => e.$2.listings));
+    expect(prductWuthListingsStream, emitsInOrder([isNotEmpty]));
   });
 }

--- a/drift/test/manager/manager_referenced_filter_test.dart
+++ b/drift/test/manager/manager_referenced_filter_test.dart
@@ -61,76 +61,76 @@ void main() {
     // Filter on related table's reference id - Does not require a join
     ComposableFilter? filter;
     expect(
-        db.managers.product.filter((f) {
+        await db.managers.product.filter((f) {
           filter = f.department.id(departments[0].id);
           return filter!;
         }).count(),
-        completion(3));
+        3);
     expect(filter?.joinBuilders.length, 0);
 
     // Filter on a unrelated column on a related table - Requires a join
     expect(
-        db.managers.product.filter((f) {
+        await db.managers.product.filter((f) {
           filter = f.department.name("Electronics");
           return filter!;
         }).count(),
-        completion(3));
+        3);
     expect(filter?.joinBuilders.length, 1);
 
     // Filter on a unrelated column on a related table & on
     // a related table's reference id - Requires a join
     expect(
-        db.managers.product.filter((f) {
+        await db.managers.product.filter((f) {
           filter = f.department.name("Electronics") |
               f.department.id(departments[1].id);
           return filter!;
         }).count(),
-        completion(5));
+        5);
     expect(filter?.joinBuilders.length, 1);
 
     // Ordering on current table & Filtering on related table
     expect(
-        db.managers.product
+        await db.managers.product
             .filter((f) => f.department.name("Electronics"))
             .orderBy((f) => f.name.asc())
             .get(),
-        completion([
+        [
           products[1],
           products[2],
           products[0],
-        ]));
+        ]);
 
     // Ordering on related table & Filtering on current table
     expect(
-        db.managers.product
+        await db.managers.product
             .filter((f) => f.name.startsWith("c"))
             .orderBy((f) => f.department.name.asc() & f.name.desc())
             .get(),
-        completion([
+        [
           products[8],
           products[2],
           products[1],
           products[3],
-        ]));
+        ]);
 
     // Filtering on reverse related table
     expect(
         // Any product that is available for more than $10
         // Socks & Cap are excluded
-        db.managers.product
+        await db.managers.product
             .filter((f) => f.listings((f) => f.price.isBiggerThan(10.0)))
             .count(distinct: true),
-        completion(7));
+        7);
 
     // Filtering on reverse related table with ordering
     expect(
         // Any product that is available for more than $10
         // Socks & Cap are excluded, and the rest are ordered by name
-        db.managers.product
+        await db.managers.product
             .filter((f) => f.listings((f) => f.price.isBiggerThan(10.0)))
             .orderBy((f) => f.name.asc())
             .get(distinct: true),
-        completion([
+        [
           products[1],
           products[3],
           products[2],
@@ -138,76 +138,76 @@ void main() {
           products[6],
           products[5],
           products[0],
-        ]));
+        ]);
 
     // Filter on reverse related column and then a related column
     expect(
-        db.managers.product.filter((f) {
+        await db.managers.product.filter((f) {
           filter = f.listings((f) => f.store.name("Target"));
           return filter!;
         }).count(),
-        completion(6));
+        6);
     expect(filter?.joinBuilders.length, 2);
     expect(
-        db.managers.product.filter((f) {
+        await db.managers.product.filter((f) {
           filter = f.listings((f) => f.store.name("Target")) | f.name("TV");
           return filter!;
         }).count(),
-        completion(7));
+        7);
     expect(filter?.joinBuilders.length, 2);
 
     // Filter on a related column and then a related column
     expect(
-        db.managers.listing.filter((f) {
+        await db.managers.listing.filter((f) {
           // Listings of products in the electronics department
           filter = f.product.department.name("Electronics");
           return filter!;
         }).count(),
-        completion(8));
+        8);
     expect(
-        db.managers.listing.filter((f) {
+        await db.managers.listing.filter((f) {
           // Listings of products in the electronics department
           filter = f.product.department.name("Electronics") |
               f.price.isBiggerThan(150.0);
           return filter!;
         }).count(),
-        completion(9));
+        9);
 
     // Filter on a reverse related column and then a reverse related column
     expect(
-        db.managers.department.filter((f) {
+        await db.managers.department.filter((f) {
           // Departments that have products listed for more than $10
           filter = f.productRefs(
               (f) => f.listings((f) => f.price.isBiggerThan(100.0)));
           return filter!;
         }).count(),
-        completion(2));
+        2);
     expect(
-        db.managers.department.filter((f) {
+        await db.managers.department.filter((f) {
           // Departments that have products listed for more than $10 or is available at Walmart
           filter = f.productRefs((f) => f.listings(
               (f) => f.price.isBiggerThan(100.0) | f.store.name("Walmart")));
           return filter!;
         }).count(),
-        completion(3));
+        3);
 
     // Stores that have products in the clothing department
     expect(
-        db.managers.store.filter((f) {
+        await db.managers.store.filter((f) {
           // Products that are sold in a store that sells clothing
           filter = f.listings((f) => f.product.department.name("Clothing"));
           return filter!;
         }).count(),
-        completion(2));
+        2);
 
     // Any product that is sold in a store that sells clothing
     expect(
-        db.managers.product.filter((f) {
+        await db.managers.product.filter((f) {
           filter = f.listings((f) =>
               f.store.listings((f) => f.product.department.name("Clothing")));
           return filter!;
         }).count(distinct: true),
-        completion(9));
+        9);
   });
 
   test('manager - filter related with custom type for primary key', () async {
@@ -215,56 +215,56 @@ void main() {
 
     // Equals
     expect(
-        db.managers.todosTable
+        await db.managers.todosTable
             .filter((f) => f.category.id(_todoCategoryData[0].id))
             .count(),
-        completion(4));
+        4);
 
     // Not Equals
     expect(
-        db.managers.todosTable
+        await db.managers.todosTable
             .filter((f) => f.category.id.not(_todoCategoryData[0].id))
             .count(),
-        completion(4));
+        4);
 
     // Multiple filters
     expect(
-        db.managers.todosTable
+        await db.managers.todosTable
             .filter((f) => f.category.id(
                   _todoCategoryData[0].id,
                 ))
             .filter((f) => f.status.equals(TodoStatus.open))
             .count(),
-        completion(2));
+        2);
 
     // Multiple use related filters twice
     expect(
-        db.managers.todosTable
+        await db.managers.todosTable
             .filter((f) =>
                 f.category.priority(CategoryPriority.low) |
                 f.category.descriptionInUpperCase("SCHOOL"))
             .count(),
-        completion(8));
+        8);
 
     // Use .filter multiple times
     expect(
-        db.managers.todosTable
+        await db.managers.todosTable
             .filter((f) => f.category.priority.equals(CategoryPriority.high))
             .filter((f) => f.category.descriptionInUpperCase("SCHOOL"))
             .count(),
-        completion(4));
+        4);
 
     // Use backreference
     expect(
-        db.managers.categories
+        await db.managers.categories
             .filter((f) => f.todos((f) => f.title.equals("Math Homework")))
             .getSingle()
             .then((value) => value.description),
-        completion("School"));
+        "School");
 
     // Nested backreference
     expect(
-        db.managers.categories
+        await db.managers.categories
             .filter((f) => f.todos((f) {
                   final q =
                       f.category.todos((f) => f.title.equals("Math Homework"));
@@ -272,14 +272,14 @@ void main() {
                 }))
             .getSingle()
             .then((value) => value.description),
-        completion("School"));
+        "School");
   });
 
   test('manager - filter related with regualar id with references', () async {
     // Filter on related table's reference id - Does not require a join
     ComposableFilter? filter;
     expect(
-        db.managers.product
+        await db.managers.product
             .filter((f) {
               filter = f.department.id(departments[0].id);
               return filter!;
@@ -287,12 +287,12 @@ void main() {
             .withReferences()
             .get(distinct: true)
             .then((value) => value.length),
-        completion(3));
+        3);
     expect(filter?.joinBuilders.length, 0);
 
     // Filter on a unrelated column on a related table - Requires a join
     expect(
-        db.managers.product
+        await db.managers.product
             .filter((f) {
               filter = f.department.name("Electronics");
               return filter!;
@@ -300,13 +300,13 @@ void main() {
             .withReferences()
             .get(distinct: true)
             .then((value) => value.length),
-        completion(3));
+        3);
     expect(filter?.joinBuilders.length, 1);
 
     // Filter on a unrelated column on a related table & on
     // a related table's reference id - Requires a join
     expect(
-        db.managers.product
+        await db.managers.product
             .filter((f) {
               filter = f.department.name("Electronics") |
                   f.department.id(departments[1].id);
@@ -315,60 +315,60 @@ void main() {
             .withReferences()
             .get(distinct: true)
             .then((value) => value.length),
-        completion(5));
+        5);
     expect(filter?.joinBuilders.length, 1);
 
     // Ordering on current table & Filtering on related table
     expect(
-        db.managers.product
+        await db.managers.product
             .filter((f) => f.department.name("Electronics"))
             .orderBy((f) => f.name.asc())
             .withReferences()
             .get()
             .then((value) => value.map((e) => e.$1).toList()),
-        completion([
+        [
           products[1],
           products[2],
           products[0],
-        ]));
+        ]);
 
     // Ordering on related table & Filtering on current table
     expect(
-        db.managers.product
+        await db.managers.product
             .filter((f) => f.name.startsWith("c"))
             .orderBy((f) => f.department.name.asc() & f.name.desc())
             .withReferences()
             .get()
             .then((value) => value.map((e) => e.$1).toList()),
-        completion([
+        [
           products[8],
           products[2],
           products[1],
           products[3],
-        ]));
+        ]);
 
     // Filtering on reverse related table
     expect(
         // Any product that is available for more than $10
         // Socks & Cap are excluded
-        db.managers.product
+        await db.managers.product
             .filter((f) => f.listings((f) => f.price.isBiggerThan(10.0)))
             .withReferences()
             .get(distinct: true)
             .then((value) => value.length),
-        completion(7));
+        7);
 
     // Filtering on reverse related table with ordering
     expect(
         // Any product that is available for more than $10
         // Socks & Cap are excluded, and the rest are ordered by name
-        db.managers.product
+        await db.managers.product
             .filter((f) => f.listings((f) => f.price.isBiggerThan(10.0)))
             .orderBy((f) => f.name.asc())
             .withReferences()
             .get(distinct: true)
             .then((value) => value.map((e) => e.$1).toList()),
-        completion([
+        [
           products[1],
           products[3],
           products[2],
@@ -376,11 +376,11 @@ void main() {
           products[6],
           products[5],
           products[0],
-        ]));
+        ]);
 
     // Filter on reverse related column and then a related column
     expect(
-        db.managers.product
+        await db.managers.product
             .filter((f) {
               filter = f.listings((f) => f.store.name("Target"));
               return filter!;
@@ -388,10 +388,10 @@ void main() {
             .withReferences()
             .get(distinct: true)
             .then((value) => value.length),
-        completion(6));
+        6);
     expect(filter?.joinBuilders.length, 2);
     expect(
-        db.managers.product
+        await db.managers.product
             .filter((f) {
               filter = f.listings((f) => f.store.name("Target")) | f.name("TV");
               return filter!;
@@ -399,12 +399,12 @@ void main() {
             .withReferences()
             .get(distinct: true)
             .then((value) => value.length),
-        completion(7));
+        7);
     expect(filter?.joinBuilders.length, 2);
 
     // Filter on a related column and then a related column
     expect(
-        db.managers.listing
+        await db.managers.listing
             .filter((f) {
               // Listings of products in the electronics department
               filter = f.product.department.name("Electronics");
@@ -413,9 +413,9 @@ void main() {
             .withReferences()
             .get(distinct: true)
             .then((value) => value.length),
-        completion(8));
+        8);
     expect(
-        db.managers.listing
+        await db.managers.listing
             .filter((f) {
               // Listings of products in the electronics department
               filter = f.product.department.name("Electronics") |
@@ -425,11 +425,11 @@ void main() {
             .withReferences()
             .get(distinct: true)
             .then((value) => value.length),
-        completion(9));
+        9);
 
     // Filter on a reverse related column and then a reverse related column
     expect(
-        db.managers.department
+        await db.managers.department
             .filter((f) {
               // Departments that have products listed for more than $10
               filter = f.productRefs(
@@ -439,9 +439,9 @@ void main() {
             .withReferences()
             .get(distinct: true)
             .then((value) => value.length),
-        completion(2));
+        2);
     expect(
-        db.managers.department
+        await db.managers.department
             .filter((f) {
               // Departments that have products listed for more than $10 or is available at Walmart
               filter = f.productRefs((f) => f.listings((f) =>
@@ -451,11 +451,11 @@ void main() {
             .withReferences()
             .get(distinct: true)
             .then((value) => value.length),
-        completion(3));
+        3);
 
     // Stores that have products in the clothing department
     expect(
-        db.managers.store
+        await db.managers.store
             .filter((f) {
               // Products that are sold in a store that sells clothing
               filter = f.listings((f) => f.product.department.name("Clothing"));
@@ -464,11 +464,11 @@ void main() {
             .withReferences()
             .get(distinct: true)
             .then((value) => value.length),
-        completion(2));
+        2);
 
     // Any product that is sold in a store that sells clothing
     expect(
-        db.managers.product
+        await db.managers.product
             .filter((f) {
               filter = f.listings((f) => f.store
                   .listings((f) => f.product.department.name("Clothing")));
@@ -477,7 +477,7 @@ void main() {
             .withReferences()
             .get(distinct: true)
             .then((value) => value.length),
-        completion(9));
+        9);
   });
 
   test(
@@ -485,25 +485,25 @@ void main() {
       () async {
     // Equals
     expect(
-        db.managers.todosTable
+        await db.managers.todosTable
             .filter((f) => f.category.id(_todoCategoryData[0].id))
             .withReferences()
             .get(distinct: true)
             .then((value) => value.length),
-        completion(4));
+        4);
 
     // Not Equals
     expect(
-        db.managers.todosTable
+        await db.managers.todosTable
             .filter((f) => f.category.id.not(_todoCategoryData[0].id))
             .withReferences()
             .get(distinct: true)
             .then((value) => value.length),
-        completion(4));
+        4);
 
     // Multiple filters
     expect(
-        db.managers.todosTable
+        await db.managers.todosTable
             .filter((f) => f.category.id(
                   _todoCategoryData[0].id,
                 ))
@@ -511,41 +511,41 @@ void main() {
             .withReferences()
             .get(distinct: true)
             .then((value) => value.length),
-        completion(2));
+        2);
 
     // Multiple use related filters twice
     expect(
-        db.managers.todosTable
+        await db.managers.todosTable
             .filter((f) =>
                 f.category.priority(CategoryPriority.low) |
                 f.category.descriptionInUpperCase("SCHOOL"))
             .withReferences()
             .get(distinct: true)
             .then((value) => value.length),
-        completion(8));
+        8);
 
     // Use .filter multiple times
     expect(
-        db.managers.todosTable
+        await db.managers.todosTable
             .filter((f) => f.category.priority.equals(CategoryPriority.high))
             .filter((f) => f.category.descriptionInUpperCase("SCHOOL"))
             .withReferences()
             .get(distinct: true)
             .then((value) => value.length),
-        completion(4));
+        4);
 
     // Use backreference
     expect(
-        db.managers.categories
+        await db.managers.categories
             .filter((f) => f.todos((f) => f.title.equals("Math Homework")))
             .withReferences()
             .getSingle()
             .then((value) => value.$1.description),
-        completion("School"));
+        "School");
 
     // Nested backreference
     expect(
-        db.managers.categories
+        await db.managers.categories
             .filter((f) => f.todos((f) {
                   final q =
                       f.category.todos((f) => f.title.equals("Math Homework"));
@@ -554,13 +554,13 @@ void main() {
             .withReferences()
             .getSingle()
             .then((value) => value.$1.description),
-        completion("School"));
+        "School");
   });
 
   test('manager - with references tests', () async {
     // Get department for the 1st product
     expect(
-        db.managers.product
+        await db.managers.product
             .withReferences()
             .get(distinct: true)
             .then((value) =>
@@ -568,15 +568,15 @@ void main() {
             .then(
               (value) => value?.id,
             ),
-        completion(departments[0].id));
+        departments[0].id);
 
     // Get the amount of products in the 1st department
     expect(
-        db.managers.department
+        await db.managers.department
             .withReferences()
             .get(distinct: true)
             .then((value) => value.first.$2.productRefs.count()),
-        completion(3));
+        3);
 
     // Get all the products with all their listings
     final listingsWithProducts = <ProductData, List<ListingData>>{};
@@ -601,12 +601,12 @@ void main() {
 
     // Get the amount of products in the department id 2
     expect(
-        db.managers.department
+        await db.managers.department
             .filter((f) => f.id.equals(2))
             .withReferences()
             .getSingle()
             .then((value) => value.$2.productRefs.count()),
-        completion(2));
+        2);
   });
 }
 

--- a/drift/test/manager/manager_referenced_filter_test.dart
+++ b/drift/test/manager/manager_referenced_filter_test.dart
@@ -1,6 +1,9 @@
 // ignore_for_file: unused_local_variable
 
+import 'dart:async';
+
 import 'package:drift/drift.dart';
+import 'package:drift/src/utils/async.dart';
 import 'package:test/test.dart';
 
 import '../generated/todos.dart';
@@ -8,193 +11,53 @@ import '../test_utils/test_utils.dart';
 
 void main() {
   late TodoDb db;
+  late List<StoreData> stores;
+  late List<DepartmentData> departments;
+  late List<ProductData> products;
+  late List<ListingData> listings;
 
-  setUp(() {
+  setUp(() async {
     db = TodoDb(testInMemoryDatabase());
+    stores = await _storeData.mapAsyncAndAwait((p0) => db.managers.store
+        .createReturning((o) => o(name: Value(p0.name), id: Value(p0.id))));
+
+    departments = await _departmentData.mapAsyncAndAwait(
+      (p0) => db.managers.department
+          .createReturning((o) => o(name: Value(p0.name), id: Value(p0.id))),
+    );
+
+    products = await _productData.mapAsyncAndAwait(
+      (p0) => db.managers.product.createReturning(
+          (o) => o(name: p0.name, department: p0.department, id: Value(p0.id))),
+    );
+
+    listings = await _listingsData.mapAsyncAndAwait(
+      (p0) => db.managers.listing.createReturning((o) => o(
+          product: Value(p0.product),
+          store: Value(p0.store),
+          price: Value(p0.price))),
+    );
+
+    final categories =
+        await _todoCategoryData.mapAsyncAndAwait((categoryData) async {
+      await db.managers.categories.createReturning((o) => o(
+          priority: categoryData.priority,
+          id: Value(categoryData.id),
+          description: categoryData.description));
+    });
+    final todos = await _todosData.mapAsyncAndAwait((todoData) async {
+      await db.managers.todosTable.createReturning((o) => o(
+          content: todoData.content,
+          title: todoData.title,
+          category: todoData.category,
+          status: todoData.status,
+          targetDate: todoData.targetDate));
+    });
   });
 
   tearDown(() => db.close());
 
   test('manager - filter related with regualar id', () async {
-    final stores = [
-      await db.managers.store.createReturning((o) => o(name: Value("Walmart"))),
-      await db.managers.store.createReturning((o) => o(name: Value("Target"))),
-      await db.managers.store.createReturning((o) => o(name: Value("Costco")))
-    ];
-
-    final departments = [
-      await db.managers.department
-          .createReturning((o) => o(name: Value("Electronics"))),
-      await db.managers.department
-          .createReturning((o) => o(name: Value("Grocery"))),
-      await db.managers.department
-          .createReturning((o) => o(name: Value("Clothing")))
-    ];
-
-    final products = [
-      // Electronics
-      await db.managers.product.createReturning(
-          (o) => o(name: Value("TV"), department: Value(departments[0].id))),
-      await db.managers.product.createReturning((o) =>
-          o(name: Value("Cell Phone"), department: Value(departments[0].id))),
-      await db.managers.product.createReturning((o) =>
-          o(name: Value("Charger"), department: Value(departments[0].id))),
-      // Grocery
-      await db.managers.product.createReturning((o) =>
-          o(name: Value("Cereal"), department: Value(departments[1].id))),
-      await db.managers.product.createReturning(
-          (o) => o(name: Value("Meat"), department: Value(departments[1].id))),
-      // Clothing
-      await db.managers.product.createReturning(
-          (o) => o(name: Value("Shirt"), department: Value(departments[2].id))),
-      await db.managers.product.createReturning(
-          (o) => o(name: Value("Pants"), department: Value(departments[2].id))),
-      await db.managers.product.createReturning(
-          (o) => o(name: Value("Socks"), department: Value(departments[2].id))),
-      await db.managers.product.createReturning(
-          (o) => o(name: Value("Cap"), department: Value(departments[2].id)))
-    ];
-
-    final listings = [
-      // Walmart - Electronics
-      await db.managers.listing.create((o) => o(
-          product: Value(products[0].id),
-          store: Value(stores[0].id),
-          price: Value(100.0))),
-      await db.managers.listing.create((o) => o(
-          product: Value(products[1].id),
-          store: Value(stores[0].id),
-          price: Value(200.0))),
-      await db.managers.listing.create((o) => o(
-          product: Value(products[2].id),
-          store: Value(stores[0].id),
-          price: Value(10.0))),
-
-      // Walmart - Grocery
-      await db.managers.listing.create((o) => o(
-          product: Value(products[3].id),
-          store: Value(stores[0].id),
-          price: Value(5.0))),
-      await db.managers.listing.create((o) => o(
-          product: Value(products[4].id),
-          store: Value(stores[0].id),
-          price: Value(15.0))),
-
-      // Walmart - Clothing
-      await db.managers.listing.create((o) => o(
-          product: Value(products[5].id),
-          store: Value(stores[0].id),
-          price: Value(20.0))),
-      await db.managers.listing.create((o) => o(
-          product: Value(products[6].id),
-          store: Value(stores[0].id),
-          price: Value(30.0))),
-      await db.managers.listing.create((o) => o(
-          product: Value(products[7].id),
-          store: Value(stores[0].id),
-          price: Value(5.0))),
-      await db.managers.listing.create((o) => o(
-          product: Value(products[8].id),
-          store: Value(stores[0].id),
-          price: Value(10.0))),
-
-      // Target - Electronics
-
-      // Target does not have any TVs
-      // But is otherwise cheaper on electronics
-      // await db.managers.listing.create((o) => o(
-      //     product: Value(products[0].id),
-      //     store: Value(stores[0].id),
-      //     price: Value(100.0))),
-      await db.managers.listing.create((o) => o(
-          product: Value(products[1].id),
-          store: Value(stores[1].id),
-          price: Value(150.0))),
-      await db.managers.listing.create((o) => o(
-          product: Value(products[2].id),
-          store: Value(stores[1].id),
-          price: Value(15.0))),
-
-      // Target - Grocery
-
-      // More expensive groceries
-      await db.managers.listing.create((o) => o(
-          product: Value(products[3].id),
-          store: Value(stores[1].id),
-          price: Value(10.0))),
-      await db.managers.listing.create((o) => o(
-          product: Value(products[4].id),
-          store: Value(stores[1].id),
-          price: Value(20.0))),
-
-      // Target - Clothing
-
-      // Does not have any shirts or pants
-      // await db.managers.listing.create((o) => o(
-      //     product: Value(products[5].id),
-      //     store: Value(stores[1].id),
-      //     price: Value(20.0))),
-      // await db.managers.listing.create((o) => o(
-      //     product: Value(products[6].id),
-      //     store: Value(stores[1].id),
-      //     price: Value(30.0))),
-      await db.managers.listing.create((o) => o(
-          product: Value(products[7].id),
-          store: Value(stores[1].id),
-          price: Value(5.0))),
-      await db.managers.listing.create((o) => o(
-          product: Value(products[8].id),
-          store: Value(stores[1].id),
-          price: Value(10.0))),
-
-      // Costco - Electronics
-      // Much cheaper electronics
-      await db.managers.listing.create((o) => o(
-          product: Value(products[0].id),
-          store: Value(stores[2].id),
-          price: Value(50.0))),
-      await db.managers.listing.create((o) => o(
-          product: Value(products[1].id),
-          store: Value(stores[2].id),
-          price: Value(100.0))),
-      await db.managers.listing.create((o) => o(
-          product: Value(products[2].id),
-          store: Value(stores[2].id),
-          price: Value(2.50))),
-
-      // Costco - Grocery
-
-      // More expensive groceries
-      await db.managers.listing.create((o) => o(
-          product: Value(products[3].id),
-          store: Value(stores[2].id),
-          price: Value(20.0))),
-      await db.managers.listing.create((o) => o(
-          product: Value(products[4].id),
-          store: Value(stores[2].id),
-          price: Value(900.0))),
-
-      // Costco - Clothing
-
-      // Does not have any clothing
-      // await db.managers.listing.create((o) => o(
-      //     product: Value(products[5].id),
-      //     store: Value(stores[0].id),
-      //     price: Value(20.0))),
-      // await db.managers.listing.create((o) => o(
-      //     product: Value(products[6].id),
-      //     store: Value(stores[0].id),
-      //     price: Value(30.0))),
-      // await db.managers.listing.create((o) => o(
-      //     product: Value(products[7].id),
-      //     store: Value(stores[0].id),
-      //     price: Value(5.0))),
-      // await db.managers.listing.create((o) => o(
-      //     product: Value(products[8].id),
-      //     store: Value(stores[0].id),
-      //     price: Value(10.0))),
-    ];
-
     // Filter on related table's reference id - Does not require a join
     ComposableFilter? filter;
     expect(
@@ -348,124 +211,19 @@ void main() {
   });
 
   test('manager - filter related with custom type for primary key', () async {
-    final categoryData = [
-      (description: "School", priority: Value(CategoryPriority.high)),
-      (description: "Work", priority: Value(CategoryPriority.low)),
-    ];
-
-    final schoolCategoryId = await db.managers.categories.create((o) => o(
-        priority: categoryData[0].priority,
-        description: categoryData[0].description));
-    final workCategoryId = await db.managers.categories.create((o) => o(
-        priority: categoryData[1].priority,
-        description: categoryData[1].description));
-
-    final todoData = <({
-      Value<int> category,
-      String content,
-      Value<TodoStatus> status,
-      Value<DateTime> targetDate,
-      Value<String> title
-    })>[
-      // School
-      (
-        content: "Get that math homework done",
-        title: Value("Math Homework"),
-        category: Value(schoolCategoryId),
-        status: Value(TodoStatus.open),
-        targetDate: Value(DateTime.now().add(Duration(days: 1, seconds: 10)))
-      ),
-      (
-        content: "Finish that report",
-        title: Value("Report"),
-        category: Value(schoolCategoryId),
-        status: Value(TodoStatus.workInProgress),
-        targetDate: Value(DateTime.now().add(Duration(days: 2, seconds: 10)))
-      ),
-      (
-        content: "Get that english homework done",
-        title: Value("English Homework"),
-        category: Value(schoolCategoryId),
-        status: Value(TodoStatus.open),
-        targetDate: Value(DateTime.now().add(Duration(days: 1, seconds: 15)))
-      ),
-      (
-        content: "Finish that Book report",
-        title: Value("Book Report"),
-        category: Value(schoolCategoryId),
-        status: Value(TodoStatus.done),
-        targetDate:
-            Value(DateTime.now().subtract(Duration(days: 2, seconds: 15)))
-      ),
-      // Work
-      (
-        content: "File those reports",
-        title: Value("File Reports"),
-        category: Value(workCategoryId),
-        status: Value(TodoStatus.open),
-        targetDate: Value(DateTime.now().add(Duration(days: 1, seconds: 20)))
-      ),
-      (
-        content: "Clean the office",
-        title: Value("Clean Office"),
-        category: Value(workCategoryId),
-        status: Value(TodoStatus.workInProgress),
-        targetDate: Value(DateTime.now().add(Duration(days: 2, seconds: 20)))
-      ),
-      (
-        content: "Nail that presentation",
-        title: Value("Presentation"),
-        category: Value(workCategoryId),
-        status: Value(TodoStatus.open),
-        targetDate: Value(DateTime.now().add(Duration(days: 1, seconds: 25)))
-      ),
-      (
-        content: "Take a break",
-        title: Value("Break"),
-        category: Value(workCategoryId),
-        status: Value(TodoStatus.done),
-        targetDate:
-            Value(DateTime.now().subtract(Duration(days: 2, seconds: 25)))
-      ),
-      // Items with no category
-      (
-        content: "Get Whiteboard",
-        title: Value("Whiteboard"),
-        status: Value(TodoStatus.open),
-        targetDate: Value(DateTime.now().add(Duration(days: 1, seconds: 50))),
-        category: Value.absent(),
-      ),
-      (
-        category: Value.absent(),
-        content: "Drink Water",
-        title: Value("Water"),
-        status: Value(TodoStatus.workInProgress),
-        targetDate: Value(DateTime.now().add(Duration(days: 2, seconds: 50)))
-      ),
-    ];
-
-    for (var i in todoData) {
-      await db.managers.todosTable.create((o) => o(
-          content: i.content,
-          title: i.title,
-          category: i.category,
-          status: i.status,
-          targetDate: i.targetDate));
-    }
-
     // item without title
 
     // Equals
     expect(
         db.managers.todosTable
-            .filter((f) => f.category.id(RowId(schoolCategoryId)))
+            .filter((f) => f.category.id(_todoCategoryData[0].id))
             .count(),
         completion(4));
 
     // Not Equals
     expect(
         db.managers.todosTable
-            .filter((f) => f.category.id.not(RowId(schoolCategoryId)))
+            .filter((f) => f.category.id.not(_todoCategoryData[0].id))
             .count(),
         completion(4));
 
@@ -473,7 +231,7 @@ void main() {
     expect(
         db.managers.todosTable
             .filter((f) => f.category.id(
-                  RowId(schoolCategoryId),
+                  _todoCategoryData[0].id,
                 ))
             .filter((f) => f.status.equals(TodoStatus.open))
             .count(),
@@ -516,4 +274,478 @@ void main() {
             .then((value) => value.description),
         completion("School"));
   });
+
+  test('manager - filter related with regualar id with references', () async {
+    // Filter on related table's reference id - Does not require a join
+    ComposableFilter? filter;
+    expect(
+        db.managers.product
+            .filter((f) {
+              filter = f.department.id(departments[0].id);
+              return filter!;
+            })
+            .withReferences()
+            .get(distinct: true)
+            .then((value) => value.length),
+        completion(3));
+    expect(filter?.joinBuilders.length, 0);
+
+    // Filter on a unrelated column on a related table - Requires a join
+    expect(
+        db.managers.product
+            .filter((f) {
+              filter = f.department.name("Electronics");
+              return filter!;
+            })
+            .withReferences()
+            .get(distinct: true)
+            .then((value) => value.length),
+        completion(3));
+    expect(filter?.joinBuilders.length, 1);
+
+    // Filter on a unrelated column on a related table & on
+    // a related table's reference id - Requires a join
+    expect(
+        db.managers.product
+            .filter((f) {
+              filter = f.department.name("Electronics") |
+                  f.department.id(departments[1].id);
+              return filter!;
+            })
+            .withReferences()
+            .get(distinct: true)
+            .then((value) => value.length),
+        completion(5));
+    expect(filter?.joinBuilders.length, 1);
+
+    // Ordering on current table & Filtering on related table
+    expect(
+        db.managers.product
+            .filter((f) => f.department.name("Electronics"))
+            .orderBy((f) => f.name.asc())
+            .withReferences()
+            .get()
+            .then((value) => value.map((e) => e.$1).toList()),
+        completion([
+          products[1],
+          products[2],
+          products[0],
+        ]));
+
+    // Ordering on related table & Filtering on current table
+    expect(
+        db.managers.product
+            .filter((f) => f.name.startsWith("c"))
+            .orderBy((f) => f.department.name.asc() & f.name.desc())
+            .withReferences()
+            .get()
+            .then((value) => value.map((e) => e.$1).toList()),
+        completion([
+          products[8],
+          products[2],
+          products[1],
+          products[3],
+        ]));
+
+    // Filtering on reverse related table
+    expect(
+        // Any product that is available for more than $10
+        // Socks & Cap are excluded
+        db.managers.product
+            .filter((f) => f.listings((f) => f.price.isBiggerThan(10.0)))
+            .withReferences()
+            .get(distinct: true)
+            .then((value) => value.length),
+        completion(7));
+
+    // Filtering on reverse related table with ordering
+    expect(
+        // Any product that is available for more than $10
+        // Socks & Cap are excluded, and the rest are ordered by name
+        db.managers.product
+            .filter((f) => f.listings((f) => f.price.isBiggerThan(10.0)))
+            .orderBy((f) => f.name.asc())
+            .withReferences()
+            .get(distinct: true)
+            .then((value) => value.map((e) => e.$1).toList()),
+        completion([
+          products[1],
+          products[3],
+          products[2],
+          products[4],
+          products[6],
+          products[5],
+          products[0],
+        ]));
+
+    // Filter on reverse related column and then a related column
+    expect(
+        db.managers.product
+            .filter((f) {
+              filter = f.listings((f) => f.store.name("Target"));
+              return filter!;
+            })
+            .withReferences()
+            .get(distinct: true)
+            .then((value) => value.length),
+        completion(6));
+    expect(filter?.joinBuilders.length, 2);
+    expect(
+        db.managers.product
+            .filter((f) {
+              filter = f.listings((f) => f.store.name("Target")) | f.name("TV");
+              return filter!;
+            })
+            .withReferences()
+            .get(distinct: true)
+            .then((value) => value.length),
+        completion(7));
+    expect(filter?.joinBuilders.length, 2);
+
+    // Filter on a related column and then a related column
+    expect(
+        db.managers.listing
+            .filter((f) {
+              // Listings of products in the electronics department
+              filter = f.product.department.name("Electronics");
+              return filter!;
+            })
+            .withReferences()
+            .get(distinct: true)
+            .then((value) => value.length),
+        completion(8));
+    expect(
+        db.managers.listing
+            .filter((f) {
+              // Listings of products in the electronics department
+              filter = f.product.department.name("Electronics") |
+                  f.price.isBiggerThan(150.0);
+              return filter!;
+            })
+            .withReferences()
+            .get(distinct: true)
+            .then((value) => value.length),
+        completion(9));
+
+    // Filter on a reverse related column and then a reverse related column
+    expect(
+        db.managers.department
+            .filter((f) {
+              // Departments that have products listed for more than $10
+              filter = f.productRefs(
+                  (f) => f.listings((f) => f.price.isBiggerThan(100.0)));
+              return filter!;
+            })
+            .withReferences()
+            .get(distinct: true)
+            .then((value) => value.length),
+        completion(2));
+    expect(
+        db.managers.department
+            .filter((f) {
+              // Departments that have products listed for more than $10 or is available at Walmart
+              filter = f.productRefs((f) => f.listings((f) =>
+                  f.price.isBiggerThan(100.0) | f.store.name("Walmart")));
+              return filter!;
+            })
+            .withReferences()
+            .get(distinct: true)
+            .then((value) => value.length),
+        completion(3));
+
+    // Stores that have products in the clothing department
+    expect(
+        db.managers.store
+            .filter((f) {
+              // Products that are sold in a store that sells clothing
+              filter = f.listings((f) => f.product.department.name("Clothing"));
+              return filter!;
+            })
+            .withReferences()
+            .get(distinct: true)
+            .then((value) => value.length),
+        completion(2));
+
+    // Any product that is sold in a store that sells clothing
+    expect(
+        db.managers.product
+            .filter((f) {
+              filter = f.listings((f) => f.store
+                  .listings((f) => f.product.department.name("Clothing")));
+              return filter!;
+            })
+            .withReferences()
+            .get(distinct: true)
+            .then((value) => value.length),
+        completion(9));
+  });
+
+  test(
+      'manager - filter related with custom type for primary key with references',
+      () async {
+    // Equals
+    expect(
+        db.managers.todosTable
+            .filter((f) => f.category.id(_todoCategoryData[0].id))
+            .withReferences()
+            .get(distinct: true)
+            .then((value) => value.length),
+        completion(4));
+
+    // Not Equals
+    expect(
+        db.managers.todosTable
+            .filter((f) => f.category.id.not(_todoCategoryData[0].id))
+            .withReferences()
+            .get(distinct: true)
+            .then((value) => value.length),
+        completion(4));
+
+    // Multiple filters
+    expect(
+        db.managers.todosTable
+            .filter((f) => f.category.id(
+                  _todoCategoryData[0].id,
+                ))
+            .filter((f) => f.status.equals(TodoStatus.open))
+            .withReferences()
+            .get(distinct: true)
+            .then((value) => value.length),
+        completion(2));
+
+    // Multiple use related filters twice
+    expect(
+        db.managers.todosTable
+            .filter((f) =>
+                f.category.priority(CategoryPriority.low) |
+                f.category.descriptionInUpperCase("SCHOOL"))
+            .withReferences()
+            .get(distinct: true)
+            .then((value) => value.length),
+        completion(8));
+
+    // Use .filter multiple times
+    expect(
+        db.managers.todosTable
+            .filter((f) => f.category.priority.equals(CategoryPriority.high))
+            .filter((f) => f.category.descriptionInUpperCase("SCHOOL"))
+            .withReferences()
+            .get(distinct: true)
+            .then((value) => value.length),
+        completion(4));
+
+    // Use backreference
+    expect(
+        db.managers.categories
+            .filter((f) => f.todos((f) => f.title.equals("Math Homework")))
+            .withReferences()
+            .getSingle()
+            .then((value) => value.$1.description),
+        completion("School"));
+
+    // Nested backreference
+    expect(
+        db.managers.categories
+            .filter((f) => f.todos((f) {
+                  final q =
+                      f.category.todos((f) => f.title.equals("Math Homework"));
+                  return q;
+                }))
+            .withReferences()
+            .getSingle()
+            .then((value) => value.$1.description),
+        completion("School"));
+  });
+
+  test('manager - with references tests', () async {
+    // Get department for the 1st product
+    expect(
+        db.managers.product
+            .withReferences()
+            .get(distinct: true)
+            .then((value) =>
+                value.first.$2.department?.getSingle() ?? Future.value(null))
+            .then(
+              (value) => value?.id,
+            ),
+        completion(departments[0].id));
+
+    // Get the amount of products in the 1st department
+    expect(
+        db.managers.department
+            .withReferences()
+            .get(distinct: true)
+            .then((value) => value.first.$2.productRefs.count()),
+        completion(3));
+
+    // Get all the products with all their listings
+    final listingsWithProducts = <ProductData, List<ListingData>>{};
+    for (final i
+        in await db.managers.listing.withReferences().get(distinct: true)) {
+      final product = await i.$2.product?.getSingle();
+      if (product != null) {
+        if (!listingsWithProducts.containsKey(product)) {
+          listingsWithProducts[product] = [i.$1];
+        } else {
+          listingsWithProducts[product]!.add(i.$1);
+        }
+      }
+    }
+    expect(listingsWithProducts.length, 9);
+    expect(
+        listingsWithProducts.entries.fold(
+          0,
+          (i, o) => i + o.value.length,
+        ),
+        20);
+
+    // Get the amount of products in the department id 2
+    expect(
+        db.managers.department
+            .filter((f) => f.id.equals(2))
+            .withReferences()
+            .getSingle()
+            .then((value) => value.$2.productRefs.count()),
+        completion(2));
+  });
 }
+
+const _todoCategoryData = [
+  (description: "School", priority: Value(CategoryPriority.high), id: RowId(1)),
+  (description: "Work", priority: Value(CategoryPriority.low), id: RowId(2)),
+];
+
+const _storeData = [
+  (name: "Walmart", id: 1),
+  (name: "Target", id: 2),
+  (name: "Costco", id: 3),
+];
+
+const _departmentData = [
+  (name: "Electronics", id: 1),
+  (name: "Grocery", id: 2),
+  (name: "Clothing", id: 3),
+];
+
+final _productData = [
+  (name: Value("TV"), department: Value(_departmentData[0].id), id: 1),
+  (name: Value("Cell Phone"), department: Value(_departmentData[0].id), id: 2),
+  (name: Value("Charger"), department: Value(_departmentData[0].id), id: 3),
+  (name: Value("Cereal"), department: Value(_departmentData[1].id), id: 4),
+  (name: Value("Meat"), department: Value(_departmentData[1].id), id: 5),
+  (name: Value("Shirt"), department: Value(_departmentData[2].id), id: 6),
+  (name: Value("Pants"), department: Value(_departmentData[2].id), id: 7),
+  (name: Value("Socks"), department: Value(_departmentData[2].id), id: 8),
+  (name: Value("Cap"), department: Value(_departmentData[2].id), id: 9),
+];
+final _listingsData = [
+  // Walmart - Electronics
+  (product: 1, store: 1, price: 100.0),
+  (product: 2, store: 1, price: 200.0),
+  (product: 3, store: 1, price: 10.0),
+  // Walmart - Grocery
+  (product: 4, store: 1, price: 5.0),
+  (product: 5, store: 1, price: 15.0),
+  // Walmart - Clothing
+  (product: 6, store: 1, price: 20.0),
+  (product: 7, store: 1, price: 30.0),
+  (product: 8, store: 1, price: 5.0),
+  (product: 9, store: 1, price: 10.0),
+  // Target - Electronics
+  (product: 2, store: 2, price: 150.0),
+  (product: 3, store: 2, price: 15.0),
+  // Target - Grocery
+  (product: 4, store: 2, price: 10.0),
+  (product: 5, store: 2, price: 20.0),
+  // Target - Clothing
+  (product: 8, store: 2, price: 5.0),
+  (product: 9, store: 2, price: 10.0),
+  // Costco - Electronics
+  (product: 1, store: 3, price: 50.0),
+  (product: 2, store: 3, price: 100.0),
+  (product: 3, store: 3, price: 2.50),
+  // Costco - Grocery
+  (product: 4, store: 3, price: 20.0),
+  (product: 5, store: 3, price: 900.0),
+];
+final _todosData = <({
+  Value<RowId> category,
+  String content,
+  Value<TodoStatus> status,
+  Value<DateTime> targetDate,
+  Value<String> title
+})>[
+  // School
+  (
+    content: "Get that math homework done",
+    title: Value("Math Homework"),
+    category: Value(_todoCategoryData[0].id),
+    status: Value(TodoStatus.open),
+    targetDate: Value(DateTime.now().add(Duration(days: 1, seconds: 10)))
+  ),
+  (
+    content: "Finish that report",
+    title: Value("Report"),
+    category: Value(_todoCategoryData[0].id),
+    status: Value(TodoStatus.workInProgress),
+    targetDate: Value(DateTime.now().add(Duration(days: 2, seconds: 10)))
+  ),
+  (
+    content: "Get that english homework done",
+    title: Value("English Homework"),
+    category: Value(_todoCategoryData[0].id),
+    status: Value(TodoStatus.open),
+    targetDate: Value(DateTime.now().add(Duration(days: 1, seconds: 15)))
+  ),
+  (
+    content: "Finish that Book report",
+    title: Value("Book Report"),
+    category: Value(_todoCategoryData[0].id),
+    status: Value(TodoStatus.done),
+    targetDate: Value(DateTime.now().subtract(Duration(days: 2, seconds: 15)))
+  ),
+  // Work
+  (
+    content: "File those reports",
+    title: Value("File Reports"),
+    category: Value(_todoCategoryData[1].id),
+    status: Value(TodoStatus.open),
+    targetDate: Value(DateTime.now().add(Duration(days: 1, seconds: 20)))
+  ),
+  (
+    content: "Clean the office",
+    title: Value("Clean Office"),
+    category: Value(_todoCategoryData[1].id),
+    status: Value(TodoStatus.workInProgress),
+    targetDate: Value(DateTime.now().add(Duration(days: 2, seconds: 20)))
+  ),
+  (
+    content: "Nail that presentation",
+    title: Value("Presentation"),
+    category: Value(_todoCategoryData[1].id),
+    status: Value(TodoStatus.open),
+    targetDate: Value(DateTime.now().add(Duration(days: 1, seconds: 25)))
+  ),
+  (
+    content: "Take a break",
+    title: Value("Break"),
+    category: Value(_todoCategoryData[1].id),
+    status: Value(TodoStatus.done),
+    targetDate: Value(DateTime.now().subtract(Duration(days: 2, seconds: 25)))
+  ),
+  // Items with no category
+  (
+    content: "Get Whiteboard",
+    title: Value("Whiteboard"),
+    status: Value(TodoStatus.open),
+    targetDate: Value(DateTime.now().add(Duration(days: 1, seconds: 50))),
+    category: Value.absent(),
+  ),
+  (
+    category: Value.absent(),
+    content: "Drink Water",
+    title: Value("Water"),
+    status: Value(TodoStatus.workInProgress),
+    targetDate: Value(DateTime.now().add(Duration(days: 2, seconds: 50)))
+  ),
+];

--- a/drift/test/manager/manager_selectable_test.dart
+++ b/drift/test/manager/manager_selectable_test.dart
@@ -1,0 +1,131 @@
+// ignore_for_file: unused_local_variable
+
+import 'package:drift/drift.dart';
+import 'package:drift/src/utils/async.dart';
+import 'package:test/test.dart';
+
+import '../generated/todos.dart';
+import '../test_utils/test_utils.dart';
+
+/// All managers `Managers` are Selectable classes that
+/// are used by the Manager API to return results.
+/// This test will ensure that they all behave as expected, no matter what filters/ordering/limit/offsets/references are applied.
+
+void main() {
+  late TodoDb db;
+
+  setUp(() {
+    db = TodoDb(testInMemoryDatabase());
+  });
+
+  tearDown(() => db.close());
+
+  test('manager - selectable tests', () async {
+    final stores = await _storeData.mapAsyncAndAwait((p0) => db.managers.store
+        .createReturning((o) => o(name: Value(p0.name), id: Value(p0.id))));
+
+    final departments = await _departmentData.mapAsyncAndAwait(
+      (p0) => db.managers.department
+          .createReturning((o) => o(name: Value(p0.name), id: Value(p0.id))),
+    );
+
+    final products = await _productData.mapAsyncAndAwait(
+      (p0) => db.managers.product.createReturning(
+          (o) => o(name: p0.name, department: p0.department, id: Value(p0.id))),
+    );
+
+    final listings = await _listingsData.mapAsyncAndAwait(
+      (p0) => db.managers.listing.createReturning((o) => o(
+          product: Value(p0.product),
+          store: Value(p0.store),
+          price: Value(p0.price))),
+    );
+
+    final getAllStores = db.managers.store;
+    final getAllStoresWithFilter =
+        db.managers.store.filter((f) => f.id.not(10));
+    final getAllStoresWithOrdering =
+        db.managers.store.orderBy((f) => f.id.asc());
+    final getAllStoresWithFilterAndOrdering = db.managers.store
+        .filter((f) => f.id.not(10))
+        .orderBy((f) => f.id.asc());
+    final getAllStoresWithFilterAndOrderingWithReferences = db.managers.store
+        .filter((f) => f.id.not(10))
+        .orderBy((f) => f.id.asc())
+        .withReferences();
+
+    Future testManager<T, M>(
+        BaseTableManager<dynamic, dynamic, T, dynamic, dynamic, dynamic,
+                dynamic, M, T, dynamic>
+            selectable) async {
+      expect(await selectable.get(), hasLength(3));
+      expect(await selectable.get(limit: 1), hasLength(1));
+      expect(await selectable.get(offset: 1, limit: 2), hasLength(2));
+      expect(await selectable.get(offset: 1, limit: 2), hasLength(2));
+    }
+
+    for (final selectable in <BaseTableManager>[
+      getAllStores,
+      getAllStoresWithFilter,
+      getAllStoresWithOrdering,
+      getAllStoresWithFilterAndOrdering,
+      getAllStoresWithFilterAndOrderingWithReferences,
+    ]) {
+      await testManager(selectable);
+    }
+  });
+}
+
+const _storeData = [
+  (name: "Walmart", id: 1),
+  (name: "Target", id: 2),
+  (name: "Costco", id: 3),
+];
+
+const _departmentData = [
+  (name: "Electronics", id: 1),
+  (name: "Grocery", id: 2),
+  (name: "Clothing", id: 3),
+];
+
+final _productData = [
+  (name: Value("TV"), department: Value(_departmentData[0].id), id: 1),
+  (name: Value("Cell Phone"), department: Value(_departmentData[0].id), id: 2),
+  (name: Value("Charger"), department: Value(_departmentData[0].id), id: 3),
+  (name: Value("Cereal"), department: Value(_departmentData[1].id), id: 4),
+  (name: Value("Meat"), department: Value(_departmentData[1].id), id: 5),
+  (name: Value("Shirt"), department: Value(_departmentData[2].id), id: 6),
+  (name: Value("Pants"), department: Value(_departmentData[2].id), id: 7),
+  (name: Value("Socks"), department: Value(_departmentData[2].id), id: 8),
+  (name: Value("Cap"), department: Value(_departmentData[2].id), id: 9),
+];
+final _listingsData = [
+  // Walmart - Electronics
+  (product: 1, store: 1, price: 100.0),
+  (product: 2, store: 1, price: 200.0),
+  (product: 3, store: 1, price: 10.0),
+  // Walmart - Grocery
+  (product: 4, store: 1, price: 5.0),
+  (product: 5, store: 1, price: 15.0),
+  // Walmart - Clothing
+  (product: 6, store: 1, price: 20.0),
+  (product: 7, store: 1, price: 30.0),
+  (product: 8, store: 1, price: 5.0),
+  (product: 9, store: 1, price: 10.0),
+  // Target - Electronics
+  (product: 2, store: 2, price: 150.0),
+  (product: 3, store: 2, price: 15.0),
+  // Target - Grocery
+  (product: 4, store: 2, price: 10.0),
+  (product: 5, store: 2, price: 20.0),
+  // Target - Clothing
+  (product: 8, store: 2, price: 5.0),
+  (product: 9, store: 2, price: 10.0),
+  // Costco - Electronics
+  (product: 1, store: 3, price: 50.0),
+  (product: 2, store: 3, price: 100.0),
+  (product: 3, store: 3, price: 2.50),
+  // Costco - Grocery
+  (product: 4, store: 3, price: 20.0),
+  (product: 5, store: 3, price: 900.0),
+];

--- a/drift/test/manager/manager_test.dart
+++ b/drift/test/manager/manager_test.dart
@@ -18,19 +18,19 @@ void main() {
 
   test('manager - create', () async {
     // Initial count should be 0
-    expect(db.managers.categories.count(), completion(0));
+    expect(await db.managers.categories.count(), 0);
 
     // Creating a row should return the id
     final create1 = db.managers.categories.create(
         (o) => o(priority: Value(CategoryPriority.high), description: "High"));
-    expect(create1, completion(1));
-    expect(db.managers.categories.count(), completion(1));
+    expect(await create1, 1);
+    expect(await db.managers.categories.count(), 1);
 
     // Creating another row should increment the id
     final create2 = db.managers.categories.create(
         (o) => o(priority: Value(CategoryPriority.low), description: "Low"));
-    expect(create2, completion(2));
-    expect(db.managers.categories.count(), completion(2));
+    expect(await create2, 2);
+    expect(await db.managers.categories.count(), 2);
 
     // Using an existing id should throw an exception
     final create3 = db.managers.categories.create((o) => o(
@@ -48,8 +48,8 @@ void main() {
             id: Value(RowId(1))),
         onConflict: DoNothing());
     // The is incorrect when using onConflict
-    expect(create4, completion(2));
-    expect(db.managers.categories.count(), completion(2));
+    expect(await create4, 2);
+    expect(await db.managers.categories.count(), 2);
 
     // Likewise, test that mode is passed to the create method
     final create5 = db.managers.categories.create(
@@ -60,14 +60,14 @@ void main() {
         mode: InsertMode.insertOrIgnore);
 
     // The is incorrect when using mode
-    expect(create5, completion(2));
-    expect(db.managers.categories.count(), completion(2));
+    expect(await create5, 2);
+    expect(await db.managers.categories.count(), 2);
 
     // Test the other create methods
     final create6 = db.managers.categories.createReturning((o) =>
         o(priority: Value(CategoryPriority.high), description: "Other High"));
-    expect(create6, completion(isA<Category>()));
-    expect(db.managers.categories.count(), completion(3));
+    expect(await create6, isA<Category>());
+    expect(await db.managers.categories.count(), 3);
 
     // Will return null because the description is not unique
     final create7 = db.managers.categories.createReturningOrNull(
@@ -76,7 +76,7 @@ void main() {
               description: "High",
             ),
         mode: InsertMode.insertOrIgnore);
-    expect(create7, completion(null));
+    expect(await create7, null);
 
     // Test batch create
     await db.managers.categories.bulkCreate((o) => [
@@ -86,7 +86,7 @@ void main() {
               priority: Value(CategoryPriority.medium),
               description: "Super Medium")
         ]);
-    expect(db.managers.categories.count(), completion(6));
+    expect(await db.managers.categories.count(), 6);
   });
 
   test('manager - update', () async {
@@ -99,13 +99,13 @@ void main() {
     // Replace the row
     final update1 =
         db.managers.categories.replace(obj1.copyWith(description: "Hello"));
-    expect(update1, completion(true));
+    expect(await update1, true);
     expect(
-        db.managers.categories
+        await db.managers.categories
             .filter(((f) => f.id(obj1.id)))
             .getSingle()
             .then((value) => value.description),
-        completion("Hello"));
+        "Hello");
 
     // Bulk Replace
     await db.managers.categories.bulkReplace([
@@ -113,34 +113,34 @@ void main() {
       obj2.copyWith(description: "World")
     ]);
     expect(
-        db.managers.categories
+        await db.managers.categories
             .filter(((f) => f.id(obj1.id)))
             .getSingle()
             .then((value) => value.description),
-        completion("Hello"));
+        "Hello");
     expect(
-        db.managers.categories
+        await db.managers.categories
             .filter(((f) => f.id(obj2.id)))
             .getSingle()
             .then((value) => value.description),
-        completion("World"));
+        "World");
 
     // Update All Rows
     final update2 = db.managers.categories
         .update((o) => o(priority: Value(CategoryPriority.high)));
-    expect(update2, completion(2));
+    expect(await update2, 2);
 
     // Update a single row
     final update3 = db.managers.categories
         .filter(((f) => f.id(obj2.id)))
         .update((o) => o(description: Value("World")));
-    expect(update3, completion(1));
+    expect(await update3, 1);
     expect(
-        db.managers.categories
+        await db.managers.categories
             .filter(((f) => f.id(obj2.id)))
             .getSingle()
             .then((value) => value.description),
-        completion("World"));
+        "World");
   });
 
   test('manager - delete', () async {
@@ -153,13 +153,13 @@ void main() {
     // Delete a single row
     final delete1 =
         db.managers.categories.filter(((f) => f.id(obj1.id))).delete();
-    expect(delete1, completion(1));
-    expect(db.managers.categories.count(), completion(1));
+    expect(await delete1, 1);
+    expect(await db.managers.categories.count(), 1);
 
     // Delete all rows
     final delete2 = db.managers.categories.delete();
-    expect(delete2, completion(1));
-    expect(db.managers.categories.count(), completion(0));
+    expect(await delete2, 1);
+    expect(await db.managers.categories.count(), 0);
   });
 
   test('can use custom row classes', () async {

--- a/drift/test/manager/processed_manager_test.dart
+++ b/drift/test/manager/processed_manager_test.dart
@@ -15,6 +15,7 @@ void main() {
 
   test('processed manager', () async {
     await db.managers.tableWithEveryColumnType.create((o) => o(
+        id: Value(RowId(1)),
         aText: Value("Get that math homework done"),
         anIntEnum: Value(TodoStatus.open),
         aReal: Value(5.0),
@@ -29,20 +30,16 @@ void main() {
         aReal: Value(3.0),
         aDateTime: Value(DateTime.now().add(Duration(days: 3)))));
     // Test count
-    expect(db.managers.tableWithEveryColumnType.count(), completion(3));
+    expect(await db.managers.tableWithEveryColumnType.count(), 3);
     // Test get
-    expect(
-        db.managers.tableWithEveryColumnType
-            .get()
-            .then((value) => value.length),
-        completion(3));
+    expect(await db.managers.tableWithEveryColumnType.get(), hasLength(3));
     // Test getSingle with limit
     expect(
-        db.managers.tableWithEveryColumnType
+        await db.managers.tableWithEveryColumnType
             .limit(1, offset: 1)
             .getSingle()
             .then((value) => value.id),
-        completion(2));
+        2);
     // Test filtered delete
     expect(
         db.managers.tableWithEveryColumnType
@@ -52,36 +49,36 @@ void main() {
 
     // Test filtered update
     expect(
-        db.managers.tableWithEveryColumnType
+        await db.managers.tableWithEveryColumnType
             .filter((f) => f.id(RowId(1)))
             .update((o) => o(aReal: Value(10.0))),
-        completion(1));
+        1);
     expect(
-        db.managers.tableWithEveryColumnType
+        await db.managers.tableWithEveryColumnType
             .filter((f) => f.id(RowId(1)))
             .getSingle()
             .then((value) => value.aReal),
-        completion(10.0));
+        10.0);
     // Test filtered exists
     expect(
-        db.managers.tableWithEveryColumnType
+        await db.managers.tableWithEveryColumnType
             .filter((f) => f.id(RowId(1)))
             .exists(),
-        completion(true));
+        true);
 
     // Test filtered count
     expect(
-        db.managers.tableWithEveryColumnType
+        await db.managers.tableWithEveryColumnType
             .filter((f) => f.id(RowId(1)))
             .count(),
-        completion(1));
-    // Test delte all
-    expect(db.managers.tableWithEveryColumnType.delete(), completion(2));
+        1);
+    // Test delete all
+    expect(await db.managers.tableWithEveryColumnType.delete(), 2);
     // Test exists - false
     expect(
-        db.managers.tableWithEveryColumnType
+        await db.managers.tableWithEveryColumnType
             .filter((f) => f.id(RowId(1)))
             .exists(),
-        completion(false));
+        false);
   });
 }

--- a/drift/test/manager/processed_manager_test.dart
+++ b/drift/test/manager/processed_manager_test.dart
@@ -42,10 +42,10 @@ void main() {
         2);
     // Test filtered delete
     expect(
-        db.managers.tableWithEveryColumnType
+        await db.managers.tableWithEveryColumnType
             .filter((f) => f.id(RowId(2)))
             .delete(),
-        completion(1));
+        1);
 
     // Test filtered update
     expect(

--- a/drift/test/serialization_test.dart
+++ b/drift/test/serialization_test.dart
@@ -10,7 +10,7 @@ final TodoEntry _someTodoEntry = TodoEntry(
   title: null,
   content: 'content',
   targetDate: _someDate,
-  category: 3,
+  category: RowId(3),
   status: TodoStatus.open,
 );
 

--- a/drift/test/test_utils/test_utils.mocks.dart
+++ b/drift/test/test_utils/test_utils.mocks.dart
@@ -268,7 +268,7 @@ class MockSupportedTransactionDelegate extends _i1.Mock
 /// See the documentation for Mockito's code generation for more information.
 class MockStreamQueries extends _i1.Mock implements _i7.StreamQueryStore {
   @override
-  _i5.Stream<T> registerStream<T>(
+  _i5.Stream<T> registerStream<T extends Object>(
     _i7.QueryStreamFetcher<T>? fetcher,
     _i6.DatabaseConnectionUser? database,
   ) =>
@@ -307,7 +307,7 @@ class MockStreamQueries extends _i1.Mock implements _i7.StreamQueryStore {
 
   @override
   void markAsClosed(
-    _i7.QueryStream<dynamic>? stream,
+    _i7.QueryStream<Object>? stream,
     void Function()? whenRemoved,
   ) =>
       super.noSuchMethod(
@@ -322,7 +322,7 @@ class MockStreamQueries extends _i1.Mock implements _i7.StreamQueryStore {
       );
 
   @override
-  void markAsOpened(_i7.QueryStream<dynamic>? stream) => super.noSuchMethod(
+  void markAsOpened(_i7.QueryStream<Object>? stream) => super.noSuchMethod(
         Invocation.method(
           #markAsOpened,
           [stream],

--- a/drift/test/test_utils/test_utils.mocks.dart
+++ b/drift/test/test_utils/test_utils.mocks.dart
@@ -268,8 +268,8 @@ class MockSupportedTransactionDelegate extends _i1.Mock
 /// See the documentation for Mockito's code generation for more information.
 class MockStreamQueries extends _i1.Mock implements _i7.StreamQueryStore {
   @override
-  _i5.Stream<List<Map<String, Object?>>> registerStream(
-    _i7.QueryStreamFetcher? fetcher,
+  _i5.Stream<T> registerStream<T>(
+    _i7.QueryStreamFetcher<T>? fetcher,
     _i6.DatabaseConnectionUser? database,
   ) =>
       (super.noSuchMethod(
@@ -280,10 +280,9 @@ class MockStreamQueries extends _i1.Mock implements _i7.StreamQueryStore {
             database,
           ],
         ),
-        returnValue: _i5.Stream<List<Map<String, Object?>>>.empty(),
-        returnValueForMissingStub:
-            _i5.Stream<List<Map<String, Object?>>>.empty(),
-      ) as _i5.Stream<List<Map<String, Object?>>>);
+        returnValue: _i5.Stream<T>.empty(),
+        returnValueForMissingStub: _i5.Stream<T>.empty(),
+      ) as _i5.Stream<T>);
 
   @override
   _i5.Stream<Set<_i6.TableUpdate>> updatesForSync(
@@ -308,7 +307,7 @@ class MockStreamQueries extends _i1.Mock implements _i7.StreamQueryStore {
 
   @override
   void markAsClosed(
-    _i7.QueryStream? stream,
+    _i7.QueryStream<dynamic>? stream,
     void Function()? whenRemoved,
   ) =>
       super.noSuchMethod(
@@ -323,7 +322,7 @@ class MockStreamQueries extends _i1.Mock implements _i7.StreamQueryStore {
       );
 
   @override
-  void markAsOpened(_i7.QueryStream? stream) => super.noSuchMethod(
+  void markAsOpened(_i7.QueryStream<dynamic>? stream) => super.noSuchMethod(
         Invocation.method(
           #markAsOpened,
           [stream],

--- a/drift_dev/lib/src/writer/manager/database_manager_writer.dart
+++ b/drift_dev/lib/src/writer/manager/database_manager_writer.dart
@@ -1,5 +1,3 @@
-import 'dart:math';
-
 import 'package:collection/collection.dart';
 import 'package:drift_dev/src/analysis/results/results.dart';
 import 'package:drift_dev/src/writer/tables/update_companion_writer.dart';

--- a/drift_dev/lib/src/writer/manager/database_manager_writer.dart
+++ b/drift_dev/lib/src/writer/manager/database_manager_writer.dart
@@ -1,3 +1,5 @@
+import 'dart:math';
+
 import 'package:collection/collection.dart';
 import 'package:drift_dev/src/analysis/results/results.dart';
 import 'package:drift_dev/src/writer/tables/update_companion_writer.dart';

--- a/drift_dev/lib/src/writer/manager/manager_templates.dart
+++ b/drift_dev/lib/src/writer/manager/manager_templates.dart
@@ -549,7 +549,7 @@ class _ManagerCodeTemplates {
     ).join('\n');
 
     return """
-      class $rowClassWithReferencesName extends ${leaf.drift("BaseReferences")}<
+      final class $rowClassWithReferencesName extends ${leaf.drift("BaseReferences")}<
         ${databaseType(leaf, dbClassName)},
         ${tableClassWithPrefix(table, leaf)},
         ${rowClassWithPrefix(table, leaf)}> {

--- a/drift_dev/lib/src/writer/manager/manager_templates.dart
+++ b/drift_dev/lib/src/writer/manager/manager_templates.dart
@@ -498,7 +498,9 @@ class _ManagerCodeTemplates {
         > _${relation.fieldName}Table($dbName db) =>
           ${leaf.drift("MultiTypedResultKey")}.fromTable(
           db.${relation.referencedTable.dbGetterName}, 
-          aliasName: "${relation.fieldName}__${_generateRandomString(10)}"
+          aliasName: ${leaf.drift("\$_aliasNameGenerator")}(
+            db.${relation.currentTable.dbGetterName}.${relation.currentColumn.nameInDart},
+            db.${relation.referencedTable.dbGetterName}.${relation.referencedColumn.nameInDart})
         );""";
 
           return """

--- a/drift_dev/lib/src/writer/manager/manager_templates.dart
+++ b/drift_dev/lib/src/writer/manager/manager_templates.dart
@@ -261,7 +261,8 @@ class _ManagerCodeTemplates {
                 return state;
               }
 """},
-            withPrefetches: (items) async {
+            prefetchedDataStreamsCallback: (items, {required bool watch}) {
+            return [
             ${reverseRelations.map((relation) {
                 final referencesClassName = rowReferencesClassName(
                     table: table,
@@ -270,8 +271,8 @@ class _ManagerCodeTemplates {
                     leaf: leaf,
                     withTypeArgs: false);
                 return """
-            items = await ${leaf.drift("typedResultsWithPrefetched")}(
-                  doPrefetch: ${relation.fieldName},
+          if (${relation.fieldName}) ${leaf.drift("\$_streamPrefetched")}(
+                  watch: watch,
                   currentTable: table,
                   referencedTable:
                       $referencesClassName._${relation.fieldName}Table(db),
@@ -279,10 +280,10 @@ class _ManagerCodeTemplates {
                       $referencesClassName(db, table, p0).${relation.fieldName},
                   referencedItemsForCurrentItem: (item, referencedItems) =>
                       referencedItems.where((e) => e.${relation.referencedColumn.nameInDart} == item.${relation.currentColumn.nameInDart}),
-                  typedResults: items);
+                  typedResults: items)
             """;
-              }).join('\n')}
-                return items;
+              }).join(',')}
+                ];
               },
           );
         }

--- a/drift_dev/lib/src/writer/manager/manager_templates.dart
+++ b/drift_dev/lib/src/writer/manager/manager_templates.dart
@@ -171,7 +171,17 @@ class _ManagerCodeTemplates {
 
   /// Generic type arguments for the root and processed table manager
   String _tableManagerTypeArguments(
-      DriftTable table, String dbClassName, TextEmitter leaf) {
+    DriftTable table,
+    String dbClassName,
+    TextEmitter leaf,
+    List<_Relation> relations,
+  ) {
+    final String rowClassWithReferences = rowReferencesClassName(
+        table: table,
+        relations: relations,
+        dbClassName: dbClassName,
+        leaf: leaf,
+        withTypeArgs: true);
     return """
     <${databaseType(leaf, dbClassName)},
     ${tableClassWithPrefix(table, leaf)},
@@ -179,7 +189,11 @@ class _ManagerCodeTemplates {
     ${filterComposerNameWithPrefix(table, leaf)},
     ${orderingComposerNameWithPrefix(table, leaf)},
     ${createCompanionBuilderTypeDef(table)},
-    ${updateCompanionBuilderTypeDefName(table)}>""";
+    ${updateCompanionBuilderTypeDefName(table)},
+    (${rowClassWithPrefix(table, leaf)},$rowClassWithReferences),
+    ${rowClassWithPrefix(table, leaf)},
+    ${createCreatePrefetchHooksCallbackType(currentTable: table, relations: relations, leaf: leaf, dbClassName: dbClassName)}
+    >""";
   }
 
   /// Code for getting a table from inside a composer
@@ -195,8 +209,11 @@ class _ManagerCodeTemplates {
     required TextEmitter leaf,
     required String updateCompanionBuilder,
     required String createCompanionBuilder,
+    required List<_Relation> relations,
   }) {
-    return """class ${rootTableManagerName(table)} extends ${leaf.drift("RootTableManager")}${_tableManagerTypeArguments(table, dbClassName, leaf)} {
+    final forwardRelations = relations.where((e) => !e.isReverse).toList();
+    final reverseRelations = relations.where((e) => e.isReverse).toList();
+    return """class ${rootTableManagerName(table)} extends ${leaf.drift("RootTableManager")}${_tableManagerTypeArguments(table, dbClassName, leaf, relations)} {
     ${rootTableManagerName(table)}(${databaseType(leaf, dbClassName)} db, ${tableClassWithPrefix(table, leaf)} table) : super(
       ${leaf.drift("TableManagerState")}(
         db: db,
@@ -204,7 +221,73 @@ class _ManagerCodeTemplates {
         filteringComposer: ${filterComposerNameWithPrefix(table, leaf)}(${leaf.drift("ComposerState")}(db, table)),
         orderingComposer: ${orderingComposerNameWithPrefix(table, leaf)}(${leaf.drift("ComposerState")}(db, table)),
         updateCompanionCallback: $updateCompanionBuilder,
-        createCompanionCallback: $createCompanionBuilder,));
+        createCompanionCallback: $createCompanionBuilder,
+        withReferenceMapper: (p0) => p0
+              .map(
+                  (e) =>
+                     (e.readTable(table), ${rowReferencesClassName(table: table, relations: relations, dbClassName: dbClassName, leaf: leaf, withTypeArgs: false)}(db, table, e))
+                  )
+              .toList(),
+        prefetchHooksCallback: ${relations.isEmpty || _scope.generationOptions.isModular ? 'null' : """
+        (${"{${relations.map(
+                  (e) => "${e.fieldName} = false",
+                ).join(",")}}"}){
+          return ${leaf.drift("PrefetchHooks")}(
+            addJoins: ${forwardRelations.isEmpty ? 'null' : """
+<T extends TableManagerState<dynamic,dynamic,dynamic,dynamic,dynamic,dynamic,dynamic,dynamic,dynamic,dynamic>>(state) {
+
+                ${forwardRelations.map((relation) {
+                    final referencesClassName = rowReferencesClassName(
+                        table: table,
+                        relations: relations,
+                        dbClassName: dbClassName,
+                        leaf: leaf,
+                        withTypeArgs: false);
+                    return """
+                  if (${relation.fieldName}){
+                  state = state.withJoin(
+                    currentTable: table,
+                    currentColumn: table.${relation.currentColumn.nameInDart},
+                    referencedTable:
+                        $referencesClassName._${relation.fieldName}Table(db),
+                    referencedColumn:
+                        $referencesClassName._${relation.fieldName}Table(db).id,
+                  ) as T;
+               }""";
+                  }).join('\n')}
+
+
+
+                return state;
+              }
+"""},
+            withPrefetches: (items) async {
+            ${reverseRelations.map((relation) {
+                final referencesClassName = rowReferencesClassName(
+                    table: table,
+                    relations: relations,
+                    dbClassName: dbClassName,
+                    leaf: leaf,
+                    withTypeArgs: false);
+                return """
+            items = await ${leaf.drift("typedResultsWithPrefetched")}(
+                  doPrefetch: ${relation.fieldName},
+                  currentTable: table,
+                  referencedTable:
+                      $referencesClassName._${relation.fieldName}Table(db),
+                  managerFromTypedResult: (p0) =>
+                      $referencesClassName(db, table, p0).${relation.fieldName},
+                  referencedItemsForCurrentItem: (item, referencedItems) =>
+                      referencedItems.where((e) => e.${relation.referencedColumn.nameInDart} == item.${relation.currentColumn.nameInDart}),
+                  typedResults: items);
+            """;
+              }).join('\n')}
+                return items;
+              },
+          );
+        }
+"""},
+        ));
         }
     """;
   }
@@ -338,4 +421,146 @@ class _ManagerCodeTemplates {
         ))
               );""";
   }
+
+  /// Returns the name of the processed table manager class for a table
+  ///
+  /// This does not contain any prefixes, as this will always be generated in the same file
+  /// as the table manager and is not used outside of the file
+  ///
+  /// E.g. `$UserTableProcessedTableManager`
+  String processedTableManagerTypedefName(DriftTable table) {
+    return '\$${table.entityInfoName}ProcessedTableManager';
+  }
+
+  /// Code for a processed table manager typedef
+  String processedTableManagerTypeDef({
+    required DriftTable table,
+    required String dbClassName,
+    required TextEmitter leaf,
+    required List<_Relation> relations,
+  }) {
+    return """typedef ${processedTableManagerTypedefName(table)} = ${leaf.drift("ProcessedTableManager")}${_tableManagerTypeArguments(table, dbClassName, leaf, relations)};""";
+  }
+
+  /// Name of the class which is used to represent a rows references
+  ///
+  /// If there are no relations, or if generation is modular, we will generate a base class instead.
+  String rowReferencesClassName(
+      {required DriftTable table,
+      required List<_Relation> relations,
+      required String dbClassName,
+      required TextEmitter leaf,
+      required bool withTypeArgs}) {
+    if (!_scope.generationOptions.isModular && relations.isNotEmpty) {
+      return '\$${table.entityInfoName}References';
+    } else {
+      if (withTypeArgs) {
+        return "${leaf.drift('BaseReferences')}<${databaseType(leaf, dbClassName)},${tableClassWithPrefix(table, leaf)},${rowClassWithPrefix(table, leaf)}>";
+      } else {
+        return leaf.drift('BaseReferences');
+      }
+    }
+  }
+
+  // The name of the type defenition to use for the callback that creates the prefetches class
+  String createCreatePrefetchHooksCallbackType(
+      {required DriftTable currentTable,
+      required List<_Relation> relations,
+      required TextEmitter leaf,
+      required String dbClassName}) {
+    return "${leaf.drift("PrefetchHooks")} Function(${relations.isEmpty ? '' : '{${relations.map((e) => 'bool ${e.fieldName}').join(',')}}'})";
+  }
+
+  /// Name of the class which is used to represent a rows references
+  ///
+  /// If there are no relations, or if generation is modular, we will generate a base class instead.
+  String rowReferencesClass(
+      {required DriftTable table,
+      required List<_Relation> relations,
+      required String dbClassName,
+      required TextEmitter leaf}) {
+    final String rowClassWithReferencesName = rowReferencesClassName(
+        table: table,
+        relations: relations,
+        dbClassName: dbClassName,
+        leaf: leaf,
+        withTypeArgs: false);
+
+    final body = relations.map(
+      (relation) {
+        final dbName = databaseType(leaf, dbClassName);
+
+        if (relation.isReverse) {
+          final aliasedTableMethod = """
+        static ${leaf.drift("MultiTypedResultKey")}<
+          ${tableClassWithPrefix(relation.referencedTable, leaf)},
+          List<${rowClassWithPrefix(relation.referencedTable, leaf)}>
+        > _${relation.fieldName}Table($dbName db) =>
+          ${leaf.drift("MultiTypedResultKey")}.fromTable(
+          db.${relation.referencedTable.dbGetterName}, 
+          aliasName: "${relation.fieldName}__${_generateRandomString(10)}"
+        );""";
+
+          return """
+          
+          $aliasedTableMethod
+
+          ${processedTableManagerTypedefName(relation.referencedTable)} get ${relation.fieldName} {
+        final manager = ${rootTableManagerWithPrefix(relation.referencedTable, leaf)}(
+            \$_db, \$_db.${relation.referencedTable.dbGetterName}
+            ).filter(
+              (f) => f.${relation.referencedColumn.nameInDart}.${relation.currentColumn.nameInDart}(
+              \$_item.${relation.currentColumn.nameInDart}
+            )
+          );
+
+          final cache = \$_typedResult.readTableOrNull(_${relation.fieldName}Table(\$_db));
+          return ProcessedTableManager(manager.\$state.copyWith(prefetchedData: cache));
+
+
+        }
+        """;
+        } else {
+          final referenceTableType =
+              tableClassWithPrefix(relation.referencedTable, leaf);
+
+          final aliasedTableMethod = """
+          static $referenceTableType _${relation.fieldName}Table($dbName db) => 
+            db.${relation.referencedTable.dbGetterName}.createAlias(${leaf.drift("\$_aliasNameGenerator")}(
+            db.${relation.currentTable.dbGetterName}.${relation.currentColumn.nameInDart},
+            db.${relation.referencedTable.dbGetterName}.${relation.referencedColumn.nameInDart}));
+          """;
+
+          return """
+        $aliasedTableMethod
+
+        ${processedTableManagerTypedefName(relation.referencedTable)}? get ${relation.fieldName} {
+          if (\$_item.${relation.currentColumn.nameInDart} == null) return null;
+          final manager = ${rootTableManagerWithPrefix(relation.referencedTable, leaf)}(\$_db, \$_db.${relation.referencedTable.dbGetterName}).filter((f) => f.${relation.referencedColumn.nameInDart}(\$_item.${relation.currentColumn.nameInDart}!));
+          final item = \$_typedResult.readTableOrNull(_${relation.fieldName}Table(\$_db));
+          if (item == null) return manager;
+          return ProcessedTableManager(manager.\$state.copyWith(prefetchedData: [item]));
+        }
+""";
+        }
+      },
+    ).join('\n');
+
+    return """
+      class $rowClassWithReferencesName extends ${leaf.drift("BaseReferences")}<
+        ${databaseType(leaf, dbClassName)},
+        ${tableClassWithPrefix(table, leaf)},
+        ${rowClassWithPrefix(table, leaf)}> {
+        $rowClassWithReferencesName(super.\$_db, super.\$_table, super.\$_typedResult);
+        
+        $body
+
+      }""";
+  }
+}
+
+String _generateRandomString(int len) {
+  var r = Random();
+  const chars = 'AaBbCcDdEeFfGgHhIiJjKkLlMmNnOoPpQqRrSsTtUuVvWwXxYyZz';
+  return List.generate(len, (index) => chars[r.nextInt(chars.length)]).join();
 }

--- a/drift_dev/lib/src/writer/manager/manager_templates.dart
+++ b/drift_dev/lib/src/writer/manager/manager_templates.dart
@@ -231,8 +231,15 @@ class _ManagerCodeTemplates {
         prefetchHooksCallback: ${relations.isEmpty || _scope.generationOptions.isModular ? 'null' : """
         (${"{${relations.map(
                   (e) => "${e.fieldName} = false",
-                ).join(",")}}"}){
+                ).join(",")}, bool inTransaction = true}"}){
           return ${leaf.drift("PrefetchHooks")}(
+            db: db,
+            inTransaction: inTransaction,
+            explicitlyWatchedTables: [
+             ${reverseRelations.map((relation) {
+                return "if (${relation.fieldName}) db.${relation.referencedTable.dbGetterName}";
+              }).join(',')}
+            ],
             addJoins: ${forwardRelations.isEmpty ? 'null' : """
 <T extends TableManagerState<dynamic,dynamic,dynamic,dynamic,dynamic,dynamic,dynamic,dynamic,dynamic,dynamic>>(state) {
 
@@ -469,7 +476,7 @@ class _ManagerCodeTemplates {
       required List<_Relation> relations,
       required TextEmitter leaf,
       required String dbClassName}) {
-    return "${leaf.drift("PrefetchHooks")} Function(${relations.isEmpty ? '' : '{${relations.map((e) => 'bool ${e.fieldName}').join(',')}}'})";
+    return "${leaf.drift("PrefetchHooks")} Function(${relations.isEmpty ? '' : '{${relations.map((e) => 'bool ${e.fieldName}').join(',')} ,bool inTransaction}'})";
   }
 
   /// Name of the class which is used to represent a rows references

--- a/drift_dev/lib/src/writer/manager/manager_templates.dart
+++ b/drift_dev/lib/src/writer/manager/manager_templates.dart
@@ -560,9 +560,3 @@ class _ManagerCodeTemplates {
       }""";
   }
 }
-
-String _generateRandomString(int len) {
-  var r = Random();
-  const chars = 'AaBbCcDdEeFfGgHhIiJjKkLlMmNnOoPpQqRrSsTtUuVvWwXxYyZz';
-  return List.generate(len, (index) => chars[r.nextInt(chars.length)]).join();
-}

--- a/drift_dev/lib/src/writer/manager/manager_templates.dart
+++ b/drift_dev/lib/src/writer/manager/manager_templates.dart
@@ -267,7 +267,7 @@ class _ManagerCodeTemplates {
                 return state;
               }
 """},
-            prefetchedDataStreamsCallback: (items, {required bool watch}) {
+            getPrefetchedDataCallback: (items) async {
             return [
             ${reverseRelations.map((relation) {
                 final referencesClassName = rowReferencesClassName(
@@ -277,8 +277,7 @@ class _ManagerCodeTemplates {
                     leaf: leaf,
                     withTypeArgs: false);
                 return """
-          if (${relation.fieldName}) ${leaf.drift("\$_streamPrefetched")}(
-                  watch: watch,
+          if (${relation.fieldName}) await ${leaf.drift("\$_getPrefetchedData")}(
                   currentTable: table,
                   referencedTable:
                       $referencesClassName._${relation.fieldName}Table(db),

--- a/drift_dev/lib/src/writer/manager/manager_templates.dart
+++ b/drift_dev/lib/src/writer/manager/manager_templates.dart
@@ -231,10 +231,9 @@ class _ManagerCodeTemplates {
         prefetchHooksCallback: ${relations.isEmpty || _scope.generationOptions.isModular ? 'null' : """
         (${"{${relations.map(
                   (e) => "${e.fieldName} = false",
-                ).join(",")}, bool inTransaction = true}"}){
+                ).join(",")}}"}){
           return ${leaf.drift("PrefetchHooks")}(
             db: db,
-            inTransaction: inTransaction,
             explicitlyWatchedTables: [
              ${reverseRelations.map((relation) {
                 return "if (${relation.fieldName}) db.${relation.referencedTable.dbGetterName}";
@@ -476,7 +475,7 @@ class _ManagerCodeTemplates {
       required List<_Relation> relations,
       required TextEmitter leaf,
       required String dbClassName}) {
-    return "${leaf.drift("PrefetchHooks")} Function(${relations.isEmpty ? '' : '{${relations.map((e) => 'bool ${e.fieldName}').join(',')} ,bool inTransaction}'})";
+    return "${leaf.drift("PrefetchHooks")} Function(${relations.isEmpty ? '' : '{${relations.map((e) => 'bool ${e.fieldName}').join(',')}}'})";
   }
 
   /// Name of the class which is used to represent a rows references

--- a/drift_dev/lib/src/writer/manager/table_manager_writer.dart
+++ b/drift_dev/lib/src/writer/manager/table_manager_writer.dart
@@ -85,8 +85,16 @@ class _TableManagerWriter {
       return true;
     }).toList();
 
-    // Remove any relations where the type isnt exactly the same (num and int)
+    // Remove any relations where the type isn't exactly the same (num and int)
     // This is caused by using different type converters
+    //
+    // The Manager API filters will sometimes move a filter from 1 column to another
+    // ```dart
+    // f.group.id.equals(1) // Required a JOIN
+    // // becomes
+    // f.groupId.equals(Group(id: 1)) // No JOIN required
+    // ```
+    // To move the filter, the types of the columns must be the same
     relations = relations.where((relation) {
       String typeForColumn(DriftColumn column) {
         return column.typeConverter?.dartType.getDisplayString(

--- a/drift_dev/lib/src/writer/manager/table_manager_writer.dart
+++ b/drift_dev/lib/src/writer/manager/table_manager_writer.dart
@@ -100,8 +100,9 @@ class _TableManagerWriter {
         print(
             "\"${relation.currentTable.baseDartName}.${relation.currentColumn.nameInSql}\" has a type of \"$currentType\""
             " and \"${relation.referencedTable.baseDartName}.${relation.referencedColumn.nameInSql}\" has a type of \"$referencedType\"."
-            " This is caused by using different type converters for the columns."
-            " Filters, orderings and reference getters for this relation wont be generated.");
+            " Filters, orderings and reference getters for this relation wont be generated."
+            " The Manager API can only generate filters and orderings for relations where the types are exactly the same."
+            " If you aren't using the Manager API, you can ignore this message.");
         return false;
       }
       return true;

--- a/drift_flutter/example/main.g.dart
+++ b/drift_flutter/example/main.g.dart
@@ -209,42 +209,6 @@ typedef $$ExampleTableTableUpdateCompanionBuilder = ExampleTableCompanion
   Value<String> description,
 });
 
-class $$ExampleTableTableTableManager extends RootTableManager<
-    _$ExampleDatabase,
-    $ExampleTableTable,
-    ExampleTableData,
-    $$ExampleTableTableFilterComposer,
-    $$ExampleTableTableOrderingComposer,
-    $$ExampleTableTableCreateCompanionBuilder,
-    $$ExampleTableTableUpdateCompanionBuilder> {
-  $$ExampleTableTableTableManager(
-      _$ExampleDatabase db, $ExampleTableTable table)
-      : super(TableManagerState(
-          db: db,
-          table: table,
-          filteringComposer:
-              $$ExampleTableTableFilterComposer(ComposerState(db, table)),
-          orderingComposer:
-              $$ExampleTableTableOrderingComposer(ComposerState(db, table)),
-          updateCompanionCallback: ({
-            Value<int> id = const Value.absent(),
-            Value<String> description = const Value.absent(),
-          }) =>
-              ExampleTableCompanion(
-            id: id,
-            description: description,
-          ),
-          createCompanionCallback: ({
-            Value<int> id = const Value.absent(),
-            required String description,
-          }) =>
-              ExampleTableCompanion.insert(
-            id: id,
-            description: description,
-          ),
-        ));
-}
-
 class $$ExampleTableTableFilterComposer
     extends FilterComposer<_$ExampleDatabase, $ExampleTableTable> {
   $$ExampleTableTableFilterComposer(super.$state);
@@ -272,6 +236,67 @@ class $$ExampleTableTableOrderingComposer
       builder: (column, joinBuilders) =>
           ColumnOrderings(column, joinBuilders: joinBuilders));
 }
+
+class $$ExampleTableTableTableManager extends RootTableManager<
+    _$ExampleDatabase,
+    $ExampleTableTable,
+    ExampleTableData,
+    $$ExampleTableTableFilterComposer,
+    $$ExampleTableTableOrderingComposer,
+    $$ExampleTableTableCreateCompanionBuilder,
+    $$ExampleTableTableUpdateCompanionBuilder,
+    (
+      ExampleTableData,
+      BaseReferences<_$ExampleDatabase, $ExampleTableTable, ExampleTableData>
+    ),
+    ExampleTableData,
+    PrefetchHooks Function()> {
+  $$ExampleTableTableTableManager(
+      _$ExampleDatabase db, $ExampleTableTable table)
+      : super(TableManagerState(
+          db: db,
+          table: table,
+          filteringComposer:
+              $$ExampleTableTableFilterComposer(ComposerState(db, table)),
+          orderingComposer:
+              $$ExampleTableTableOrderingComposer(ComposerState(db, table)),
+          updateCompanionCallback: ({
+            Value<int> id = const Value.absent(),
+            Value<String> description = const Value.absent(),
+          }) =>
+              ExampleTableCompanion(
+            id: id,
+            description: description,
+          ),
+          createCompanionCallback: ({
+            Value<int> id = const Value.absent(),
+            required String description,
+          }) =>
+              ExampleTableCompanion.insert(
+            id: id,
+            description: description,
+          ),
+          withReferenceMapper: (p0) => p0
+              .map((e) => (e.readTable(table), BaseReferences(db, table, e)))
+              .toList(),
+          prefetchHooksCallback: null,
+        ));
+}
+
+typedef $$ExampleTableTableProcessedTableManager = ProcessedTableManager<
+    _$ExampleDatabase,
+    $ExampleTableTable,
+    ExampleTableData,
+    $$ExampleTableTableFilterComposer,
+    $$ExampleTableTableOrderingComposer,
+    $$ExampleTableTableCreateCompanionBuilder,
+    $$ExampleTableTableUpdateCompanionBuilder,
+    (
+      ExampleTableData,
+      BaseReferences<_$ExampleDatabase, $ExampleTableTable, ExampleTableData>
+    ),
+    ExampleTableData,
+    PrefetchHooks Function()>;
 
 class $ExampleDatabaseManager {
   final _$ExampleDatabase _db;

--- a/examples/app/lib/database/database.g.dart
+++ b/examples/app/lib/database/database.g.dart
@@ -755,7 +755,7 @@ typedef $$CategoriesTableUpdateCompanionBuilder = CategoriesCompanion Function({
   Value<Color> color,
 });
 
-class $$CategoriesTableReferences
+final class $$CategoriesTableReferences
     extends BaseReferences<_$AppDatabase, $CategoriesTable, Category> {
   $$CategoriesTableReferences(super.$_db, super.$_table, super.$_typedResult);
 
@@ -922,7 +922,7 @@ typedef $$TodoEntriesTableUpdateCompanionBuilder = TodoEntriesCompanion
   Value<DateTime?> dueDate,
 });
 
-class $$TodoEntriesTableReferences
+final class $$TodoEntriesTableReferences
     extends BaseReferences<_$AppDatabase, $TodoEntriesTable, TodoEntry> {
   $$TodoEntriesTableReferences(super.$_db, super.$_table, super.$_typedResult);
 

--- a/examples/app/lib/database/database.g.dart
+++ b/examples/app/lib/database/database.g.dart
@@ -838,7 +838,7 @@ class $$CategoriesTableTableManager extends RootTableManager<
     $$CategoriesTableUpdateCompanionBuilder,
     (Category, $$CategoriesTableReferences),
     Category,
-    PrefetchHooks Function({bool todoEntriesRefs})> {
+    PrefetchHooks Function({bool todoEntriesRefs, bool inTransaction})> {
   $$CategoriesTableTableManager(_$AppDatabase db, $CategoriesTable table)
       : super(TableManagerState(
           db: db,
@@ -873,8 +873,12 @@ class $$CategoriesTableTableManager extends RootTableManager<
                     $$CategoriesTableReferences(db, table, e)
                   ))
               .toList(),
-          prefetchHooksCallback: ({todoEntriesRefs = false}) {
+          prefetchHooksCallback: (
+              {todoEntriesRefs = false, bool inTransaction = true}) {
             return PrefetchHooks(
+              db: db,
+              inTransaction: inTransaction,
+              explicitlyWatchedTables: [if (todoEntriesRefs) db.todoEntries],
               addJoins: null,
               prefetchedDataStreamsCallback: (items, {required bool watch}) {
                 return [
@@ -908,7 +912,7 @@ typedef $$CategoriesTableProcessedTableManager = ProcessedTableManager<
     $$CategoriesTableUpdateCompanionBuilder,
     (Category, $$CategoriesTableReferences),
     Category,
-    PrefetchHooks Function({bool todoEntriesRefs})>;
+    PrefetchHooks Function({bool todoEntriesRefs, bool inTransaction})>;
 typedef $$TodoEntriesTableCreateCompanionBuilder = TodoEntriesCompanion
     Function({
   Value<int> id,
@@ -1015,7 +1019,7 @@ class $$TodoEntriesTableTableManager extends RootTableManager<
     $$TodoEntriesTableUpdateCompanionBuilder,
     (TodoEntry, $$TodoEntriesTableReferences),
     TodoEntry,
-    PrefetchHooks Function({bool category})> {
+    PrefetchHooks Function({bool category, bool inTransaction})> {
   $$TodoEntriesTableTableManager(_$AppDatabase db, $TodoEntriesTable table)
       : super(TableManagerState(
           db: db,
@@ -1054,8 +1058,12 @@ class $$TodoEntriesTableTableManager extends RootTableManager<
                     $$TodoEntriesTableReferences(db, table, e)
                   ))
               .toList(),
-          prefetchHooksCallback: ({category = false}) {
+          prefetchHooksCallback: (
+              {category = false, bool inTransaction = true}) {
             return PrefetchHooks(
+              db: db,
+              inTransaction: inTransaction,
+              explicitlyWatchedTables: [],
               addJoins: <
                   T extends TableManagerState<
                       dynamic,
@@ -1099,7 +1107,7 @@ typedef $$TodoEntriesTableProcessedTableManager = ProcessedTableManager<
     $$TodoEntriesTableUpdateCompanionBuilder,
     (TodoEntry, $$TodoEntriesTableReferences),
     TodoEntry,
-    PrefetchHooks Function({bool category})>;
+    PrefetchHooks Function({bool category, bool inTransaction})>;
 typedef $TextEntriesCreateCompanionBuilder = TextEntriesCompanion Function({
   required String description,
   Value<int> rowid,

--- a/examples/app/lib/database/database.g.dart
+++ b/examples/app/lib/database/database.g.dart
@@ -755,43 +755,23 @@ typedef $$CategoriesTableUpdateCompanionBuilder = CategoriesCompanion Function({
   Value<Color> color,
 });
 
-class $$CategoriesTableTableManager extends RootTableManager<
-    _$AppDatabase,
-    $CategoriesTable,
-    Category,
-    $$CategoriesTableFilterComposer,
-    $$CategoriesTableOrderingComposer,
-    $$CategoriesTableCreateCompanionBuilder,
-    $$CategoriesTableUpdateCompanionBuilder> {
-  $$CategoriesTableTableManager(_$AppDatabase db, $CategoriesTable table)
-      : super(TableManagerState(
-          db: db,
-          table: table,
-          filteringComposer:
-              $$CategoriesTableFilterComposer(ComposerState(db, table)),
-          orderingComposer:
-              $$CategoriesTableOrderingComposer(ComposerState(db, table)),
-          updateCompanionCallback: ({
-            Value<int> id = const Value.absent(),
-            Value<String> name = const Value.absent(),
-            Value<Color> color = const Value.absent(),
-          }) =>
-              CategoriesCompanion(
-            id: id,
-            name: name,
-            color: color,
-          ),
-          createCompanionCallback: ({
-            Value<int> id = const Value.absent(),
-            required String name,
-            required Color color,
-          }) =>
-              CategoriesCompanion.insert(
-            id: id,
-            name: name,
-            color: color,
-          ),
-        ));
+class $$CategoriesTableReferences
+    extends BaseReferences<_$AppDatabase, $CategoriesTable, Category> {
+  $$CategoriesTableReferences(super.$_db, super.$_table, super.$_typedResult);
+
+  static MultiTypedResultKey<$TodoEntriesTable, List<TodoEntry>>
+      _todoEntriesRefsTable(_$AppDatabase db) =>
+          MultiTypedResultKey.fromTable(db.todoEntries,
+              aliasName: "todoEntriesRefs__JDlFHElYWn");
+
+  $$TodoEntriesTableProcessedTableManager get todoEntriesRefs {
+    final manager = $$TodoEntriesTableTableManager($_db, $_db.todoEntries)
+        .filter((f) => f.category.id($_item.id));
+
+    final cache = $_typedResult.readTableOrNull(_todoEntriesRefsTable($_db));
+    return ProcessedTableManager(
+        manager.$state.copyWith(prefetchedData: cache));
+  }
 }
 
 class $$CategoriesTableFilterComposer
@@ -847,6 +827,85 @@ class $$CategoriesTableOrderingComposer
           ColumnOrderings(column, joinBuilders: joinBuilders));
 }
 
+class $$CategoriesTableTableManager extends RootTableManager<
+    _$AppDatabase,
+    $CategoriesTable,
+    Category,
+    $$CategoriesTableFilterComposer,
+    $$CategoriesTableOrderingComposer,
+    $$CategoriesTableCreateCompanionBuilder,
+    $$CategoriesTableUpdateCompanionBuilder,
+    (Category, $$CategoriesTableReferences),
+    Category,
+    PrefetchHooks Function({bool todoEntriesRefs})> {
+  $$CategoriesTableTableManager(_$AppDatabase db, $CategoriesTable table)
+      : super(TableManagerState(
+          db: db,
+          table: table,
+          filteringComposer:
+              $$CategoriesTableFilterComposer(ComposerState(db, table)),
+          orderingComposer:
+              $$CategoriesTableOrderingComposer(ComposerState(db, table)),
+          updateCompanionCallback: ({
+            Value<int> id = const Value.absent(),
+            Value<String> name = const Value.absent(),
+            Value<Color> color = const Value.absent(),
+          }) =>
+              CategoriesCompanion(
+            id: id,
+            name: name,
+            color: color,
+          ),
+          createCompanionCallback: ({
+            Value<int> id = const Value.absent(),
+            required String name,
+            required Color color,
+          }) =>
+              CategoriesCompanion.insert(
+            id: id,
+            name: name,
+            color: color,
+          ),
+          withReferenceMapper: (p0) => p0
+              .map((e) => (
+                    e.readTable(table),
+                    $$CategoriesTableReferences(db, table, e)
+                  ))
+              .toList(),
+          prefetchHooksCallback: ({todoEntriesRefs = false}) {
+            return PrefetchHooks(
+              addJoins: null,
+              withPrefetches: (items) async {
+                items = await typedResultsWithPrefetched(
+                    doPrefetch: todoEntriesRefs,
+                    currentTable: table,
+                    referencedTable:
+                        $$CategoriesTableReferences._todoEntriesRefsTable(db),
+                    managerFromTypedResult: (p0) =>
+                        $$CategoriesTableReferences(db, table, p0)
+                            .todoEntriesRefs,
+                    referencedItemsForCurrentItem: (item, referencedItems) =>
+                        referencedItems.where((e) => e.category == item.id),
+                    typedResults: items);
+
+                return items;
+              },
+            );
+          },
+        ));
+}
+
+typedef $$CategoriesTableProcessedTableManager = ProcessedTableManager<
+    _$AppDatabase,
+    $CategoriesTable,
+    Category,
+    $$CategoriesTableFilterComposer,
+    $$CategoriesTableOrderingComposer,
+    $$CategoriesTableCreateCompanionBuilder,
+    $$CategoriesTableUpdateCompanionBuilder,
+    (Category, $$CategoriesTableReferences),
+    Category,
+    PrefetchHooks Function({bool todoEntriesRefs})>;
 typedef $$TodoEntriesTableCreateCompanionBuilder = TodoEntriesCompanion
     Function({
   Value<int> id,
@@ -862,47 +921,23 @@ typedef $$TodoEntriesTableUpdateCompanionBuilder = TodoEntriesCompanion
   Value<DateTime?> dueDate,
 });
 
-class $$TodoEntriesTableTableManager extends RootTableManager<
-    _$AppDatabase,
-    $TodoEntriesTable,
-    TodoEntry,
-    $$TodoEntriesTableFilterComposer,
-    $$TodoEntriesTableOrderingComposer,
-    $$TodoEntriesTableCreateCompanionBuilder,
-    $$TodoEntriesTableUpdateCompanionBuilder> {
-  $$TodoEntriesTableTableManager(_$AppDatabase db, $TodoEntriesTable table)
-      : super(TableManagerState(
-          db: db,
-          table: table,
-          filteringComposer:
-              $$TodoEntriesTableFilterComposer(ComposerState(db, table)),
-          orderingComposer:
-              $$TodoEntriesTableOrderingComposer(ComposerState(db, table)),
-          updateCompanionCallback: ({
-            Value<int> id = const Value.absent(),
-            Value<String> description = const Value.absent(),
-            Value<int?> category = const Value.absent(),
-            Value<DateTime?> dueDate = const Value.absent(),
-          }) =>
-              TodoEntriesCompanion(
-            id: id,
-            description: description,
-            category: category,
-            dueDate: dueDate,
-          ),
-          createCompanionCallback: ({
-            Value<int> id = const Value.absent(),
-            required String description,
-            Value<int?> category = const Value.absent(),
-            Value<DateTime?> dueDate = const Value.absent(),
-          }) =>
-              TodoEntriesCompanion.insert(
-            id: id,
-            description: description,
-            category: category,
-            dueDate: dueDate,
-          ),
-        ));
+class $$TodoEntriesTableReferences
+    extends BaseReferences<_$AppDatabase, $TodoEntriesTable, TodoEntry> {
+  $$TodoEntriesTableReferences(super.$_db, super.$_table, super.$_typedResult);
+
+  static $CategoriesTable _categoryTable(_$AppDatabase db) =>
+      db.categories.createAlias(
+          $_aliasNameGenerator(db.todoEntries.category, db.categories.id));
+
+  $$CategoriesTableProcessedTableManager? get category {
+    if ($_item.category == null) return null;
+    final manager = $$CategoriesTableTableManager($_db, $_db.categories)
+        .filter((f) => f.id($_item.category!));
+    final item = $_typedResult.readTableOrNull(_categoryTable($_db));
+    if (item == null) return manager;
+    return ProcessedTableManager(
+        manager.$state.copyWith(prefetchedData: [item]));
+  }
 }
 
 class $$TodoEntriesTableFilterComposer
@@ -967,6 +1002,101 @@ class $$TodoEntriesTableOrderingComposer
   }
 }
 
+class $$TodoEntriesTableTableManager extends RootTableManager<
+    _$AppDatabase,
+    $TodoEntriesTable,
+    TodoEntry,
+    $$TodoEntriesTableFilterComposer,
+    $$TodoEntriesTableOrderingComposer,
+    $$TodoEntriesTableCreateCompanionBuilder,
+    $$TodoEntriesTableUpdateCompanionBuilder,
+    (TodoEntry, $$TodoEntriesTableReferences),
+    TodoEntry,
+    PrefetchHooks Function({bool category})> {
+  $$TodoEntriesTableTableManager(_$AppDatabase db, $TodoEntriesTable table)
+      : super(TableManagerState(
+          db: db,
+          table: table,
+          filteringComposer:
+              $$TodoEntriesTableFilterComposer(ComposerState(db, table)),
+          orderingComposer:
+              $$TodoEntriesTableOrderingComposer(ComposerState(db, table)),
+          updateCompanionCallback: ({
+            Value<int> id = const Value.absent(),
+            Value<String> description = const Value.absent(),
+            Value<int?> category = const Value.absent(),
+            Value<DateTime?> dueDate = const Value.absent(),
+          }) =>
+              TodoEntriesCompanion(
+            id: id,
+            description: description,
+            category: category,
+            dueDate: dueDate,
+          ),
+          createCompanionCallback: ({
+            Value<int> id = const Value.absent(),
+            required String description,
+            Value<int?> category = const Value.absent(),
+            Value<DateTime?> dueDate = const Value.absent(),
+          }) =>
+              TodoEntriesCompanion.insert(
+            id: id,
+            description: description,
+            category: category,
+            dueDate: dueDate,
+          ),
+          withReferenceMapper: (p0) => p0
+              .map((e) => (
+                    e.readTable(table),
+                    $$TodoEntriesTableReferences(db, table, e)
+                  ))
+              .toList(),
+          prefetchHooksCallback: ({category = false}) {
+            return PrefetchHooks(
+              addJoins: <
+                  T extends TableManagerState<
+                      dynamic,
+                      dynamic,
+                      dynamic,
+                      dynamic,
+                      dynamic,
+                      dynamic,
+                      dynamic,
+                      dynamic,
+                      dynamic,
+                      dynamic>>(state) {
+                if (category) {
+                  state = state.withJoin(
+                    currentTable: table,
+                    currentColumn: table.category,
+                    referencedTable:
+                        $$TodoEntriesTableReferences._categoryTable(db),
+                    referencedColumn:
+                        $$TodoEntriesTableReferences._categoryTable(db).id,
+                  ) as T;
+                }
+
+                return state;
+              },
+              withPrefetches: (items) async {
+                return items;
+              },
+            );
+          },
+        ));
+}
+
+typedef $$TodoEntriesTableProcessedTableManager = ProcessedTableManager<
+    _$AppDatabase,
+    $TodoEntriesTable,
+    TodoEntry,
+    $$TodoEntriesTableFilterComposer,
+    $$TodoEntriesTableOrderingComposer,
+    $$TodoEntriesTableCreateCompanionBuilder,
+    $$TodoEntriesTableUpdateCompanionBuilder,
+    (TodoEntry, $$TodoEntriesTableReferences),
+    TodoEntry,
+    PrefetchHooks Function({bool category})>;
 typedef $TextEntriesCreateCompanionBuilder = TextEntriesCompanion Function({
   required String description,
   Value<int> rowid,
@@ -976,6 +1106,24 @@ typedef $TextEntriesUpdateCompanionBuilder = TextEntriesCompanion Function({
   Value<int> rowid,
 });
 
+class $TextEntriesFilterComposer
+    extends FilterComposer<_$AppDatabase, TextEntries> {
+  $TextEntriesFilterComposer(super.$state);
+  ColumnFilters<String> get description => $state.composableBuilder(
+      column: $state.table.description,
+      builder: (column, joinBuilders) =>
+          ColumnFilters(column, joinBuilders: joinBuilders));
+}
+
+class $TextEntriesOrderingComposer
+    extends OrderingComposer<_$AppDatabase, TextEntries> {
+  $TextEntriesOrderingComposer(super.$state);
+  ColumnOrderings<String> get description => $state.composableBuilder(
+      column: $state.table.description,
+      builder: (column, joinBuilders) =>
+          ColumnOrderings(column, joinBuilders: joinBuilders));
+}
+
 class $TextEntriesTableManager extends RootTableManager<
     _$AppDatabase,
     TextEntries,
@@ -983,7 +1131,10 @@ class $TextEntriesTableManager extends RootTableManager<
     $TextEntriesFilterComposer,
     $TextEntriesOrderingComposer,
     $TextEntriesCreateCompanionBuilder,
-    $TextEntriesUpdateCompanionBuilder> {
+    $TextEntriesUpdateCompanionBuilder,
+    (TextEntry, BaseReferences<_$AppDatabase, TextEntries, TextEntry>),
+    TextEntry,
+    PrefetchHooks Function()> {
   $TextEntriesTableManager(_$AppDatabase db, TextEntries table)
       : super(TableManagerState(
           db: db,
@@ -1008,26 +1159,24 @@ class $TextEntriesTableManager extends RootTableManager<
             description: description,
             rowid: rowid,
           ),
+          withReferenceMapper: (p0) => p0
+              .map((e) => (e.readTable(table), BaseReferences(db, table, e)))
+              .toList(),
+          prefetchHooksCallback: null,
         ));
 }
 
-class $TextEntriesFilterComposer
-    extends FilterComposer<_$AppDatabase, TextEntries> {
-  $TextEntriesFilterComposer(super.$state);
-  ColumnFilters<String> get description => $state.composableBuilder(
-      column: $state.table.description,
-      builder: (column, joinBuilders) =>
-          ColumnFilters(column, joinBuilders: joinBuilders));
-}
-
-class $TextEntriesOrderingComposer
-    extends OrderingComposer<_$AppDatabase, TextEntries> {
-  $TextEntriesOrderingComposer(super.$state);
-  ColumnOrderings<String> get description => $state.composableBuilder(
-      column: $state.table.description,
-      builder: (column, joinBuilders) =>
-          ColumnOrderings(column, joinBuilders: joinBuilders));
-}
+typedef $TextEntriesProcessedTableManager = ProcessedTableManager<
+    _$AppDatabase,
+    TextEntries,
+    TextEntry,
+    $TextEntriesFilterComposer,
+    $TextEntriesOrderingComposer,
+    $TextEntriesCreateCompanionBuilder,
+    $TextEntriesUpdateCompanionBuilder,
+    (TextEntry, BaseReferences<_$AppDatabase, TextEntries, TextEntry>),
+    TextEntry,
+    PrefetchHooks Function()>;
 
 class $AppDatabaseManager {
   final _$AppDatabase _db;

--- a/examples/app/lib/database/database.g.dart
+++ b/examples/app/lib/database/database.g.dart
@@ -878,11 +878,10 @@ class $$CategoriesTableTableManager extends RootTableManager<
               db: db,
               explicitlyWatchedTables: [if (todoEntriesRefs) db.todoEntries],
               addJoins: null,
-              prefetchedDataStreamsCallback: (items, {required bool watch}) {
+              getPrefetchedDataCallback: (items) async {
                 return [
                   if (todoEntriesRefs)
-                    $_streamPrefetched(
-                        watch: watch,
+                    await $_getPrefetchedData(
                         currentTable: table,
                         referencedTable: $$CategoriesTableReferences
                             ._todoEntriesRefsTable(db),
@@ -1085,7 +1084,7 @@ class $$TodoEntriesTableTableManager extends RootTableManager<
 
                 return state;
               },
-              prefetchedDataStreamsCallback: (items, {required bool watch}) {
+              getPrefetchedDataCallback: (items) async {
                 return [];
               },
             );

--- a/examples/app/lib/database/database.g.dart
+++ b/examples/app/lib/database/database.g.dart
@@ -838,7 +838,7 @@ class $$CategoriesTableTableManager extends RootTableManager<
     $$CategoriesTableUpdateCompanionBuilder,
     (Category, $$CategoriesTableReferences),
     Category,
-    PrefetchHooks Function({bool todoEntriesRefs, bool inTransaction})> {
+    PrefetchHooks Function({bool todoEntriesRefs})> {
   $$CategoriesTableTableManager(_$AppDatabase db, $CategoriesTable table)
       : super(TableManagerState(
           db: db,
@@ -873,11 +873,9 @@ class $$CategoriesTableTableManager extends RootTableManager<
                     $$CategoriesTableReferences(db, table, e)
                   ))
               .toList(),
-          prefetchHooksCallback: (
-              {todoEntriesRefs = false, bool inTransaction = true}) {
+          prefetchHooksCallback: ({todoEntriesRefs = false}) {
             return PrefetchHooks(
               db: db,
-              inTransaction: inTransaction,
               explicitlyWatchedTables: [if (todoEntriesRefs) db.todoEntries],
               addJoins: null,
               prefetchedDataStreamsCallback: (items, {required bool watch}) {
@@ -912,7 +910,7 @@ typedef $$CategoriesTableProcessedTableManager = ProcessedTableManager<
     $$CategoriesTableUpdateCompanionBuilder,
     (Category, $$CategoriesTableReferences),
     Category,
-    PrefetchHooks Function({bool todoEntriesRefs, bool inTransaction})>;
+    PrefetchHooks Function({bool todoEntriesRefs})>;
 typedef $$TodoEntriesTableCreateCompanionBuilder = TodoEntriesCompanion
     Function({
   Value<int> id,
@@ -1019,7 +1017,7 @@ class $$TodoEntriesTableTableManager extends RootTableManager<
     $$TodoEntriesTableUpdateCompanionBuilder,
     (TodoEntry, $$TodoEntriesTableReferences),
     TodoEntry,
-    PrefetchHooks Function({bool category, bool inTransaction})> {
+    PrefetchHooks Function({bool category})> {
   $$TodoEntriesTableTableManager(_$AppDatabase db, $TodoEntriesTable table)
       : super(TableManagerState(
           db: db,
@@ -1058,11 +1056,9 @@ class $$TodoEntriesTableTableManager extends RootTableManager<
                     $$TodoEntriesTableReferences(db, table, e)
                   ))
               .toList(),
-          prefetchHooksCallback: (
-              {category = false, bool inTransaction = true}) {
+          prefetchHooksCallback: ({category = false}) {
             return PrefetchHooks(
               db: db,
-              inTransaction: inTransaction,
               explicitlyWatchedTables: [],
               addJoins: <
                   T extends TableManagerState<
@@ -1107,7 +1103,7 @@ typedef $$TodoEntriesTableProcessedTableManager = ProcessedTableManager<
     $$TodoEntriesTableUpdateCompanionBuilder,
     (TodoEntry, $$TodoEntriesTableReferences),
     TodoEntry,
-    PrefetchHooks Function({bool category, bool inTransaction})>;
+    PrefetchHooks Function({bool category})>;
 typedef $TextEntriesCreateCompanionBuilder = TextEntriesCompanion Function({
   required String description,
   Value<int> rowid,

--- a/examples/app/lib/database/database.g.dart
+++ b/examples/app/lib/database/database.g.dart
@@ -876,20 +876,22 @@ class $$CategoriesTableTableManager extends RootTableManager<
           prefetchHooksCallback: ({todoEntriesRefs = false}) {
             return PrefetchHooks(
               addJoins: null,
-              withPrefetches: (items) async {
-                items = await typedResultsWithPrefetched(
-                    doPrefetch: todoEntriesRefs,
-                    currentTable: table,
-                    referencedTable:
-                        $$CategoriesTableReferences._todoEntriesRefsTable(db),
-                    managerFromTypedResult: (p0) =>
-                        $$CategoriesTableReferences(db, table, p0)
-                            .todoEntriesRefs,
-                    referencedItemsForCurrentItem: (item, referencedItems) =>
-                        referencedItems.where((e) => e.category == item.id),
-                    typedResults: items);
-
-                return items;
+              prefetchedDataStreamsCallback: (items, {required bool watch}) {
+                return [
+                  if (todoEntriesRefs)
+                    $_streamPrefetched(
+                        watch: watch,
+                        currentTable: table,
+                        referencedTable: $$CategoriesTableReferences
+                            ._todoEntriesRefsTable(db),
+                        managerFromTypedResult: (p0) =>
+                            $$CategoriesTableReferences(db, table, p0)
+                                .todoEntriesRefs,
+                        referencedItemsForCurrentItem: (item,
+                                referencedItems) =>
+                            referencedItems.where((e) => e.category == item.id),
+                        typedResults: items)
+                ];
               },
             );
           },
@@ -1079,8 +1081,8 @@ class $$TodoEntriesTableTableManager extends RootTableManager<
 
                 return state;
               },
-              withPrefetches: (items) async {
-                return items;
+              prefetchedDataStreamsCallback: (items, {required bool watch}) {
+                return [];
               },
             );
           },

--- a/examples/app/lib/database/database.g.dart
+++ b/examples/app/lib/database/database.g.dart
@@ -760,9 +760,10 @@ class $$CategoriesTableReferences
   $$CategoriesTableReferences(super.$_db, super.$_table, super.$_typedResult);
 
   static MultiTypedResultKey<$TodoEntriesTable, List<TodoEntry>>
-      _todoEntriesRefsTable(_$AppDatabase db) =>
-          MultiTypedResultKey.fromTable(db.todoEntries,
-              aliasName: "todoEntriesRefs__JDlFHElYWn");
+      _todoEntriesRefsTable(_$AppDatabase db) => MultiTypedResultKey.fromTable(
+          db.todoEntries,
+          aliasName:
+              $_aliasNameGenerator(db.categories.id, db.todoEntries.category));
 
   $$TodoEntriesTableProcessedTableManager get todoEntriesRefs {
     final manager = $$TodoEntriesTableTableManager($_db, $_db.todoEntries)

--- a/examples/encryption/lib/database.g.dart
+++ b/examples/encryption/lib/database.g.dart
@@ -200,41 +200,6 @@ typedef $$NotesTableUpdateCompanionBuilder = NotesCompanion Function({
   Value<String> content,
 });
 
-class $$NotesTableTableManager extends RootTableManager<
-    _$MyEncryptedDatabase,
-    $NotesTable,
-    Note,
-    $$NotesTableFilterComposer,
-    $$NotesTableOrderingComposer,
-    $$NotesTableCreateCompanionBuilder,
-    $$NotesTableUpdateCompanionBuilder> {
-  $$NotesTableTableManager(_$MyEncryptedDatabase db, $NotesTable table)
-      : super(TableManagerState(
-          db: db,
-          table: table,
-          filteringComposer:
-              $$NotesTableFilterComposer(ComposerState(db, table)),
-          orderingComposer:
-              $$NotesTableOrderingComposer(ComposerState(db, table)),
-          updateCompanionCallback: ({
-            Value<int> id = const Value.absent(),
-            Value<String> content = const Value.absent(),
-          }) =>
-              NotesCompanion(
-            id: id,
-            content: content,
-          ),
-          createCompanionCallback: ({
-            Value<int> id = const Value.absent(),
-            required String content,
-          }) =>
-              NotesCompanion.insert(
-            id: id,
-            content: content,
-          ),
-        ));
-}
-
 class $$NotesTableFilterComposer
     extends FilterComposer<_$MyEncryptedDatabase, $NotesTable> {
   $$NotesTableFilterComposer(super.$state);
@@ -262,6 +227,60 @@ class $$NotesTableOrderingComposer
       builder: (column, joinBuilders) =>
           ColumnOrderings(column, joinBuilders: joinBuilders));
 }
+
+class $$NotesTableTableManager extends RootTableManager<
+    _$MyEncryptedDatabase,
+    $NotesTable,
+    Note,
+    $$NotesTableFilterComposer,
+    $$NotesTableOrderingComposer,
+    $$NotesTableCreateCompanionBuilder,
+    $$NotesTableUpdateCompanionBuilder,
+    (Note, BaseReferences<_$MyEncryptedDatabase, $NotesTable, Note>),
+    Note,
+    PrefetchHooks Function()> {
+  $$NotesTableTableManager(_$MyEncryptedDatabase db, $NotesTable table)
+      : super(TableManagerState(
+          db: db,
+          table: table,
+          filteringComposer:
+              $$NotesTableFilterComposer(ComposerState(db, table)),
+          orderingComposer:
+              $$NotesTableOrderingComposer(ComposerState(db, table)),
+          updateCompanionCallback: ({
+            Value<int> id = const Value.absent(),
+            Value<String> content = const Value.absent(),
+          }) =>
+              NotesCompanion(
+            id: id,
+            content: content,
+          ),
+          createCompanionCallback: ({
+            Value<int> id = const Value.absent(),
+            required String content,
+          }) =>
+              NotesCompanion.insert(
+            id: id,
+            content: content,
+          ),
+          withReferenceMapper: (p0) => p0
+              .map((e) => (e.readTable(table), BaseReferences(db, table, e)))
+              .toList(),
+          prefetchHooksCallback: null,
+        ));
+}
+
+typedef $$NotesTableProcessedTableManager = ProcessedTableManager<
+    _$MyEncryptedDatabase,
+    $NotesTable,
+    Note,
+    $$NotesTableFilterComposer,
+    $$NotesTableOrderingComposer,
+    $$NotesTableCreateCompanionBuilder,
+    $$NotesTableUpdateCompanionBuilder,
+    (Note, BaseReferences<_$MyEncryptedDatabase, $NotesTable, Note>),
+    Note,
+    PrefetchHooks Function()>;
 
 class $MyEncryptedDatabaseManager {
   final _$MyEncryptedDatabase _db;

--- a/examples/flutter_web_worker_example/lib/src/database/database.g.dart
+++ b/examples/flutter_web_worker_example/lib/src/database/database.g.dart
@@ -223,39 +223,6 @@ typedef $EntriesUpdateCompanionBuilder = EntriesCompanion Function({
   Value<String> value,
 });
 
-class $EntriesTableManager extends RootTableManager<
-    _$MyDatabase,
-    Entries,
-    Entry,
-    $EntriesFilterComposer,
-    $EntriesOrderingComposer,
-    $EntriesCreateCompanionBuilder,
-    $EntriesUpdateCompanionBuilder> {
-  $EntriesTableManager(_$MyDatabase db, Entries table)
-      : super(TableManagerState(
-          db: db,
-          table: table,
-          filteringComposer: $EntriesFilterComposer(ComposerState(db, table)),
-          orderingComposer: $EntriesOrderingComposer(ComposerState(db, table)),
-          updateCompanionCallback: ({
-            Value<int> id = const Value.absent(),
-            Value<String> value = const Value.absent(),
-          }) =>
-              EntriesCompanion(
-            id: id,
-            value: value,
-          ),
-          createCompanionCallback: ({
-            Value<int> id = const Value.absent(),
-            required String value,
-          }) =>
-              EntriesCompanion.insert(
-            id: id,
-            value: value,
-          ),
-        ));
-}
-
 class $EntriesFilterComposer extends FilterComposer<_$MyDatabase, Entries> {
   $EntriesFilterComposer(super.$state);
   ColumnFilters<int> get id => $state.composableBuilder(
@@ -281,6 +248,58 @@ class $EntriesOrderingComposer extends OrderingComposer<_$MyDatabase, Entries> {
       builder: (column, joinBuilders) =>
           ColumnOrderings(column, joinBuilders: joinBuilders));
 }
+
+class $EntriesTableManager extends RootTableManager<
+    _$MyDatabase,
+    Entries,
+    Entry,
+    $EntriesFilterComposer,
+    $EntriesOrderingComposer,
+    $EntriesCreateCompanionBuilder,
+    $EntriesUpdateCompanionBuilder,
+    (Entry, BaseReferences<_$MyDatabase, Entries, Entry>),
+    Entry,
+    PrefetchHooks Function()> {
+  $EntriesTableManager(_$MyDatabase db, Entries table)
+      : super(TableManagerState(
+          db: db,
+          table: table,
+          filteringComposer: $EntriesFilterComposer(ComposerState(db, table)),
+          orderingComposer: $EntriesOrderingComposer(ComposerState(db, table)),
+          updateCompanionCallback: ({
+            Value<int> id = const Value.absent(),
+            Value<String> value = const Value.absent(),
+          }) =>
+              EntriesCompanion(
+            id: id,
+            value: value,
+          ),
+          createCompanionCallback: ({
+            Value<int> id = const Value.absent(),
+            required String value,
+          }) =>
+              EntriesCompanion.insert(
+            id: id,
+            value: value,
+          ),
+          withReferenceMapper: (p0) => p0
+              .map((e) => (e.readTable(table), BaseReferences(db, table, e)))
+              .toList(),
+          prefetchHooksCallback: null,
+        ));
+}
+
+typedef $EntriesProcessedTableManager = ProcessedTableManager<
+    _$MyDatabase,
+    Entries,
+    Entry,
+    $EntriesFilterComposer,
+    $EntriesOrderingComposer,
+    $EntriesCreateCompanionBuilder,
+    $EntriesUpdateCompanionBuilder,
+    (Entry, BaseReferences<_$MyDatabase, Entries, Entry>),
+    Entry,
+    PrefetchHooks Function()>;
 
 class $MyDatabaseManager {
   final _$MyDatabase _db;

--- a/examples/migrations_example/lib/database.g.dart
+++ b/examples/migrations_example/lib/database.g.dart
@@ -942,47 +942,36 @@ typedef $$UsersTableUpdateCompanionBuilder = UsersCompanion Function({
   Value<int?> nextUser,
 });
 
-class $$UsersTableTableManager extends RootTableManager<
-    _$Database,
-    $UsersTable,
-    User,
-    $$UsersTableFilterComposer,
-    $$UsersTableOrderingComposer,
-    $$UsersTableCreateCompanionBuilder,
-    $$UsersTableUpdateCompanionBuilder> {
-  $$UsersTableTableManager(_$Database db, $UsersTable table)
-      : super(TableManagerState(
-          db: db,
-          table: table,
-          filteringComposer:
-              $$UsersTableFilterComposer(ComposerState(db, table)),
-          orderingComposer:
-              $$UsersTableOrderingComposer(ComposerState(db, table)),
-          updateCompanionCallback: ({
-            Value<int> id = const Value.absent(),
-            Value<String> name = const Value.absent(),
-            Value<DateTime?> birthday = const Value.absent(),
-            Value<int?> nextUser = const Value.absent(),
-          }) =>
-              UsersCompanion(
-            id: id,
-            name: name,
-            birthday: birthday,
-            nextUser: nextUser,
-          ),
-          createCompanionCallback: ({
-            Value<int> id = const Value.absent(),
-            Value<String> name = const Value.absent(),
-            Value<DateTime?> birthday = const Value.absent(),
-            Value<int?> nextUser = const Value.absent(),
-          }) =>
-              UsersCompanion.insert(
-            id: id,
-            name: name,
-            birthday: birthday,
-            nextUser: nextUser,
-          ),
-        ));
+class $$UsersTableReferences
+    extends BaseReferences<_$Database, $UsersTable, User> {
+  $$UsersTableReferences(super.$_db, super.$_table, super.$_typedResult);
+
+  static $UsersTable _nextUserTable(_$Database db) => db.users
+      .createAlias($_aliasNameGenerator(db.users.nextUser, db.users.id));
+
+  $$UsersTableProcessedTableManager? get nextUser {
+    if ($_item.nextUser == null) return null;
+    final manager = $$UsersTableTableManager($_db, $_db.users)
+        .filter((f) => f.id($_item.nextUser!));
+    final item = $_typedResult.readTableOrNull(_nextUserTable($_db));
+    if (item == null) return manager;
+    return ProcessedTableManager(
+        manager.$state.copyWith(prefetchedData: [item]));
+  }
+
+  static MultiTypedResultKey<Groups, List<Group>> _groupsRefsTable(
+          _$Database db) =>
+      MultiTypedResultKey.fromTable(db.groups,
+          aliasName: "groupsRefs__mmDrTcdMYq");
+
+  $GroupsProcessedTableManager get groupsRefs {
+    final manager = $GroupsTableManager($_db, $_db.groups)
+        .filter((f) => f.owner.id($_item.id));
+
+    final cache = $_typedResult.readTableOrNull(_groupsRefsTable($_db));
+    return ProcessedTableManager(
+        manager.$state.copyWith(prefetchedData: cache));
+  }
 }
 
 class $$UsersTableFilterComposer
@@ -1060,6 +1049,109 @@ class $$UsersTableOrderingComposer
   }
 }
 
+class $$UsersTableTableManager extends RootTableManager<
+    _$Database,
+    $UsersTable,
+    User,
+    $$UsersTableFilterComposer,
+    $$UsersTableOrderingComposer,
+    $$UsersTableCreateCompanionBuilder,
+    $$UsersTableUpdateCompanionBuilder,
+    (User, $$UsersTableReferences),
+    User,
+    PrefetchHooks Function({bool nextUser, bool groupsRefs})> {
+  $$UsersTableTableManager(_$Database db, $UsersTable table)
+      : super(TableManagerState(
+          db: db,
+          table: table,
+          filteringComposer:
+              $$UsersTableFilterComposer(ComposerState(db, table)),
+          orderingComposer:
+              $$UsersTableOrderingComposer(ComposerState(db, table)),
+          updateCompanionCallback: ({
+            Value<int> id = const Value.absent(),
+            Value<String> name = const Value.absent(),
+            Value<DateTime?> birthday = const Value.absent(),
+            Value<int?> nextUser = const Value.absent(),
+          }) =>
+              UsersCompanion(
+            id: id,
+            name: name,
+            birthday: birthday,
+            nextUser: nextUser,
+          ),
+          createCompanionCallback: ({
+            Value<int> id = const Value.absent(),
+            Value<String> name = const Value.absent(),
+            Value<DateTime?> birthday = const Value.absent(),
+            Value<int?> nextUser = const Value.absent(),
+          }) =>
+              UsersCompanion.insert(
+            id: id,
+            name: name,
+            birthday: birthday,
+            nextUser: nextUser,
+          ),
+          withReferenceMapper: (p0) => p0
+              .map((e) =>
+                  (e.readTable(table), $$UsersTableReferences(db, table, e)))
+              .toList(),
+          prefetchHooksCallback: ({nextUser = false, groupsRefs = false}) {
+            return PrefetchHooks(
+              addJoins: <
+                  T extends TableManagerState<
+                      dynamic,
+                      dynamic,
+                      dynamic,
+                      dynamic,
+                      dynamic,
+                      dynamic,
+                      dynamic,
+                      dynamic,
+                      dynamic,
+                      dynamic>>(state) {
+                if (nextUser) {
+                  state = state.withJoin(
+                    currentTable: table,
+                    currentColumn: table.nextUser,
+                    referencedTable: $$UsersTableReferences._nextUserTable(db),
+                    referencedColumn:
+                        $$UsersTableReferences._nextUserTable(db).id,
+                  ) as T;
+                }
+
+                return state;
+              },
+              withPrefetches: (items) async {
+                items = await typedResultsWithPrefetched(
+                    doPrefetch: groupsRefs,
+                    currentTable: table,
+                    referencedTable:
+                        $$UsersTableReferences._groupsRefsTable(db),
+                    managerFromTypedResult: (p0) =>
+                        $$UsersTableReferences(db, table, p0).groupsRefs,
+                    referencedItemsForCurrentItem: (item, referencedItems) =>
+                        referencedItems.where((e) => e.owner == item.id),
+                    typedResults: items);
+
+                return items;
+              },
+            );
+          },
+        ));
+}
+
+typedef $$UsersTableProcessedTableManager = ProcessedTableManager<
+    _$Database,
+    $UsersTable,
+    User,
+    $$UsersTableFilterComposer,
+    $$UsersTableOrderingComposer,
+    $$UsersTableCreateCompanionBuilder,
+    $$UsersTableUpdateCompanionBuilder,
+    (User, $$UsersTableReferences),
+    User,
+    PrefetchHooks Function({bool nextUser, bool groupsRefs})>;
 typedef $GroupsCreateCompanionBuilder = GroupsCompanion Function({
   Value<int> id,
   required String title,
@@ -1073,45 +1165,21 @@ typedef $GroupsUpdateCompanionBuilder = GroupsCompanion Function({
   Value<int> owner,
 });
 
-class $GroupsTableManager extends RootTableManager<
-    _$Database,
-    Groups,
-    Group,
-    $GroupsFilterComposer,
-    $GroupsOrderingComposer,
-    $GroupsCreateCompanionBuilder,
-    $GroupsUpdateCompanionBuilder> {
-  $GroupsTableManager(_$Database db, Groups table)
-      : super(TableManagerState(
-          db: db,
-          table: table,
-          filteringComposer: $GroupsFilterComposer(ComposerState(db, table)),
-          orderingComposer: $GroupsOrderingComposer(ComposerState(db, table)),
-          updateCompanionCallback: ({
-            Value<int> id = const Value.absent(),
-            Value<String> title = const Value.absent(),
-            Value<bool?> deleted = const Value.absent(),
-            Value<int> owner = const Value.absent(),
-          }) =>
-              GroupsCompanion(
-            id: id,
-            title: title,
-            deleted: deleted,
-            owner: owner,
-          ),
-          createCompanionCallback: ({
-            Value<int> id = const Value.absent(),
-            required String title,
-            Value<bool?> deleted = const Value.absent(),
-            required int owner,
-          }) =>
-              GroupsCompanion.insert(
-            id: id,
-            title: title,
-            deleted: deleted,
-            owner: owner,
-          ),
-        ));
+class $GroupsReferences extends BaseReferences<_$Database, Groups, Group> {
+  $GroupsReferences(super.$_db, super.$_table, super.$_typedResult);
+
+  static $UsersTable _ownerTable(_$Database db) =>
+      db.users.createAlias($_aliasNameGenerator(db.groups.owner, db.users.id));
+
+  $$UsersTableProcessedTableManager? get owner {
+    if ($_item.owner == null) return null;
+    final manager = $$UsersTableTableManager($_db, $_db.users)
+        .filter((f) => f.id($_item.owner!));
+    final item = $_typedResult.readTableOrNull(_ownerTable($_db));
+    if (item == null) return manager;
+    return ProcessedTableManager(
+        manager.$state.copyWith(prefetchedData: [item]));
+  }
 }
 
 class $GroupsFilterComposer extends FilterComposer<_$Database, Groups> {
@@ -1174,6 +1242,94 @@ class $GroupsOrderingComposer extends OrderingComposer<_$Database, Groups> {
   }
 }
 
+class $GroupsTableManager extends RootTableManager<
+    _$Database,
+    Groups,
+    Group,
+    $GroupsFilterComposer,
+    $GroupsOrderingComposer,
+    $GroupsCreateCompanionBuilder,
+    $GroupsUpdateCompanionBuilder,
+    (Group, $GroupsReferences),
+    Group,
+    PrefetchHooks Function({bool owner})> {
+  $GroupsTableManager(_$Database db, Groups table)
+      : super(TableManagerState(
+          db: db,
+          table: table,
+          filteringComposer: $GroupsFilterComposer(ComposerState(db, table)),
+          orderingComposer: $GroupsOrderingComposer(ComposerState(db, table)),
+          updateCompanionCallback: ({
+            Value<int> id = const Value.absent(),
+            Value<String> title = const Value.absent(),
+            Value<bool?> deleted = const Value.absent(),
+            Value<int> owner = const Value.absent(),
+          }) =>
+              GroupsCompanion(
+            id: id,
+            title: title,
+            deleted: deleted,
+            owner: owner,
+          ),
+          createCompanionCallback: ({
+            Value<int> id = const Value.absent(),
+            required String title,
+            Value<bool?> deleted = const Value.absent(),
+            required int owner,
+          }) =>
+              GroupsCompanion.insert(
+            id: id,
+            title: title,
+            deleted: deleted,
+            owner: owner,
+          ),
+          withReferenceMapper: (p0) => p0
+              .map((e) => (e.readTable(table), $GroupsReferences(db, table, e)))
+              .toList(),
+          prefetchHooksCallback: ({owner = false}) {
+            return PrefetchHooks(
+              addJoins: <
+                  T extends TableManagerState<
+                      dynamic,
+                      dynamic,
+                      dynamic,
+                      dynamic,
+                      dynamic,
+                      dynamic,
+                      dynamic,
+                      dynamic,
+                      dynamic,
+                      dynamic>>(state) {
+                if (owner) {
+                  state = state.withJoin(
+                    currentTable: table,
+                    currentColumn: table.owner,
+                    referencedTable: $GroupsReferences._ownerTable(db),
+                    referencedColumn: $GroupsReferences._ownerTable(db).id,
+                  ) as T;
+                }
+
+                return state;
+              },
+              withPrefetches: (items) async {
+                return items;
+              },
+            );
+          },
+        ));
+}
+
+typedef $GroupsProcessedTableManager = ProcessedTableManager<
+    _$Database,
+    Groups,
+    Group,
+    $GroupsFilterComposer,
+    $GroupsOrderingComposer,
+    $GroupsCreateCompanionBuilder,
+    $GroupsUpdateCompanionBuilder,
+    (Group, $GroupsReferences),
+    Group,
+    PrefetchHooks Function({bool owner})>;
 typedef $NotesCreateCompanionBuilder = NotesCompanion Function({
   required String title,
   required String content,
@@ -1186,47 +1342,6 @@ typedef $NotesUpdateCompanionBuilder = NotesCompanion Function({
   Value<String> searchTerms,
   Value<int> rowid,
 });
-
-class $NotesTableManager extends RootTableManager<
-    _$Database,
-    Notes,
-    Note,
-    $NotesFilterComposer,
-    $NotesOrderingComposer,
-    $NotesCreateCompanionBuilder,
-    $NotesUpdateCompanionBuilder> {
-  $NotesTableManager(_$Database db, Notes table)
-      : super(TableManagerState(
-          db: db,
-          table: table,
-          filteringComposer: $NotesFilterComposer(ComposerState(db, table)),
-          orderingComposer: $NotesOrderingComposer(ComposerState(db, table)),
-          updateCompanionCallback: ({
-            Value<String> title = const Value.absent(),
-            Value<String> content = const Value.absent(),
-            Value<String> searchTerms = const Value.absent(),
-            Value<int> rowid = const Value.absent(),
-          }) =>
-              NotesCompanion(
-            title: title,
-            content: content,
-            searchTerms: searchTerms,
-            rowid: rowid,
-          ),
-          createCompanionCallback: ({
-            required String title,
-            required String content,
-            required String searchTerms,
-            Value<int> rowid = const Value.absent(),
-          }) =>
-              NotesCompanion.insert(
-            title: title,
-            content: content,
-            searchTerms: searchTerms,
-            rowid: rowid,
-          ),
-        ));
-}
 
 class $NotesFilterComposer extends FilterComposer<_$Database, Notes> {
   $NotesFilterComposer(super.$state);
@@ -1263,6 +1378,66 @@ class $NotesOrderingComposer extends OrderingComposer<_$Database, Notes> {
       builder: (column, joinBuilders) =>
           ColumnOrderings(column, joinBuilders: joinBuilders));
 }
+
+class $NotesTableManager extends RootTableManager<
+    _$Database,
+    Notes,
+    Note,
+    $NotesFilterComposer,
+    $NotesOrderingComposer,
+    $NotesCreateCompanionBuilder,
+    $NotesUpdateCompanionBuilder,
+    (Note, BaseReferences<_$Database, Notes, Note>),
+    Note,
+    PrefetchHooks Function()> {
+  $NotesTableManager(_$Database db, Notes table)
+      : super(TableManagerState(
+          db: db,
+          table: table,
+          filteringComposer: $NotesFilterComposer(ComposerState(db, table)),
+          orderingComposer: $NotesOrderingComposer(ComposerState(db, table)),
+          updateCompanionCallback: ({
+            Value<String> title = const Value.absent(),
+            Value<String> content = const Value.absent(),
+            Value<String> searchTerms = const Value.absent(),
+            Value<int> rowid = const Value.absent(),
+          }) =>
+              NotesCompanion(
+            title: title,
+            content: content,
+            searchTerms: searchTerms,
+            rowid: rowid,
+          ),
+          createCompanionCallback: ({
+            required String title,
+            required String content,
+            required String searchTerms,
+            Value<int> rowid = const Value.absent(),
+          }) =>
+              NotesCompanion.insert(
+            title: title,
+            content: content,
+            searchTerms: searchTerms,
+            rowid: rowid,
+          ),
+          withReferenceMapper: (p0) => p0
+              .map((e) => (e.readTable(table), BaseReferences(db, table, e)))
+              .toList(),
+          prefetchHooksCallback: null,
+        ));
+}
+
+typedef $NotesProcessedTableManager = ProcessedTableManager<
+    _$Database,
+    Notes,
+    Note,
+    $NotesFilterComposer,
+    $NotesOrderingComposer,
+    $NotesCreateCompanionBuilder,
+    $NotesUpdateCompanionBuilder,
+    (Note, BaseReferences<_$Database, Notes, Note>),
+    Note,
+    PrefetchHooks Function()>;
 
 class $DatabaseManager {
   final _$Database _db;

--- a/examples/migrations_example/lib/database.g.dart
+++ b/examples/migrations_example/lib/database.g.dart
@@ -1059,7 +1059,8 @@ class $$UsersTableTableManager extends RootTableManager<
     $$UsersTableUpdateCompanionBuilder,
     (User, $$UsersTableReferences),
     User,
-    PrefetchHooks Function({bool nextUser, bool groupsRefs})> {
+    PrefetchHooks Function(
+        {bool nextUser, bool groupsRefs, bool inTransaction})> {
   $$UsersTableTableManager(_$Database db, $UsersTable table)
       : super(TableManagerState(
           db: db,
@@ -1096,8 +1097,14 @@ class $$UsersTableTableManager extends RootTableManager<
               .map((e) =>
                   (e.readTable(table), $$UsersTableReferences(db, table, e)))
               .toList(),
-          prefetchHooksCallback: ({nextUser = false, groupsRefs = false}) {
+          prefetchHooksCallback: (
+              {nextUser = false,
+              groupsRefs = false,
+              bool inTransaction = true}) {
             return PrefetchHooks(
+              db: db,
+              inTransaction: inTransaction,
+              explicitlyWatchedTables: [if (groupsRefs) db.groups],
               addJoins: <
                   T extends TableManagerState<
                       dynamic,
@@ -1153,7 +1160,8 @@ typedef $$UsersTableProcessedTableManager = ProcessedTableManager<
     $$UsersTableUpdateCompanionBuilder,
     (User, $$UsersTableReferences),
     User,
-    PrefetchHooks Function({bool nextUser, bool groupsRefs})>;
+    PrefetchHooks Function(
+        {bool nextUser, bool groupsRefs, bool inTransaction})>;
 typedef $GroupsCreateCompanionBuilder = GroupsCompanion Function({
   Value<int> id,
   required String title,
@@ -1255,7 +1263,7 @@ class $GroupsTableManager extends RootTableManager<
     $GroupsUpdateCompanionBuilder,
     (Group, $GroupsReferences),
     Group,
-    PrefetchHooks Function({bool owner})> {
+    PrefetchHooks Function({bool owner, bool inTransaction})> {
   $GroupsTableManager(_$Database db, Groups table)
       : super(TableManagerState(
           db: db,
@@ -1289,8 +1297,11 @@ class $GroupsTableManager extends RootTableManager<
           withReferenceMapper: (p0) => p0
               .map((e) => (e.readTable(table), $GroupsReferences(db, table, e)))
               .toList(),
-          prefetchHooksCallback: ({owner = false}) {
+          prefetchHooksCallback: ({owner = false, bool inTransaction = true}) {
             return PrefetchHooks(
+              db: db,
+              inTransaction: inTransaction,
+              explicitlyWatchedTables: [],
               addJoins: <
                   T extends TableManagerState<
                       dynamic,
@@ -1332,7 +1343,7 @@ typedef $GroupsProcessedTableManager = ProcessedTableManager<
     $GroupsUpdateCompanionBuilder,
     (Group, $GroupsReferences),
     Group,
-    PrefetchHooks Function({bool owner})>;
+    PrefetchHooks Function({bool owner, bool inTransaction})>;
 typedef $NotesCreateCompanionBuilder = NotesCompanion Function({
   required String title,
   required String content,

--- a/examples/migrations_example/lib/database.g.dart
+++ b/examples/migrations_example/lib/database.g.dart
@@ -1124,11 +1124,10 @@ class $$UsersTableTableManager extends RootTableManager<
 
                 return state;
               },
-              prefetchedDataStreamsCallback: (items, {required bool watch}) {
+              getPrefetchedDataCallback: (items) async {
                 return [
                   if (groupsRefs)
-                    $_streamPrefetched(
-                        watch: watch,
+                    await $_getPrefetchedData(
                         currentTable: table,
                         referencedTable:
                             $$UsersTableReferences._groupsRefsTable(db),
@@ -1318,7 +1317,7 @@ class $GroupsTableManager extends RootTableManager<
 
                 return state;
               },
-              prefetchedDataStreamsCallback: (items, {required bool watch}) {
+              getPrefetchedDataCallback: (items) async {
                 return [];
               },
             );

--- a/examples/migrations_example/lib/database.g.dart
+++ b/examples/migrations_example/lib/database.g.dart
@@ -1059,8 +1059,7 @@ class $$UsersTableTableManager extends RootTableManager<
     $$UsersTableUpdateCompanionBuilder,
     (User, $$UsersTableReferences),
     User,
-    PrefetchHooks Function(
-        {bool nextUser, bool groupsRefs, bool inTransaction})> {
+    PrefetchHooks Function({bool nextUser, bool groupsRefs})> {
   $$UsersTableTableManager(_$Database db, $UsersTable table)
       : super(TableManagerState(
           db: db,
@@ -1097,13 +1096,9 @@ class $$UsersTableTableManager extends RootTableManager<
               .map((e) =>
                   (e.readTable(table), $$UsersTableReferences(db, table, e)))
               .toList(),
-          prefetchHooksCallback: (
-              {nextUser = false,
-              groupsRefs = false,
-              bool inTransaction = true}) {
+          prefetchHooksCallback: ({nextUser = false, groupsRefs = false}) {
             return PrefetchHooks(
               db: db,
-              inTransaction: inTransaction,
               explicitlyWatchedTables: [if (groupsRefs) db.groups],
               addJoins: <
                   T extends TableManagerState<
@@ -1160,8 +1155,7 @@ typedef $$UsersTableProcessedTableManager = ProcessedTableManager<
     $$UsersTableUpdateCompanionBuilder,
     (User, $$UsersTableReferences),
     User,
-    PrefetchHooks Function(
-        {bool nextUser, bool groupsRefs, bool inTransaction})>;
+    PrefetchHooks Function({bool nextUser, bool groupsRefs})>;
 typedef $GroupsCreateCompanionBuilder = GroupsCompanion Function({
   Value<int> id,
   required String title,
@@ -1263,7 +1257,7 @@ class $GroupsTableManager extends RootTableManager<
     $GroupsUpdateCompanionBuilder,
     (Group, $GroupsReferences),
     Group,
-    PrefetchHooks Function({bool owner, bool inTransaction})> {
+    PrefetchHooks Function({bool owner})> {
   $GroupsTableManager(_$Database db, Groups table)
       : super(TableManagerState(
           db: db,
@@ -1297,10 +1291,9 @@ class $GroupsTableManager extends RootTableManager<
           withReferenceMapper: (p0) => p0
               .map((e) => (e.readTable(table), $GroupsReferences(db, table, e)))
               .toList(),
-          prefetchHooksCallback: ({owner = false, bool inTransaction = true}) {
+          prefetchHooksCallback: ({owner = false}) {
             return PrefetchHooks(
               db: db,
-              inTransaction: inTransaction,
               explicitlyWatchedTables: [],
               addJoins: <
                   T extends TableManagerState<
@@ -1343,7 +1336,7 @@ typedef $GroupsProcessedTableManager = ProcessedTableManager<
     $GroupsUpdateCompanionBuilder,
     (Group, $GroupsReferences),
     Group,
-    PrefetchHooks Function({bool owner, bool inTransaction})>;
+    PrefetchHooks Function({bool owner})>;
 typedef $NotesCreateCompanionBuilder = NotesCompanion Function({
   required String title,
   required String content,

--- a/examples/migrations_example/lib/database.g.dart
+++ b/examples/migrations_example/lib/database.g.dart
@@ -942,7 +942,7 @@ typedef $$UsersTableUpdateCompanionBuilder = UsersCompanion Function({
   Value<int?> nextUser,
 });
 
-class $$UsersTableReferences
+final class $$UsersTableReferences
     extends BaseReferences<_$Database, $UsersTable, User> {
   $$UsersTableReferences(super.$_db, super.$_table, super.$_typedResult);
 
@@ -1165,7 +1165,8 @@ typedef $GroupsUpdateCompanionBuilder = GroupsCompanion Function({
   Value<int> owner,
 });
 
-class $GroupsReferences extends BaseReferences<_$Database, Groups, Group> {
+final class $GroupsReferences
+    extends BaseReferences<_$Database, Groups, Group> {
   $GroupsReferences(super.$_db, super.$_table, super.$_typedResult);
 
   static $UsersTable _ownerTable(_$Database db) =>

--- a/examples/migrations_example/lib/database.g.dart
+++ b/examples/migrations_example/lib/database.g.dart
@@ -962,7 +962,7 @@ class $$UsersTableReferences
   static MultiTypedResultKey<Groups, List<Group>> _groupsRefsTable(
           _$Database db) =>
       MultiTypedResultKey.fromTable(db.groups,
-          aliasName: "groupsRefs__mmDrTcdMYq");
+          aliasName: $_aliasNameGenerator(db.users.id, db.groups.owner));
 
   $GroupsProcessedTableManager get groupsRefs {
     final manager = $GroupsTableManager($_db, $_db.groups)

--- a/examples/migrations_example/lib/database.g.dart
+++ b/examples/migrations_example/lib/database.g.dart
@@ -1122,19 +1122,21 @@ class $$UsersTableTableManager extends RootTableManager<
 
                 return state;
               },
-              withPrefetches: (items) async {
-                items = await typedResultsWithPrefetched(
-                    doPrefetch: groupsRefs,
-                    currentTable: table,
-                    referencedTable:
-                        $$UsersTableReferences._groupsRefsTable(db),
-                    managerFromTypedResult: (p0) =>
-                        $$UsersTableReferences(db, table, p0).groupsRefs,
-                    referencedItemsForCurrentItem: (item, referencedItems) =>
-                        referencedItems.where((e) => e.owner == item.id),
-                    typedResults: items);
-
-                return items;
+              prefetchedDataStreamsCallback: (items, {required bool watch}) {
+                return [
+                  if (groupsRefs)
+                    $_streamPrefetched(
+                        watch: watch,
+                        currentTable: table,
+                        referencedTable:
+                            $$UsersTableReferences._groupsRefsTable(db),
+                        managerFromTypedResult: (p0) =>
+                            $$UsersTableReferences(db, table, p0).groupsRefs,
+                        referencedItemsForCurrentItem: (item,
+                                referencedItems) =>
+                            referencedItems.where((e) => e.owner == item.id),
+                        typedResults: items)
+                ];
               },
             );
           },
@@ -1312,8 +1314,8 @@ class $GroupsTableManager extends RootTableManager<
 
                 return state;
               },
-              withPrefetches: (items) async {
-                return items;
+              prefetchedDataStreamsCallback: (items, {required bool watch}) {
+                return [];
               },
             );
           },

--- a/examples/modular/lib/src/posts.drift.dart
+++ b/examples/modular/lib/src/posts.drift.dart
@@ -308,7 +308,7 @@ class $PostsTableManager extends i0.RootTableManager<
     $PostsUpdateCompanionBuilder,
     (i1.Post, i0.BaseReferences<i0.GeneratedDatabase, i1.Posts, i1.Post>),
     i1.Post,
-    i0.PrefetchHooks Function({bool author})> {
+    i0.PrefetchHooks Function({bool author, bool inTransaction})> {
   $PostsTableManager(i0.GeneratedDatabase db, i1.Posts table)
       : super(i0.TableManagerState(
           db: db,
@@ -354,7 +354,7 @@ typedef $PostsProcessedTableManager = i0.ProcessedTableManager<
     $PostsUpdateCompanionBuilder,
     (i1.Post, i0.BaseReferences<i0.GeneratedDatabase, i1.Posts, i1.Post>),
     i1.Post,
-    i0.PrefetchHooks Function({bool author})>;
+    i0.PrefetchHooks Function({bool author, bool inTransaction})>;
 
 class Likes extends i0.Table with i0.TableInfo<Likes, i1.Like> {
   @override
@@ -649,7 +649,7 @@ class $LikesTableManager extends i0.RootTableManager<
     $LikesUpdateCompanionBuilder,
     (i1.Like, i0.BaseReferences<i0.GeneratedDatabase, i1.Likes, i1.Like>),
     i1.Like,
-    i0.PrefetchHooks Function({bool post, bool likedBy})> {
+    i0.PrefetchHooks Function({bool post, bool likedBy, bool inTransaction})> {
   $LikesTableManager(i0.GeneratedDatabase db, i1.Likes table)
       : super(i0.TableManagerState(
           db: db,
@@ -695,4 +695,4 @@ typedef $LikesProcessedTableManager = i0.ProcessedTableManager<
     $LikesUpdateCompanionBuilder,
     (i1.Like, i0.BaseReferences<i0.GeneratedDatabase, i1.Likes, i1.Like>),
     i1.Like,
-    i0.PrefetchHooks Function({bool post, bool likedBy})>;
+    i0.PrefetchHooks Function({bool post, bool likedBy, bool inTransaction})>;

--- a/examples/modular/lib/src/posts.drift.dart
+++ b/examples/modular/lib/src/posts.drift.dart
@@ -308,7 +308,7 @@ class $PostsTableManager extends i0.RootTableManager<
     $PostsUpdateCompanionBuilder,
     (i1.Post, i0.BaseReferences<i0.GeneratedDatabase, i1.Posts, i1.Post>),
     i1.Post,
-    i0.PrefetchHooks Function({bool author, bool inTransaction})> {
+    i0.PrefetchHooks Function({bool author})> {
   $PostsTableManager(i0.GeneratedDatabase db, i1.Posts table)
       : super(i0.TableManagerState(
           db: db,
@@ -354,7 +354,7 @@ typedef $PostsProcessedTableManager = i0.ProcessedTableManager<
     $PostsUpdateCompanionBuilder,
     (i1.Post, i0.BaseReferences<i0.GeneratedDatabase, i1.Posts, i1.Post>),
     i1.Post,
-    i0.PrefetchHooks Function({bool author, bool inTransaction})>;
+    i0.PrefetchHooks Function({bool author})>;
 
 class Likes extends i0.Table with i0.TableInfo<Likes, i1.Like> {
   @override
@@ -649,7 +649,7 @@ class $LikesTableManager extends i0.RootTableManager<
     $LikesUpdateCompanionBuilder,
     (i1.Like, i0.BaseReferences<i0.GeneratedDatabase, i1.Likes, i1.Like>),
     i1.Like,
-    i0.PrefetchHooks Function({bool post, bool likedBy, bool inTransaction})> {
+    i0.PrefetchHooks Function({bool post, bool likedBy})> {
   $LikesTableManager(i0.GeneratedDatabase db, i1.Likes table)
       : super(i0.TableManagerState(
           db: db,
@@ -695,4 +695,4 @@ typedef $LikesProcessedTableManager = i0.ProcessedTableManager<
     $LikesUpdateCompanionBuilder,
     (i1.Like, i0.BaseReferences<i0.GeneratedDatabase, i1.Likes, i1.Like>),
     i1.Like,
-    i0.PrefetchHooks Function({bool post, bool likedBy, bool inTransaction})>;
+    i0.PrefetchHooks Function({bool post, bool likedBy})>;

--- a/examples/modular/lib/src/posts.drift.dart
+++ b/examples/modular/lib/src/posts.drift.dart
@@ -236,45 +236,6 @@ typedef $PostsUpdateCompanionBuilder = i1.PostsCompanion Function({
   i0.Value<String?> content,
 });
 
-class $PostsTableManager extends i0.RootTableManager<
-    i0.GeneratedDatabase,
-    i1.Posts,
-    i1.Post,
-    i1.$PostsFilterComposer,
-    i1.$PostsOrderingComposer,
-    $PostsCreateCompanionBuilder,
-    $PostsUpdateCompanionBuilder> {
-  $PostsTableManager(i0.GeneratedDatabase db, i1.Posts table)
-      : super(i0.TableManagerState(
-          db: db,
-          table: table,
-          filteringComposer:
-              i1.$PostsFilterComposer(i0.ComposerState(db, table)),
-          orderingComposer:
-              i1.$PostsOrderingComposer(i0.ComposerState(db, table)),
-          updateCompanionCallback: ({
-            i0.Value<int> id = const i0.Value.absent(),
-            i0.Value<int> author = const i0.Value.absent(),
-            i0.Value<String?> content = const i0.Value.absent(),
-          }) =>
-              i1.PostsCompanion(
-            id: id,
-            author: author,
-            content: content,
-          ),
-          createCompanionCallback: ({
-            i0.Value<int> id = const i0.Value.absent(),
-            required int author,
-            i0.Value<String?> content = const i0.Value.absent(),
-          }) =>
-              i1.PostsCompanion.insert(
-            id: id,
-            author: author,
-            content: content,
-          ),
-        ));
-}
-
 class $PostsFilterComposer
     extends i0.FilterComposer<i0.GeneratedDatabase, i1.Posts> {
   $PostsFilterComposer(super.$state);
@@ -336,6 +297,64 @@ class $PostsOrderingComposer
     return composer;
   }
 }
+
+class $PostsTableManager extends i0.RootTableManager<
+    i0.GeneratedDatabase,
+    i1.Posts,
+    i1.Post,
+    i1.$PostsFilterComposer,
+    i1.$PostsOrderingComposer,
+    $PostsCreateCompanionBuilder,
+    $PostsUpdateCompanionBuilder,
+    (i1.Post, i0.BaseReferences<i0.GeneratedDatabase, i1.Posts, i1.Post>),
+    i1.Post,
+    i0.PrefetchHooks Function({bool author})> {
+  $PostsTableManager(i0.GeneratedDatabase db, i1.Posts table)
+      : super(i0.TableManagerState(
+          db: db,
+          table: table,
+          filteringComposer:
+              i1.$PostsFilterComposer(i0.ComposerState(db, table)),
+          orderingComposer:
+              i1.$PostsOrderingComposer(i0.ComposerState(db, table)),
+          updateCompanionCallback: ({
+            i0.Value<int> id = const i0.Value.absent(),
+            i0.Value<int> author = const i0.Value.absent(),
+            i0.Value<String?> content = const i0.Value.absent(),
+          }) =>
+              i1.PostsCompanion(
+            id: id,
+            author: author,
+            content: content,
+          ),
+          createCompanionCallback: ({
+            i0.Value<int> id = const i0.Value.absent(),
+            required int author,
+            i0.Value<String?> content = const i0.Value.absent(),
+          }) =>
+              i1.PostsCompanion.insert(
+            id: id,
+            author: author,
+            content: content,
+          ),
+          withReferenceMapper: (p0) => p0
+              .map((e) => (e.readTable(table), i0.BaseReferences(db, table, e)))
+              .toList(),
+          prefetchHooksCallback: null,
+        ));
+}
+
+typedef $PostsProcessedTableManager = i0.ProcessedTableManager<
+    i0.GeneratedDatabase,
+    i1.Posts,
+    i1.Post,
+    i1.$PostsFilterComposer,
+    i1.$PostsOrderingComposer,
+    $PostsCreateCompanionBuilder,
+    $PostsUpdateCompanionBuilder,
+    (i1.Post, i0.BaseReferences<i0.GeneratedDatabase, i1.Posts, i1.Post>),
+    i1.Post,
+    i0.PrefetchHooks Function({bool author})>;
 
 class Likes extends i0.Table with i0.TableInfo<Likes, i1.Like> {
   @override
@@ -544,45 +563,6 @@ typedef $LikesUpdateCompanionBuilder = i1.LikesCompanion Function({
   i0.Value<int> rowid,
 });
 
-class $LikesTableManager extends i0.RootTableManager<
-    i0.GeneratedDatabase,
-    i1.Likes,
-    i1.Like,
-    i1.$LikesFilterComposer,
-    i1.$LikesOrderingComposer,
-    $LikesCreateCompanionBuilder,
-    $LikesUpdateCompanionBuilder> {
-  $LikesTableManager(i0.GeneratedDatabase db, i1.Likes table)
-      : super(i0.TableManagerState(
-          db: db,
-          table: table,
-          filteringComposer:
-              i1.$LikesFilterComposer(i0.ComposerState(db, table)),
-          orderingComposer:
-              i1.$LikesOrderingComposer(i0.ComposerState(db, table)),
-          updateCompanionCallback: ({
-            i0.Value<int> post = const i0.Value.absent(),
-            i0.Value<int> likedBy = const i0.Value.absent(),
-            i0.Value<int> rowid = const i0.Value.absent(),
-          }) =>
-              i1.LikesCompanion(
-            post: post,
-            likedBy: likedBy,
-            rowid: rowid,
-          ),
-          createCompanionCallback: ({
-            required int post,
-            required int likedBy,
-            i0.Value<int> rowid = const i0.Value.absent(),
-          }) =>
-              i1.LikesCompanion.insert(
-            post: post,
-            likedBy: likedBy,
-            rowid: rowid,
-          ),
-        ));
-}
-
 class $LikesFilterComposer
     extends i0.FilterComposer<i0.GeneratedDatabase, i1.Likes> {
   $LikesFilterComposer(super.$state);
@@ -658,3 +638,61 @@ class $LikesOrderingComposer
     return composer;
   }
 }
+
+class $LikesTableManager extends i0.RootTableManager<
+    i0.GeneratedDatabase,
+    i1.Likes,
+    i1.Like,
+    i1.$LikesFilterComposer,
+    i1.$LikesOrderingComposer,
+    $LikesCreateCompanionBuilder,
+    $LikesUpdateCompanionBuilder,
+    (i1.Like, i0.BaseReferences<i0.GeneratedDatabase, i1.Likes, i1.Like>),
+    i1.Like,
+    i0.PrefetchHooks Function({bool post, bool likedBy})> {
+  $LikesTableManager(i0.GeneratedDatabase db, i1.Likes table)
+      : super(i0.TableManagerState(
+          db: db,
+          table: table,
+          filteringComposer:
+              i1.$LikesFilterComposer(i0.ComposerState(db, table)),
+          orderingComposer:
+              i1.$LikesOrderingComposer(i0.ComposerState(db, table)),
+          updateCompanionCallback: ({
+            i0.Value<int> post = const i0.Value.absent(),
+            i0.Value<int> likedBy = const i0.Value.absent(),
+            i0.Value<int> rowid = const i0.Value.absent(),
+          }) =>
+              i1.LikesCompanion(
+            post: post,
+            likedBy: likedBy,
+            rowid: rowid,
+          ),
+          createCompanionCallback: ({
+            required int post,
+            required int likedBy,
+            i0.Value<int> rowid = const i0.Value.absent(),
+          }) =>
+              i1.LikesCompanion.insert(
+            post: post,
+            likedBy: likedBy,
+            rowid: rowid,
+          ),
+          withReferenceMapper: (p0) => p0
+              .map((e) => (e.readTable(table), i0.BaseReferences(db, table, e)))
+              .toList(),
+          prefetchHooksCallback: null,
+        ));
+}
+
+typedef $LikesProcessedTableManager = i0.ProcessedTableManager<
+    i0.GeneratedDatabase,
+    i1.Likes,
+    i1.Like,
+    i1.$LikesFilterComposer,
+    i1.$LikesOrderingComposer,
+    $LikesCreateCompanionBuilder,
+    $LikesUpdateCompanionBuilder,
+    (i1.Like, i0.BaseReferences<i0.GeneratedDatabase, i1.Likes, i1.Like>),
+    i1.Like,
+    i0.PrefetchHooks Function({bool post, bool likedBy})>;

--- a/examples/modular/lib/src/search.drift.dart
+++ b/examples/modular/lib/src/search.drift.dart
@@ -224,45 +224,6 @@ typedef $SearchInPostsUpdateCompanionBuilder = i1.SearchInPostsCompanion
   i0.Value<int> rowid,
 });
 
-class $SearchInPostsTableManager extends i0.RootTableManager<
-    i0.GeneratedDatabase,
-    i1.SearchInPosts,
-    i1.SearchInPost,
-    i1.$SearchInPostsFilterComposer,
-    i1.$SearchInPostsOrderingComposer,
-    $SearchInPostsCreateCompanionBuilder,
-    $SearchInPostsUpdateCompanionBuilder> {
-  $SearchInPostsTableManager(i0.GeneratedDatabase db, i1.SearchInPosts table)
-      : super(i0.TableManagerState(
-          db: db,
-          table: table,
-          filteringComposer:
-              i1.$SearchInPostsFilterComposer(i0.ComposerState(db, table)),
-          orderingComposer:
-              i1.$SearchInPostsOrderingComposer(i0.ComposerState(db, table)),
-          updateCompanionCallback: ({
-            i0.Value<String> author = const i0.Value.absent(),
-            i0.Value<String> content = const i0.Value.absent(),
-            i0.Value<int> rowid = const i0.Value.absent(),
-          }) =>
-              i1.SearchInPostsCompanion(
-            author: author,
-            content: content,
-            rowid: rowid,
-          ),
-          createCompanionCallback: ({
-            required String author,
-            required String content,
-            i0.Value<int> rowid = const i0.Value.absent(),
-          }) =>
-              i1.SearchInPostsCompanion.insert(
-            author: author,
-            content: content,
-            rowid: rowid,
-          ),
-        ));
-}
-
 class $SearchInPostsFilterComposer
     extends i0.FilterComposer<i0.GeneratedDatabase, i1.SearchInPosts> {
   $SearchInPostsFilterComposer(super.$state);
@@ -291,6 +252,69 @@ class $SearchInPostsOrderingComposer
           i0.ColumnOrderings(column, joinBuilders: joinBuilders));
 }
 
+class $SearchInPostsTableManager extends i0.RootTableManager<
+    i0.GeneratedDatabase,
+    i1.SearchInPosts,
+    i1.SearchInPost,
+    i1.$SearchInPostsFilterComposer,
+    i1.$SearchInPostsOrderingComposer,
+    $SearchInPostsCreateCompanionBuilder,
+    $SearchInPostsUpdateCompanionBuilder,
+    (
+      i1.SearchInPost,
+      i0.BaseReferences<i0.GeneratedDatabase, i1.SearchInPosts, i1.SearchInPost>
+    ),
+    i1.SearchInPost,
+    i0.PrefetchHooks Function()> {
+  $SearchInPostsTableManager(i0.GeneratedDatabase db, i1.SearchInPosts table)
+      : super(i0.TableManagerState(
+          db: db,
+          table: table,
+          filteringComposer:
+              i1.$SearchInPostsFilterComposer(i0.ComposerState(db, table)),
+          orderingComposer:
+              i1.$SearchInPostsOrderingComposer(i0.ComposerState(db, table)),
+          updateCompanionCallback: ({
+            i0.Value<String> author = const i0.Value.absent(),
+            i0.Value<String> content = const i0.Value.absent(),
+            i0.Value<int> rowid = const i0.Value.absent(),
+          }) =>
+              i1.SearchInPostsCompanion(
+            author: author,
+            content: content,
+            rowid: rowid,
+          ),
+          createCompanionCallback: ({
+            required String author,
+            required String content,
+            i0.Value<int> rowid = const i0.Value.absent(),
+          }) =>
+              i1.SearchInPostsCompanion.insert(
+            author: author,
+            content: content,
+            rowid: rowid,
+          ),
+          withReferenceMapper: (p0) => p0
+              .map((e) => (e.readTable(table), i0.BaseReferences(db, table, e)))
+              .toList(),
+          prefetchHooksCallback: null,
+        ));
+}
+
+typedef $SearchInPostsProcessedTableManager = i0.ProcessedTableManager<
+    i0.GeneratedDatabase,
+    i1.SearchInPosts,
+    i1.SearchInPost,
+    i1.$SearchInPostsFilterComposer,
+    i1.$SearchInPostsOrderingComposer,
+    $SearchInPostsCreateCompanionBuilder,
+    $SearchInPostsUpdateCompanionBuilder,
+    (
+      i1.SearchInPost,
+      i0.BaseReferences<i0.GeneratedDatabase, i1.SearchInPosts, i1.SearchInPost>
+    ),
+    i1.SearchInPost,
+    i0.PrefetchHooks Function()>;
 i0.Trigger get postsInsert => i0.Trigger(
     'CREATE TRIGGER posts_insert AFTER INSERT ON posts BEGIN INSERT INTO search_in_posts ("rowid", author, content) VALUES (new.id, new.author, new.content);END',
     'posts_insert');

--- a/examples/modular/lib/src/users.drift.dart
+++ b/examples/modular/lib/src/users.drift.dart
@@ -769,8 +769,7 @@ class $FollowsTableManager extends i0.RootTableManager<
     $FollowsUpdateCompanionBuilder,
     (i1.Follow, i0.BaseReferences<i0.GeneratedDatabase, i1.Follows, i1.Follow>),
     i1.Follow,
-    i0.PrefetchHooks Function(
-        {bool followed, bool follower, bool inTransaction})> {
+    i0.PrefetchHooks Function({bool followed, bool follower})> {
   $FollowsTableManager(i0.GeneratedDatabase db, i1.Follows table)
       : super(i0.TableManagerState(
           db: db,
@@ -816,8 +815,7 @@ typedef $FollowsProcessedTableManager = i0.ProcessedTableManager<
     $FollowsUpdateCompanionBuilder,
     (i1.Follow, i0.BaseReferences<i0.GeneratedDatabase, i1.Follows, i1.Follow>),
     i1.Follow,
-    i0.PrefetchHooks Function(
-        {bool followed, bool follower, bool inTransaction})>;
+    i0.PrefetchHooks Function({bool followed, bool follower})>;
 
 class PopularUser extends i0.DataClass {
   final int id;

--- a/examples/modular/lib/src/users.drift.dart
+++ b/examples/modular/lib/src/users.drift.dart
@@ -769,7 +769,8 @@ class $FollowsTableManager extends i0.RootTableManager<
     $FollowsUpdateCompanionBuilder,
     (i1.Follow, i0.BaseReferences<i0.GeneratedDatabase, i1.Follows, i1.Follow>),
     i1.Follow,
-    i0.PrefetchHooks Function({bool followed, bool follower})> {
+    i0.PrefetchHooks Function(
+        {bool followed, bool follower, bool inTransaction})> {
   $FollowsTableManager(i0.GeneratedDatabase db, i1.Follows table)
       : super(i0.TableManagerState(
           db: db,
@@ -815,7 +816,8 @@ typedef $FollowsProcessedTableManager = i0.ProcessedTableManager<
     $FollowsUpdateCompanionBuilder,
     (i1.Follow, i0.BaseReferences<i0.GeneratedDatabase, i1.Follows, i1.Follow>),
     i1.Follow,
-    i0.PrefetchHooks Function({bool followed, bool follower})>;
+    i0.PrefetchHooks Function(
+        {bool followed, bool follower, bool inTransaction})>;
 
 class PopularUser extends i0.DataClass {
   final int id;

--- a/examples/modular/lib/src/users.drift.dart
+++ b/examples/modular/lib/src/users.drift.dart
@@ -342,53 +342,6 @@ typedef $UsersUpdateCompanionBuilder = i1.UsersCompanion Function({
   i0.Value<i3.Uint8List?> profilePicture,
 });
 
-class $UsersTableManager extends i0.RootTableManager<
-    i0.GeneratedDatabase,
-    i1.Users,
-    i1.User,
-    i1.$UsersFilterComposer,
-    i1.$UsersOrderingComposer,
-    $UsersCreateCompanionBuilder,
-    $UsersUpdateCompanionBuilder> {
-  $UsersTableManager(i0.GeneratedDatabase db, i1.Users table)
-      : super(i0.TableManagerState(
-          db: db,
-          table: table,
-          filteringComposer:
-              i1.$UsersFilterComposer(i0.ComposerState(db, table)),
-          orderingComposer:
-              i1.$UsersOrderingComposer(i0.ComposerState(db, table)),
-          updateCompanionCallback: ({
-            i0.Value<int> id = const i0.Value.absent(),
-            i0.Value<String> name = const i0.Value.absent(),
-            i0.Value<String?> biography = const i0.Value.absent(),
-            i0.Value<i2.Preferences?> preferences = const i0.Value.absent(),
-            i0.Value<i3.Uint8List?> profilePicture = const i0.Value.absent(),
-          }) =>
-              i1.UsersCompanion(
-            id: id,
-            name: name,
-            biography: biography,
-            preferences: preferences,
-            profilePicture: profilePicture,
-          ),
-          createCompanionCallback: ({
-            i0.Value<int> id = const i0.Value.absent(),
-            required String name,
-            i0.Value<String?> biography = const i0.Value.absent(),
-            i0.Value<i2.Preferences?> preferences = const i0.Value.absent(),
-            i0.Value<i3.Uint8List?> profilePicture = const i0.Value.absent(),
-          }) =>
-              i1.UsersCompanion.insert(
-            id: id,
-            name: name,
-            biography: biography,
-            preferences: preferences,
-            profilePicture: profilePicture,
-          ),
-        ));
-}
-
 class $UsersFilterComposer
     extends i0.FilterComposer<i0.GeneratedDatabase, i1.Users> {
   $UsersFilterComposer(super.$state);
@@ -450,6 +403,71 @@ class $UsersOrderingComposer
               i0.ColumnOrderings(column, joinBuilders: joinBuilders));
 }
 
+class $UsersTableManager extends i0.RootTableManager<
+    i0.GeneratedDatabase,
+    i1.Users,
+    i1.User,
+    i1.$UsersFilterComposer,
+    i1.$UsersOrderingComposer,
+    $UsersCreateCompanionBuilder,
+    $UsersUpdateCompanionBuilder,
+    (i1.User, i0.BaseReferences<i0.GeneratedDatabase, i1.Users, i1.User>),
+    i1.User,
+    i0.PrefetchHooks Function()> {
+  $UsersTableManager(i0.GeneratedDatabase db, i1.Users table)
+      : super(i0.TableManagerState(
+          db: db,
+          table: table,
+          filteringComposer:
+              i1.$UsersFilterComposer(i0.ComposerState(db, table)),
+          orderingComposer:
+              i1.$UsersOrderingComposer(i0.ComposerState(db, table)),
+          updateCompanionCallback: ({
+            i0.Value<int> id = const i0.Value.absent(),
+            i0.Value<String> name = const i0.Value.absent(),
+            i0.Value<String?> biography = const i0.Value.absent(),
+            i0.Value<i2.Preferences?> preferences = const i0.Value.absent(),
+            i0.Value<i3.Uint8List?> profilePicture = const i0.Value.absent(),
+          }) =>
+              i1.UsersCompanion(
+            id: id,
+            name: name,
+            biography: biography,
+            preferences: preferences,
+            profilePicture: profilePicture,
+          ),
+          createCompanionCallback: ({
+            i0.Value<int> id = const i0.Value.absent(),
+            required String name,
+            i0.Value<String?> biography = const i0.Value.absent(),
+            i0.Value<i2.Preferences?> preferences = const i0.Value.absent(),
+            i0.Value<i3.Uint8List?> profilePicture = const i0.Value.absent(),
+          }) =>
+              i1.UsersCompanion.insert(
+            id: id,
+            name: name,
+            biography: biography,
+            preferences: preferences,
+            profilePicture: profilePicture,
+          ),
+          withReferenceMapper: (p0) => p0
+              .map((e) => (e.readTable(table), i0.BaseReferences(db, table, e)))
+              .toList(),
+          prefetchHooksCallback: null,
+        ));
+}
+
+typedef $UsersProcessedTableManager = i0.ProcessedTableManager<
+    i0.GeneratedDatabase,
+    i1.Users,
+    i1.User,
+    i1.$UsersFilterComposer,
+    i1.$UsersOrderingComposer,
+    $UsersCreateCompanionBuilder,
+    $UsersUpdateCompanionBuilder,
+    (i1.User, i0.BaseReferences<i0.GeneratedDatabase, i1.Users, i1.User>),
+    i1.User,
+    i0.PrefetchHooks Function()>;
 i0.Index get usersName =>
     i0.Index('users_name', 'CREATE INDEX users_name ON users (name)');
 
@@ -665,45 +683,6 @@ typedef $FollowsUpdateCompanionBuilder = i1.FollowsCompanion Function({
   i0.Value<int> rowid,
 });
 
-class $FollowsTableManager extends i0.RootTableManager<
-    i0.GeneratedDatabase,
-    i1.Follows,
-    i1.Follow,
-    i1.$FollowsFilterComposer,
-    i1.$FollowsOrderingComposer,
-    $FollowsCreateCompanionBuilder,
-    $FollowsUpdateCompanionBuilder> {
-  $FollowsTableManager(i0.GeneratedDatabase db, i1.Follows table)
-      : super(i0.TableManagerState(
-          db: db,
-          table: table,
-          filteringComposer:
-              i1.$FollowsFilterComposer(i0.ComposerState(db, table)),
-          orderingComposer:
-              i1.$FollowsOrderingComposer(i0.ComposerState(db, table)),
-          updateCompanionCallback: ({
-            i0.Value<int> followed = const i0.Value.absent(),
-            i0.Value<int> follower = const i0.Value.absent(),
-            i0.Value<int> rowid = const i0.Value.absent(),
-          }) =>
-              i1.FollowsCompanion(
-            followed: followed,
-            follower: follower,
-            rowid: rowid,
-          ),
-          createCompanionCallback: ({
-            required int followed,
-            required int follower,
-            i0.Value<int> rowid = const i0.Value.absent(),
-          }) =>
-              i1.FollowsCompanion.insert(
-            followed: followed,
-            follower: follower,
-            rowid: rowid,
-          ),
-        ));
-}
-
 class $FollowsFilterComposer
     extends i0.FilterComposer<i0.GeneratedDatabase, i1.Follows> {
   $FollowsFilterComposer(super.$state);
@@ -779,6 +758,64 @@ class $FollowsOrderingComposer
     return composer;
   }
 }
+
+class $FollowsTableManager extends i0.RootTableManager<
+    i0.GeneratedDatabase,
+    i1.Follows,
+    i1.Follow,
+    i1.$FollowsFilterComposer,
+    i1.$FollowsOrderingComposer,
+    $FollowsCreateCompanionBuilder,
+    $FollowsUpdateCompanionBuilder,
+    (i1.Follow, i0.BaseReferences<i0.GeneratedDatabase, i1.Follows, i1.Follow>),
+    i1.Follow,
+    i0.PrefetchHooks Function({bool followed, bool follower})> {
+  $FollowsTableManager(i0.GeneratedDatabase db, i1.Follows table)
+      : super(i0.TableManagerState(
+          db: db,
+          table: table,
+          filteringComposer:
+              i1.$FollowsFilterComposer(i0.ComposerState(db, table)),
+          orderingComposer:
+              i1.$FollowsOrderingComposer(i0.ComposerState(db, table)),
+          updateCompanionCallback: ({
+            i0.Value<int> followed = const i0.Value.absent(),
+            i0.Value<int> follower = const i0.Value.absent(),
+            i0.Value<int> rowid = const i0.Value.absent(),
+          }) =>
+              i1.FollowsCompanion(
+            followed: followed,
+            follower: follower,
+            rowid: rowid,
+          ),
+          createCompanionCallback: ({
+            required int followed,
+            required int follower,
+            i0.Value<int> rowid = const i0.Value.absent(),
+          }) =>
+              i1.FollowsCompanion.insert(
+            followed: followed,
+            follower: follower,
+            rowid: rowid,
+          ),
+          withReferenceMapper: (p0) => p0
+              .map((e) => (e.readTable(table), i0.BaseReferences(db, table, e)))
+              .toList(),
+          prefetchHooksCallback: null,
+        ));
+}
+
+typedef $FollowsProcessedTableManager = i0.ProcessedTableManager<
+    i0.GeneratedDatabase,
+    i1.Follows,
+    i1.Follow,
+    i1.$FollowsFilterComposer,
+    i1.$FollowsOrderingComposer,
+    $FollowsCreateCompanionBuilder,
+    $FollowsUpdateCompanionBuilder,
+    (i1.Follow, i0.BaseReferences<i0.GeneratedDatabase, i1.Follows, i1.Follow>),
+    i1.Follow,
+    i0.PrefetchHooks Function({bool followed, bool follower})>;
 
 class PopularUser extends i0.DataClass {
   final int id;

--- a/examples/multi_package/server/lib/database.drift.dart
+++ b/examples/multi_package/server/lib/database.drift.dart
@@ -319,7 +319,7 @@ class $$ActiveSessionsTableTableManager extends i0.RootTableManager<
           i3.ActiveSession>
     ),
     i3.ActiveSession,
-    i0.PrefetchHooks Function({bool user})> {
+    i0.PrefetchHooks Function({bool user, bool inTransaction})> {
   $$ActiveSessionsTableTableManager(
       i0.GeneratedDatabase db, i3.$ActiveSessionsTable table)
       : super(i0.TableManagerState(
@@ -370,4 +370,4 @@ typedef $$ActiveSessionsTableProcessedTableManager = i0.ProcessedTableManager<
           i3.ActiveSession>
     ),
     i3.ActiveSession,
-    i0.PrefetchHooks Function({bool user})>;
+    i0.PrefetchHooks Function({bool user, bool inTransaction})>;

--- a/examples/multi_package/server/lib/database.drift.dart
+++ b/examples/multi_package/server/lib/database.drift.dart
@@ -253,46 +253,6 @@ typedef $$ActiveSessionsTableUpdateCompanionBuilder = i3.ActiveSessionsCompanion
   i0.Value<int> rowid,
 });
 
-class $$ActiveSessionsTableTableManager extends i0.RootTableManager<
-    i0.GeneratedDatabase,
-    i3.$ActiveSessionsTable,
-    i3.ActiveSession,
-    i3.$$ActiveSessionsTableFilterComposer,
-    i3.$$ActiveSessionsTableOrderingComposer,
-    $$ActiveSessionsTableCreateCompanionBuilder,
-    $$ActiveSessionsTableUpdateCompanionBuilder> {
-  $$ActiveSessionsTableTableManager(
-      i0.GeneratedDatabase db, i3.$ActiveSessionsTable table)
-      : super(i0.TableManagerState(
-          db: db,
-          table: table,
-          filteringComposer: i3
-              .$$ActiveSessionsTableFilterComposer(i0.ComposerState(db, table)),
-          orderingComposer: i3.$$ActiveSessionsTableOrderingComposer(
-              i0.ComposerState(db, table)),
-          updateCompanionCallback: ({
-            i0.Value<int> user = const i0.Value.absent(),
-            i0.Value<String> bearerToken = const i0.Value.absent(),
-            i0.Value<int> rowid = const i0.Value.absent(),
-          }) =>
-              i3.ActiveSessionsCompanion(
-            user: user,
-            bearerToken: bearerToken,
-            rowid: rowid,
-          ),
-          createCompanionCallback: ({
-            required int user,
-            required String bearerToken,
-            i0.Value<int> rowid = const i0.Value.absent(),
-          }) =>
-              i3.ActiveSessionsCompanion.insert(
-            user: user,
-            bearerToken: bearerToken,
-            rowid: rowid,
-          ),
-        ));
-}
-
 class $$ActiveSessionsTableFilterComposer
     extends i0.FilterComposer<i0.GeneratedDatabase, i3.$ActiveSessionsTable> {
   $$ActiveSessionsTableFilterComposer(super.$state);
@@ -344,3 +304,70 @@ class $$ActiveSessionsTableOrderingComposer
     return composer;
   }
 }
+
+class $$ActiveSessionsTableTableManager extends i0.RootTableManager<
+    i0.GeneratedDatabase,
+    i3.$ActiveSessionsTable,
+    i3.ActiveSession,
+    i3.$$ActiveSessionsTableFilterComposer,
+    i3.$$ActiveSessionsTableOrderingComposer,
+    $$ActiveSessionsTableCreateCompanionBuilder,
+    $$ActiveSessionsTableUpdateCompanionBuilder,
+    (
+      i3.ActiveSession,
+      i0.BaseReferences<i0.GeneratedDatabase, i3.$ActiveSessionsTable,
+          i3.ActiveSession>
+    ),
+    i3.ActiveSession,
+    i0.PrefetchHooks Function({bool user})> {
+  $$ActiveSessionsTableTableManager(
+      i0.GeneratedDatabase db, i3.$ActiveSessionsTable table)
+      : super(i0.TableManagerState(
+          db: db,
+          table: table,
+          filteringComposer: i3
+              .$$ActiveSessionsTableFilterComposer(i0.ComposerState(db, table)),
+          orderingComposer: i3.$$ActiveSessionsTableOrderingComposer(
+              i0.ComposerState(db, table)),
+          updateCompanionCallback: ({
+            i0.Value<int> user = const i0.Value.absent(),
+            i0.Value<String> bearerToken = const i0.Value.absent(),
+            i0.Value<int> rowid = const i0.Value.absent(),
+          }) =>
+              i3.ActiveSessionsCompanion(
+            user: user,
+            bearerToken: bearerToken,
+            rowid: rowid,
+          ),
+          createCompanionCallback: ({
+            required int user,
+            required String bearerToken,
+            i0.Value<int> rowid = const i0.Value.absent(),
+          }) =>
+              i3.ActiveSessionsCompanion.insert(
+            user: user,
+            bearerToken: bearerToken,
+            rowid: rowid,
+          ),
+          withReferenceMapper: (p0) => p0
+              .map((e) => (e.readTable(table), i0.BaseReferences(db, table, e)))
+              .toList(),
+          prefetchHooksCallback: null,
+        ));
+}
+
+typedef $$ActiveSessionsTableProcessedTableManager = i0.ProcessedTableManager<
+    i0.GeneratedDatabase,
+    i3.$ActiveSessionsTable,
+    i3.ActiveSession,
+    i3.$$ActiveSessionsTableFilterComposer,
+    i3.$$ActiveSessionsTableOrderingComposer,
+    $$ActiveSessionsTableCreateCompanionBuilder,
+    $$ActiveSessionsTableUpdateCompanionBuilder,
+    (
+      i3.ActiveSession,
+      i0.BaseReferences<i0.GeneratedDatabase, i3.$ActiveSessionsTable,
+          i3.ActiveSession>
+    ),
+    i3.ActiveSession,
+    i0.PrefetchHooks Function({bool user})>;

--- a/examples/multi_package/server/lib/database.drift.dart
+++ b/examples/multi_package/server/lib/database.drift.dart
@@ -319,7 +319,7 @@ class $$ActiveSessionsTableTableManager extends i0.RootTableManager<
           i3.ActiveSession>
     ),
     i3.ActiveSession,
-    i0.PrefetchHooks Function({bool user, bool inTransaction})> {
+    i0.PrefetchHooks Function({bool user})> {
   $$ActiveSessionsTableTableManager(
       i0.GeneratedDatabase db, i3.$ActiveSessionsTable table)
       : super(i0.TableManagerState(
@@ -370,4 +370,4 @@ typedef $$ActiveSessionsTableProcessedTableManager = i0.ProcessedTableManager<
           i3.ActiveSession>
     ),
     i3.ActiveSession,
-    i0.PrefetchHooks Function({bool user, bool inTransaction})>;
+    i0.PrefetchHooks Function({bool user})>;

--- a/examples/multi_package/shared/lib/shared.drift.dart
+++ b/examples/multi_package/shared/lib/shared.drift.dart
@@ -28,8 +28,10 @@ class SharedDrift extends i1.ModularAccessor {
         ));
   }
 
-  i2.Posts get posts => this.resultSet<i2.Posts>('posts');
-  i3.$UsersTable get users => this.resultSet<i3.$UsersTable>('users');
+  i2.Posts get posts =>
+      i1.ReadDatabaseContainer(attachedDatabase).resultSet<i2.Posts>('posts');
+  i3.$UsersTable get users => i1.ReadDatabaseContainer(attachedDatabase)
+      .resultSet<i3.$UsersTable>('users');
 }
 
 class AllPostsResult {

--- a/examples/multi_package/shared/lib/src/posts.drift.dart
+++ b/examples/multi_package/shared/lib/src/posts.drift.dart
@@ -278,7 +278,7 @@ class $PostsTableManager extends i0.RootTableManager<
     $PostsUpdateCompanionBuilder,
     (i1.Post, i0.BaseReferences<i0.GeneratedDatabase, i1.Posts, i1.Post>),
     i1.Post,
-    i0.PrefetchHooks Function({bool author, bool inTransaction})> {
+    i0.PrefetchHooks Function({bool author})> {
   $PostsTableManager(i0.GeneratedDatabase db, i1.Posts table)
       : super(i0.TableManagerState(
           db: db,
@@ -324,4 +324,4 @@ typedef $PostsProcessedTableManager = i0.ProcessedTableManager<
     $PostsUpdateCompanionBuilder,
     (i1.Post, i0.BaseReferences<i0.GeneratedDatabase, i1.Posts, i1.Post>),
     i1.Post,
-    i0.PrefetchHooks Function({bool author, bool inTransaction})>;
+    i0.PrefetchHooks Function({bool author})>;

--- a/examples/multi_package/shared/lib/src/posts.drift.dart
+++ b/examples/multi_package/shared/lib/src/posts.drift.dart
@@ -216,45 +216,6 @@ typedef $PostsUpdateCompanionBuilder = i1.PostsCompanion Function({
   i0.Value<int> rowid,
 });
 
-class $PostsTableManager extends i0.RootTableManager<
-    i0.GeneratedDatabase,
-    i1.Posts,
-    i1.Post,
-    i1.$PostsFilterComposer,
-    i1.$PostsOrderingComposer,
-    $PostsCreateCompanionBuilder,
-    $PostsUpdateCompanionBuilder> {
-  $PostsTableManager(i0.GeneratedDatabase db, i1.Posts table)
-      : super(i0.TableManagerState(
-          db: db,
-          table: table,
-          filteringComposer:
-              i1.$PostsFilterComposer(i0.ComposerState(db, table)),
-          orderingComposer:
-              i1.$PostsOrderingComposer(i0.ComposerState(db, table)),
-          updateCompanionCallback: ({
-            i0.Value<int> author = const i0.Value.absent(),
-            i0.Value<String?> content = const i0.Value.absent(),
-            i0.Value<int> rowid = const i0.Value.absent(),
-          }) =>
-              i1.PostsCompanion(
-            author: author,
-            content: content,
-            rowid: rowid,
-          ),
-          createCompanionCallback: ({
-            required int author,
-            i0.Value<String?> content = const i0.Value.absent(),
-            i0.Value<int> rowid = const i0.Value.absent(),
-          }) =>
-              i1.PostsCompanion.insert(
-            author: author,
-            content: content,
-            rowid: rowid,
-          ),
-        ));
-}
-
 class $PostsFilterComposer
     extends i0.FilterComposer<i0.GeneratedDatabase, i1.Posts> {
   $PostsFilterComposer(super.$state);
@@ -306,3 +267,61 @@ class $PostsOrderingComposer
     return composer;
   }
 }
+
+class $PostsTableManager extends i0.RootTableManager<
+    i0.GeneratedDatabase,
+    i1.Posts,
+    i1.Post,
+    i1.$PostsFilterComposer,
+    i1.$PostsOrderingComposer,
+    $PostsCreateCompanionBuilder,
+    $PostsUpdateCompanionBuilder,
+    (i1.Post, i0.BaseReferences<i0.GeneratedDatabase, i1.Posts, i1.Post>),
+    i1.Post,
+    i0.PrefetchHooks Function({bool author})> {
+  $PostsTableManager(i0.GeneratedDatabase db, i1.Posts table)
+      : super(i0.TableManagerState(
+          db: db,
+          table: table,
+          filteringComposer:
+              i1.$PostsFilterComposer(i0.ComposerState(db, table)),
+          orderingComposer:
+              i1.$PostsOrderingComposer(i0.ComposerState(db, table)),
+          updateCompanionCallback: ({
+            i0.Value<int> author = const i0.Value.absent(),
+            i0.Value<String?> content = const i0.Value.absent(),
+            i0.Value<int> rowid = const i0.Value.absent(),
+          }) =>
+              i1.PostsCompanion(
+            author: author,
+            content: content,
+            rowid: rowid,
+          ),
+          createCompanionCallback: ({
+            required int author,
+            i0.Value<String?> content = const i0.Value.absent(),
+            i0.Value<int> rowid = const i0.Value.absent(),
+          }) =>
+              i1.PostsCompanion.insert(
+            author: author,
+            content: content,
+            rowid: rowid,
+          ),
+          withReferenceMapper: (p0) => p0
+              .map((e) => (e.readTable(table), i0.BaseReferences(db, table, e)))
+              .toList(),
+          prefetchHooksCallback: null,
+        ));
+}
+
+typedef $PostsProcessedTableManager = i0.ProcessedTableManager<
+    i0.GeneratedDatabase,
+    i1.Posts,
+    i1.Post,
+    i1.$PostsFilterComposer,
+    i1.$PostsOrderingComposer,
+    $PostsCreateCompanionBuilder,
+    $PostsUpdateCompanionBuilder,
+    (i1.Post, i0.BaseReferences<i0.GeneratedDatabase, i1.Posts, i1.Post>),
+    i1.Post,
+    i0.PrefetchHooks Function({bool author})>;

--- a/examples/multi_package/shared/lib/src/posts.drift.dart
+++ b/examples/multi_package/shared/lib/src/posts.drift.dart
@@ -278,7 +278,7 @@ class $PostsTableManager extends i0.RootTableManager<
     $PostsUpdateCompanionBuilder,
     (i1.Post, i0.BaseReferences<i0.GeneratedDatabase, i1.Posts, i1.Post>),
     i1.Post,
-    i0.PrefetchHooks Function({bool author})> {
+    i0.PrefetchHooks Function({bool author, bool inTransaction})> {
   $PostsTableManager(i0.GeneratedDatabase db, i1.Posts table)
       : super(i0.TableManagerState(
           db: db,
@@ -324,4 +324,4 @@ typedef $PostsProcessedTableManager = i0.ProcessedTableManager<
     $PostsUpdateCompanionBuilder,
     (i1.Post, i0.BaseReferences<i0.GeneratedDatabase, i1.Posts, i1.Post>),
     i1.Post,
-    i0.PrefetchHooks Function({bool author})>;
+    i0.PrefetchHooks Function({bool author, bool inTransaction})>;

--- a/examples/multi_package/shared/lib/src/users.drift.dart
+++ b/examples/multi_package/shared/lib/src/users.drift.dart
@@ -189,41 +189,6 @@ typedef $$UsersTableUpdateCompanionBuilder = i1.UsersCompanion Function({
   i0.Value<String> name,
 });
 
-class $$UsersTableTableManager extends i0.RootTableManager<
-    i0.GeneratedDatabase,
-    i1.$UsersTable,
-    i1.User,
-    i1.$$UsersTableFilterComposer,
-    i1.$$UsersTableOrderingComposer,
-    $$UsersTableCreateCompanionBuilder,
-    $$UsersTableUpdateCompanionBuilder> {
-  $$UsersTableTableManager(i0.GeneratedDatabase db, i1.$UsersTable table)
-      : super(i0.TableManagerState(
-          db: db,
-          table: table,
-          filteringComposer:
-              i1.$$UsersTableFilterComposer(i0.ComposerState(db, table)),
-          orderingComposer:
-              i1.$$UsersTableOrderingComposer(i0.ComposerState(db, table)),
-          updateCompanionCallback: ({
-            i0.Value<int> id = const i0.Value.absent(),
-            i0.Value<String> name = const i0.Value.absent(),
-          }) =>
-              i1.UsersCompanion(
-            id: id,
-            name: name,
-          ),
-          createCompanionCallback: ({
-            i0.Value<int> id = const i0.Value.absent(),
-            required String name,
-          }) =>
-              i1.UsersCompanion.insert(
-            id: id,
-            name: name,
-          ),
-        ));
-}
-
 class $$UsersTableFilterComposer
     extends i0.FilterComposer<i0.GeneratedDatabase, i1.$UsersTable> {
   $$UsersTableFilterComposer(super.$state);
@@ -251,3 +216,57 @@ class $$UsersTableOrderingComposer
       builder: (column, joinBuilders) =>
           i0.ColumnOrderings(column, joinBuilders: joinBuilders));
 }
+
+class $$UsersTableTableManager extends i0.RootTableManager<
+    i0.GeneratedDatabase,
+    i1.$UsersTable,
+    i1.User,
+    i1.$$UsersTableFilterComposer,
+    i1.$$UsersTableOrderingComposer,
+    $$UsersTableCreateCompanionBuilder,
+    $$UsersTableUpdateCompanionBuilder,
+    (i1.User, i0.BaseReferences<i0.GeneratedDatabase, i1.$UsersTable, i1.User>),
+    i1.User,
+    i0.PrefetchHooks Function()> {
+  $$UsersTableTableManager(i0.GeneratedDatabase db, i1.$UsersTable table)
+      : super(i0.TableManagerState(
+          db: db,
+          table: table,
+          filteringComposer:
+              i1.$$UsersTableFilterComposer(i0.ComposerState(db, table)),
+          orderingComposer:
+              i1.$$UsersTableOrderingComposer(i0.ComposerState(db, table)),
+          updateCompanionCallback: ({
+            i0.Value<int> id = const i0.Value.absent(),
+            i0.Value<String> name = const i0.Value.absent(),
+          }) =>
+              i1.UsersCompanion(
+            id: id,
+            name: name,
+          ),
+          createCompanionCallback: ({
+            i0.Value<int> id = const i0.Value.absent(),
+            required String name,
+          }) =>
+              i1.UsersCompanion.insert(
+            id: id,
+            name: name,
+          ),
+          withReferenceMapper: (p0) => p0
+              .map((e) => (e.readTable(table), i0.BaseReferences(db, table, e)))
+              .toList(),
+          prefetchHooksCallback: null,
+        ));
+}
+
+typedef $$UsersTableProcessedTableManager = i0.ProcessedTableManager<
+    i0.GeneratedDatabase,
+    i1.$UsersTable,
+    i1.User,
+    i1.$$UsersTableFilterComposer,
+    i1.$$UsersTableOrderingComposer,
+    $$UsersTableCreateCompanionBuilder,
+    $$UsersTableUpdateCompanionBuilder,
+    (i1.User, i0.BaseReferences<i0.GeneratedDatabase, i1.$UsersTable, i1.User>),
+    i1.User,
+    i0.PrefetchHooks Function()>;

--- a/examples/with_built_value/lib/tables.drift.dart
+++ b/examples/with_built_value/lib/tables.drift.dart
@@ -190,41 +190,6 @@ typedef $UsersUpdateCompanionBuilder = i1.UsersCompanion Function({
   i0.Value<String> name,
 });
 
-class $UsersTableManager extends i0.RootTableManager<
-    i0.GeneratedDatabase,
-    i1.Users,
-    i1.User,
-    i1.$UsersFilterComposer,
-    i1.$UsersOrderingComposer,
-    $UsersCreateCompanionBuilder,
-    $UsersUpdateCompanionBuilder> {
-  $UsersTableManager(i0.GeneratedDatabase db, i1.Users table)
-      : super(i0.TableManagerState(
-          db: db,
-          table: table,
-          filteringComposer:
-              i1.$UsersFilterComposer(i0.ComposerState(db, table)),
-          orderingComposer:
-              i1.$UsersOrderingComposer(i0.ComposerState(db, table)),
-          updateCompanionCallback: ({
-            i0.Value<int> id = const i0.Value.absent(),
-            i0.Value<String> name = const i0.Value.absent(),
-          }) =>
-              i1.UsersCompanion(
-            id: id,
-            name: name,
-          ),
-          createCompanionCallback: ({
-            i0.Value<int> id = const i0.Value.absent(),
-            required String name,
-          }) =>
-              i1.UsersCompanion.insert(
-            id: id,
-            name: name,
-          ),
-        ));
-}
-
 class $UsersFilterComposer
     extends i0.FilterComposer<i0.GeneratedDatabase, i1.Users> {
   $UsersFilterComposer(super.$state);
@@ -252,3 +217,57 @@ class $UsersOrderingComposer
       builder: (column, joinBuilders) =>
           i0.ColumnOrderings(column, joinBuilders: joinBuilders));
 }
+
+class $UsersTableManager extends i0.RootTableManager<
+    i0.GeneratedDatabase,
+    i1.Users,
+    i1.User,
+    i1.$UsersFilterComposer,
+    i1.$UsersOrderingComposer,
+    $UsersCreateCompanionBuilder,
+    $UsersUpdateCompanionBuilder,
+    (i1.User, i0.BaseReferences<i0.GeneratedDatabase, i1.Users, i1.User>),
+    i1.User,
+    i0.PrefetchHooks Function()> {
+  $UsersTableManager(i0.GeneratedDatabase db, i1.Users table)
+      : super(i0.TableManagerState(
+          db: db,
+          table: table,
+          filteringComposer:
+              i1.$UsersFilterComposer(i0.ComposerState(db, table)),
+          orderingComposer:
+              i1.$UsersOrderingComposer(i0.ComposerState(db, table)),
+          updateCompanionCallback: ({
+            i0.Value<int> id = const i0.Value.absent(),
+            i0.Value<String> name = const i0.Value.absent(),
+          }) =>
+              i1.UsersCompanion(
+            id: id,
+            name: name,
+          ),
+          createCompanionCallback: ({
+            i0.Value<int> id = const i0.Value.absent(),
+            required String name,
+          }) =>
+              i1.UsersCompanion.insert(
+            id: id,
+            name: name,
+          ),
+          withReferenceMapper: (p0) => p0
+              .map((e) => (e.readTable(table), i0.BaseReferences(db, table, e)))
+              .toList(),
+          prefetchHooksCallback: null,
+        ));
+}
+
+typedef $UsersProcessedTableManager = i0.ProcessedTableManager<
+    i0.GeneratedDatabase,
+    i1.Users,
+    i1.User,
+    i1.$UsersFilterComposer,
+    i1.$UsersOrderingComposer,
+    $UsersCreateCompanionBuilder,
+    $UsersUpdateCompanionBuilder,
+    (i1.User, i0.BaseReferences<i0.GeneratedDatabase, i1.Users, i1.User>),
+    i1.User,
+    i0.PrefetchHooks Function()>;

--- a/extras/drift_postgres/example/main.g.dart
+++ b/extras/drift_postgres/example/main.g.dart
@@ -211,6 +211,34 @@ typedef $$UsersTableUpdateCompanionBuilder = UsersCompanion Function({
   Value<int> rowid,
 });
 
+class $$UsersTableFilterComposer
+    extends FilterComposer<_$DriftPostgresDatabase, $UsersTable> {
+  $$UsersTableFilterComposer(super.$state);
+  ColumnFilters<UuidValue> get id => $state.composableBuilder(
+      column: $state.table.id,
+      builder: (column, joinBuilders) =>
+          ColumnFilters(column, joinBuilders: joinBuilders));
+
+  ColumnFilters<String> get name => $state.composableBuilder(
+      column: $state.table.name,
+      builder: (column, joinBuilders) =>
+          ColumnFilters(column, joinBuilders: joinBuilders));
+}
+
+class $$UsersTableOrderingComposer
+    extends OrderingComposer<_$DriftPostgresDatabase, $UsersTable> {
+  $$UsersTableOrderingComposer(super.$state);
+  ColumnOrderings<UuidValue> get id => $state.composableBuilder(
+      column: $state.table.id,
+      builder: (column, joinBuilders) =>
+          ColumnOrderings(column, joinBuilders: joinBuilders));
+
+  ColumnOrderings<String> get name => $state.composableBuilder(
+      column: $state.table.name,
+      builder: (column, joinBuilders) =>
+          ColumnOrderings(column, joinBuilders: joinBuilders));
+}
+
 class $$UsersTableTableManager extends RootTableManager<
     _$DriftPostgresDatabase,
     $UsersTable,
@@ -218,7 +246,10 @@ class $$UsersTableTableManager extends RootTableManager<
     $$UsersTableFilterComposer,
     $$UsersTableOrderingComposer,
     $$UsersTableCreateCompanionBuilder,
-    $$UsersTableUpdateCompanionBuilder> {
+    $$UsersTableUpdateCompanionBuilder,
+    (User, BaseReferences<_$DriftPostgresDatabase, $UsersTable, User>),
+    User,
+    PrefetchHooks Function()> {
   $$UsersTableTableManager(_$DriftPostgresDatabase db, $UsersTable table)
       : super(TableManagerState(
           db: db,
@@ -247,36 +278,24 @@ class $$UsersTableTableManager extends RootTableManager<
             name: name,
             rowid: rowid,
           ),
+          withReferenceMapper: (p0) => p0
+              .map((e) => (e.readTable(table), BaseReferences(db, table, e)))
+              .toList(),
+          prefetchHooksCallback: null,
         ));
 }
 
-class $$UsersTableFilterComposer
-    extends FilterComposer<_$DriftPostgresDatabase, $UsersTable> {
-  $$UsersTableFilterComposer(super.$state);
-  ColumnFilters<UuidValue> get id => $state.composableBuilder(
-      column: $state.table.id,
-      builder: (column, joinBuilders) =>
-          ColumnFilters(column, joinBuilders: joinBuilders));
-
-  ColumnFilters<String> get name => $state.composableBuilder(
-      column: $state.table.name,
-      builder: (column, joinBuilders) =>
-          ColumnFilters(column, joinBuilders: joinBuilders));
-}
-
-class $$UsersTableOrderingComposer
-    extends OrderingComposer<_$DriftPostgresDatabase, $UsersTable> {
-  $$UsersTableOrderingComposer(super.$state);
-  ColumnOrderings<UuidValue> get id => $state.composableBuilder(
-      column: $state.table.id,
-      builder: (column, joinBuilders) =>
-          ColumnOrderings(column, joinBuilders: joinBuilders));
-
-  ColumnOrderings<String> get name => $state.composableBuilder(
-      column: $state.table.name,
-      builder: (column, joinBuilders) =>
-          ColumnOrderings(column, joinBuilders: joinBuilders));
-}
+typedef $$UsersTableProcessedTableManager = ProcessedTableManager<
+    _$DriftPostgresDatabase,
+    $UsersTable,
+    User,
+    $$UsersTableFilterComposer,
+    $$UsersTableOrderingComposer,
+    $$UsersTableCreateCompanionBuilder,
+    $$UsersTableUpdateCompanionBuilder,
+    (User, BaseReferences<_$DriftPostgresDatabase, $UsersTable, User>),
+    User,
+    PrefetchHooks Function()>;
 
 class $DriftPostgresDatabaseManager {
   final _$DriftPostgresDatabase _db;

--- a/extras/integration_tests/drift_testcases/lib/database/database.g.dart
+++ b/extras/integration_tests/drift_testcases/lib/database/database.g.dart
@@ -733,53 +733,6 @@ typedef $$UsersTableUpdateCompanionBuilder = UsersCompanion Function({
   Value<Preferences?> preferences,
 });
 
-class $$UsersTableTableManager extends RootTableManager<
-    _$Database,
-    $UsersTable,
-    User,
-    $$UsersTableFilterComposer,
-    $$UsersTableOrderingComposer,
-    $$UsersTableCreateCompanionBuilder,
-    $$UsersTableUpdateCompanionBuilder> {
-  $$UsersTableTableManager(_$Database db, $UsersTable table)
-      : super(TableManagerState(
-          db: db,
-          table: table,
-          filteringComposer:
-              $$UsersTableFilterComposer(ComposerState(db, table)),
-          orderingComposer:
-              $$UsersTableOrderingComposer(ComposerState(db, table)),
-          updateCompanionCallback: ({
-            Value<int> id = const Value.absent(),
-            Value<String> name = const Value.absent(),
-            Value<DateTime> birthDate = const Value.absent(),
-            Value<Uint8List?> profilePicture = const Value.absent(),
-            Value<Preferences?> preferences = const Value.absent(),
-          }) =>
-              UsersCompanion(
-            id: id,
-            name: name,
-            birthDate: birthDate,
-            profilePicture: profilePicture,
-            preferences: preferences,
-          ),
-          createCompanionCallback: ({
-            Value<int> id = const Value.absent(),
-            required String name,
-            required DateTime birthDate,
-            Value<Uint8List?> profilePicture = const Value.absent(),
-            Value<Preferences?> preferences = const Value.absent(),
-          }) =>
-              UsersCompanion.insert(
-            id: id,
-            name: name,
-            birthDate: birthDate,
-            profilePicture: profilePicture,
-            preferences: preferences,
-          ),
-        ));
-}
-
 class $$UsersTableFilterComposer
     extends FilterComposer<_$Database, $UsersTable> {
   $$UsersTableFilterComposer(super.$state);
@@ -840,6 +793,71 @@ class $$UsersTableOrderingComposer
           ColumnOrderings(column, joinBuilders: joinBuilders));
 }
 
+class $$UsersTableTableManager extends RootTableManager<
+    _$Database,
+    $UsersTable,
+    User,
+    $$UsersTableFilterComposer,
+    $$UsersTableOrderingComposer,
+    $$UsersTableCreateCompanionBuilder,
+    $$UsersTableUpdateCompanionBuilder,
+    (User, BaseReferences<_$Database, $UsersTable, User>),
+    User,
+    PrefetchHooks Function()> {
+  $$UsersTableTableManager(_$Database db, $UsersTable table)
+      : super(TableManagerState(
+          db: db,
+          table: table,
+          filteringComposer:
+              $$UsersTableFilterComposer(ComposerState(db, table)),
+          orderingComposer:
+              $$UsersTableOrderingComposer(ComposerState(db, table)),
+          updateCompanionCallback: ({
+            Value<int> id = const Value.absent(),
+            Value<String> name = const Value.absent(),
+            Value<DateTime> birthDate = const Value.absent(),
+            Value<Uint8List?> profilePicture = const Value.absent(),
+            Value<Preferences?> preferences = const Value.absent(),
+          }) =>
+              UsersCompanion(
+            id: id,
+            name: name,
+            birthDate: birthDate,
+            profilePicture: profilePicture,
+            preferences: preferences,
+          ),
+          createCompanionCallback: ({
+            Value<int> id = const Value.absent(),
+            required String name,
+            required DateTime birthDate,
+            Value<Uint8List?> profilePicture = const Value.absent(),
+            Value<Preferences?> preferences = const Value.absent(),
+          }) =>
+              UsersCompanion.insert(
+            id: id,
+            name: name,
+            birthDate: birthDate,
+            profilePicture: profilePicture,
+            preferences: preferences,
+          ),
+          withReferenceMapper: (p0) => p0
+              .map((e) => (e.readTable(table), BaseReferences(db, table, e)))
+              .toList(),
+          prefetchHooksCallback: null,
+        ));
+}
+
+typedef $$UsersTableProcessedTableManager = ProcessedTableManager<
+    _$Database,
+    $UsersTable,
+    User,
+    $$UsersTableFilterComposer,
+    $$UsersTableOrderingComposer,
+    $$UsersTableCreateCompanionBuilder,
+    $$UsersTableUpdateCompanionBuilder,
+    (User, BaseReferences<_$Database, $UsersTable, User>),
+    User,
+    PrefetchHooks Function()>;
 typedef $$FriendshipsTableCreateCompanionBuilder = FriendshipsCompanion
     Function({
   required int firstUser,
@@ -854,49 +872,6 @@ typedef $$FriendshipsTableUpdateCompanionBuilder = FriendshipsCompanion
   Value<bool> reallyGoodFriends,
   Value<int> rowid,
 });
-
-class $$FriendshipsTableTableManager extends RootTableManager<
-    _$Database,
-    $FriendshipsTable,
-    Friendship,
-    $$FriendshipsTableFilterComposer,
-    $$FriendshipsTableOrderingComposer,
-    $$FriendshipsTableCreateCompanionBuilder,
-    $$FriendshipsTableUpdateCompanionBuilder> {
-  $$FriendshipsTableTableManager(_$Database db, $FriendshipsTable table)
-      : super(TableManagerState(
-          db: db,
-          table: table,
-          filteringComposer:
-              $$FriendshipsTableFilterComposer(ComposerState(db, table)),
-          orderingComposer:
-              $$FriendshipsTableOrderingComposer(ComposerState(db, table)),
-          updateCompanionCallback: ({
-            Value<int> firstUser = const Value.absent(),
-            Value<int> secondUser = const Value.absent(),
-            Value<bool> reallyGoodFriends = const Value.absent(),
-            Value<int> rowid = const Value.absent(),
-          }) =>
-              FriendshipsCompanion(
-            firstUser: firstUser,
-            secondUser: secondUser,
-            reallyGoodFriends: reallyGoodFriends,
-            rowid: rowid,
-          ),
-          createCompanionCallback: ({
-            required int firstUser,
-            required int secondUser,
-            Value<bool> reallyGoodFriends = const Value.absent(),
-            Value<int> rowid = const Value.absent(),
-          }) =>
-              FriendshipsCompanion.insert(
-            firstUser: firstUser,
-            secondUser: secondUser,
-            reallyGoodFriends: reallyGoodFriends,
-            rowid: rowid,
-          ),
-        ));
-}
 
 class $$FriendshipsTableFilterComposer
     extends FilterComposer<_$Database, $FriendshipsTable> {
@@ -935,6 +910,68 @@ class $$FriendshipsTableOrderingComposer
       builder: (column, joinBuilders) =>
           ColumnOrderings(column, joinBuilders: joinBuilders));
 }
+
+class $$FriendshipsTableTableManager extends RootTableManager<
+    _$Database,
+    $FriendshipsTable,
+    Friendship,
+    $$FriendshipsTableFilterComposer,
+    $$FriendshipsTableOrderingComposer,
+    $$FriendshipsTableCreateCompanionBuilder,
+    $$FriendshipsTableUpdateCompanionBuilder,
+    (Friendship, BaseReferences<_$Database, $FriendshipsTable, Friendship>),
+    Friendship,
+    PrefetchHooks Function()> {
+  $$FriendshipsTableTableManager(_$Database db, $FriendshipsTable table)
+      : super(TableManagerState(
+          db: db,
+          table: table,
+          filteringComposer:
+              $$FriendshipsTableFilterComposer(ComposerState(db, table)),
+          orderingComposer:
+              $$FriendshipsTableOrderingComposer(ComposerState(db, table)),
+          updateCompanionCallback: ({
+            Value<int> firstUser = const Value.absent(),
+            Value<int> secondUser = const Value.absent(),
+            Value<bool> reallyGoodFriends = const Value.absent(),
+            Value<int> rowid = const Value.absent(),
+          }) =>
+              FriendshipsCompanion(
+            firstUser: firstUser,
+            secondUser: secondUser,
+            reallyGoodFriends: reallyGoodFriends,
+            rowid: rowid,
+          ),
+          createCompanionCallback: ({
+            required int firstUser,
+            required int secondUser,
+            Value<bool> reallyGoodFriends = const Value.absent(),
+            Value<int> rowid = const Value.absent(),
+          }) =>
+              FriendshipsCompanion.insert(
+            firstUser: firstUser,
+            secondUser: secondUser,
+            reallyGoodFriends: reallyGoodFriends,
+            rowid: rowid,
+          ),
+          withReferenceMapper: (p0) => p0
+              .map((e) => (e.readTable(table), BaseReferences(db, table, e)))
+              .toList(),
+          prefetchHooksCallback: null,
+        ));
+}
+
+typedef $$FriendshipsTableProcessedTableManager = ProcessedTableManager<
+    _$Database,
+    $FriendshipsTable,
+    Friendship,
+    $$FriendshipsTableFilterComposer,
+    $$FriendshipsTableOrderingComposer,
+    $$FriendshipsTableCreateCompanionBuilder,
+    $$FriendshipsTableUpdateCompanionBuilder,
+    (Friendship, BaseReferences<_$Database, $FriendshipsTable, Friendship>),
+    Friendship,
+    PrefetchHooks Function()>;
 
 class $DatabaseManager {
   final _$Database _db;

--- a/extras/integration_tests/web_wasm/lib/src/database.g.dart
+++ b/extras/integration_tests/web_wasm/lib/src/database.g.dart
@@ -203,41 +203,6 @@ typedef $$TestTableTableUpdateCompanionBuilder = TestTableCompanion Function({
   Value<String> content,
 });
 
-class $$TestTableTableTableManager extends RootTableManager<
-    _$TestDatabase,
-    $TestTableTable,
-    TestTableData,
-    $$TestTableTableFilterComposer,
-    $$TestTableTableOrderingComposer,
-    $$TestTableTableCreateCompanionBuilder,
-    $$TestTableTableUpdateCompanionBuilder> {
-  $$TestTableTableTableManager(_$TestDatabase db, $TestTableTable table)
-      : super(TableManagerState(
-          db: db,
-          table: table,
-          filteringComposer:
-              $$TestTableTableFilterComposer(ComposerState(db, table)),
-          orderingComposer:
-              $$TestTableTableOrderingComposer(ComposerState(db, table)),
-          updateCompanionCallback: ({
-            Value<int> id = const Value.absent(),
-            Value<String> content = const Value.absent(),
-          }) =>
-              TestTableCompanion(
-            id: id,
-            content: content,
-          ),
-          createCompanionCallback: ({
-            Value<int> id = const Value.absent(),
-            required String content,
-          }) =>
-              TestTableCompanion.insert(
-            id: id,
-            content: content,
-          ),
-        ));
-}
-
 class $$TestTableTableFilterComposer
     extends FilterComposer<_$TestDatabase, $TestTableTable> {
   $$TestTableTableFilterComposer(super.$state);
@@ -265,6 +230,66 @@ class $$TestTableTableOrderingComposer
       builder: (column, joinBuilders) =>
           ColumnOrderings(column, joinBuilders: joinBuilders));
 }
+
+class $$TestTableTableTableManager extends RootTableManager<
+    _$TestDatabase,
+    $TestTableTable,
+    TestTableData,
+    $$TestTableTableFilterComposer,
+    $$TestTableTableOrderingComposer,
+    $$TestTableTableCreateCompanionBuilder,
+    $$TestTableTableUpdateCompanionBuilder,
+    (
+      TestTableData,
+      BaseReferences<_$TestDatabase, $TestTableTable, TestTableData>
+    ),
+    TestTableData,
+    PrefetchHooks Function()> {
+  $$TestTableTableTableManager(_$TestDatabase db, $TestTableTable table)
+      : super(TableManagerState(
+          db: db,
+          table: table,
+          filteringComposer:
+              $$TestTableTableFilterComposer(ComposerState(db, table)),
+          orderingComposer:
+              $$TestTableTableOrderingComposer(ComposerState(db, table)),
+          updateCompanionCallback: ({
+            Value<int> id = const Value.absent(),
+            Value<String> content = const Value.absent(),
+          }) =>
+              TestTableCompanion(
+            id: id,
+            content: content,
+          ),
+          createCompanionCallback: ({
+            Value<int> id = const Value.absent(),
+            required String content,
+          }) =>
+              TestTableCompanion.insert(
+            id: id,
+            content: content,
+          ),
+          withReferenceMapper: (p0) => p0
+              .map((e) => (e.readTable(table), BaseReferences(db, table, e)))
+              .toList(),
+          prefetchHooksCallback: null,
+        ));
+}
+
+typedef $$TestTableTableProcessedTableManager = ProcessedTableManager<
+    _$TestDatabase,
+    $TestTableTable,
+    TestTableData,
+    $$TestTableTableFilterComposer,
+    $$TestTableTableOrderingComposer,
+    $$TestTableTableCreateCompanionBuilder,
+    $$TestTableTableUpdateCompanionBuilder,
+    (
+      TestTableData,
+      BaseReferences<_$TestDatabase, $TestTableTable, TestTableData>
+    ),
+    TestTableData,
+    PrefetchHooks Function()>;
 
 class $TestDatabaseManager {
   final _$TestDatabase _db;


### PR DESCRIPTION
After hundreds of man--hours finding the most optimal way to add support for prefetching, I've come up with this.

Let me know if you need more info. This is a massive PR, and I'm happy to explain any part of it.


### References

This function with return a new manager which will return each item in the database with its references

The references are returned as a prefiltered manager, which will only return the items which are related to the item

For example:
```dart
for (final (group,refs) in await groups.withReferences().get()) {
  final usersInGroup = await refs.users.get();
  /// Is identical to:
  final usersInGroup = await users.filter((f) => f.group.id(group.id)).get();
}
 ```
### Prefetching

The keen among you may notice that the above code is extremly inefficient, as it will run a query for each group to get the users in that group.
This could mean hundreds of queries for a single page of data, grinding your application to a halt.

The solution to this is to use prefetching, which will run a single query to get all the data you need.

For example:
```dart
for (final (group,refs) in await groups.withReferences((prefetch) => prefetch(users: true)).get()) {
   final usersInGroup = refs.users.prefetchedData;
}
```

Note that `prefetchedData` will be null if the reference was not prefetched.

### Symmetrical Type Converters
This PR fixes a bug where referenced filters which didn't share the exact same type would not act correctly.
The Manager API now ignores references whose type converters arrent the same. The Tests were updated to support this.

### Internals

The is much going on, if we go through this step by step, it should come clear


#### References

When `withReferences`, we create a new manager which has it's `ActiveDataclass` generic updated to the `DataclassWithReferences` generic. The ActiveDataclass is the class which is returned by any of the `get`/`watch` functions.
When any of these `get`/`watch` method are called, we apply the `_withReferenceMapper` if the  `ActiveDataclass` is a `DataclassWithReferences`.

What is returned from a withReferences call is a record, with the item, along with an object which has getters for prefiltered managers.


```dart
for (final (group,refs) in await groups.withReferences().get()) {
    group; // Original Item
    refs; // Prefiltered Managers
    final usersInGroupManager = refs.users  // Prefiltered Manager
    final usersInGroupManager = refs.users  // Prefiltered Manager
}
```

#### Prefetching

When `withReferences` is called with a prefetcher, we create a class called `PrefetchHooks` and add it to the manager. This class will be different depening on what was prefetched.

```dart
groups.withReferences((prefetch) => prefetch(users: false, admin: true))
```
Would create a `PrefetchHooks` which was configured to only prefetch `admin`.

This `PrefetchHooks` class has 2 jobs:
 1. Add joins to the query before it is executed
 2. Execute a 2nd query to get reverse references and store it's result in each `TypedResult` object.

When a referenced manager is created that has prefetch data in it's `TypedResult` object, it will be loaded into the `prefetchedData` field of the manager.


```dart
$$TodosTableTableProcessedTableManager get todos {
    final manager = $$TodosTableTableTableManager($_db, $_db.todosTable)
        .filter((f) => f.category.id($_item.id));

    final cache = $_typedResult.readTableOrNull(_todosTable($_db)); // Loads the prefetched data from the TypedResult
    return ProcessedTableManager(
        manager.$state.copyWith(prefetchedData: cache));
  }
```

#### Hacks
Loading in multiple items into a single `TypedResult` object wasn't currently supported.
Reading a table from a `TypedResult` expects a single item, so we had to hack around this by creating a new `MultiTypedResultKey`. This item is only meant to act as a key for the `TypedResult` object, and is never actually used to read the data. Although, nothing bad would happen if it was. 


####  More work:


- [x] Docs
- [ ] Tests

