### PR TITLE
feat: add support for `late final` fields

### DIFF
--- a/drift/test/generated/todos.dart
+++ b/drift/test/generated/todos.dart
@@ -14,7 +14,7 @@ extension type RowId._(int id) {
 }
 
 mixin AutoIncrement on Table {
-  IntColumn get id => integer()
+  late final id = integer()
       .autoIncrement()
       .map(TypeConverter.extensionType<RowId, int>())();
 }
@@ -24,17 +24,17 @@ class TodosTable extends Table with AutoIncrement {
   @override
   String get tableName => 'todos';
 
-  TextColumn get title => text().withLength(min: 4, max: 16).nullable()();
-  TextColumn get content => text()();
+  late final title = text().withLength(min: 4, max: 16).nullable()();
+  late final content = text()();
   @JsonKey('target_date')
-  DateTimeColumn get targetDate => dateTime().nullable().unique()();
+  late final targetDate = dateTime().nullable().unique()();
   @ReferenceName("todos")
-  IntColumn get category => integer()
+  late final category = integer()
       .references(Categories, #id, initiallyDeferred: true)
       .map(TypeConverter.extensionType<RowId, int>())
       .nullable()();
 
-  TextColumn get status => textEnum<TodoStatus>().nullable()();
+  late final status = textEnum<TodoStatus>().nullable()();
 
   @override
   List<Set<Column>>? get uniqueKeys => [
@@ -46,11 +46,11 @@ class TodosTable extends Table with AutoIncrement {
 enum TodoStatus { open, workInProgress, done }
 
 class Users extends Table with AutoIncrement {
-  TextColumn get name => text().withLength(min: 6, max: 32).unique()();
-  BoolColumn get isAwesome => boolean().withDefault(const Constant(true))();
+  late final name = text().withLength(min: 6, max: 32).unique()();
+  late final isAwesome = boolean().withDefault(const Constant(true))();
 
-  BlobColumn get profilePicture => blob()();
-  DateTimeColumn get creationTime => dateTime()
+  late final profilePicture = blob()();
+  late final DateTimeColumn creationTime = dateTime()
       // ignore: recursive_getters
       .check(creationTime.isBiggerThan(Constant(DateTime.utc(1950))))
       .withDefault(currentDateAndTime)();
@@ -58,20 +58,19 @@ class Users extends Table with AutoIncrement {
 
 @DataClassName('Category')
 class Categories extends Table with AutoIncrement {
-  TextColumn get description =>
+  late final description =
       text().named('desc').customConstraint('NOT NULL UNIQUE')();
-  IntColumn get priority =>
+  late final priority =
       intEnum<CategoryPriority>().withDefault(const Constant(0))();
 
-  TextColumn get descriptionInUpperCase =>
-      text().generatedAs(description.upper())();
+  late final descriptionInUpperCase = text().generatedAs(description.upper())();
 }
 
 enum CategoryPriority { low, medium, high }
 
 class SharedTodos extends Table {
-  IntColumn get todo => integer()();
-  IntColumn get user => integer()();
+  late final todo = integer()();
+  late final user = integer()();
 
   @override
   Set<Column> get primaryKey => {todo, user};
@@ -87,24 +86,24 @@ const _uuid = Uuid();
 
 @UseRowClass(CustomRowClass, constructor: 'map', generateInsertable: true)
 class TableWithoutPK extends Table {
-  IntColumn get notReallyAnId => integer()();
-  RealColumn get someFloat => real()();
-  Int64Column get webSafeInt => int64().nullable()();
+  late final notReallyAnId = integer()();
+  late final someFloat = real()();
+  late final webSafeInt = int64().nullable()();
 
-  TextColumn get custom =>
+  late final custom =
       text().map(const CustomConverter()).clientDefault(_uuid.v4)();
 }
 
 class TableWithEveryColumnType extends Table with AutoIncrement {
-  BoolColumn get aBool => boolean().nullable()();
-  DateTimeColumn get aDateTime => dateTime().nullable()();
-  TextColumn get aText => text().nullable()();
-  IntColumn get anInt => integer().nullable()();
-  Int64Column get anInt64 => int64().nullable()();
-  RealColumn get aReal => real().nullable()();
-  BlobColumn get aBlob => blob().nullable()();
-  IntColumn get anIntEnum => intEnum<TodoStatus>().nullable()();
-  TextColumn get aTextWithConverter => text()
+  late final aBool = boolean().nullable()();
+  late final aDateTime = dateTime().nullable()();
+  late final aText = text().nullable()();
+  late final anInt = integer().nullable()();
+  late final anInt64 = int64().nullable()();
+  late final aReal = real().nullable()();
+  late final aBlob = blob().nullable()();
+  late final anIntEnum = intEnum<TodoStatus>().nullable()();
+  late final aTextWithConverter = text()
       .named('insert')
       .map(const CustomJsonConverter())
       .nullable()
@@ -112,29 +111,28 @@ class TableWithEveryColumnType extends Table with AutoIncrement {
 }
 
 class Department extends Table {
-  IntColumn get id => integer().autoIncrement()();
-  TextColumn get name => text().nullable()();
+  late final id = integer().autoIncrement()();
+  late final name = text().nullable()();
 }
 
 class Product extends Table {
-  TextColumn get sku => text()();
-  TextColumn get name => text().nullable()();
-  IntColumn get department =>
-      integer().references(Department, #id).nullable()();
+  late final sku = text()();
+  late final name = text().nullable()();
+  late final department = integer().references(Department, #id).nullable()();
 }
 
 class Listing extends Table {
-  IntColumn get id => integer().autoIncrement()();
+  late final id = integer().autoIncrement()();
   @ReferenceName('listings')
-  TextColumn get product => text().references(Product, #sku).nullable()();
+  late final product = text().references(Product, #sku).nullable()();
   @ReferenceName('listings')
-  IntColumn get store => integer().references(Store, #id).nullable()();
-  RealColumn get price => real().nullable()();
+  late final store = integer().references(Store, #id).nullable()();
+  late final price = real().nullable()();
 }
 
 class Store extends Table {
-  IntColumn get id => integer().autoIncrement()();
-  TextColumn get name => text().nullable()();
+  late final id = integer().autoIncrement()();
+  late final name = text().nullable()();
 }
 
 class CustomRowClass {
@@ -159,7 +157,7 @@ class CustomRowClass {
 
 class PureDefaults extends Table {
   // name after keyword to ensure it's escaped properly
-  TextColumn get txt =>
+  late final txt =
       text().named('insert').map(const CustomJsonConverter()).nullable()();
 
   @override

--- a/drift/test/generated/todos.dart
+++ b/drift/test/generated/todos.dart
@@ -86,24 +86,24 @@ const _uuid = Uuid();
 
 @UseRowClass(CustomRowClass, constructor: 'map', generateInsertable: true)
 class TableWithoutPK extends Table {
-  late final notReallyAnId = integer()();
-  late final someFloat = real()();
-  late final webSafeInt = int64().nullable()();
+  IntColumn get notReallyAnId => integer()();
+  RealColumn get someFloat => real()();
+  Int64Column get webSafeInt => int64().nullable()();
 
-  late final custom =
+  TextColumn get custom =>
       text().map(const CustomConverter()).clientDefault(_uuid.v4)();
 }
 
 class TableWithEveryColumnType extends Table with AutoIncrement {
-  late final aBool = boolean().nullable()();
-  late final aDateTime = dateTime().nullable()();
-  late final aText = text().nullable()();
-  late final anInt = integer().nullable()();
-  late final anInt64 = int64().nullable()();
-  late final aReal = real().nullable()();
-  late final aBlob = blob().nullable()();
-  late final anIntEnum = intEnum<TodoStatus>().nullable()();
-  late final aTextWithConverter = text()
+  BoolColumn get aBool => boolean().nullable()();
+  DateTimeColumn get aDateTime => dateTime().nullable()();
+  TextColumn get aText => text().nullable()();
+  IntColumn get anInt => integer().nullable()();
+  Int64Column get anInt64 => int64().nullable()();
+  RealColumn get aReal => real().nullable()();
+  BlobColumn get aBlob => blob().nullable()();
+  IntColumn get anIntEnum => intEnum<TodoStatus>().nullable()();
+  TextColumn get aTextWithConverter => text()
       .named('insert')
       .map(const CustomJsonConverter())
       .nullable()
@@ -111,28 +111,29 @@ class TableWithEveryColumnType extends Table with AutoIncrement {
 }
 
 class Department extends Table {
-  late final id = integer().autoIncrement()();
-  late final name = text().nullable()();
+  IntColumn get id => integer().autoIncrement()();
+  TextColumn get name => text().nullable()();
 }
 
 class Product extends Table {
-  late final sku = text()();
-  late final name = text().nullable()();
-  late final department = integer().references(Department, #id).nullable()();
+  TextColumn get sku => text()();
+  TextColumn get name => text().nullable()();
+  IntColumn get department =>
+      integer().references(Department, #id).nullable()();
 }
 
 class Listing extends Table {
-  late final id = integer().autoIncrement()();
+  IntColumn get id => integer().autoIncrement()();
   @ReferenceName('listings')
-  late final product = text().references(Product, #sku).nullable()();
+  TextColumn get product => text().references(Product, #sku).nullable()();
   @ReferenceName('listings')
-  late final store = integer().references(Store, #id).nullable()();
-  late final price = real().nullable()();
+  IntColumn get store => integer().references(Store, #id).nullable()();
+  RealColumn get price => real().nullable()();
 }
 
 class Store extends Table {
-  late final id = integer().autoIncrement()();
-  late final name = text().nullable()();
+  IntColumn get id => integer().autoIncrement()();
+  TextColumn get name => text().nullable()();
 }
 
 class CustomRowClass {
@@ -157,7 +158,7 @@ class CustomRowClass {
 
 class PureDefaults extends Table {
   // name after keyword to ensure it's escaped properly
-  late final txt =
+  TextColumn get txt =>
       text().named('insert').map(const CustomJsonConverter()).nullable()();
 
   @override

--- a/drift_dev/CHANGELOG.md
+++ b/drift_dev/CHANGELOG.md
@@ -2,6 +2,17 @@
 
 - Fix Dart-defined `check` constraints not being considered in exported
   schemas.
+- Columns can now be defined with `late final` fields. Defining columns with getters `=>` is still supported too.
+  ```dart
+  class MyTable extends Table {
+    // Before:
+    IntColumn get id => integer().autoIncrement()();
+
+    // After:
+    late final id = integer().nullable()();
+  }
+  ```
+
 
 ## 2.20.3
 

--- a/drift_dev/lib/src/analysis/resolver/dart/column.dart
+++ b/drift_dev/lib/src/analysis/resolver/dart/column.dart
@@ -81,8 +81,8 @@ class ColumnParser {
   ColumnParser(this._resolver);
 
   Future<PendingColumnInformation?> parse(
-      MethodDeclaration getter, Element element) async {
-    final expr = returnExpressionOfMethod(getter);
+      ColumnDeclaration columnDeclaration, Element element) async {
+    final expr = columnDeclaration.expression;
 
     if (expr is! FunctionExpressionInvocation) {
       _resolver.reportError(
@@ -353,7 +353,7 @@ class ColumnParser {
 
     final sqlName = foundExplicitName ??
         _resolver.resolver.driver.options.caseFromDartToSql
-            .apply(getter.name.lexeme);
+            .apply(columnDeclaration.lexemeName);
     ColumnType columnType;
 
     final helper = await _resolver.resolver.driver.knownTypes;
@@ -461,8 +461,9 @@ class ColumnParser {
       );
     }
 
-    final docString =
-        getter.documentationComment?.tokens.map((t) => t.toString()).join('\n');
+    final docString = columnDeclaration.documentationComment?.tokens
+        .map((t) => t.toString())
+        .join('\n');
 
     foundConstraints.addAll(await _driftConstraintsFromCustomConstraints(
       isNullable: nullable,

--- a/drift_dev/lib/src/analysis/resolver/dart/helper.dart
+++ b/drift_dev/lib/src/analysis/resolver/dart/helper.dart
@@ -171,6 +171,15 @@ bool isColumn(DartType type) {
       !name.contains('Builder');
 }
 
+bool isColumnBuilder(DartType type) {
+  final name = type.nameIfInterfaceType;
+
+  return isFromDrift(type) &&
+      name != null &&
+      name.contains('Column') &&
+      name.contains('Builder');
+}
+
 bool isFromDrift(DartType type) {
   if (type is! InterfaceType) return false;
 

--- a/drift_dev/lib/src/analysis/resolver/dart/table.dart
+++ b/drift_dev/lib/src/analysis/resolver/dart/table.dart
@@ -283,9 +283,9 @@ class DartTableResolver extends LocalElementResolver<DiscoveredDartTable> {
               .loadElementDeclaration(e.declaration) as VariableDeclaration);
           reportError(DriftAnalysisError.inDartAst(
             declaration.declaredElement!,
-            declaration,
-            'It seems that you forgot to initialize the `${e.getter?.name}` column on the `${element.name}` table.\n'
-            'Add an extra pair of parentheses at the end of the column declaration like this: `$declaration()`.',
+            declaration.endToken,
+            '\nIt seems that you forgot to initialize the `${e.getter?.name}` column on the `${element.name}` table.\n'
+            'Solution: Add an extra pair of parentheses at the end of the column: `$declaration()`.',
           ));
         }
         return false;

--- a/drift_dev/test/analysis/resolver/dart/column_test.dart
+++ b/drift_dev/test/analysis/resolver/dart/column_test.dart
@@ -390,4 +390,56 @@ class TestTable extends Table {
       expect(table.isColumnRequiredForInsert(column), isFalse);
     });
   });
+  test('columns by getter and declaration', () async {
+    final state = await TestBackend.inTest({
+      'a|lib/a.dart': '''
+import 'package:drift/drift.dart';
+
+class Students extends Table {
+  @JsonKey('group_id')
+  @ReferenceName('students')
+  IntColumn get myGroup => integer().references(Groups,#id)();
+}
+
+class Teachers extends Table {
+  @JsonKey('group_id')
+  @ReferenceName('teachers')
+  late final myGroup = integer().references(Groups,#id);
+}
+
+class Groups extends Table {
+  late final id = integer().autoIncrement()();
+}
+
+@DriftDatabase(tables: [Groups, Students, Teachers])
+class Database {}
+''',
+    });
+
+    final file = await state.analyze('package:a/a.dart');
+    state.expectNoErrors();
+    final tables = file.analyzedElements.whereType<DriftTable>();
+
+    final studentTable =
+        tables.where((element) => element.schemaName == 'students').single;
+    final teacherTable =
+        tables.where((element) => element.schemaName == 'teachers').single;
+    final studentGroupColumn = studentTable.columns.single;
+    final teacherGroupColumn = teacherTable.columns.single;
+
+    // Ensure that the columns are the same
+    expect(studentGroupColumn.customConstraints,
+        equals(teacherGroupColumn.customConstraints));
+    expect(
+        studentGroupColumn.nameInDart, equals(teacherGroupColumn.nameInDart));
+    expect(studentGroupColumn.nameInSql, equals(teacherGroupColumn.nameInSql));
+    expect(studentGroupColumn.sqlType, equals(teacherGroupColumn.sqlType));
+    expect(studentGroupColumn.nullable, equals(teacherGroupColumn.nullable));
+    expect(studentGroupColumn.overriddenJsonName,
+        equals(teacherGroupColumn.overriddenJsonName));
+
+    // Ensure that the correct reference name is set
+    expect(studentGroupColumn.referenceName, equals('students'));
+    expect(teacherGroupColumn.referenceName, equals('teachers'));
+  });
 }

--- a/drift_dev/test/analysis/resolver/dart/column_test.dart
+++ b/drift_dev/test/analysis/resolver/dart/column_test.dart
@@ -404,7 +404,7 @@ class Students extends Table {
 class Teachers extends Table {
   @JsonKey('group_id')
   @ReferenceName('teachers')
-  late final myGroup = integer().references(Groups,#id);
+  late final myGroup = integer().references(Groups,#id)();
 }
 
 class Groups extends Table {
@@ -433,7 +433,8 @@ class Database {}
     expect(
         studentGroupColumn.nameInDart, equals(teacherGroupColumn.nameInDart));
     expect(studentGroupColumn.nameInSql, equals(teacherGroupColumn.nameInSql));
-    expect(studentGroupColumn.sqlType, equals(teacherGroupColumn.sqlType));
+    expect(studentGroupColumn.sqlType.builtin,
+        equals(teacherGroupColumn.sqlType.builtin));
     expect(studentGroupColumn.nullable, equals(teacherGroupColumn.nullable));
     expect(studentGroupColumn.overriddenJsonName,
         equals(teacherGroupColumn.overriddenJsonName));


### PR DESCRIPTION
Writing fields with getters is hard. You are effectively writing the column twice with `IntColumn` and again with `integer()`.

This PR will allow you to write a table like:

```dart
class Users extends Table {
  late final id = integer()();
}
```

- [x] Some more `drift_dev` tests just to be 100% certain there is no bugs

Closes https://github.com/simolus3/drift/issues/3093