### PR TITLE
feat(drift_dev): Support view triggers in drift SQL

### DIFF
--- a/drift_dev/lib/src/analysis/resolver/drift/trigger.dart
+++ b/drift_dev/lib/src/analysis/resolver/drift/trigger.dart
@@ -60,7 +60,8 @@ class DriftTriggerResolver
     return DriftTrigger(
       discovered.ownId,
       DriftDeclaration.driftFile(stmt, file.ownUri),
-      on: findInResolved(references, stmt.onTable.tableName) as DriftTable?,
+      on: findInResolved(references, stmt.onTable.tableName)
+          as DriftElementWithResultSet?,
       onWrite: onWrite,
       references: references,
       createStmt: source.substring(stmt.firstPosition, stmt.lastPosition),

--- a/drift_dev/lib/src/analysis/resolver/resolver.dart
+++ b/drift_dev/lib/src/analysis/resolver/resolver.dart
@@ -48,7 +48,7 @@ class DriftResolver {
         return await _deserializer.readDriftElement(element);
       }
     } on CouldNotDeserializeException catch (e, s) {
-      driver.backend.log.fine('Could not deserialize $element', e, s);
+      driver.backend.log.warning('Could not deserialize $element', e, s);
     }
 
     // We can't resolve the element from cache, so we need to resolve it.

--- a/drift_dev/lib/src/analysis/results/query.dart
+++ b/drift_dev/lib/src/analysis/results/query.dart
@@ -398,11 +398,9 @@ class UpdatingQuery extends SqlQuery {
   @override
   final AstNode root;
 
-  bool get isOnlyDelete =>
-      updates.isNotEmpty && updates.every((w) => w.kind == UpdateKind.delete);
+  bool get isOnlyDelete => updates.every((w) => w.kind == UpdateKind.delete);
 
-  bool get isOnlyUpdate =>
-      updates.isNotEmpty && updates.every((w) => w.kind == UpdateKind.update);
+  bool get isOnlyUpdate => updates.every((w) => w.kind == UpdateKind.update);
 
   UpdatingQuery(
     String name,

--- a/drift_dev/lib/src/analysis/results/query.dart
+++ b/drift_dev/lib/src/analysis/results/query.dart
@@ -398,9 +398,11 @@ class UpdatingQuery extends SqlQuery {
   @override
   final AstNode root;
 
-  bool get isOnlyDelete => updates.every((w) => w.kind == UpdateKind.delete);
+  bool get isOnlyDelete =>
+      updates.isNotEmpty && updates.every((w) => w.kind == UpdateKind.delete);
 
-  bool get isOnlyUpdate => updates.every((w) => w.kind == UpdateKind.update);
+  bool get isOnlyUpdate =>
+      updates.isNotEmpty && updates.every((w) => w.kind == UpdateKind.update);
 
   UpdatingQuery(
     String name,

--- a/drift_dev/lib/src/analysis/results/trigger.dart
+++ b/drift_dev/lib/src/analysis/results/trigger.dart
@@ -1,13 +1,11 @@
-import 'package:drift/drift.dart';
+import 'package:drift/drift.dart' hide DriftView;
 import 'package:sqlparser/sqlparser.dart';
 
-import 'element.dart';
-import 'query.dart';
-import 'table.dart';
+import 'results.dart';
 
 class DriftTrigger extends DriftSchemaElement {
-  /// The table whose writes trigger this trigger.
-  final DriftTable? on;
+  /// The [DriftTable] or [DriftView] whose writes trigger this trigger.
+  final DriftElementWithResultSet? on;
 
   /// The kind of write (insert, update, delete) causing this trigger to run.
   final UpdateKind onWrite;

--- a/drift_dev/lib/src/analysis/serializer.dart
+++ b/drift_dev/lib/src/analysis/serializer.dart
@@ -626,10 +626,11 @@ class ElementDeserializer {
           dartTypes: types,
         );
       case 'trigger':
-        DriftTable? on;
+        DriftElementWithResultSet? on;
 
         if (json['on'] != null) {
-          on = await _readElementReference(json['on'] as Map) as DriftTable;
+          on = await _readElementReference(json['on'] as Map)
+              as DriftElementWithResultSet;
         }
 
         return DriftTrigger(
@@ -698,7 +699,7 @@ class ElementDeserializer {
               AnnotatedDartCode.fromJson(entry as Map)
           ],
           nameOfRowClass: json['name_of_row_class'] as String,
-          nameOfCompanionClass: json['name_of_companion_class'] as String,
+          nameOfCompanionClass: json['name_of_companion_class'] as String?,
           existingRowClass: json['existing_data_class'] != null
               ? await _readExistingRowClass(
                   id.libraryUri, json['existing_data_class'] as Map)

--- a/drift_dev/lib/src/writer/queries/query_writer.dart
+++ b/drift_dev/lib/src/writer/queries/query_writer.dart
@@ -573,6 +573,9 @@ class QueryWriter {
   }
 
   void _writeUpdateKind(UpdatingQuery update) {
+    if (update.updates.isEmpty) {
+      return;
+    }
     if (update.isOnlyDelete) {
       _buffer.write(', updateKind: ${_emitter.drift('UpdateKind.delete')}');
     } else if (update.isOnlyUpdate) {


### PR DESCRIPTION
Adds support for triggers on views created by `CREATE TRIGGER` expressions.

https://www.sqlite.org/lang_createtrigger.html#instead_of_triggers