### PR TITLE
Fix the links of the comments on update and delete methods

### DIFF
--- a/drift/lib/src/runtime/api/batch.dart
+++ b/drift/lib/src/runtime/api/batch.dart
@@ -86,7 +86,7 @@ class Batch {
   /// that match the [where] clause.
   ///
   /// For more details on how updates work in drift, check out
-  /// [UpdateStatement.write] or the [documentation with examples](https://drift.simonbinder.eu/docs/getting-started/writing_queries/#updates-and-deletes)
+  /// [UpdateStatement.write] or the [documentation with examples](https://drift.simonbinder.eu/docs/dart-api/writes/#updates-and-deletes)
   void update<T extends Table, D>(TableInfo<T, D> table, Insertable<D> row,
       {Expression<bool> Function(T table)? where}) {
     _addUpdate(table, UpdateKind.update);

--- a/drift/lib/src/runtime/api/connection_user.dart
+++ b/drift/lib/src/runtime/api/connection_user.dart
@@ -274,7 +274,7 @@ abstract class DatabaseConnectionUser {
 
   /// Starts a [DeleteStatement] that can be used to delete rows from a table.
   ///
-  /// See the [documentation](https://drift.simonbinder.eu/docs/getting-started/writing_queries/#updates-and-deletes)
+  /// See the [documentation](https://drift.simonbinder.eu/docs/dart-api/writes/#updates-and-deletes)
   /// for more details and example on how delete statements work.
   DeleteStatement<T, D> delete<T extends Table, D>(TableInfo<T, D> table) {
     return DeleteStatement<T, D>(this, table);


### PR DESCRIPTION
This is a trivial fix of comments.
I couldn't find the details of delete and update methods from the links of the comments. That's why I fixed the links.