### PR TITLE
Delete unreachable `default` clauses.

### DIFF
--- a/drift/lib/src/runtime/executor/helpers/engines.dart
+++ b/drift/lib/src/runtime/executor/helpers/engines.dart
@@ -501,8 +501,6 @@ class DelegatedDatabase extends _BaseExecutor {
             this, context, noTransactionDelegate);
       case SupportedTransactionDelegate supported:
         return _WrappingTransactionExecutor(this, supported);
-      default:
-        throw StateError('Unknown transaction delegate: $transactionDelegate');
     }
   }
 

--- a/drift/lib/src/runtime/executor/helpers/engines.dart
+++ b/drift/lib/src/runtime/executor/helpers/engines.dart
@@ -493,8 +493,6 @@ class DelegatedDatabase extends _BaseExecutor {
   @override
   // ignore: library_private_types_in_public_api
   TransactionExecutor beginTransactionInContext(_BaseExecutor context) {
-    final transactionDelegate = delegate.transactionDelegate;
-
     switch (delegate.transactionDelegate) {
       case NoTransactionDelegate noTransactionDelegate:
         return _StatementBasedTransactionExecutor(

--- a/sqlparser/lib/utils/node_to_text.dart
+++ b/sqlparser/lib/utils/node_to_text.dart
@@ -403,9 +403,6 @@ class NodeSqlBuilder extends AstVisitor<void, void> {
         keyword(TokenType.instead);
         keyword(TokenType.of);
         break;
-      default:
-        // Can happen if e.mode == null
-        break;
     }
 
     visit(e.target, arg);


### PR DESCRIPTION
The Dart analyzer will soon be changed so that if the `default` clause of a `switch` statement is determined to be unreachable by the exhaustiveness checker, a new warning of type
`unreachable_switch_default` will be issued. This parallels the behavior of the existing `unreachable_switch_case` warning, which is issued whenever a `case` clause of a `switch` statement is determined to be unreachable. For details see
https://github.com/dart-lang/sdk/issues/54575.

This PR deletes unreachable `default` clauses from `drift` now, to avoid spurious warnings when the analyzer change lands.