### PR TITLE
fix(drift_dev): Deserialization of view triggers

### DIFF
--- a/drift_dev/lib/src/services/schema/schema_files.dart
+++ b/drift_dev/lib/src/services/schema/schema_files.dart
@@ -4,9 +4,9 @@ import 'package:pub_semver/pub_semver.dart';
 import 'package:recase/recase.dart';
 import 'package:sqlparser/sqlparser.dart' hide PrimaryKeyColumn;
 
+import '../../analysis/options.dart';
 import '../../analysis/resolver/shared/data_class.dart';
 import '../../analysis/results/results.dart';
-import '../../analysis/options.dart';
 import '../../writer/utils/column_constraints.dart';
 
 class _ExportedSchemaVersion {
@@ -346,7 +346,7 @@ class SchemaReader {
   }
 
   DriftTrigger _readTrigger(Map<String, dynamic> content) {
-    final on = _existingEntity<DriftTable>(content['on']);
+    final on = _existingEntity<DriftElementWithResultSet>(content['on']);
     final name = content['name'] as String;
     final sql = content['sql'] as String;
 

--- a/drift_dev/test/services/schema/sqlite_to_drift_test.dart
+++ b/drift_dev/test/services/schema/sqlite_to_drift_test.dart
@@ -11,6 +11,10 @@ void main() {
       ..execute('CREATE VIEW my_view AS SELECT bar FROM foo')
       ..execute('CREATE TRIGGER my_trigger AFTER UPDATE ON foo BEGIN '
           'UPDATE foo SET bar = old.bar; '
+          'END;')
+      ..execute(
+          'CREATE TRIGGER my_view_trigger INSTEAD OF UPDATE ON my_view BEGIN '
+          'UPDATE foo SET bar = old.bar; '
           'END;');
     addTearDown(database.dispose);
 
@@ -23,6 +27,8 @@ void main() {
         isA<DriftView>().having((e) => e.schemaName, 'schemaName', 'my_view'),
         isA<DriftTrigger>()
             .having((e) => e.schemaName, 'schemaName', 'my_trigger'),
+        isA<DriftTrigger>()
+            .having((e) => e.schemaName, 'schemaName', 'my_view_trigger'),
       ]),
     );
   });

--- a/drift_dev/test/services/schema/verifier_impl_test.dart
+++ b/drift_dev/test/services/schema/verifier_impl_test.dart
@@ -64,9 +64,13 @@ void main() {
       await db.customStatement('CREATE TRIGGER x4 AFTER INSERT ON x1 BEGIN '
           'DELETE FROM x1;'
           'END;');
+      await db
+          .customStatement('CREATE TRIGGER x5 INSTEAD OF INSERT ON x2 BEGIN '
+              'DELETE FROM x1;'
+              'END;');
 
       final inputs = await db.collectSchemaInput(const []);
-      expect(inputs.map((e) => e.name), ['x1', 'x2', 'x3', 'x4']);
+      expect(inputs.map((e) => e.name), ['x1', 'x2', 'x3', 'x4', 'x5']);
     });
 
     test('does not contain shadow tables', () async {

--- a/drift_dev/test/services/schema/writer_test.dart
+++ b/drift_dev/test/services/schema/writer_test.dart
@@ -57,6 +57,10 @@ CREATE INDEX groups_name ON "groups"(name, upper(name));
 
 CREATE VIEW my_view WITH MyViewRow AS SELECT id FROM "groups";
 
+CREATE TRIGGER my_view_trigger INSTEAD OF UPDATE ON my_view BEGIN
+  UPDATE "groups" SET id = old.id;
+END;
+
 simple_query: SELECT * FROM my_view; -- not part of the schema
       ''',
         'a|lib/main.dart': '''
@@ -415,6 +419,17 @@ const expected = r'''
                         "dsl_features": []
                     }
                 ]
+            }
+        },
+        {
+            "id": 7,
+            "references": [6, 0],
+            "type": "trigger",
+            "data": {
+                "on": 6,
+                "references_in_body": [6, 0],
+                "name": "my_view_trigger",
+                "sql": "CREATE TRIGGER my_view_trigger INSTEAD OF UPDATE ON my_view BEGIN\n  UPDATE \"groups\" SET id = old.id;\nEND;"
             }
         }
     ]


### PR DESCRIPTION
Follow up from https://github.com/simolus3/drift/pull/3190. Fixes another spot where either a `DriftTable` or `DriftView` could be stored for a trigger's `on` entity.

Adds tests for view triggers in the `schema/` folder.