### PR TITLE
Support `null` in `ColumnFilters.call`

### DIFF
--- a/drift/lib/src/runtime/manager/filter.dart
+++ b/drift/lib/src/runtime/manager/filter.dart
@@ -71,10 +71,11 @@ class ColumnFilters<T extends Object> extends _BaseColumnFilters<T> {
       ColumnFilters(column, inverted: !inverted, joinBuilders: joinBuilders);
 
   /// Create a filter that checks if the column equals a value.
-  ComposableFilter equals(T value) => $composableFilter(column.equals(value));
+  ComposableFilter equals(T? value) =>
+      $composableFilter(column.equalsNullable(value));
 
   /// Shortcut for [equals]
-  ComposableFilter call(T value) => equals(value);
+  ComposableFilter call(T? value) => equals(value);
 
   /// Create a filter that checks if the column is in a list of values.
   ComposableFilter isIn(Iterable<T> values) =>

--- a/drift/test/manager/manager_filter_test.dart
+++ b/drift/test/manager/manager_filter_test.dart
@@ -408,4 +408,13 @@ void main() {
             .count(),
         1);
   });
+
+  test('can use shorthand filter for nulls', () async {
+    final row = await db.todosTable.insertReturning(
+        TodosTableCompanion.insert(content: 'my test content'));
+
+    final query =
+        await db.managers.todosTable.filter((f) => f.targetDate(null)).get();
+    expect(query, [row]);
+  });
 }


### PR DESCRIPTION
Let me know if you think there's a better way for this @dickermoshe. This allows filtering for columns with a null value with the shorthand `equals/`/`call` syntax through `ColumnFilters`.

This is useful as we currently generate broken code when we have nullable references (these tables don't really make much sense, but they reproduce the issue):

```dart
class Users extends Table {
  IntColumn get id => integer().nullable().autoIncrement()();
}

class Wallets extends Table {
  IntColumn get userId =>
      integer().nullable().customConstraint('NULL REFERENCES users(id)')();
}
```

Here, we generate

```dart
  $$WalletsTableProcessedTableManager get walletsRefs {
    final manager = $$WalletsTableTableManager($_db, $_db.wallets)
        .filter((f) => f.userId.id($_item.id));

    final cache = $_typedResult.readTableOrNull(_walletsRefsTable($_db));
    return ProcessedTableManager(
        manager.$state.copyWith(prefetchedData: cache));
  }
```

which then fails because `$_item.id` is nullable. I think for forward references we have a null check here so maybe there's a better way to address this, but that should fix the compilation error at least.

Closes https://github.com/simolus3/drift/issues/3187.