### PR TITLE
New docs issue template

### DIFF
--- a/.github/ISSUE_TEMPLATE/docs.md
+++ b/.github/ISSUE_TEMPLATE/docs.md
@@ -1,0 +1,31 @@
+---
+name: 'Drift docs: Issue / Feature request'
+about: Create a report to help improve drift's docs
+title: ''
+labels: ['docs']
+assignees: ''
+---
+
+**Description**
+
+Thanks for taking the time to file an issue for drift's docs!
+
+For feature requests, please describe the feature you're interested in.
+
+For information requests, please describe what you think is missing from
+the docs and if possible where should this information be placed.
+
+For bug reports, please describe what is wrongand what do you believe should
+be written instead.
+
+**Versions**
+
+Please add here the versions of `drift` you're using. It might be relevant to the docs to show somethings version-wise in specific cases.
+
+**Screenshots**
+
+Add screenshots and videos here if needed to help explain your point. For example if something in the website is not behaving correctly.
+
+**Aditional info**
+
+Write down any aditional info/discussion for this issue.

--- a/.github/ISSUE_TEMPLATE/docs.md
+++ b/.github/ISSUE_TEMPLATE/docs.md
@@ -15,8 +15,9 @@ For feature requests, please describe the feature you're interested in.
 For information requests, please describe what you think is missing from
 the docs and if possible where should this information be placed.
 
-For bug reports, please describe what is wrongand what do you believe should
-be written instead.
+If something on a page appears to be wrong or outdated, please include a link to
+the relevant section and mention what didn't work (or possibly what should be
+written instead).
 
 **Versions**
 

--- a/.github/ISSUE_TEMPLATE/docs.md
+++ b/.github/ISSUE_TEMPLATE/docs.md
@@ -18,14 +18,7 @@ If something on a page appears to be wrong or outdated, please include a link to
 the relevant section and mention what didn't work (or possibly what should be
 written instead).
 
-**Versions**
-
-Please add here the versions of `drift` you're using. It might be relevant to the docs to show somethings version-wise in specific cases.
-
-**Screenshots**
-
-Add screenshots and videos here if needed to help explain your point. For example if something in the website is not behaving correctly.
-
 **Aditional info**
 
-Write down any aditional info/discussion for this issue.
+Write down any aditional info/discussion for this issue. If you think the documentation issue may be related to your drift version, please include the versions of `drift` you're using.
+Also, feel free to add screenshots or videos if they help explaining the documentation issue.

--- a/.github/ISSUE_TEMPLATE/docs.md
+++ b/.github/ISSUE_TEMPLATE/docs.md
@@ -10,10 +10,9 @@ assignees: ''
 
 Thanks for taking the time to file an issue for drift's documentation website or dartdocs!
 
-For feature requests, please describe the feature you're interested in.
-
-For information requests, please describe what you think is missing from
-the docs and if possible where should this information be placed.
+If you are looking for information that you feel is not sufficiently explained on the
+website (or too hard to find), please describe what the site is missing and, if possible,
+where you think the information should be added.
 
 If something on a page appears to be wrong or outdated, please include a link to
 the relevant section and mention what didn't work (or possibly what should be

--- a/.github/ISSUE_TEMPLATE/docs.md
+++ b/.github/ISSUE_TEMPLATE/docs.md
@@ -8,7 +8,7 @@ assignees: ''
 
 **Description**
 
-Thanks for taking the time to file an issue for drift's docs!
+Thanks for taking the time to file an issue for drift's documentation website or dartdocs!
 
 For feature requests, please describe the feature you're interested in.
 

--- a/docs/templates/partials/page-meta-links.html
+++ b/docs/templates/partials/page-meta-links.html
@@ -1,0 +1,9 @@
+{% assign branch = site.github_branch | default: 'develop' %}
+{% assign subdir = site.github_subdir | default: '' %}
+{% assign edit_url = site.github_repo | append: '/edit/', branch, '/', subdir, page.source %}
+{% assign issues_url = site.github_repo | append: '/issues/new?template=docs.md&title=Documentation issue: ', page.title %}
+
+<div class="td-page-meta ms-2 pb-1 pt-2 mb-0">
+    <a href="{{ issues_url }}" class="td-page-meta--issue" target="_blank" rel="noopener"></i class="fa-solid fa-list-check fa-fw"> {{ "post_create_issue" | i18n }}</a>
+    <a href="{{ edit_url }}" class="td-page-meta--edit" target="_blank" rel="noopener"><i class="fa-solid fa-pen-to-square fa-fw"></i> {{ "post_edit_this" | i18n }}</a>
+</div>


### PR DESCRIPTION
Inspired by https://github.com/simolus3/drift/pull/3179.

This is just the new template for the docs issue.

I could not find the right-side tab for the docs website. So I figured you make it whenever building it with the current tool.

The new link would be:

```
https://github.com/simolus3/drift/issues/new?template=docs.md
```