### PR TITLE
Change type of `UpsertMultiple.clauses` from `List<DoUpdate>` to `List<UpsertClause>`

### DIFF
--- a/drift/lib/src/runtime/query_builder/statements/insert.dart
+++ b/drift/lib/src/runtime/query_builder/statements/insert.dart
@@ -556,12 +556,14 @@ class DoUpdate<T extends Table, D> extends UpsertClause<T, D> {
 ///
 /// The first [DoUpdate.target] matched by this upsert will be run.
 class UpsertMultiple<T extends Table, D> extends UpsertClause<T, D> {
-  /// All [DoUpdate] clauses that are part of this upsert.
+  /// All [DoUpdate] and [DoNothing] clauses that are part of this upsert.
   ///
-  /// The first clause with a matching [DoUpdate.target] will be considered.
-  final List<DoUpdate<T, D>> clauses;
+  /// The first clause with a matching [DoUpdate.target] or [DoNothing.target]
+  /// will be considered.
+  final List<UpsertClause<T, D>> clauses;
 
-  /// Creates an upsert consisting of multiple [DoUpdate] clauses.
+  /// Creates an upsert consisting of multiple [DoUpdate] and [DoNothing]
+  /// clauses.
   ///
   /// This requires a fairly recent sqlite3 version (3.35.0, released on 2021-
   /// 03-12).


### PR DESCRIPTION
SQLite supports mixing `DO UPDATE` and `DO NOTHING` conflict actions (see https://www.sqlite.org/lang_upsert.html), while the `UpsertMultiple` class allows the use of only the former. This change aims to fix that using a generic type extended by the `DoUpdate` and `DoNothing` classes.

The `InsertStatement._writeOnConflict` is already compatible with the change and correctly handles nested `UpsertMultiple` objects.