### PR TITLE
Fix name of referenced column in prefetch

### DIFF
--- a/drift/test/generated/todos.dart
+++ b/drift/test/generated/todos.dart
@@ -117,7 +117,7 @@ class Department extends Table {
 }
 
 class Product extends Table {
-  IntColumn get id => integer().autoIncrement()();
+  TextColumn get sku => text()();
   TextColumn get name => text().nullable()();
   IntColumn get department =>
       integer().references(Department, #id).nullable()();
@@ -126,7 +126,7 @@ class Product extends Table {
 class Listing extends Table {
   IntColumn get id => integer().autoIncrement()();
   @ReferenceName('listings')
-  IntColumn get product => integer().references(Product, #id).nullable()();
+  TextColumn get product => text().references(Product, #sku).nullable()();
   @ReferenceName('listings')
   IntColumn get store => integer().references(Store, #id).nullable()();
   RealColumn get price => real().nullable()();

--- a/drift/test/generated/todos.g.dart
+++ b/drift/test/generated/todos.g.dart
@@ -2435,15 +2435,11 @@ class $ProductTable extends Product with TableInfo<$ProductTable, ProductData> {
   final GeneratedDatabase attachedDatabase;
   final String? _alias;
   $ProductTable(this.attachedDatabase, [this._alias]);
-  static const VerificationMeta _idMeta = const VerificationMeta('id');
+  static const VerificationMeta _skuMeta = const VerificationMeta('sku');
   @override
-  late final GeneratedColumn<int> id = GeneratedColumn<int>(
-      'id', aliasedName, false,
-      hasAutoIncrement: true,
-      type: DriftSqlType.int,
-      requiredDuringInsert: false,
-      defaultConstraints:
-          GeneratedColumn.constraintIsAlways('PRIMARY KEY AUTOINCREMENT'));
+  late final GeneratedColumn<String> sku = GeneratedColumn<String>(
+      'sku', aliasedName, false,
+      type: DriftSqlType.string, requiredDuringInsert: true);
   static const VerificationMeta _nameMeta = const VerificationMeta('name');
   @override
   late final GeneratedColumn<String> name = GeneratedColumn<String>(
@@ -2459,7 +2455,7 @@ class $ProductTable extends Product with TableInfo<$ProductTable, ProductData> {
       defaultConstraints:
           GeneratedColumn.constraintIsAlways('REFERENCES department (id)'));
   @override
-  List<GeneratedColumn> get $columns => [id, name, department];
+  List<GeneratedColumn> get $columns => [sku, name, department];
   @override
   String get aliasedName => _alias ?? actualTableName;
   @override
@@ -2470,8 +2466,11 @@ class $ProductTable extends Product with TableInfo<$ProductTable, ProductData> {
       {bool isInserting = false}) {
     final context = VerificationContext();
     final data = instance.toColumns(true);
-    if (data.containsKey('id')) {
-      context.handle(_idMeta, id.isAcceptableOrUnknown(data['id']!, _idMeta));
+    if (data.containsKey('sku')) {
+      context.handle(
+          _skuMeta, sku.isAcceptableOrUnknown(data['sku']!, _skuMeta));
+    } else if (isInserting) {
+      context.missing(_skuMeta);
     }
     if (data.containsKey('name')) {
       context.handle(
@@ -2487,13 +2486,13 @@ class $ProductTable extends Product with TableInfo<$ProductTable, ProductData> {
   }
 
   @override
-  Set<GeneratedColumn> get $primaryKey => {id};
+  Set<GeneratedColumn> get $primaryKey => const {};
   @override
   ProductData map(Map<String, dynamic> data, {String? tablePrefix}) {
     final effectivePrefix = tablePrefix != null ? '$tablePrefix.' : '';
     return ProductData(
-      id: attachedDatabase.typeMapping
-          .read(DriftSqlType.int, data['${effectivePrefix}id'])!,
+      sku: attachedDatabase.typeMapping
+          .read(DriftSqlType.string, data['${effectivePrefix}sku'])!,
       name: attachedDatabase.typeMapping
           .read(DriftSqlType.string, data['${effectivePrefix}name']),
       department: attachedDatabase.typeMapping
@@ -2508,14 +2507,14 @@ class $ProductTable extends Product with TableInfo<$ProductTable, ProductData> {
 }
 
 class ProductData extends DataClass implements Insertable<ProductData> {
-  final int id;
+  final String sku;
   final String? name;
   final int? department;
-  const ProductData({required this.id, this.name, this.department});
+  const ProductData({required this.sku, this.name, this.department});
   @override
   Map<String, Expression> toColumns(bool nullToAbsent) {
     final map = <String, Expression>{};
-    map['id'] = Variable<int>(id);
+    map['sku'] = Variable<String>(sku);
     if (!nullToAbsent || name != null) {
       map['name'] = Variable<String>(name);
     }
@@ -2527,7 +2526,7 @@ class ProductData extends DataClass implements Insertable<ProductData> {
 
   ProductCompanion toCompanion(bool nullToAbsent) {
     return ProductCompanion(
-      id: Value(id),
+      sku: Value(sku),
       name: name == null && nullToAbsent ? const Value.absent() : Value(name),
       department: department == null && nullToAbsent
           ? const Value.absent()
@@ -2539,7 +2538,7 @@ class ProductData extends DataClass implements Insertable<ProductData> {
       {ValueSerializer? serializer}) {
     serializer ??= driftRuntimeOptions.defaultSerializer;
     return ProductData(
-      id: serializer.fromJson<int>(json['id']),
+      sku: serializer.fromJson<String>(json['sku']),
       name: serializer.fromJson<String?>(json['name']),
       department: serializer.fromJson<int?>(json['department']),
     );
@@ -2553,24 +2552,24 @@ class ProductData extends DataClass implements Insertable<ProductData> {
   Map<String, dynamic> toJson({ValueSerializer? serializer}) {
     serializer ??= driftRuntimeOptions.defaultSerializer;
     return <String, dynamic>{
-      'id': serializer.toJson<int>(id),
+      'sku': serializer.toJson<String>(sku),
       'name': serializer.toJson<String?>(name),
       'department': serializer.toJson<int?>(department),
     };
   }
 
   ProductData copyWith(
-          {int? id,
+          {String? sku,
           Value<String?> name = const Value.absent(),
           Value<int?> department = const Value.absent()}) =>
       ProductData(
-        id: id ?? this.id,
+        sku: sku ?? this.sku,
         name: name.present ? name.value : this.name,
         department: department.present ? department.value : this.department,
       );
   ProductData copyWithCompanion(ProductCompanion data) {
     return ProductData(
-      id: data.id.present ? data.id.value : this.id,
+      sku: data.sku.present ? data.sku.value : this.sku,
       name: data.name.present ? data.name.value : this.name,
       department:
           data.department.present ? data.department.value : this.department,
@@ -2580,7 +2579,7 @@ class ProductData extends DataClass implements Insertable<ProductData> {
   @override
   String toString() {
     return (StringBuffer('ProductData(')
-          ..write('id: $id, ')
+          ..write('sku: $sku, ')
           ..write('name: $name, ')
           ..write('department: $department')
           ..write(')'))
@@ -2588,56 +2587,65 @@ class ProductData extends DataClass implements Insertable<ProductData> {
   }
 
   @override
-  int get hashCode => Object.hash(id, name, department);
+  int get hashCode => Object.hash(sku, name, department);
   @override
   bool operator ==(Object other) =>
       identical(this, other) ||
       (other is ProductData &&
-          other.id == this.id &&
+          other.sku == this.sku &&
           other.name == this.name &&
           other.department == this.department);
 }
 
 class ProductCompanion extends UpdateCompanion<ProductData> {
-  final Value<int> id;
+  final Value<String> sku;
   final Value<String?> name;
   final Value<int?> department;
+  final Value<int> rowid;
   const ProductCompanion({
-    this.id = const Value.absent(),
+    this.sku = const Value.absent(),
     this.name = const Value.absent(),
     this.department = const Value.absent(),
+    this.rowid = const Value.absent(),
   });
   ProductCompanion.insert({
-    this.id = const Value.absent(),
+    required String sku,
     this.name = const Value.absent(),
     this.department = const Value.absent(),
-  });
+    this.rowid = const Value.absent(),
+  }) : sku = Value(sku);
   static Insertable<ProductData> custom({
-    Expression<int>? id,
+    Expression<String>? sku,
     Expression<String>? name,
     Expression<int>? department,
+    Expression<int>? rowid,
   }) {
     return RawValuesInsertable({
-      if (id != null) 'id': id,
+      if (sku != null) 'sku': sku,
       if (name != null) 'name': name,
       if (department != null) 'department': department,
+      if (rowid != null) 'rowid': rowid,
     });
   }
 
   ProductCompanion copyWith(
-      {Value<int>? id, Value<String?>? name, Value<int?>? department}) {
+      {Value<String>? sku,
+      Value<String?>? name,
+      Value<int?>? department,
+      Value<int>? rowid}) {
     return ProductCompanion(
-      id: id ?? this.id,
+      sku: sku ?? this.sku,
       name: name ?? this.name,
       department: department ?? this.department,
+      rowid: rowid ?? this.rowid,
     );
   }
 
   @override
   Map<String, Expression> toColumns(bool nullToAbsent) {
     final map = <String, Expression>{};
-    if (id.present) {
-      map['id'] = Variable<int>(id.value);
+    if (sku.present) {
+      map['sku'] = Variable<String>(sku.value);
     }
     if (name.present) {
       map['name'] = Variable<String>(name.value);
@@ -2645,15 +2653,19 @@ class ProductCompanion extends UpdateCompanion<ProductData> {
     if (department.present) {
       map['department'] = Variable<int>(department.value);
     }
+    if (rowid.present) {
+      map['rowid'] = Variable<int>(rowid.value);
+    }
     return map;
   }
 
   @override
   String toString() {
     return (StringBuffer('ProductCompanion(')
-          ..write('id: $id, ')
+          ..write('sku: $sku, ')
           ..write('name: $name, ')
-          ..write('department: $department')
+          ..write('department: $department, ')
+          ..write('rowid: $rowid')
           ..write(')'))
         .toString();
   }
@@ -2858,12 +2870,12 @@ class $ListingTable extends Listing with TableInfo<$ListingTable, ListingData> {
   static const VerificationMeta _productMeta =
       const VerificationMeta('product');
   @override
-  late final GeneratedColumn<int> product = GeneratedColumn<int>(
+  late final GeneratedColumn<String> product = GeneratedColumn<String>(
       'product', aliasedName, true,
-      type: DriftSqlType.int,
+      type: DriftSqlType.string,
       requiredDuringInsert: false,
       defaultConstraints:
-          GeneratedColumn.constraintIsAlways('REFERENCES product (id)'));
+          GeneratedColumn.constraintIsAlways('REFERENCES product (sku)'));
   static const VerificationMeta _storeMeta = const VerificationMeta('store');
   @override
   late final GeneratedColumn<int> store = GeneratedColumn<int>(
@@ -2916,7 +2928,7 @@ class $ListingTable extends Listing with TableInfo<$ListingTable, ListingData> {
       id: attachedDatabase.typeMapping
           .read(DriftSqlType.int, data['${effectivePrefix}id'])!,
       product: attachedDatabase.typeMapping
-          .read(DriftSqlType.int, data['${effectivePrefix}product']),
+          .read(DriftSqlType.string, data['${effectivePrefix}product']),
       store: attachedDatabase.typeMapping
           .read(DriftSqlType.int, data['${effectivePrefix}store']),
       price: attachedDatabase.typeMapping
@@ -2932,7 +2944,7 @@ class $ListingTable extends Listing with TableInfo<$ListingTable, ListingData> {
 
 class ListingData extends DataClass implements Insertable<ListingData> {
   final int id;
-  final int? product;
+  final String? product;
   final int? store;
   final double? price;
   const ListingData({required this.id, this.product, this.store, this.price});
@@ -2941,7 +2953,7 @@ class ListingData extends DataClass implements Insertable<ListingData> {
     final map = <String, Expression>{};
     map['id'] = Variable<int>(id);
     if (!nullToAbsent || product != null) {
-      map['product'] = Variable<int>(product);
+      map['product'] = Variable<String>(product);
     }
     if (!nullToAbsent || store != null) {
       map['store'] = Variable<int>(store);
@@ -2970,7 +2982,7 @@ class ListingData extends DataClass implements Insertable<ListingData> {
     serializer ??= driftRuntimeOptions.defaultSerializer;
     return ListingData(
       id: serializer.fromJson<int>(json['id']),
-      product: serializer.fromJson<int?>(json['product']),
+      product: serializer.fromJson<String?>(json['product']),
       store: serializer.fromJson<int?>(json['store']),
       price: serializer.fromJson<double?>(json['price']),
     );
@@ -2985,7 +2997,7 @@ class ListingData extends DataClass implements Insertable<ListingData> {
     serializer ??= driftRuntimeOptions.defaultSerializer;
     return <String, dynamic>{
       'id': serializer.toJson<int>(id),
-      'product': serializer.toJson<int?>(product),
+      'product': serializer.toJson<String?>(product),
       'store': serializer.toJson<int?>(store),
       'price': serializer.toJson<double?>(price),
     };
@@ -2993,7 +3005,7 @@ class ListingData extends DataClass implements Insertable<ListingData> {
 
   ListingData copyWith(
           {int? id,
-          Value<int?> product = const Value.absent(),
+          Value<String?> product = const Value.absent(),
           Value<int?> store = const Value.absent(),
           Value<double?> price = const Value.absent()}) =>
       ListingData(
@@ -3036,7 +3048,7 @@ class ListingData extends DataClass implements Insertable<ListingData> {
 
 class ListingCompanion extends UpdateCompanion<ListingData> {
   final Value<int> id;
-  final Value<int?> product;
+  final Value<String?> product;
   final Value<int?> store;
   final Value<double?> price;
   const ListingCompanion({
@@ -3053,7 +3065,7 @@ class ListingCompanion extends UpdateCompanion<ListingData> {
   });
   static Insertable<ListingData> custom({
     Expression<int>? id,
-    Expression<int>? product,
+    Expression<String>? product,
     Expression<int>? store,
     Expression<double>? price,
   }) {
@@ -3067,7 +3079,7 @@ class ListingCompanion extends UpdateCompanion<ListingData> {
 
   ListingCompanion copyWith(
       {Value<int>? id,
-      Value<int?>? product,
+      Value<String?>? product,
       Value<int?>? store,
       Value<double?>? price}) {
     return ListingCompanion(
@@ -3085,7 +3097,7 @@ class ListingCompanion extends UpdateCompanion<ListingData> {
       map['id'] = Variable<int>(id.value);
     }
     if (product.present) {
-      map['product'] = Variable<int>(product.value);
+      map['product'] = Variable<String>(product.value);
     }
     if (store.present) {
       map['store'] = Variable<int>(store.value);
@@ -4781,14 +4793,16 @@ typedef $$DepartmentTableProcessedTableManager = ProcessedTableManager<
     DepartmentData,
     PrefetchHooks Function({bool productRefs})>;
 typedef $$ProductTableCreateCompanionBuilder = ProductCompanion Function({
-  Value<int> id,
+  required String sku,
   Value<String?> name,
   Value<int?> department,
+  Value<int> rowid,
 });
 typedef $$ProductTableUpdateCompanionBuilder = ProductCompanion Function({
-  Value<int> id,
+  Value<String> sku,
   Value<String?> name,
   Value<int?> department,
+  Value<int> rowid,
 });
 
 final class $$ProductTableReferences
@@ -4812,11 +4826,11 @@ final class $$ProductTableReferences
   static MultiTypedResultKey<$ListingTable, List<ListingData>> _listingsTable(
           _$TodoDb db) =>
       MultiTypedResultKey.fromTable(db.listing,
-          aliasName: $_aliasNameGenerator(db.product.id, db.listing.product));
+          aliasName: $_aliasNameGenerator(db.product.sku, db.listing.product));
 
   $$ListingTableProcessedTableManager get listings {
     final manager = $$ListingTableTableManager($_db, $_db.listing)
-        .filter((f) => f.product.id($_item.id));
+        .filter((f) => f.product.sku($_item.sku));
 
     final cache = $_typedResult.readTableOrNull(_listingsTable($_db));
     return ProcessedTableManager(
@@ -4827,8 +4841,8 @@ final class $$ProductTableReferences
 class $$ProductTableFilterComposer
     extends FilterComposer<_$TodoDb, $ProductTable> {
   $$ProductTableFilterComposer(super.$state);
-  ColumnFilters<int> get id => $state.composableBuilder(
-      column: $state.table.id,
+  ColumnFilters<String> get sku => $state.composableBuilder(
+      column: $state.table.sku,
       builder: (column, joinBuilders) =>
           ColumnFilters(column, joinBuilders: joinBuilders));
 
@@ -4853,7 +4867,7 @@ class $$ProductTableFilterComposer
       ComposableFilter Function($$ListingTableFilterComposer f) f) {
     final $$ListingTableFilterComposer composer = $state.composerBuilder(
         composer: this,
-        getCurrentColumn: (t) => t.id,
+        getCurrentColumn: (t) => t.sku,
         referencedTable: $state.db.listing,
         getReferencedColumn: (t) => t.product,
         builder: (joinBuilder, parentComposers) => $$ListingTableFilterComposer(
@@ -4866,8 +4880,8 @@ class $$ProductTableFilterComposer
 class $$ProductTableOrderingComposer
     extends OrderingComposer<_$TodoDb, $ProductTable> {
   $$ProductTableOrderingComposer(super.$state);
-  ColumnOrderings<int> get id => $state.composableBuilder(
-      column: $state.table.id,
+  ColumnOrderings<String> get sku => $state.composableBuilder(
+      column: $state.table.sku,
       builder: (column, joinBuilders) =>
           ColumnOrderings(column, joinBuilders: joinBuilders));
 
@@ -4909,24 +4923,28 @@ class $$ProductTableTableManager extends RootTableManager<
           orderingComposer:
               $$ProductTableOrderingComposer(ComposerState(db, table)),
           updateCompanionCallback: ({
-            Value<int> id = const Value.absent(),
+            Value<String> sku = const Value.absent(),
             Value<String?> name = const Value.absent(),
             Value<int?> department = const Value.absent(),
+            Value<int> rowid = const Value.absent(),
           }) =>
               ProductCompanion(
-            id: id,
+            sku: sku,
             name: name,
             department: department,
+            rowid: rowid,
           ),
           createCompanionCallback: ({
-            Value<int> id = const Value.absent(),
+            required String sku,
             Value<String?> name = const Value.absent(),
             Value<int?> department = const Value.absent(),
+            Value<int> rowid = const Value.absent(),
           }) =>
               ProductCompanion.insert(
-            id: id,
+            sku: sku,
             name: name,
             department: department,
+            rowid: rowid,
           ),
           withReferenceMapper: (p0) => p0
               .map((e) =>
@@ -4972,7 +4990,7 @@ class $$ProductTableTableManager extends RootTableManager<
                             $$ProductTableReferences(db, table, p0).listings,
                         referencedItemsForCurrentItem: (item,
                                 referencedItems) =>
-                            referencedItems.where((e) => e.product == item.id),
+                            referencedItems.where((e) => e.product == item.sku),
                         typedResults: items)
                 ];
               },
@@ -5137,13 +5155,13 @@ typedef $$StoreTableProcessedTableManager = ProcessedTableManager<
     PrefetchHooks Function({bool listings})>;
 typedef $$ListingTableCreateCompanionBuilder = ListingCompanion Function({
   Value<int> id,
-  Value<int?> product,
+  Value<String?> product,
   Value<int?> store,
   Value<double?> price,
 });
 typedef $$ListingTableUpdateCompanionBuilder = ListingCompanion Function({
   Value<int> id,
-  Value<int?> product,
+  Value<String?> product,
   Value<int?> store,
   Value<double?> price,
 });
@@ -5153,12 +5171,12 @@ final class $$ListingTableReferences
   $$ListingTableReferences(super.$_db, super.$_table, super.$_typedResult);
 
   static $ProductTable _productTable(_$TodoDb db) => db.product
-      .createAlias($_aliasNameGenerator(db.listing.product, db.product.id));
+      .createAlias($_aliasNameGenerator(db.listing.product, db.product.sku));
 
   $$ProductTableProcessedTableManager? get product {
     if ($_item.product == null) return null;
     final manager = $$ProductTableTableManager($_db, $_db.product)
-        .filter((f) => f.id($_item.product!));
+        .filter((f) => f.sku($_item.product!));
     final item = $_typedResult.readTableOrNull(_productTable($_db));
     if (item == null) return manager;
     return ProcessedTableManager(
@@ -5197,7 +5215,7 @@ class $$ListingTableFilterComposer
         composer: this,
         getCurrentColumn: (t) => t.product,
         referencedTable: $state.db.product,
-        getReferencedColumn: (t) => t.id,
+        getReferencedColumn: (t) => t.sku,
         builder: (joinBuilder, parentComposers) => $$ProductTableFilterComposer(
             ComposerState(
                 $state.db, $state.db.product, joinBuilder, parentComposers)));
@@ -5235,7 +5253,7 @@ class $$ListingTableOrderingComposer
         composer: this,
         getCurrentColumn: (t) => t.product,
         referencedTable: $state.db.product,
-        getReferencedColumn: (t) => t.id,
+        getReferencedColumn: (t) => t.sku,
         builder: (joinBuilder, parentComposers) =>
             $$ProductTableOrderingComposer(ComposerState(
                 $state.db, $state.db.product, joinBuilder, parentComposers)));
@@ -5276,7 +5294,7 @@ class $$ListingTableTableManager extends RootTableManager<
               $$ListingTableOrderingComposer(ComposerState(db, table)),
           updateCompanionCallback: ({
             Value<int> id = const Value.absent(),
-            Value<int?> product = const Value.absent(),
+            Value<String?> product = const Value.absent(),
             Value<int?> store = const Value.absent(),
             Value<double?> price = const Value.absent(),
           }) =>
@@ -5288,7 +5306,7 @@ class $$ListingTableTableManager extends RootTableManager<
           ),
           createCompanionCallback: ({
             Value<int> id = const Value.absent(),
-            Value<int?> product = const Value.absent(),
+            Value<String?> product = const Value.absent(),
             Value<int?> store = const Value.absent(),
             Value<double?> price = const Value.absent(),
           }) =>
@@ -5324,7 +5342,7 @@ class $$ListingTableTableManager extends RootTableManager<
                     currentColumn: table.product,
                     referencedTable: $$ListingTableReferences._productTable(db),
                     referencedColumn:
-                        $$ListingTableReferences._productTable(db).id,
+                        $$ListingTableReferences._productTable(db).sku,
                   ) as T;
                 }
                 if (store) {

--- a/drift/test/manager/manager_prefetch_test.dart
+++ b/drift/test/manager/manager_prefetch_test.dart
@@ -12,30 +12,29 @@ void main() {
   late List<DepartmentData> departments;
   late List<ProductData> products;
   late List<int> listings;
+
+  const departmentsData = [
+    (name: "Electronics", id: 1),
+    (name: "Clothing", id: 2),
+    (name: "Books", id: 3)
+  ];
+  const productsData = [
+    (name: "TV", department: 1, id: "1"),
+    (name: "Shirt", department: 2, id: "2"),
+    (name: "Book", department: 3, id: "3"),
+    (name: "Another Book", department: 3, id: "4"),
+  ];
+
   setUp(() async {
     db = TodoDb(testInMemoryDatabase());
-  });
 
-  tearDown(() => db.close());
-
-  test("manager - with references tests - foreign key", () async {
-    final departmentsData = [
-      (name: "Electronics", id: 1),
-      (name: "Clothing", id: 2),
-      (name: "Books", id: 3)
-    ];
-    final productsData = [
-      (name: "TV", department: 1, id: 1),
-      (name: "Shirt", department: 2, id: 2),
-      (name: "Book", department: 3, id: 3),
-      (name: "Another Book", department: 3, id: 4),
-    ];
     await db.managers.product.bulkCreate(
       (o) {
         return productsData.map((e) => o(
-            name: Value(e.name),
-            department: Value(e.department),
-            id: Value(e.id)));
+              sku: e.id,
+              name: Value(e.name),
+              department: Value(e.department),
+            ));
       },
     );
     await db.managers.department.bulkCreate(
@@ -44,7 +43,11 @@ void main() {
             .map((e) => o(name: Value(e.name), id: Value(e.id)));
       },
     );
+  });
 
+  tearDown(() => db.close());
+
+  test("manager - with references tests - foreign key", () async {
     /// Test that nothing is prefetched if not requested
     for (final (product, refs)
         in await db.managers.product.withReferences().get()) {
@@ -77,32 +80,6 @@ void main() {
   });
 
   test("manager - with references tests - reverse reference", () async {
-    final departmentsData = [
-      (name: "Electronics", id: 1),
-      (name: "Clothing", id: 2),
-      (name: "Books", id: 3)
-    ];
-    final productsData = [
-      (name: "TV", department: 1, id: 1),
-      (name: "Shirt", department: 2, id: 2),
-      (name: "Book", department: 3, id: 3),
-      (name: "Another Book", department: 3, id: 4),
-    ];
-    await db.managers.product.bulkCreate(
-      (o) {
-        return productsData.map((e) => o(
-            name: Value(e.name),
-            department: Value(e.department),
-            id: Value(e.id)));
-      },
-    );
-    await db.managers.department.bulkCreate(
-      (o) {
-        return departmentsData
-            .map((e) => o(name: Value(e.name), id: Value(e.id)));
-      },
-    );
-
     /// Test that nothing is prefetched if not requested
     for (final (department, refs)
         in await db.managers.department.withReferences().get()) {
@@ -120,7 +97,7 @@ void main() {
 
     /// Department which contains Product ID #3
     final booksDepartment = await db.managers.department
-        .filter((f) => f.productRefs((f) => f.id(3)))
+        .filter((f) => f.productRefs((f) => f.sku("3")))
         .withReferences((prefetch) => prefetch(productRefs: true))
         .get();
     for (final (department, refs) in booksDepartment) {
@@ -130,42 +107,17 @@ void main() {
 
   test("manager - with references tests - foreign key & reverse reference ",
       () async {
-    final departmentsData = [
-      (name: "Electronics", id: 1),
-      (name: "Clothing", id: 2),
-      (name: "Books", id: 3)
-    ];
-    final productsData = [
-      (name: "TV", department: 1, id: 1),
-      (name: "Shirt", department: 2, id: 2),
-      (name: "Book", department: 3, id: 3),
-      (name: "Another Book", department: 3, id: 4),
-    ];
     final listingsData = [
-      (product: 1, store: 1, price: 100.0),
-      (product: 2, store: 1, price: 50.0),
-      (product: 3, store: 2, price: 20.0),
-      (product: 4, store: 3, price: 10.0),
+      (product: "1", store: 1, price: 100.0),
+      (product: "2", store: 1, price: 50.0),
+      (product: "3", store: 2, price: 20.0),
+      (product: "4", store: 3, price: 10.0),
     ];
     final storesData = [
       (name: "Walmart", id: 1),
       (name: "Target", id: 2),
       (name: "Costco", id: 3)
     ];
-    await db.managers.product.bulkCreate(
-      (o) {
-        return productsData.map((e) => o(
-            name: Value(e.name),
-            department: Value(e.department),
-            id: Value(e.id)));
-      },
-    );
-    await db.managers.department.bulkCreate(
-      (o) {
-        return departmentsData
-            .map((e) => o(name: Value(e.name), id: Value(e.id)));
-      },
-    );
     await db.managers.store.bulkCreate(
       (o) {
         return storesData.map((e) => o(name: Value(e.name), id: Value(e.id)));
@@ -192,44 +144,17 @@ void main() {
   });
 
   test("manager - with references tests - watch ", () async {
-    final departmentsData = [
-      (name: "Electronics", id: 1),
-      (name: "Clothing", id: 2),
-      (name: "Books", id: 3)
-    ];
-    final productsData = [
-      (name: "TV", department: 1, id: 1),
-      (name: "Shirt", department: 2, id: 2),
-      (name: "Book", department: 3, id: 3),
-      (name: "Another Book", department: 3, id: 4),
-    ];
     final storesData = [
       (name: "Walmart", id: 1),
       (name: "Target", id: 2),
       (name: "Costco", id: 3)
     ];
     final listingsData = [
-      (product: 1, store: 1, price: 100.0),
-      (product: 2, store: 1, price: 50.0),
-      (product: 3, store: 2, price: 20.0),
-      (product: 4, store: 3, price: 10.0),
+      (product: "1", store: 1, price: 100.0),
+      (product: "2", store: 1, price: 50.0),
+      (product: "3", store: 2, price: 20.0),
+      (product: "4", store: 3, price: 10.0),
     ];
-    await db.managers.department.bulkCreate(
-      (o) {
-        return departmentsData
-            .map((e) => o(name: Value(e.name), id: Value(e.id)));
-      },
-    );
-
-    await db.managers.product.bulkCreate(
-      (o) {
-        return productsData.map((e) => o(
-            name: Value(e.name),
-            department: Value(e.department),
-            id: Value(e.id)));
-      },
-    );
-
     await db.managers.store.bulkCreate(
       (o) {
         return storesData.map((e) => o(name: Value(e.name), id: Value(e.id)));
@@ -259,7 +184,7 @@ void main() {
     final productCount = products!.length;
 
     // Delete a product
-    await db.managers.product.filter((f) => f.id(1)).delete();
+    await db.managers.product.filter((f) => f.sku("1")).delete();
     await pumpEventQueue();
     expect(products!.length, productCount - 1);
 

--- a/drift/test/manager/manager_referenced_filter_test.dart
+++ b/drift/test/manager/manager_referenced_filter_test.dart
@@ -28,7 +28,7 @@ void main() {
 
     products = await _productData.mapAsyncAndAwait(
       (p0) => db.managers.product.createReturning(
-          (o) => o(name: p0.name, department: p0.department, id: Value(p0.id))),
+          (o) => o(name: p0.name, department: p0.department, sku: p0.id)),
     );
 
     listings = await _listingsData.mapAsyncAndAwait(
@@ -628,45 +628,49 @@ const _departmentData = [
 ];
 
 final _productData = [
-  (name: Value("TV"), department: Value(_departmentData[0].id), id: 1),
-  (name: Value("Cell Phone"), department: Value(_departmentData[0].id), id: 2),
-  (name: Value("Charger"), department: Value(_departmentData[0].id), id: 3),
-  (name: Value("Cereal"), department: Value(_departmentData[1].id), id: 4),
-  (name: Value("Meat"), department: Value(_departmentData[1].id), id: 5),
-  (name: Value("Shirt"), department: Value(_departmentData[2].id), id: 6),
-  (name: Value("Pants"), department: Value(_departmentData[2].id), id: 7),
-  (name: Value("Socks"), department: Value(_departmentData[2].id), id: 8),
-  (name: Value("Cap"), department: Value(_departmentData[2].id), id: 9),
+  (name: Value("TV"), department: Value(_departmentData[0].id), id: "1"),
+  (
+    name: Value("Cell Phone"),
+    department: Value(_departmentData[0].id),
+    id: "2"
+  ),
+  (name: Value("Charger"), department: Value(_departmentData[0].id), id: "3"),
+  (name: Value("Cereal"), department: Value(_departmentData[1].id), id: "4"),
+  (name: Value("Meat"), department: Value(_departmentData[1].id), id: "5"),
+  (name: Value("Shirt"), department: Value(_departmentData[2].id), id: "6"),
+  (name: Value("Pants"), department: Value(_departmentData[2].id), id: "7"),
+  (name: Value("Socks"), department: Value(_departmentData[2].id), id: "8"),
+  (name: Value("Cap"), department: Value(_departmentData[2].id), id: "9"),
 ];
 final _listingsData = [
   // Walmart - Electronics
-  (product: 1, store: 1, price: 100.0),
-  (product: 2, store: 1, price: 200.0),
-  (product: 3, store: 1, price: 10.0),
+  (product: "1", store: 1, price: 100.0),
+  (product: "2", store: 1, price: 200.0),
+  (product: "3", store: 1, price: 10.0),
   // Walmart - Grocery
-  (product: 4, store: 1, price: 5.0),
-  (product: 5, store: 1, price: 15.0),
+  (product: "4", store: 1, price: 5.0),
+  (product: "5", store: 1, price: 15.0),
   // Walmart - Clothing
-  (product: 6, store: 1, price: 20.0),
-  (product: 7, store: 1, price: 30.0),
-  (product: 8, store: 1, price: 5.0),
-  (product: 9, store: 1, price: 10.0),
+  (product: "6", store: 1, price: 20.0),
+  (product: "7", store: 1, price: 30.0),
+  (product: "8", store: 1, price: 5.0),
+  (product: "9", store: 1, price: 10.0),
   // Target - Electronics
-  (product: 2, store: 2, price: 150.0),
-  (product: 3, store: 2, price: 15.0),
+  (product: "2", store: 2, price: 150.0),
+  (product: "3", store: 2, price: 15.0),
   // Target - Grocery
-  (product: 4, store: 2, price: 10.0),
-  (product: 5, store: 2, price: 20.0),
+  (product: "4", store: 2, price: 10.0),
+  (product: "5", store: 2, price: 20.0),
   // Target - Clothing
-  (product: 8, store: 2, price: 5.0),
-  (product: 9, store: 2, price: 10.0),
+  (product: "8", store: 2, price: 5.0),
+  (product: "9", store: 2, price: 10.0),
   // Costco - Electronics
-  (product: 1, store: 3, price: 50.0),
-  (product: 2, store: 3, price: 100.0),
-  (product: 3, store: 3, price: 2.50),
+  (product: "1", store: 3, price: 50.0),
+  (product: "2", store: 3, price: 100.0),
+  (product: "3", store: 3, price: 2.50),
   // Costco - Grocery
-  (product: 4, store: 3, price: 20.0),
-  (product: 5, store: 3, price: 900.0),
+  (product: "4", store: 3, price: 20.0),
+  (product: "5", store: 3, price: 900.0),
 ];
 final _todosData = <({
   Value<RowId> category,

--- a/drift/test/manager/manager_selectable_test.dart
+++ b/drift/test/manager/manager_selectable_test.dart
@@ -31,7 +31,7 @@ void main() {
 
     final products = await _productData.mapAsyncAndAwait(
       (p0) => db.managers.product.createReturning(
-          (o) => o(name: p0.name, department: p0.department, id: Value(p0.id))),
+          (o) => o(name: p0.name, department: p0.department, sku: p0.sku)),
     );
 
     final listings = await _listingsData.mapAsyncAndAwait(
@@ -89,43 +89,47 @@ const _departmentData = [
 ];
 
 final _productData = [
-  (name: Value("TV"), department: Value(_departmentData[0].id), id: 1),
-  (name: Value("Cell Phone"), department: Value(_departmentData[0].id), id: 2),
-  (name: Value("Charger"), department: Value(_departmentData[0].id), id: 3),
-  (name: Value("Cereal"), department: Value(_departmentData[1].id), id: 4),
-  (name: Value("Meat"), department: Value(_departmentData[1].id), id: 5),
-  (name: Value("Shirt"), department: Value(_departmentData[2].id), id: 6),
-  (name: Value("Pants"), department: Value(_departmentData[2].id), id: 7),
-  (name: Value("Socks"), department: Value(_departmentData[2].id), id: 8),
-  (name: Value("Cap"), department: Value(_departmentData[2].id), id: 9),
+  (name: Value("TV"), department: Value(_departmentData[0].id), sku: "1"),
+  (
+    name: Value("Cell Phone"),
+    department: Value(_departmentData[0].id),
+    sku: "2"
+  ),
+  (name: Value("Charger"), department: Value(_departmentData[0].id), sku: "3"),
+  (name: Value("Cereal"), department: Value(_departmentData[1].id), sku: "4"),
+  (name: Value("Meat"), department: Value(_departmentData[1].id), sku: "5"),
+  (name: Value("Shirt"), department: Value(_departmentData[2].id), sku: "6"),
+  (name: Value("Pants"), department: Value(_departmentData[2].id), sku: "7"),
+  (name: Value("Socks"), department: Value(_departmentData[2].id), sku: "8"),
+  (name: Value("Cap"), department: Value(_departmentData[2].id), sku: "9"),
 ];
 final _listingsData = [
   // Walmart - Electronics
-  (product: 1, store: 1, price: 100.0),
-  (product: 2, store: 1, price: 200.0),
-  (product: 3, store: 1, price: 10.0),
+  (product: "1", store: 1, price: 100.0),
+  (product: "2", store: 1, price: 200.0),
+  (product: "3", store: 1, price: 10.0),
   // Walmart - Grocery
-  (product: 4, store: 1, price: 5.0),
-  (product: 5, store: 1, price: 15.0),
+  (product: "4", store: 1, price: 5.0),
+  (product: "5", store: 1, price: 15.0),
   // Walmart - Clothing
-  (product: 6, store: 1, price: 20.0),
-  (product: 7, store: 1, price: 30.0),
-  (product: 8, store: 1, price: 5.0),
-  (product: 9, store: 1, price: 10.0),
+  (product: "6", store: 1, price: 20.0),
+  (product: "7", store: 1, price: 30.0),
+  (product: "8", store: 1, price: 5.0),
+  (product: "9", store: 1, price: 10.0),
   // Target - Electronics
-  (product: 2, store: 2, price: 150.0),
-  (product: 3, store: 2, price: 15.0),
+  (product: "2", store: 2, price: 150.0),
+  (product: "3", store: 2, price: 15.0),
   // Target - Grocery
-  (product: 4, store: 2, price: 10.0),
-  (product: 5, store: 2, price: 20.0),
+  (product: "4", store: 2, price: 10.0),
+  (product: "5", store: 2, price: 20.0),
   // Target - Clothing
-  (product: 8, store: 2, price: 5.0),
-  (product: 9, store: 2, price: 10.0),
+  (product: "8", store: 2, price: 5.0),
+  (product: "9", store: 2, price: 10.0),
   // Costco - Electronics
-  (product: 1, store: 3, price: 50.0),
-  (product: 2, store: 3, price: 100.0),
-  (product: 3, store: 3, price: 2.50),
+  (product: "1", store: 3, price: 50.0),
+  (product: "2", store: 3, price: 100.0),
+  (product: "3", store: 3, price: 2.50),
   // Costco - Grocery
-  (product: 4, store: 3, price: 20.0),
-  (product: 5, store: 3, price: 900.0),
+  (product: "4", store: 3, price: 20.0),
+  (product: "5", store: 3, price: 900.0),
 ];

--- a/drift_dev/lib/src/writer/manager/manager_templates.dart
+++ b/drift_dev/lib/src/writer/manager/manager_templates.dart
@@ -257,12 +257,10 @@ class _ManagerCodeTemplates {
                     referencedTable:
                         $referencesClassName._${relation.fieldName}Table(db),
                     referencedColumn:
-                        $referencesClassName._${relation.fieldName}Table(db).id,
+                        $referencesClassName._${relation.fieldName}Table(db).${relation.referencedColumn.nameInDart},
                   ) as T;
                }""";
                   }).join('\n')}
-
-
 
                 return state;
               }


### PR DESCRIPTION
In the code generation template, the prefetch builder responsible for creating joins used to always use a referenced column named "id". Obviously we can reference different columns as well, but we didn't catch this in our tests because all references were towards an "id" column.

I've fixed the code and updated the example database in `drift/test` to reference a primary key that is not named "id". This closes https://github.com/simolus3/drift/issues/3160.