### PR TITLE
Test Code Generation with Flutter Version

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -209,6 +209,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
+        # We want to support the two latest stable Flutter versions
         flutter: [3.19, 3.22]
 
     steps:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -228,6 +228,12 @@ jobs:
       - name: Generate code
         run: dart run build_runner build --delete-conflicting-outputs
         working-directory: examples/app
+      - name: Test CLI
+        run: |
+          dart run drift_dev schema dump lib/database/database.dart drift_schemas/
+          dart run drift_dev schema generate drift_schemas/ test/generated_migrations/
+          dart run drift_dev schema steps drift_schemas/ lib/database/schema_versions.dart
+        working-directory: examples/app
       - run: flutter analyze
         working-directory: examples/app
       - run: flutter test

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -207,11 +207,16 @@ jobs:
           dart test
   test_flutter:
     runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        flutter: [3.19, 3.22]
+
     steps:
       - uses: actions/checkout@v4
       - name: Setup Flutter
         uses: subosito/flutter-action@v2
         with:
+          flutter-version: ${{ matrix.flutter }}
           cache: true
           cache-key: "flutter-:os:-:channel:-:version:-:arch:-:hash:"
           cache-path: "${{ runner.tool_cache }}/flutter/:channel:-:version:-:arch:"
@@ -220,6 +225,9 @@ jobs:
         shell: bash
       - name: Install dependencies in drift/example/app
         run: melos bootstrap --scope app
+      - name: Generate code
+        run: dart run build_runner build --delete-conflicting-outputs
+        working-directory: examples/app
       - run: flutter analyze
         working-directory: examples/app
       - run: flutter test

--- a/drift/pubspec.yaml
+++ b/drift/pubspec.yaml
@@ -13,13 +13,13 @@ funding:
   - https://github.com/sponsors/simolus3
 
 environment:
-  sdk: '>=3.3.0 <4.0.0'
+  sdk: ">=3.3.0 <4.0.0"
 
 dependencies:
   async: ^2.5.0
   convert: ^3.0.0
   collection: ^1.15.0
-  js: '>=0.6.3 <0.8.0'
+  js: ">=0.6.3 <0.8.0"
   meta: ^1.3.0
   stream_channel: ^2.1.0
   sqlite3: ^2.4.3
@@ -32,14 +32,14 @@ dev_dependencies:
   analyzer: ^6.4.1
   build_test: ^2.0.0
   build_runner_core: ^7.0.0
-  build_verify: ^3.0.0
+  build_verify: ^3.1.0
   build_web_compilers: ^4.0.3
   drift_dev: any
   drift_testcases:
     path: ../extras/integration_tests/drift_testcases
   http: ^1.2.1
   lints: ^3.0.0
-  uuid: ^4.0.0
+  uuid: ^4.4.0
   build_runner: ^2.0.0
   test: ^1.17.0
   mockito: ^5.4.3
@@ -47,4 +47,3 @@ dev_dependencies:
   shelf: ^1.3.0
   test_descriptor: ^2.0.1
   vm_service: ^14.0.0
-

--- a/drift_dev/pubspec.yaml
+++ b/drift_dev/pubspec.yaml
@@ -18,7 +18,7 @@ environment:
   sdk: ">=3.0.0 <4.0.0"
 
 dependencies:
-  charcode: ^1.2.0
+  charcode: ^1.3.1
   collection: ^1.14.0
   recase: ">=2.0.1 <5.0.0"
   meta: ^1.1.0

--- a/drift_dev/test/analysis/resolver/drift/table_test.dart
+++ b/drift_dev/test/analysis/resolver/drift/table_test.dart
@@ -123,6 +123,7 @@ CREATE TABLE b (
             'expression',
             contains('EnumIndexConverter<Fruits>'),
           )
+          // ignore: deprecated_member_use
           .having((e) => e.dartType.getDisplayString(withNullability: true),
               'dartType', 'Fruits'),
     );
@@ -154,6 +155,7 @@ CREATE TABLE b (
             'expression',
             contains('EnumNameConverter<Fruits>'),
           )
+          // ignore: deprecated_member_use
           .having((e) => e.dartType.getDisplayString(withNullability: true),
               'dartType', 'Fruits'),
     );

--- a/drift_dev/test/analysis/resolver/drift/table_test.dart
+++ b/drift_dev/test/analysis/resolver/drift/table_test.dart
@@ -123,7 +123,8 @@ CREATE TABLE b (
             'expression',
             contains('EnumIndexConverter<Fruits>'),
           )
-          .having((e) => e.dartType.getDisplayString(), 'dartType', 'Fruits'),
+          .having((e) => e.dartType.getDisplayString(withNullability: true),
+              'dartType', 'Fruits'),
     );
 
     final withGenericIndexColumn = table.columns
@@ -153,7 +154,8 @@ CREATE TABLE b (
             'expression',
             contains('EnumNameConverter<Fruits>'),
           )
