### PR TITLE
fix(drift_dev): Strip leading numerics in modular generation

### DIFF
--- a/drift_dev/lib/src/utils/string_escaper.dart
+++ b/drift_dev/lib/src/utils/string_escaper.dart
@@ -11,3 +11,8 @@ String escapeForDart(String value) {
       .replaceAll('\r', '\\r')
       .replaceAll('\n', '\\n');
 }
+
+final _leadingNumerics = RegExp(r'^[0-9]+');
+String stripLeadingNumerics(String className) {
+  return className.replaceFirst(_leadingNumerics, '');
+}

--- a/drift_dev/lib/src/writer/writer.dart
+++ b/drift_dev/lib/src/writer/writer.dart
@@ -71,7 +71,9 @@ abstract class _NodeOrWriter {
 
     return AnnotatedDartCode([
       DartTopLevelSymbol(
-          ReCase(url.basename(driftFile.path)).pascalCase, id.modularImportUri),
+        ReCase(stripLeadingNumerics(url.basename(driftFile.path))).pascalCase,
+        id.modularImportUri,
+      ),
     ]);
   }
 


### PR DESCRIPTION
For drift modules of the form `\d+_foo.drift` which is a common naming convention for migration files, strip the leading numerics when generating module accessors.

Currently, module accessors result in classes of the form `class 001Foo extends ModuleAccessor` which is invalid Dart syntax. Escaping with `$` also solves the problem, but simply stripping the numerics leads to cleaner code.