### PR TITLE
fix(drift_dev): Infer `json_extract` type from context

### DIFF
--- a/drift_dev/test/analysis/resolver/drift/json1_test.dart
+++ b/drift_dev/test/analysis/resolver/drift/json1_test.dart
@@ -1,0 +1,34 @@
+import 'package:drift_dev/src/analysis/options.dart';
+import 'package:sqlparser/sqlparser.dart';
+import 'package:test/test.dart';
+
+import '../../test_utils.dart';
+
+void main() {
+  test('json_extract result type is inferred by context', () async {
+    final state = await TestBackend.inTest(
+      {
+        'foo|lib/a.drift': r'''
+CREATE TABLE IF NOT EXISTS foo (
+  bar TEXT NOT NULL,
+  baz TEXT NOT NULL
+);
+
+insertFoo(:foo_jsons AS TEXT):
+INSERT INTO foo(bar, baz)
+SELECT json_extract(value, '$.bar'), json_extract(value, '$.baz')
+FROM json_each(:foo_jsons);
+      ''',
+      },
+      options: const DriftOptions.defaults(
+        modules: [SqlModule.json1],
+        sqliteAnalysisOptions:
+            SqliteAnalysisOptions(version: SqliteVersion.v3_39),
+      ),
+    );
+
+    await state.analyze('package:foo/a.drift');
+
+    state.expectNoErrors();
+  });
+}

--- a/sqlparser/lib/src/engine/module/json1.dart
+++ b/sqlparser/lib/src/engine/module/json1.dart
@@ -82,7 +82,7 @@ class _Json1Functions implements FunctionHandler {
           return const ResolveResult(ResolvedType.bool());
         case 'json_extract':
         case 'jsonb_extract':
-          return const ResolveResult.unknown();
+          return const ResolveResult.needsContext();
         case 'json_array_length':
           return const ResolveResult(ResolvedType(type: BasicType.int));
       }


### PR DESCRIPTION
Currently, inference of all `json_extract` expressions results in an unknown type for inference. However, there are cases where the type can be known/coerced, for example with `INSERT INTO SELECT` statements when the column types are inferred from the written table.

In those cases, we use the expectation type to resolve `json_extract` expressions.