-          .having((e) => e.dartType.getDisplayString(), 'dartType', 'Fruits'),
+          .having((e) => e.dartType.getDisplayString(withNullability: true),
+              'dartType', 'Fruits'),
     );
 
     expect(

--- a/drift_dev/test/analysis/resolver/queries/existing_row_classes_test.dart
+++ b/drift_dev/test/analysis/resolver/queries/existing_row_classes_test.dart
@@ -30,7 +30,8 @@ class MyRow {
     state.expectNoErrors();
     final query = file.analyzedElements.single as DefinedSqlQuery;
     expect(query.resultClassName, isNull);
-    expect(query.existingDartType?.type.getDisplayString(), 'MyRow');
+    expect(query.existingDartType?.type.getDisplayString(withNullability: true),
+        'MyRow');
   });
 
   test('can use named constructors', () async {
@@ -55,7 +56,8 @@ class MyRow {
     state.expectNoErrors();
     final query = file.analyzedElements.single as DefinedSqlQuery;
     expect(query.resultClassName, isNull);
-    expect(query.existingDartType?.type.getDisplayString(), 'MyRow');
+    expect(query.existingDartType?.type.getDisplayString(withNullability: true),
+        'MyRow');
 
     final resolvedQuery = file.fileAnalysis!.resolvedQueries.values.single;
     expect(

--- a/drift_dev/test/analysis/resolver/queries/existing_row_classes_test.dart
+++ b/drift_dev/test/analysis/resolver/queries/existing_row_classes_test.dart
@@ -30,6 +30,7 @@ class MyRow {
     state.expectNoErrors();
     final query = file.analyzedElements.single as DefinedSqlQuery;
     expect(query.resultClassName, isNull);
+    // ignore: deprecated_member_use
     expect(query.existingDartType?.type.getDisplayString(withNullability: true),
         'MyRow');
   });
@@ -56,6 +57,7 @@ class MyRow {
     state.expectNoErrors();
     final query = file.analyzedElements.single as DefinedSqlQuery;
     expect(query.resultClassName, isNull);
+    // ignore: deprecated_member_use
     expect(query.existingDartType?.type.getDisplayString(withNullability: true),
         'MyRow');
 

--- a/drift_flutter/pubspec.yaml
+++ b/drift_flutter/pubspec.yaml
@@ -21,7 +21,7 @@ dependencies:
     sdk: flutter
   path: ^1.9.0
   path_provider: ^2.1.3
-  sqlite3: ^2.4.4
+  sqlite3: ^2.0.0
   sqlite3_flutter_libs: ^0.5.24
 
 dev_dependencies:

--- a/drift_flutter/pubspec.yaml
+++ b/drift_flutter/pubspec.yaml
@@ -13,7 +13,7 @@ funding:
   - https://github.com/sponsors/simolus3
 
 environment:
-  sdk: ^3.4.0
+  sdk: ^3.3.0
 
 dependencies:
   drift: ^2.17.0

--- a/examples/app/lib/screens/home/drawer.dart
+++ b/examples/app/lib/screens/home/drawer.dart
@@ -124,13 +124,11 @@ class _CategoryDrawerEntry extends ConsumerWidget {
                       },
                     ),
                     TextButton(
-                      style: ButtonStyle(
-                        foregroundColor: WidgetStateProperty.all(Colors.red),
-                      ),
                       onPressed: () {
                         Navigator.pop(context, true);
                       },
-                      child: const Text('Delete'),
+                      child: const Text('Delete',
+                          style: TextStyle(color: Colors.red)),
                     ),
                   ],
                 );

--- a/examples/app/lib/screens/home/todo_edit_dialog.dart
+++ b/examples/app/lib/screens/home/todo_edit_dialog.dart
@@ -82,15 +82,10 @@ class _TodoEditDialogState extends ConsumerState<TodoEditDialog> {
       ),
       actions: [
         TextButton(
-          style: ButtonStyle(
-            textStyle: WidgetStateProperty.all(
-              const TextStyle(color: Colors.black),
-            ),
-          ),
           onPressed: () {
             Navigator.pop(context);
           },
-          child: const Text('Cancel'),
+          child: const Text('Cancel', style: TextStyle(color: Colors.black)),
         ),
         TextButton(
           child: const Text('Save'),

--- a/melos.yaml
+++ b/melos.yaml
@@ -2,40 +2,44 @@ name: drift
 repository: https://github.com/simolus3/drift
 
 packages:
- - docs
- - drift
- - drift_sqflite
- - drift_dev
- - drift_flutter
- - sqlparser
- - examples/*
- - examples/multi_package/*
- - extras/benchmarks
- - extras/drift_devtools_extension
- - extras/drift_mariadb
- - extras/drift_postgres
- - extras/encryption
- - extras/integration_tests/*
- - extras/plugin_example
- - extras/assets/*
+  - docs
+  - drift
+  - drift_sqflite
+  - drift_dev
+  - drift_flutter
+  - sqlparser
+  - examples/*
+  - examples/multi_package/*
+  - extras/benchmarks
+  - extras/drift_devtools_extension
+  - extras/drift_mariadb
+  - extras/drift_postgres
+  - extras/encryption
+  - extras/integration_tests/*
+  - extras/plugin_example
+  - extras/assets/*
 
 scripts:
+  downgrade:
+    run: dart pub downgrade
+    exec: { concurrency: 1 }
+
   check_format:
     run: dart format -o none --set-exit-if-changed .
 
   analyze:
     run: dart analyze --fatal-infos
-    exec: {concurrency: 1}
+    exec: { concurrency: 1 }
 
   build:
     run: dart run build_runner build --delete-conflicting-outputs
-    exec: {concurrency: 1}
+    exec: { concurrency: 1 }
     packageFilters:
       dependsOn: build_runner
 
   test:
     run: dart test
-    exec: {concurrency: 1}
+    exec: { concurrency: 1 }
     packageFilters:
       dependsOn: test
       ignore: drift_postgres # this is an integration test

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -61,10 +61,10 @@ packages:
     dependency: transitive
     description:
       name: collection
-      sha256: ee67cb0715911d28db6bf4af1026078bd6f0128b07a5f66fb2ed94ec6783c09a
+      sha256: a1ace0a119f20aabc852d165077c036cd864315bd99b7eaa10a60100341941bf
       url: "https://pub.dev"
     source: hosted
-    version: "1.18.0"
+    version: "1.19.0"
   conventional_commit:
     dependency: transitive
     description:
@@ -93,26 +93,26 @@ packages:
     dependency: transitive
     description:
       name: graphs
-      sha256: aedc5a15e78fc65a6e23bcd927f24c64dd995062bcd1ca6eda65a3cff92a4d19
+      sha256: "741bbf84165310a68ff28fe9e727332eef1407342fca52759cb21ad8177bb8d0"
       url: "https://pub.dev"
     source: hosted
-    version: "2.3.1"
+    version: "2.3.2"
   http:
     dependency: transitive
     description:
       name: http
-      sha256: "761a297c042deedc1ffbb156d6e2af13886bb305c2a343a4d972504cd67dd938"
+      sha256: b9c29a161230ee03d3ccf545097fccd9b87a5264228c5d348202e0f0c28f9010
       url: "https://pub.dev"
     source: hosted
-    version: "1.2.1"
+    version: "1.2.2"
   http_parser:
     dependency: transitive
     description:
       name: http_parser
-      sha256: "2aa08ce0341cc9b354a498388e30986515406668dbcc4f7c950c3e715496693b"
+      sha256: "40f592dd352890c3b60fec1b68e786cefb9603e05ff303dbc4dda49b304ecdf4"
       url: "https://pub.dev"
     source: hosted
-    version: "4.0.2"
+    version: "4.1.0"
   io:
     dependency: transitive
     description:
@@ -261,10 +261,10 @@ packages:
     dependency: transitive
     description:
       name: string_scanner
-      sha256: "556692adab6cfa87322a115640c11f13cb77b3f076ddcc5d6ae3c20242bedcde"
+      sha256: "688af5ed3402a4bde5b3a6c15fd768dbf2621a614950b17f04626c431ab3c4c3"
       url: "https://pub.dev"
     source: hosted
-    version: "1.2.0"
+    version: "1.3.0"
   term_glyph:
     dependency: transitive
     description:
@@ -277,10 +277,10 @@ packages:
     dependency: transitive
     description:
       name: test_api
-      sha256: "5b8a98dafc4d5c4c9c72d8b31ab2b23fc13422348d2997120294d3bac86b4ddb"
+      sha256: "664d3a9a64782fcdeb83ce9c6b39e78fd2971d4e37827b9b06c3aa1edc5e760c"
       url: "https://pub.dev"
     source: hosted
-    version: "0.7.2"
+    version: "0.7.3"
   typed_data:
     dependency: transitive
     description:
@@ -301,10 +301,10 @@ packages:
     dependency: transitive
     description:
       name: web
-      sha256: "97da13628db363c635202ad97068d47c5b8aa555808e7a9411963c533b449b27"
+      sha256: d43c1d6b787bf0afad444700ae7f4db8827f701bc61c255ac8d328c6f4d52062
       url: "https://pub.dev"
     source: hosted
-    version: "0.5.1"
+    version: "1.0.0"
   yaml:
     dependency: transitive
     description:
@@ -322,4 +322,4 @@ packages:
     source: hosted
     version: "2.2.1"
 sdks:
-  dart: ">=3.3.0 <4.0.0"
+  dart: ">=3.4.0 <4.0.0"


### PR DESCRIPTION
Flutter is not always on the latest version of dart.
We wan't to test that the version of dart that flutter is using is works with drift_dev.
I've also changed the `sqlite3` constraints on the `drift_flutter` package to be compatible with older versions of dart.

I've also added testing for Flutter 3.19. 3.22 changed lots of stuff. IMHO I think we should support the 2 latest version of Flutter.

EDIT:
I've also set better lower version constraints for come packages.
All packages should still work if `pub downgrade` is ran. 