### PR TITLE
`managers` extends public classes

### DIFF
--- a/docs/lib/snippets/drift_files/custom_queries.drift.dart
+++ b/docs/lib/snippets/drift_files/custom_queries.drift.dart
@@ -5,7 +5,6 @@ import 'package:drift_docs/snippets/_shared/todo_tables.drift.dart' as i1;
 
 abstract class $MyDatabase extends i0.GeneratedDatabase {
   $MyDatabase(i0.QueryExecutor e) : super(e);
-  $MyDatabaseManager get managers => $MyDatabaseManager(this);
   late final i1.$CategoriesTable categories = i1.$CategoriesTable(this);
   late final i1.$TodoItemsTable todoItems = i1.$TodoItemsTable(this);
   i0.Selectable<CategoriesWithCountResult> categoriesWithCount() {

--- a/docs/lib/snippets/modular/many_to_many/json.drift.dart
+++ b/docs/lib/snippets/modular/many_to_many/json.drift.dart
@@ -138,7 +138,6 @@ typedef $$ShoppingCartsTableProcessedTableManager = i0.ProcessedTableManager<
 
 abstract class $JsonBasedDatabase extends i0.GeneratedDatabase {
   $JsonBasedDatabase(i0.QueryExecutor e) : super(e);
-  $JsonBasedDatabaseManager get managers => $JsonBasedDatabaseManager(this);
   late final i1.$BuyableItemsTable buyableItems = i1.$BuyableItemsTable(this);
   late final i2.$ShoppingCartsTable shoppingCarts =
       i2.$ShoppingCartsTable(this);

--- a/docs/lib/snippets/modular/many_to_many/relational.drift.dart
+++ b/docs/lib/snippets/modular/many_to_many/relational.drift.dart
@@ -425,7 +425,6 @@ typedef $$ShoppingCartEntriesTableProcessedTableManager
 
 abstract class $RelationalDatabase extends i0.GeneratedDatabase {
   $RelationalDatabase(i0.QueryExecutor e) : super(e);
-  $RelationalDatabaseManager get managers => $RelationalDatabaseManager(this);
   late final i1.$BuyableItemsTable buyableItems = i1.$BuyableItemsTable(this);
   late final i2.$ShoppingCartsTable shoppingCarts =
       i2.$ShoppingCartsTable(this);

--- a/drift/example/main.g.dart
+++ b/drift/example/main.g.dart
@@ -692,7 +692,6 @@ class $TodoItemWithCategoryNameViewView extends ViewInfo<
 
 abstract class _$Database extends GeneratedDatabase {
   _$Database(QueryExecutor e) : super(e);
-  $DatabaseManager get managers => $DatabaseManager(this);
   late final $TodoCategoriesTable todoCategories = $TodoCategoriesTable(this);
   late final $TodoItemsTable todoItems = $TodoItemsTable(this);
   late final $TodoCategoryItemCountView todoCategoryItemCount =
@@ -1187,4 +1186,8 @@ class $DatabaseManager {
       $$TodoCategoriesTableTableManager(_db, _db.todoCategories);
   $$TodoItemsTableTableManager get todoItems =>
       $$TodoItemsTableTableManager(_db, _db.todoItems);
+}
+
+extension $DatabaseManagerExt on _$Database {
+  $DatabaseManager get managers => $DatabaseManager(this);
 }

--- a/drift/example/main.g.dart
+++ b/drift/example/main.g.dart
@@ -725,12 +725,12 @@ typedef $$TodoCategoriesTableUpdateCompanionBuilder = TodoCategoriesCompanion
 });
 
 final class $$TodoCategoriesTableReferences
-    extends BaseReferences<_$Database, $TodoCategoriesTable, TodoCategory> {
+    extends BaseReferences<Database, $TodoCategoriesTable, TodoCategory> {
   $$TodoCategoriesTableReferences(
       super.$_db, super.$_table, super.$_typedResult);
 
   static MultiTypedResultKey<$TodoItemsTable, List<TodoItem>>
-      _todoItemsRefsTable(_$Database db) =>
+      _todoItemsRefsTable(Database db) =>
           MultiTypedResultKey.fromTable(db.todoItems,
               aliasName: $_aliasNameGenerator(
                   db.todoCategories.id, db.todoItems.categoryId));
@@ -746,7 +746,7 @@ final class $$TodoCategoriesTableReferences
 }
 
 class $$TodoCategoriesTableFilterComposer
-    extends Composer<_$Database, $TodoCategoriesTable> {
+    extends Composer<Database, $TodoCategoriesTable> {
   $$TodoCategoriesTableFilterComposer({
     required super.$db,
     required super.$table,
@@ -783,7 +783,7 @@ class $$TodoCategoriesTableFilterComposer
 }
 
 class $$TodoCategoriesTableOrderingComposer
-    extends Composer<_$Database, $TodoCategoriesTable> {
+    extends Composer<Database, $TodoCategoriesTable> {
   $$TodoCategoriesTableOrderingComposer({
     required super.$db,
     required super.$table,
@@ -799,7 +799,7 @@ class $$TodoCategoriesTableOrderingComposer
 }
 
 class $$TodoCategoriesTableAnnotationComposer
-    extends Composer<_$Database, $TodoCategoriesTable> {
+    extends Composer<Database, $TodoCategoriesTable> {
   $$TodoCategoriesTableAnnotationComposer({
     required super.$db,
     required super.$table,
@@ -836,7 +836,7 @@ class $$TodoCategoriesTableAnnotationComposer
 }
 
 class $$TodoCategoriesTableTableManager extends RootTableManager<
-    _$Database,
+    Database,
     $TodoCategoriesTable,
     TodoCategory,
     $$TodoCategoriesTableFilterComposer,
@@ -847,7 +847,7 @@ class $$TodoCategoriesTableTableManager extends RootTableManager<
     (TodoCategory, $$TodoCategoriesTableReferences),
     TodoCategory,
     PrefetchHooks Function({bool todoItemsRefs})> {
-  $$TodoCategoriesTableTableManager(_$Database db, $TodoCategoriesTable table)
+  $$TodoCategoriesTableTableManager(Database db, $TodoCategoriesTable table)
       : super(TableManagerState(
           db: db,
           table: table,
@@ -906,7 +906,7 @@ class $$TodoCategoriesTableTableManager extends RootTableManager<
 }
 
 typedef $$TodoCategoriesTableProcessedTableManager = ProcessedTableManager<
-    _$Database,
+    Database,
     $TodoCategoriesTable,
     TodoCategory,
     $$TodoCategoriesTableFilterComposer,
@@ -931,10 +931,10 @@ typedef $$TodoItemsTableUpdateCompanionBuilder = TodoItemsCompanion Function({
 });
 
 final class $$TodoItemsTableReferences
-    extends BaseReferences<_$Database, $TodoItemsTable, TodoItem> {
+    extends BaseReferences<Database, $TodoItemsTable, TodoItem> {
   $$TodoItemsTableReferences(super.$_db, super.$_table, super.$_typedResult);
 
-  static $TodoCategoriesTable _categoryIdTable(_$Database db) =>
+  static $TodoCategoriesTable _categoryIdTable(Database db) =>
       db.todoCategories.createAlias(
           $_aliasNameGenerator(db.todoItems.categoryId, db.todoCategories.id));
 
@@ -950,7 +950,7 @@ final class $$TodoItemsTableReferences
 }
 
 class $$TodoItemsTableFilterComposer
-    extends Composer<_$Database, $TodoItemsTable> {
+    extends Composer<Database, $TodoItemsTable> {
   $$TodoItemsTableFilterComposer({
     required super.$db,
     required super.$table,
@@ -992,7 +992,7 @@ class $$TodoItemsTableFilterComposer
 }
 
 class $$TodoItemsTableOrderingComposer
-    extends Composer<_$Database, $TodoItemsTable> {
+    extends Composer<Database, $TodoItemsTable> {
   $$TodoItemsTableOrderingComposer({
     required super.$db,
     required super.$table,
@@ -1035,7 +1035,7 @@ class $$TodoItemsTableOrderingComposer
 }
 
 class $$TodoItemsTableAnnotationComposer
-    extends Composer<_$Database, $TodoItemsTable> {
+    extends Composer<Database, $TodoItemsTable> {
   $$TodoItemsTableAnnotationComposer({
     required super.$db,
     required super.$table,
@@ -1077,7 +1077,7 @@ class $$TodoItemsTableAnnotationComposer
 }
 
 class $$TodoItemsTableTableManager extends RootTableManager<
-    _$Database,
+    Database,
     $TodoItemsTable,
     TodoItem,
     $$TodoItemsTableFilterComposer,
@@ -1088,7 +1088,7 @@ class $$TodoItemsTableTableManager extends RootTableManager<
     (TodoItem, $$TodoItemsTableReferences),
     TodoItem,
     PrefetchHooks Function({bool categoryId})> {
-  $$TodoItemsTableTableManager(_$Database db, $TodoItemsTable table)
+  $$TodoItemsTableTableManager(Database db, $TodoItemsTable table)
       : super(TableManagerState(
           db: db,
           table: table,
@@ -1167,7 +1167,7 @@ class $$TodoItemsTableTableManager extends RootTableManager<
 }
 
 typedef $$TodoItemsTableProcessedTableManager = ProcessedTableManager<
-    _$Database,
+    Database,
     $TodoItemsTable,
     TodoItem,
     $$TodoItemsTableFilterComposer,
@@ -1179,15 +1179,15 @@ typedef $$TodoItemsTableProcessedTableManager = ProcessedTableManager<
     TodoItem,
     PrefetchHooks Function({bool categoryId})>;
 
-class $DatabaseManager {
-  final _$Database _db;
-  $DatabaseManager(this._db);
+class DatabaseManager {
+  final Database _db;
+  DatabaseManager(this._db);
   $$TodoCategoriesTableTableManager get todoCategories =>
       $$TodoCategoriesTableTableManager(_db, _db.todoCategories);
   $$TodoItemsTableTableManager get todoItems =>
       $$TodoItemsTableTableManager(_db, _db.todoItems);
 }
 
-extension $DatabaseManagerExt on _$Database {
-  $DatabaseManager get managers => $DatabaseManager(this);
+extension DatabaseManagerExt on Database {
+  DatabaseManager get managers => DatabaseManager(this);
 }

--- a/drift/test/extensions/geopoly_integration_test.g.dart
+++ b/drift/test/extensions/geopoly_integration_test.g.dart
@@ -244,7 +244,7 @@ typedef $GeopolyTestUpdateCompanionBuilder = GeopolyTestCompanion Function({
 });
 
 class $GeopolyTestFilterComposer
-    extends Composer<_$_GeopolyTestDatabase, GeopolyTest> {
+    extends Composer<_GeopolyTestDatabase, GeopolyTest> {
   $GeopolyTestFilterComposer({
     required super.$db,
     required super.$table,
@@ -260,7 +260,7 @@ class $GeopolyTestFilterComposer
 }
 
 class $GeopolyTestOrderingComposer
-    extends Composer<_$_GeopolyTestDatabase, GeopolyTest> {
+    extends Composer<_GeopolyTestDatabase, GeopolyTest> {
   $GeopolyTestOrderingComposer({
     required super.$db,
     required super.$table,
@@ -276,7 +276,7 @@ class $GeopolyTestOrderingComposer
 }
 
 class $GeopolyTestAnnotationComposer
-    extends Composer<_$_GeopolyTestDatabase, GeopolyTest> {
+    extends Composer<_GeopolyTestDatabase, GeopolyTest> {
   $GeopolyTestAnnotationComposer({
     required super.$db,
     required super.$table,
@@ -292,7 +292,7 @@ class $GeopolyTestAnnotationComposer
 }
 
 class $GeopolyTestTableManager extends RootTableManager<
-    _$_GeopolyTestDatabase,
+    _GeopolyTestDatabase,
     GeopolyTest,
     GeopolyTestData,
     $GeopolyTestFilterComposer,
@@ -302,11 +302,11 @@ class $GeopolyTestTableManager extends RootTableManager<
     $GeopolyTestUpdateCompanionBuilder,
     (
       GeopolyTestData,
-      BaseReferences<_$_GeopolyTestDatabase, GeopolyTest, GeopolyTestData>
+      BaseReferences<_GeopolyTestDatabase, GeopolyTest, GeopolyTestData>
     ),
     GeopolyTestData,
     PrefetchHooks Function()> {
-  $GeopolyTestTableManager(_$_GeopolyTestDatabase db, GeopolyTest table)
+  $GeopolyTestTableManager(_GeopolyTestDatabase db, GeopolyTest table)
       : super(TableManagerState(
           db: db,
           table: table,
@@ -344,7 +344,7 @@ class $GeopolyTestTableManager extends RootTableManager<
 }
 
 typedef $GeopolyTestProcessedTableManager = ProcessedTableManager<
-    _$_GeopolyTestDatabase,
+    _GeopolyTestDatabase,
     GeopolyTest,
     GeopolyTestData,
     $GeopolyTestFilterComposer,
@@ -354,19 +354,18 @@ typedef $GeopolyTestProcessedTableManager = ProcessedTableManager<
     $GeopolyTestUpdateCompanionBuilder,
     (
       GeopolyTestData,
-      BaseReferences<_$_GeopolyTestDatabase, GeopolyTest, GeopolyTestData>
+      BaseReferences<_GeopolyTestDatabase, GeopolyTest, GeopolyTestData>
     ),
     GeopolyTestData,
     PrefetchHooks Function()>;
 
-class $_GeopolyTestDatabaseManager {
-  final _$_GeopolyTestDatabase _db;
-  $_GeopolyTestDatabaseManager(this._db);
+class GeopolyTestDatabaseManager {
+  final _GeopolyTestDatabase _db;
+  GeopolyTestDatabaseManager(this._db);
   $GeopolyTestTableManager get geopolyTest =>
       $GeopolyTestTableManager(_db, _db.geopolyTest);
 }
 
-extension $_GeopolyTestDatabaseManagerExt on _$_GeopolyTestDatabase {
-  $_GeopolyTestDatabaseManager get managers =>
-      $_GeopolyTestDatabaseManager(this);
+extension GeopolyTestDatabaseManagerExt on _GeopolyTestDatabase {
+  GeopolyTestDatabaseManager get managers => GeopolyTestDatabaseManager(this);
 }

--- a/drift/test/extensions/geopoly_integration_test.g.dart
+++ b/drift/test/extensions/geopoly_integration_test.g.dart
@@ -213,8 +213,6 @@ class GeopolyTestCompanion extends UpdateCompanion<GeopolyTestData> {
 
 abstract class _$_GeopolyTestDatabase extends GeneratedDatabase {
   _$_GeopolyTestDatabase(QueryExecutor e) : super(e);
-  $_GeopolyTestDatabaseManager get managers =>
-      $_GeopolyTestDatabaseManager(this);
   late final GeopolyTest geopolyTest = GeopolyTest(this);
   Selectable<double?> area(int var1) {
     return customSelect(
@@ -366,4 +364,9 @@ class $_GeopolyTestDatabaseManager {
   $_GeopolyTestDatabaseManager(this._db);
   $GeopolyTestTableManager get geopolyTest =>
       $GeopolyTestTableManager(_db, _db.geopolyTest);
+}
+
+extension $_GeopolyTestDatabaseManagerExt on _$_GeopolyTestDatabase {
+  $_GeopolyTestDatabaseManager get managers =>
+      $_GeopolyTestDatabaseManager(this);
 }

--- a/drift/test/generated/custom_tables.g.dart
+++ b/drift/test/generated/custom_tables.g.dart
@@ -2030,7 +2030,7 @@ typedef $NoIdsUpdateCompanionBuilder = NoIdsCompanion Function({
   Value<Uint8List> payload,
 });
 
-class $NoIdsFilterComposer extends Composer<_$CustomTablesDb, NoIds> {
+class $NoIdsFilterComposer extends Composer<CustomTablesDb, NoIds> {
   $NoIdsFilterComposer({
     required super.$db,
     required super.$table,
@@ -2042,7 +2042,7 @@ class $NoIdsFilterComposer extends Composer<_$CustomTablesDb, NoIds> {
       column: $table.payload, builder: (column) => ColumnFilters(column));
 }
 
-class $NoIdsOrderingComposer extends Composer<_$CustomTablesDb, NoIds> {
+class $NoIdsOrderingComposer extends Composer<CustomTablesDb, NoIds> {
   $NoIdsOrderingComposer({
     required super.$db,
     required super.$table,
@@ -2054,7 +2054,7 @@ class $NoIdsOrderingComposer extends Composer<_$CustomTablesDb, NoIds> {
       column: $table.payload, builder: (column) => ColumnOrderings(column));
 }
 
-class $NoIdsAnnotationComposer extends Composer<_$CustomTablesDb, NoIds> {
+class $NoIdsAnnotationComposer extends Composer<CustomTablesDb, NoIds> {
   $NoIdsAnnotationComposer({
     required super.$db,
     required super.$table,
@@ -2067,7 +2067,7 @@ class $NoIdsAnnotationComposer extends Composer<_$CustomTablesDb, NoIds> {
 }
 
 class $NoIdsTableManager extends RootTableManager<
-    _$CustomTablesDb,
+    CustomTablesDb,
     NoIds,
     NoIdRow,
     $NoIdsFilterComposer,
@@ -2075,10 +2075,10 @@ class $NoIdsTableManager extends RootTableManager<
     $NoIdsAnnotationComposer,
     $NoIdsCreateCompanionBuilder,
     $NoIdsUpdateCompanionBuilder,
-    (NoIdRow, BaseReferences<_$CustomTablesDb, NoIds, NoIdRow>),
+    (NoIdRow, BaseReferences<CustomTablesDb, NoIds, NoIdRow>),
     NoIdRow,
     PrefetchHooks Function()> {
-  $NoIdsTableManager(_$CustomTablesDb db, NoIds table)
+  $NoIdsTableManager(CustomTablesDb db, NoIds table)
       : super(TableManagerState(
           db: db,
           table: table,
@@ -2108,7 +2108,7 @@ class $NoIdsTableManager extends RootTableManager<
 }
 
 typedef $NoIdsProcessedTableManager = ProcessedTableManager<
-    _$CustomTablesDb,
+    CustomTablesDb,
     NoIds,
     NoIdRow,
     $NoIdsFilterComposer,
@@ -2116,7 +2116,7 @@ typedef $NoIdsProcessedTableManager = ProcessedTableManager<
     $NoIdsAnnotationComposer,
     $NoIdsCreateCompanionBuilder,
     $NoIdsUpdateCompanionBuilder,
-    (NoIdRow, BaseReferences<_$CustomTablesDb, NoIds, NoIdRow>),
+    (NoIdRow, BaseReferences<CustomTablesDb, NoIds, NoIdRow>),
     NoIdRow,
     PrefetchHooks Function()>;
 typedef $WithDefaultsCreateCompanionBuilder = WithDefaultsCompanion Function({
@@ -2131,7 +2131,7 @@ typedef $WithDefaultsUpdateCompanionBuilder = WithDefaultsCompanion Function({
 });
 
 class $WithDefaultsFilterComposer
-    extends Composer<_$CustomTablesDb, WithDefaults> {
+    extends Composer<CustomTablesDb, WithDefaults> {
   $WithDefaultsFilterComposer({
     required super.$db,
     required super.$table,
@@ -2147,7 +2147,7 @@ class $WithDefaultsFilterComposer
 }
 
 class $WithDefaultsOrderingComposer
-    extends Composer<_$CustomTablesDb, WithDefaults> {
+    extends Composer<CustomTablesDb, WithDefaults> {
   $WithDefaultsOrderingComposer({
     required super.$db,
     required super.$table,
@@ -2163,7 +2163,7 @@ class $WithDefaultsOrderingComposer
 }
 
 class $WithDefaultsAnnotationComposer
-    extends Composer<_$CustomTablesDb, WithDefaults> {
+    extends Composer<CustomTablesDb, WithDefaults> {
   $WithDefaultsAnnotationComposer({
     required super.$db,
     required super.$table,
@@ -2179,7 +2179,7 @@ class $WithDefaultsAnnotationComposer
 }
 
 class $WithDefaultsTableManager extends RootTableManager<
-    _$CustomTablesDb,
+    CustomTablesDb,
     WithDefaults,
     WithDefault,
     $WithDefaultsFilterComposer,
@@ -2187,10 +2187,10 @@ class $WithDefaultsTableManager extends RootTableManager<
     $WithDefaultsAnnotationComposer,
     $WithDefaultsCreateCompanionBuilder,
     $WithDefaultsUpdateCompanionBuilder,
-    (WithDefault, BaseReferences<_$CustomTablesDb, WithDefaults, WithDefault>),
+    (WithDefault, BaseReferences<CustomTablesDb, WithDefaults, WithDefault>),
     WithDefault,
     PrefetchHooks Function()> {
-  $WithDefaultsTableManager(_$CustomTablesDb db, WithDefaults table)
+  $WithDefaultsTableManager(CustomTablesDb db, WithDefaults table)
       : super(TableManagerState(
           db: db,
           table: table,
@@ -2228,7 +2228,7 @@ class $WithDefaultsTableManager extends RootTableManager<
 }
 
 typedef $WithDefaultsProcessedTableManager = ProcessedTableManager<
-    _$CustomTablesDb,
+    CustomTablesDb,
     WithDefaults,
     WithDefault,
     $WithDefaultsFilterComposer,
@@ -2236,7 +2236,7 @@ typedef $WithDefaultsProcessedTableManager = ProcessedTableManager<
     $WithDefaultsAnnotationComposer,
     $WithDefaultsCreateCompanionBuilder,
     $WithDefaultsUpdateCompanionBuilder,
-    (WithDefault, BaseReferences<_$CustomTablesDb, WithDefaults, WithDefault>),
+    (WithDefault, BaseReferences<CustomTablesDb, WithDefaults, WithDefault>),
     WithDefault,
     PrefetchHooks Function()>;
 typedef $WithConstraintsCreateCompanionBuilder = WithConstraintsCompanion
@@ -2255,7 +2255,7 @@ typedef $WithConstraintsUpdateCompanionBuilder = WithConstraintsCompanion
 });
 
 class $WithConstraintsFilterComposer
-    extends Composer<_$CustomTablesDb, WithConstraints> {
+    extends Composer<CustomTablesDb, WithConstraints> {
   $WithConstraintsFilterComposer({
     required super.$db,
     required super.$table,
@@ -2274,7 +2274,7 @@ class $WithConstraintsFilterComposer
 }
 
 class $WithConstraintsOrderingComposer
-    extends Composer<_$CustomTablesDb, WithConstraints> {
+    extends Composer<CustomTablesDb, WithConstraints> {
   $WithConstraintsOrderingComposer({
     required super.$db,
     required super.$table,
@@ -2293,7 +2293,7 @@ class $WithConstraintsOrderingComposer
 }
 
 class $WithConstraintsAnnotationComposer
-    extends Composer<_$CustomTablesDb, WithConstraints> {
+    extends Composer<CustomTablesDb, WithConstraints> {
   $WithConstraintsAnnotationComposer({
     required super.$db,
     required super.$table,
@@ -2312,7 +2312,7 @@ class $WithConstraintsAnnotationComposer
 }
 
 class $WithConstraintsTableManager extends RootTableManager<
-    _$CustomTablesDb,
+    CustomTablesDb,
     WithConstraints,
     WithConstraint,
     $WithConstraintsFilterComposer,
@@ -2322,11 +2322,11 @@ class $WithConstraintsTableManager extends RootTableManager<
     $WithConstraintsUpdateCompanionBuilder,
     (
       WithConstraint,
-      BaseReferences<_$CustomTablesDb, WithConstraints, WithConstraint>
+      BaseReferences<CustomTablesDb, WithConstraints, WithConstraint>
     ),
     WithConstraint,
     PrefetchHooks Function()> {
-  $WithConstraintsTableManager(_$CustomTablesDb db, WithConstraints table)
+  $WithConstraintsTableManager(CustomTablesDb db, WithConstraints table)
       : super(TableManagerState(
           db: db,
           table: table,
@@ -2368,7 +2368,7 @@ class $WithConstraintsTableManager extends RootTableManager<
 }
 
 typedef $WithConstraintsProcessedTableManager = ProcessedTableManager<
-    _$CustomTablesDb,
+    CustomTablesDb,
     WithConstraints,
     WithConstraint,
     $WithConstraintsFilterComposer,
@@ -2378,7 +2378,7 @@ typedef $WithConstraintsProcessedTableManager = ProcessedTableManager<
     $WithConstraintsUpdateCompanionBuilder,
     (
       WithConstraint,
-      BaseReferences<_$CustomTablesDb, WithConstraints, WithConstraint>
+      BaseReferences<CustomTablesDb, WithConstraints, WithConstraint>
     ),
     WithConstraint,
     PrefetchHooks Function()>;
@@ -2397,8 +2397,7 @@ typedef $ConfigTableUpdateCompanionBuilder = ConfigCompanion Function({
   Value<int> rowid,
 });
 
-class $ConfigTableFilterComposer
-    extends Composer<_$CustomTablesDb, ConfigTable> {
+class $ConfigTableFilterComposer extends Composer<CustomTablesDb, ConfigTable> {
   $ConfigTableFilterComposer({
     required super.$db,
     required super.$table,
@@ -2424,7 +2423,7 @@ class $ConfigTableFilterComposer
 }
 
 class $ConfigTableOrderingComposer
-    extends Composer<_$CustomTablesDb, ConfigTable> {
+    extends Composer<CustomTablesDb, ConfigTable> {
   $ConfigTableOrderingComposer({
     required super.$db,
     required super.$table,
@@ -2447,7 +2446,7 @@ class $ConfigTableOrderingComposer
 }
 
 class $ConfigTableAnnotationComposer
-    extends Composer<_$CustomTablesDb, ConfigTable> {
+    extends Composer<CustomTablesDb, ConfigTable> {
   $ConfigTableAnnotationComposer({
     required super.$db,
     required super.$table,
@@ -2470,7 +2469,7 @@ class $ConfigTableAnnotationComposer
 }
 
 class $ConfigTableTableManager extends RootTableManager<
-    _$CustomTablesDb,
+    CustomTablesDb,
     ConfigTable,
     Config,
     $ConfigTableFilterComposer,
@@ -2478,10 +2477,10 @@ class $ConfigTableTableManager extends RootTableManager<
     $ConfigTableAnnotationComposer,
     $ConfigTableCreateCompanionBuilder,
     $ConfigTableUpdateCompanionBuilder,
-    (Config, BaseReferences<_$CustomTablesDb, ConfigTable, Config>),
+    (Config, BaseReferences<CustomTablesDb, ConfigTable, Config>),
     Config,
     PrefetchHooks Function()> {
-  $ConfigTableTableManager(_$CustomTablesDb db, ConfigTable table)
+  $ConfigTableTableManager(CustomTablesDb db, ConfigTable table)
       : super(TableManagerState(
           db: db,
           table: table,
@@ -2527,7 +2526,7 @@ class $ConfigTableTableManager extends RootTableManager<
 }
 
 typedef $ConfigTableProcessedTableManager = ProcessedTableManager<
-    _$CustomTablesDb,
+    CustomTablesDb,
     ConfigTable,
     Config,
     $ConfigTableFilterComposer,
@@ -2535,7 +2534,7 @@ typedef $ConfigTableProcessedTableManager = ProcessedTableManager<
     $ConfigTableAnnotationComposer,
     $ConfigTableCreateCompanionBuilder,
     $ConfigTableUpdateCompanionBuilder,
-    (Config, BaseReferences<_$CustomTablesDb, ConfigTable, Config>),
+    (Config, BaseReferences<CustomTablesDb, ConfigTable, Config>),
     Config,
     PrefetchHooks Function()>;
 typedef $MytableCreateCompanionBuilder = MytableCompanion Function({
@@ -2551,7 +2550,7 @@ typedef $MytableUpdateCompanionBuilder = MytableCompanion Function({
   Value<DateTime?> somedate,
 });
 
-class $MytableFilterComposer extends Composer<_$CustomTablesDb, Mytable> {
+class $MytableFilterComposer extends Composer<CustomTablesDb, Mytable> {
   $MytableFilterComposer({
     required super.$db,
     required super.$table,
@@ -2572,7 +2571,7 @@ class $MytableFilterComposer extends Composer<_$CustomTablesDb, Mytable> {
       column: $table.somedate, builder: (column) => ColumnFilters(column));
 }
 
-class $MytableOrderingComposer extends Composer<_$CustomTablesDb, Mytable> {
+class $MytableOrderingComposer extends Composer<CustomTablesDb, Mytable> {
   $MytableOrderingComposer({
     required super.$db,
     required super.$table,
@@ -2593,7 +2592,7 @@ class $MytableOrderingComposer extends Composer<_$CustomTablesDb, Mytable> {
       column: $table.somedate, builder: (column) => ColumnOrderings(column));
 }
 
-class $MytableAnnotationComposer extends Composer<_$CustomTablesDb, Mytable> {
+class $MytableAnnotationComposer extends Composer<CustomTablesDb, Mytable> {
   $MytableAnnotationComposer({
     required super.$db,
     required super.$table,
@@ -2615,7 +2614,7 @@ class $MytableAnnotationComposer extends Composer<_$CustomTablesDb, Mytable> {
 }
 
 class $MytableTableManager extends RootTableManager<
-    _$CustomTablesDb,
+    CustomTablesDb,
     Mytable,
     MytableData,
     $MytableFilterComposer,
@@ -2623,10 +2622,10 @@ class $MytableTableManager extends RootTableManager<
     $MytableAnnotationComposer,
     $MytableCreateCompanionBuilder,
     $MytableUpdateCompanionBuilder,
-    (MytableData, BaseReferences<_$CustomTablesDb, Mytable, MytableData>),
+    (MytableData, BaseReferences<CustomTablesDb, Mytable, MytableData>),
     MytableData,
     PrefetchHooks Function()> {
-  $MytableTableManager(_$CustomTablesDb db, Mytable table)
+  $MytableTableManager(CustomTablesDb db, Mytable table)
       : super(TableManagerState(
           db: db,
           table: table,
@@ -2668,7 +2667,7 @@ class $MytableTableManager extends RootTableManager<
 }
 
 typedef $MytableProcessedTableManager = ProcessedTableManager<
-    _$CustomTablesDb,
+    CustomTablesDb,
     Mytable,
     MytableData,
     $MytableFilterComposer,
@@ -2676,7 +2675,7 @@ typedef $MytableProcessedTableManager = ProcessedTableManager<
     $MytableAnnotationComposer,
     $MytableCreateCompanionBuilder,
     $MytableUpdateCompanionBuilder,
-    (MytableData, BaseReferences<_$CustomTablesDb, Mytable, MytableData>),
+    (MytableData, BaseReferences<CustomTablesDb, Mytable, MytableData>),
     MytableData,
     PrefetchHooks Function()>;
 typedef $EmailCreateCompanionBuilder = EmailCompanion Function({
@@ -2692,7 +2691,7 @@ typedef $EmailUpdateCompanionBuilder = EmailCompanion Function({
   Value<int> rowid,
 });
 
-class $EmailFilterComposer extends Composer<_$CustomTablesDb, Email> {
+class $EmailFilterComposer extends Composer<CustomTablesDb, Email> {
   $EmailFilterComposer({
     required super.$db,
     required super.$table,
@@ -2710,7 +2709,7 @@ class $EmailFilterComposer extends Composer<_$CustomTablesDb, Email> {
       column: $table.body, builder: (column) => ColumnFilters(column));
 }
 
-class $EmailOrderingComposer extends Composer<_$CustomTablesDb, Email> {
+class $EmailOrderingComposer extends Composer<CustomTablesDb, Email> {
   $EmailOrderingComposer({
     required super.$db,
     required super.$table,
@@ -2728,7 +2727,7 @@ class $EmailOrderingComposer extends Composer<_$CustomTablesDb, Email> {
       column: $table.body, builder: (column) => ColumnOrderings(column));
 }
 
-class $EmailAnnotationComposer extends Composer<_$CustomTablesDb, Email> {
+class $EmailAnnotationComposer extends Composer<CustomTablesDb, Email> {
   $EmailAnnotationComposer({
     required super.$db,
     required super.$table,
@@ -2747,7 +2746,7 @@ class $EmailAnnotationComposer extends Composer<_$CustomTablesDb, Email> {
 }
 
 class $EmailTableManager extends RootTableManager<
-    _$CustomTablesDb,
+    CustomTablesDb,
     Email,
     EMail,
     $EmailFilterComposer,
@@ -2755,10 +2754,10 @@ class $EmailTableManager extends RootTableManager<
     $EmailAnnotationComposer,
     $EmailCreateCompanionBuilder,
     $EmailUpdateCompanionBuilder,
-    (EMail, BaseReferences<_$CustomTablesDb, Email, EMail>),
+    (EMail, BaseReferences<CustomTablesDb, Email, EMail>),
     EMail,
     PrefetchHooks Function()> {
-  $EmailTableManager(_$CustomTablesDb db, Email table)
+  $EmailTableManager(CustomTablesDb db, Email table)
       : super(TableManagerState(
           db: db,
           table: table,
@@ -2800,7 +2799,7 @@ class $EmailTableManager extends RootTableManager<
 }
 
 typedef $EmailProcessedTableManager = ProcessedTableManager<
-    _$CustomTablesDb,
+    CustomTablesDb,
     Email,
     EMail,
     $EmailFilterComposer,
@@ -2808,7 +2807,7 @@ typedef $EmailProcessedTableManager = ProcessedTableManager<
     $EmailAnnotationComposer,
     $EmailCreateCompanionBuilder,
     $EmailUpdateCompanionBuilder,
-    (EMail, BaseReferences<_$CustomTablesDb, Email, EMail>),
+    (EMail, BaseReferences<CustomTablesDb, Email, EMail>),
     EMail,
     PrefetchHooks Function()>;
 typedef $WeirdTableCreateCompanionBuilder = WeirdTableCompanion Function({
@@ -2822,7 +2821,7 @@ typedef $WeirdTableUpdateCompanionBuilder = WeirdTableCompanion Function({
   Value<int> rowid,
 });
 
-class $WeirdTableFilterComposer extends Composer<_$CustomTablesDb, WeirdTable> {
+class $WeirdTableFilterComposer extends Composer<CustomTablesDb, WeirdTable> {
   $WeirdTableFilterComposer({
     required super.$db,
     required super.$table,
@@ -2837,8 +2836,7 @@ class $WeirdTableFilterComposer extends Composer<_$CustomTablesDb, WeirdTable> {
       column: $table.textColumn, builder: (column) => ColumnFilters(column));
 }
 
-class $WeirdTableOrderingComposer
-    extends Composer<_$CustomTablesDb, WeirdTable> {
+class $WeirdTableOrderingComposer extends Composer<CustomTablesDb, WeirdTable> {
   $WeirdTableOrderingComposer({
     required super.$db,
     required super.$table,
@@ -2854,7 +2852,7 @@ class $WeirdTableOrderingComposer
 }
 
 class $WeirdTableAnnotationComposer
-    extends Composer<_$CustomTablesDb, WeirdTable> {
+    extends Composer<CustomTablesDb, WeirdTable> {
   $WeirdTableAnnotationComposer({
     required super.$db,
     required super.$table,
@@ -2870,7 +2868,7 @@ class $WeirdTableAnnotationComposer
 }
 
 class $WeirdTableTableManager extends RootTableManager<
-    _$CustomTablesDb,
+    CustomTablesDb,
     WeirdTable,
     WeirdData,
     $WeirdTableFilterComposer,
@@ -2878,10 +2876,10 @@ class $WeirdTableTableManager extends RootTableManager<
     $WeirdTableAnnotationComposer,
     $WeirdTableCreateCompanionBuilder,
     $WeirdTableUpdateCompanionBuilder,
-    (WeirdData, BaseReferences<_$CustomTablesDb, WeirdTable, WeirdData>),
+    (WeirdData, BaseReferences<CustomTablesDb, WeirdTable, WeirdData>),
     WeirdData,
     PrefetchHooks Function()> {
-  $WeirdTableTableManager(_$CustomTablesDb db, WeirdTable table)
+  $WeirdTableTableManager(CustomTablesDb db, WeirdTable table)
       : super(TableManagerState(
           db: db,
           table: table,
@@ -2919,7 +2917,7 @@ class $WeirdTableTableManager extends RootTableManager<
 }
 
 typedef $WeirdTableProcessedTableManager = ProcessedTableManager<
-    _$CustomTablesDb,
+    CustomTablesDb,
     WeirdTable,
     WeirdData,
     $WeirdTableFilterComposer,
@@ -2927,13 +2925,13 @@ typedef $WeirdTableProcessedTableManager = ProcessedTableManager<
     $WeirdTableAnnotationComposer,
     $WeirdTableCreateCompanionBuilder,
     $WeirdTableUpdateCompanionBuilder,
-    (WeirdData, BaseReferences<_$CustomTablesDb, WeirdTable, WeirdData>),
+    (WeirdData, BaseReferences<CustomTablesDb, WeirdTable, WeirdData>),
     WeirdData,
     PrefetchHooks Function()>;
 
-class $CustomTablesDbManager {
-  final _$CustomTablesDb _db;
-  $CustomTablesDbManager(this._db);
+class CustomTablesDbManager {
+  final CustomTablesDb _db;
+  CustomTablesDbManager(this._db);
   $NoIdsTableManager get noIds => $NoIdsTableManager(_db, _db.noIds);
   $WithDefaultsTableManager get withDefaults =>
       $WithDefaultsTableManager(_db, _db.withDefaults);
@@ -2947,8 +2945,8 @@ class $CustomTablesDbManager {
       $WeirdTableTableManager(_db, _db.weirdTable);
 }
 
-extension $CustomTablesDbManagerExt on _$CustomTablesDb {
-  $CustomTablesDbManager get managers => $CustomTablesDbManager(this);
+extension CustomTablesDbManagerExt on CustomTablesDb {
+  CustomTablesDbManager get managers => CustomTablesDbManager(this);
 }
 
 typedef ReadMultiple$clause = OrderBy Function(ConfigTable config);

--- a/drift/test/generated/custom_tables.g.dart
+++ b/drift/test/generated/custom_tables.g.dart
@@ -1710,7 +1710,6 @@ class MyView extends ViewInfo<MyView, MyViewData> implements HasResultSet {
 
 abstract class _$CustomTablesDb extends GeneratedDatabase {
   _$CustomTablesDb(QueryExecutor e) : super(e);
-  $CustomTablesDbManager get managers => $CustomTablesDbManager(this);
   late final NoIds noIds = NoIds(this);
   late final WithDefaults withDefaults = WithDefaults(this);
   late final WithConstraints withConstraints = WithConstraints(this);
@@ -2946,6 +2945,10 @@ class $CustomTablesDbManager {
   $EmailTableManager get email => $EmailTableManager(_db, _db.email);
   $WeirdTableTableManager get weirdTable =>
       $WeirdTableTableManager(_db, _db.weirdTable);
+}
+
+extension $CustomTablesDbManagerExt on _$CustomTablesDb {
+  $CustomTablesDbManager get managers => $CustomTablesDbManager(this);
 }
 
 typedef ReadMultiple$clause = OrderBy Function(ConfigTable config);

--- a/drift/test/generated/todos.dart
+++ b/drift/test/generated/todos.dart
@@ -3,7 +3,7 @@ import 'package:mockito/annotations.dart';
 import 'package:uuid/uuid.dart';
 
 // Generate mocks for drift
-@GenerateNiceMocks([MockSpec<TodoDb>()])
+@GenerateNiceMocks([MockSpec<TodoDb>(), MockSpec<$TodoDbManager>()])
 // ignore: unused_import
 import 'todos.mocks.dart';
 

--- a/drift/test/generated/todos.dart
+++ b/drift/test/generated/todos.dart
@@ -3,7 +3,10 @@ import 'package:mockito/annotations.dart';
 import 'package:uuid/uuid.dart';
 
 // Generate mocks for drift
-@GenerateNiceMocks([MockSpec<TodoDb>(), MockSpec<$TodoDbManager>()])
+@GenerateNiceMocks([
+  MockSpec<TodoDb>(),
+  MockSpec<TodoDbManager>(),
+])
 // ignore: unused_import
 import 'todos.mocks.dart';
 

--- a/drift/test/generated/todos.g.dart
+++ b/drift/test/generated/todos.g.dart
@@ -3467,11 +3467,11 @@ typedef $$CategoriesTableUpdateCompanionBuilder = CategoriesCompanion Function({
 });
 
 final class $$CategoriesTableReferences
-    extends BaseReferences<_$TodoDb, $CategoriesTable, Category> {
+    extends BaseReferences<TodoDb, $CategoriesTable, Category> {
   $$CategoriesTableReferences(super.$_db, super.$_table, super.$_typedResult);
 
   static MultiTypedResultKey<$TodosTableTable, List<TodoEntry>> _todosTable(
-          _$TodoDb db) =>
+          TodoDb db) =>
       MultiTypedResultKey.fromTable(db.todosTable,
           aliasName:
               $_aliasNameGenerator(db.categories.id, db.todosTable.category));
@@ -3487,7 +3487,7 @@ final class $$CategoriesTableReferences
 }
 
 class $$CategoriesTableFilterComposer
-    extends Composer<_$TodoDb, $CategoriesTable> {
+    extends Composer<TodoDb, $CategoriesTable> {
   $$CategoriesTableFilterComposer({
     required super.$db,
     required super.$table,
@@ -3535,7 +3535,7 @@ class $$CategoriesTableFilterComposer
 }
 
 class $$CategoriesTableOrderingComposer
-    extends Composer<_$TodoDb, $CategoriesTable> {
+    extends Composer<TodoDb, $CategoriesTable> {
   $$CategoriesTableOrderingComposer({
     required super.$db,
     required super.$table,
@@ -3558,7 +3558,7 @@ class $$CategoriesTableOrderingComposer
 }
 
 class $$CategoriesTableAnnotationComposer
-    extends Composer<_$TodoDb, $CategoriesTable> {
+    extends Composer<TodoDb, $CategoriesTable> {
   $$CategoriesTableAnnotationComposer({
     required super.$db,
     required super.$table,
@@ -3601,7 +3601,7 @@ class $$CategoriesTableAnnotationComposer
 }
 
 class $$CategoriesTableTableManager extends RootTableManager<
-    _$TodoDb,
+    TodoDb,
     $CategoriesTable,
     Category,
     $$CategoriesTableFilterComposer,
@@ -3612,7 +3612,7 @@ class $$CategoriesTableTableManager extends RootTableManager<
     (Category, $$CategoriesTableReferences),
     Category,
     PrefetchHooks Function({bool todos})> {
-  $$CategoriesTableTableManager(_$TodoDb db, $CategoriesTable table)
+  $$CategoriesTableTableManager(TodoDb db, $CategoriesTable table)
       : super(TableManagerState(
           db: db,
           table: table,
@@ -3674,7 +3674,7 @@ class $$CategoriesTableTableManager extends RootTableManager<
 }
 
 typedef $$CategoriesTableProcessedTableManager = ProcessedTableManager<
-    _$TodoDb,
+    TodoDb,
     $CategoriesTable,
     Category,
     $$CategoriesTableFilterComposer,
@@ -3703,10 +3703,10 @@ typedef $$TodosTableTableUpdateCompanionBuilder = TodosTableCompanion Function({
 });
 
 final class $$TodosTableTableReferences
-    extends BaseReferences<_$TodoDb, $TodosTableTable, TodoEntry> {
+    extends BaseReferences<TodoDb, $TodosTableTable, TodoEntry> {
   $$TodosTableTableReferences(super.$_db, super.$_table, super.$_typedResult);
 
-  static $CategoriesTable _categoryTable(_$TodoDb db) =>
+  static $CategoriesTable _categoryTable(TodoDb db) =>
       db.categories.createAlias(
           $_aliasNameGenerator(db.todosTable.category, db.categories.id));
 
@@ -3722,7 +3722,7 @@ final class $$TodosTableTableReferences
 }
 
 class $$TodosTableTableFilterComposer
-    extends Composer<_$TodoDb, $TodosTableTable> {
+    extends Composer<TodoDb, $TodosTableTable> {
   $$TodosTableTableFilterComposer({
     required super.$db,
     required super.$table,
@@ -3771,7 +3771,7 @@ class $$TodosTableTableFilterComposer
 }
 
 class $$TodosTableTableOrderingComposer
-    extends Composer<_$TodoDb, $TodosTableTable> {
+    extends Composer<TodoDb, $TodosTableTable> {
   $$TodosTableTableOrderingComposer({
     required super.$db,
     required super.$table,
@@ -3816,7 +3816,7 @@ class $$TodosTableTableOrderingComposer
 }
 
 class $$TodosTableTableAnnotationComposer
-    extends Composer<_$TodoDb, $TodosTableTable> {
+    extends Composer<TodoDb, $TodosTableTable> {
   $$TodosTableTableAnnotationComposer({
     required super.$db,
     required super.$table,
@@ -3861,7 +3861,7 @@ class $$TodosTableTableAnnotationComposer
 }
 
 class $$TodosTableTableTableManager extends RootTableManager<
-    _$TodoDb,
+    TodoDb,
     $TodosTableTable,
     TodoEntry,
     $$TodosTableTableFilterComposer,
@@ -3872,7 +3872,7 @@ class $$TodosTableTableTableManager extends RootTableManager<
     (TodoEntry, $$TodosTableTableReferences),
     TodoEntry,
     PrefetchHooks Function({bool category})> {
-  $$TodosTableTableTableManager(_$TodoDb db, $TodosTableTable table)
+  $$TodosTableTableTableManager(TodoDb db, $TodosTableTable table)
       : super(TableManagerState(
           db: db,
           table: table,
@@ -3959,7 +3959,7 @@ class $$TodosTableTableTableManager extends RootTableManager<
 }
 
 typedef $$TodosTableTableProcessedTableManager = ProcessedTableManager<
-    _$TodoDb,
+    TodoDb,
     $TodosTableTable,
     TodoEntry,
     $$TodosTableTableFilterComposer,
@@ -3985,7 +3985,7 @@ typedef $$UsersTableUpdateCompanionBuilder = UsersCompanion Function({
   Value<DateTime> creationTime,
 });
 
-class $$UsersTableFilterComposer extends Composer<_$TodoDb, $UsersTable> {
+class $$UsersTableFilterComposer extends Composer<TodoDb, $UsersTable> {
   $$UsersTableFilterComposer({
     required super.$db,
     required super.$table,
@@ -4012,7 +4012,7 @@ class $$UsersTableFilterComposer extends Composer<_$TodoDb, $UsersTable> {
       column: $table.creationTime, builder: (column) => ColumnFilters(column));
 }
 
-class $$UsersTableOrderingComposer extends Composer<_$TodoDb, $UsersTable> {
+class $$UsersTableOrderingComposer extends Composer<TodoDb, $UsersTable> {
   $$UsersTableOrderingComposer({
     required super.$db,
     required super.$table,
@@ -4038,7 +4038,7 @@ class $$UsersTableOrderingComposer extends Composer<_$TodoDb, $UsersTable> {
       builder: (column) => ColumnOrderings(column));
 }
 
-class $$UsersTableAnnotationComposer extends Composer<_$TodoDb, $UsersTable> {
+class $$UsersTableAnnotationComposer extends Composer<TodoDb, $UsersTable> {
   $$UsersTableAnnotationComposer({
     required super.$db,
     required super.$table,
@@ -4063,7 +4063,7 @@ class $$UsersTableAnnotationComposer extends Composer<_$TodoDb, $UsersTable> {
 }
 
 class $$UsersTableTableManager extends RootTableManager<
-    _$TodoDb,
+    TodoDb,
     $UsersTable,
     User,
     $$UsersTableFilterComposer,
@@ -4071,10 +4071,10 @@ class $$UsersTableTableManager extends RootTableManager<
     $$UsersTableAnnotationComposer,
     $$UsersTableCreateCompanionBuilder,
     $$UsersTableUpdateCompanionBuilder,
-    (User, BaseReferences<_$TodoDb, $UsersTable, User>),
+    (User, BaseReferences<TodoDb, $UsersTable, User>),
     User,
     PrefetchHooks Function()> {
-  $$UsersTableTableManager(_$TodoDb db, $UsersTable table)
+  $$UsersTableTableManager(TodoDb db, $UsersTable table)
       : super(TableManagerState(
           db: db,
           table: table,
@@ -4120,7 +4120,7 @@ class $$UsersTableTableManager extends RootTableManager<
 }
 
 typedef $$UsersTableProcessedTableManager = ProcessedTableManager<
-    _$TodoDb,
+    TodoDb,
     $UsersTable,
     User,
     $$UsersTableFilterComposer,
@@ -4128,7 +4128,7 @@ typedef $$UsersTableProcessedTableManager = ProcessedTableManager<
     $$UsersTableAnnotationComposer,
     $$UsersTableCreateCompanionBuilder,
     $$UsersTableUpdateCompanionBuilder,
-    (User, BaseReferences<_$TodoDb, $UsersTable, User>),
+    (User, BaseReferences<TodoDb, $UsersTable, User>),
     User,
     PrefetchHooks Function()>;
 typedef $$SharedTodosTableCreateCompanionBuilder = SharedTodosCompanion
@@ -4145,7 +4145,7 @@ typedef $$SharedTodosTableUpdateCompanionBuilder = SharedTodosCompanion
 });
 
 class $$SharedTodosTableFilterComposer
-    extends Composer<_$TodoDb, $SharedTodosTable> {
+    extends Composer<TodoDb, $SharedTodosTable> {
   $$SharedTodosTableFilterComposer({
     required super.$db,
     required super.$table,
@@ -4161,7 +4161,7 @@ class $$SharedTodosTableFilterComposer
 }
 
 class $$SharedTodosTableOrderingComposer
-    extends Composer<_$TodoDb, $SharedTodosTable> {
+    extends Composer<TodoDb, $SharedTodosTable> {
   $$SharedTodosTableOrderingComposer({
     required super.$db,
     required super.$table,
@@ -4177,7 +4177,7 @@ class $$SharedTodosTableOrderingComposer
 }
 
 class $$SharedTodosTableAnnotationComposer
-    extends Composer<_$TodoDb, $SharedTodosTable> {
+    extends Composer<TodoDb, $SharedTodosTable> {
   $$SharedTodosTableAnnotationComposer({
     required super.$db,
     required super.$table,
@@ -4193,7 +4193,7 @@ class $$SharedTodosTableAnnotationComposer
 }
 
 class $$SharedTodosTableTableManager extends RootTableManager<
-    _$TodoDb,
+    TodoDb,
     $SharedTodosTable,
     SharedTodo,
     $$SharedTodosTableFilterComposer,
@@ -4201,10 +4201,10 @@ class $$SharedTodosTableTableManager extends RootTableManager<
     $$SharedTodosTableAnnotationComposer,
     $$SharedTodosTableCreateCompanionBuilder,
     $$SharedTodosTableUpdateCompanionBuilder,
-    (SharedTodo, BaseReferences<_$TodoDb, $SharedTodosTable, SharedTodo>),
+    (SharedTodo, BaseReferences<TodoDb, $SharedTodosTable, SharedTodo>),
     SharedTodo,
     PrefetchHooks Function()> {
-  $$SharedTodosTableTableManager(_$TodoDb db, $SharedTodosTable table)
+  $$SharedTodosTableTableManager(TodoDb db, $SharedTodosTable table)
       : super(TableManagerState(
           db: db,
           table: table,
@@ -4242,7 +4242,7 @@ class $$SharedTodosTableTableManager extends RootTableManager<
 }
 
 typedef $$SharedTodosTableProcessedTableManager = ProcessedTableManager<
-    _$TodoDb,
+    TodoDb,
     $SharedTodosTable,
     SharedTodo,
     $$SharedTodosTableFilterComposer,
@@ -4250,7 +4250,7 @@ typedef $$SharedTodosTableProcessedTableManager = ProcessedTableManager<
     $$SharedTodosTableAnnotationComposer,
     $$SharedTodosTableCreateCompanionBuilder,
     $$SharedTodosTableUpdateCompanionBuilder,
-    (SharedTodo, BaseReferences<_$TodoDb, $SharedTodosTable, SharedTodo>),
+    (SharedTodo, BaseReferences<TodoDb, $SharedTodosTable, SharedTodo>),
     SharedTodo,
     PrefetchHooks Function()>;
 typedef $$TableWithoutPKTableCreateCompanionBuilder = TableWithoutPKCompanion
@@ -4271,7 +4271,7 @@ typedef $$TableWithoutPKTableUpdateCompanionBuilder = TableWithoutPKCompanion
 });
 
 class $$TableWithoutPKTableFilterComposer
-    extends Composer<_$TodoDb, $TableWithoutPKTable> {
+    extends Composer<TodoDb, $TableWithoutPKTable> {
   $$TableWithoutPKTableFilterComposer({
     required super.$db,
     required super.$table,
@@ -4295,7 +4295,7 @@ class $$TableWithoutPKTableFilterComposer
 }
 
 class $$TableWithoutPKTableOrderingComposer
-    extends Composer<_$TodoDb, $TableWithoutPKTable> {
+    extends Composer<TodoDb, $TableWithoutPKTable> {
   $$TableWithoutPKTableOrderingComposer({
     required super.$db,
     required super.$table,
@@ -4318,7 +4318,7 @@ class $$TableWithoutPKTableOrderingComposer
 }
 
 class $$TableWithoutPKTableAnnotationComposer
-    extends Composer<_$TodoDb, $TableWithoutPKTable> {
+    extends Composer<TodoDb, $TableWithoutPKTable> {
   $$TableWithoutPKTableAnnotationComposer({
     required super.$db,
     required super.$table,
@@ -4340,7 +4340,7 @@ class $$TableWithoutPKTableAnnotationComposer
 }
 
 class $$TableWithoutPKTableTableManager extends RootTableManager<
-    _$TodoDb,
+    TodoDb,
     $TableWithoutPKTable,
     CustomRowClass,
     $$TableWithoutPKTableFilterComposer,
@@ -4350,11 +4350,11 @@ class $$TableWithoutPKTableTableManager extends RootTableManager<
     $$TableWithoutPKTableUpdateCompanionBuilder,
     (
       CustomRowClass,
-      BaseReferences<_$TodoDb, $TableWithoutPKTable, CustomRowClass>
+      BaseReferences<TodoDb, $TableWithoutPKTable, CustomRowClass>
     ),
     CustomRowClass,
     PrefetchHooks Function()> {
-  $$TableWithoutPKTableTableManager(_$TodoDb db, $TableWithoutPKTable table)
+  $$TableWithoutPKTableTableManager(TodoDb db, $TableWithoutPKTable table)
       : super(TableManagerState(
           db: db,
           table: table,
@@ -4400,7 +4400,7 @@ class $$TableWithoutPKTableTableManager extends RootTableManager<
 }
 
 typedef $$TableWithoutPKTableProcessedTableManager = ProcessedTableManager<
-    _$TodoDb,
+    TodoDb,
     $TableWithoutPKTable,
     CustomRowClass,
     $$TableWithoutPKTableFilterComposer,
@@ -4410,7 +4410,7 @@ typedef $$TableWithoutPKTableProcessedTableManager = ProcessedTableManager<
     $$TableWithoutPKTableUpdateCompanionBuilder,
     (
       CustomRowClass,
-      BaseReferences<_$TodoDb, $TableWithoutPKTable, CustomRowClass>
+      BaseReferences<TodoDb, $TableWithoutPKTable, CustomRowClass>
     ),
     CustomRowClass,
     PrefetchHooks Function()>;
@@ -4426,7 +4426,7 @@ typedef $$PureDefaultsTableUpdateCompanionBuilder = PureDefaultsCompanion
 });
 
 class $$PureDefaultsTableFilterComposer
-    extends Composer<_$TodoDb, $PureDefaultsTable> {
+    extends Composer<TodoDb, $PureDefaultsTable> {
   $$PureDefaultsTableFilterComposer({
     required super.$db,
     required super.$table,
@@ -4441,7 +4441,7 @@ class $$PureDefaultsTableFilterComposer
 }
 
 class $$PureDefaultsTableOrderingComposer
-    extends Composer<_$TodoDb, $PureDefaultsTable> {
+    extends Composer<TodoDb, $PureDefaultsTable> {
   $$PureDefaultsTableOrderingComposer({
     required super.$db,
     required super.$table,
@@ -4454,7 +4454,7 @@ class $$PureDefaultsTableOrderingComposer
 }
 
 class $$PureDefaultsTableAnnotationComposer
-    extends Composer<_$TodoDb, $PureDefaultsTable> {
+    extends Composer<TodoDb, $PureDefaultsTable> {
   $$PureDefaultsTableAnnotationComposer({
     required super.$db,
     required super.$table,
@@ -4467,7 +4467,7 @@ class $$PureDefaultsTableAnnotationComposer
 }
 
 class $$PureDefaultsTableTableManager extends RootTableManager<
-    _$TodoDb,
+    TodoDb,
     $PureDefaultsTable,
     PureDefault,
     $$PureDefaultsTableFilterComposer,
@@ -4475,10 +4475,10 @@ class $$PureDefaultsTableTableManager extends RootTableManager<
     $$PureDefaultsTableAnnotationComposer,
     $$PureDefaultsTableCreateCompanionBuilder,
     $$PureDefaultsTableUpdateCompanionBuilder,
-    (PureDefault, BaseReferences<_$TodoDb, $PureDefaultsTable, PureDefault>),
+    (PureDefault, BaseReferences<TodoDb, $PureDefaultsTable, PureDefault>),
     PureDefault,
     PrefetchHooks Function()> {
-  $$PureDefaultsTableTableManager(_$TodoDb db, $PureDefaultsTable table)
+  $$PureDefaultsTableTableManager(TodoDb db, $PureDefaultsTable table)
       : super(TableManagerState(
           db: db,
           table: table,
@@ -4512,7 +4512,7 @@ class $$PureDefaultsTableTableManager extends RootTableManager<
 }
 
 typedef $$PureDefaultsTableProcessedTableManager = ProcessedTableManager<
-    _$TodoDb,
+    TodoDb,
     $PureDefaultsTable,
     PureDefault,
     $$PureDefaultsTableFilterComposer,
@@ -4520,7 +4520,7 @@ typedef $$PureDefaultsTableProcessedTableManager = ProcessedTableManager<
     $$PureDefaultsTableAnnotationComposer,
     $$PureDefaultsTableCreateCompanionBuilder,
     $$PureDefaultsTableUpdateCompanionBuilder,
-    (PureDefault, BaseReferences<_$TodoDb, $PureDefaultsTable, PureDefault>),
+    (PureDefault, BaseReferences<TodoDb, $PureDefaultsTable, PureDefault>),
     PureDefault,
     PrefetchHooks Function()>;
 typedef $$WithCustomTypeTableCreateCompanionBuilder = WithCustomTypeCompanion
@@ -4535,7 +4535,7 @@ typedef $$WithCustomTypeTableUpdateCompanionBuilder = WithCustomTypeCompanion
 });
 
 class $$WithCustomTypeTableFilterComposer
-    extends Composer<_$TodoDb, $WithCustomTypeTable> {
+    extends Composer<TodoDb, $WithCustomTypeTable> {
   $$WithCustomTypeTableFilterComposer({
     required super.$db,
     required super.$table,
@@ -4548,7 +4548,7 @@ class $$WithCustomTypeTableFilterComposer
 }
 
 class $$WithCustomTypeTableOrderingComposer
-    extends Composer<_$TodoDb, $WithCustomTypeTable> {
+    extends Composer<TodoDb, $WithCustomTypeTable> {
   $$WithCustomTypeTableOrderingComposer({
     required super.$db,
     required super.$table,
@@ -4561,7 +4561,7 @@ class $$WithCustomTypeTableOrderingComposer
 }
 
 class $$WithCustomTypeTableAnnotationComposer
-    extends Composer<_$TodoDb, $WithCustomTypeTable> {
+    extends Composer<TodoDb, $WithCustomTypeTable> {
   $$WithCustomTypeTableAnnotationComposer({
     required super.$db,
     required super.$table,
@@ -4574,7 +4574,7 @@ class $$WithCustomTypeTableAnnotationComposer
 }
 
 class $$WithCustomTypeTableTableManager extends RootTableManager<
-    _$TodoDb,
+    TodoDb,
     $WithCustomTypeTable,
     WithCustomTypeData,
     $$WithCustomTypeTableFilterComposer,
@@ -4584,11 +4584,11 @@ class $$WithCustomTypeTableTableManager extends RootTableManager<
     $$WithCustomTypeTableUpdateCompanionBuilder,
     (
       WithCustomTypeData,
-      BaseReferences<_$TodoDb, $WithCustomTypeTable, WithCustomTypeData>
+      BaseReferences<TodoDb, $WithCustomTypeTable, WithCustomTypeData>
     ),
     WithCustomTypeData,
     PrefetchHooks Function()> {
-  $$WithCustomTypeTableTableManager(_$TodoDb db, $WithCustomTypeTable table)
+  $$WithCustomTypeTableTableManager(TodoDb db, $WithCustomTypeTable table)
       : super(TableManagerState(
           db: db,
           table: table,
@@ -4622,7 +4622,7 @@ class $$WithCustomTypeTableTableManager extends RootTableManager<
 }
 
 typedef $$WithCustomTypeTableProcessedTableManager = ProcessedTableManager<
-    _$TodoDb,
+    TodoDb,
     $WithCustomTypeTable,
     WithCustomTypeData,
     $$WithCustomTypeTableFilterComposer,
@@ -4632,7 +4632,7 @@ typedef $$WithCustomTypeTableProcessedTableManager = ProcessedTableManager<
     $$WithCustomTypeTableUpdateCompanionBuilder,
     (
       WithCustomTypeData,
-      BaseReferences<_$TodoDb, $WithCustomTypeTable, WithCustomTypeData>
+      BaseReferences<TodoDb, $WithCustomTypeTable, WithCustomTypeData>
     ),
     WithCustomTypeData,
     PrefetchHooks Function()>;
@@ -4664,7 +4664,7 @@ typedef $$TableWithEveryColumnTypeTableUpdateCompanionBuilder
 });
 
 class $$TableWithEveryColumnTypeTableFilterComposer
-    extends Composer<_$TodoDb, $TableWithEveryColumnTypeTable> {
+    extends Composer<TodoDb, $TableWithEveryColumnTypeTable> {
   $$TableWithEveryColumnTypeTableFilterComposer({
     required super.$db,
     required super.$table,
@@ -4710,7 +4710,7 @@ class $$TableWithEveryColumnTypeTableFilterComposer
 }
 
 class $$TableWithEveryColumnTypeTableOrderingComposer
-    extends Composer<_$TodoDb, $TableWithEveryColumnTypeTable> {
+    extends Composer<TodoDb, $TableWithEveryColumnTypeTable> {
   $$TableWithEveryColumnTypeTableOrderingComposer({
     required super.$db,
     required super.$table,
@@ -4751,7 +4751,7 @@ class $$TableWithEveryColumnTypeTableOrderingComposer
 }
 
 class $$TableWithEveryColumnTypeTableAnnotationComposer
-    extends Composer<_$TodoDb, $TableWithEveryColumnTypeTable> {
+    extends Composer<TodoDb, $TableWithEveryColumnTypeTable> {
   $$TableWithEveryColumnTypeTableAnnotationComposer({
     required super.$db,
     required super.$table,
@@ -4792,7 +4792,7 @@ class $$TableWithEveryColumnTypeTableAnnotationComposer
 }
 
 class $$TableWithEveryColumnTypeTableTableManager extends RootTableManager<
-    _$TodoDb,
+    TodoDb,
     $TableWithEveryColumnTypeTable,
     TableWithEveryColumnTypeData,
     $$TableWithEveryColumnTypeTableFilterComposer,
@@ -4802,13 +4802,13 @@ class $$TableWithEveryColumnTypeTableTableManager extends RootTableManager<
     $$TableWithEveryColumnTypeTableUpdateCompanionBuilder,
     (
       TableWithEveryColumnTypeData,
-      BaseReferences<_$TodoDb, $TableWithEveryColumnTypeTable,
+      BaseReferences<TodoDb, $TableWithEveryColumnTypeTable,
           TableWithEveryColumnTypeData>
     ),
     TableWithEveryColumnTypeData,
     PrefetchHooks Function()> {
   $$TableWithEveryColumnTypeTableTableManager(
-      _$TodoDb db, $TableWithEveryColumnTypeTable table)
+      TodoDb db, $TableWithEveryColumnTypeTable table)
       : super(TableManagerState(
           db: db,
           table: table,
@@ -4878,7 +4878,7 @@ class $$TableWithEveryColumnTypeTableTableManager extends RootTableManager<
 
 typedef $$TableWithEveryColumnTypeTableProcessedTableManager
     = ProcessedTableManager<
-        _$TodoDb,
+        TodoDb,
         $TableWithEveryColumnTypeTable,
         TableWithEveryColumnTypeData,
         $$TableWithEveryColumnTypeTableFilterComposer,
@@ -4888,7 +4888,7 @@ typedef $$TableWithEveryColumnTypeTableProcessedTableManager
         $$TableWithEveryColumnTypeTableUpdateCompanionBuilder,
         (
           TableWithEveryColumnTypeData,
-          BaseReferences<_$TodoDb, $TableWithEveryColumnTypeTable,
+          BaseReferences<TodoDb, $TableWithEveryColumnTypeTable,
               TableWithEveryColumnTypeData>
         ),
         TableWithEveryColumnTypeData,
@@ -4903,12 +4903,11 @@ typedef $$DepartmentTableUpdateCompanionBuilder = DepartmentCompanion Function({
 });
 
 final class $$DepartmentTableReferences
-    extends BaseReferences<_$TodoDb, $DepartmentTable, DepartmentData> {
+    extends BaseReferences<TodoDb, $DepartmentTable, DepartmentData> {
   $$DepartmentTableReferences(super.$_db, super.$_table, super.$_typedResult);
 
   static MultiTypedResultKey<$ProductTable, List<ProductData>>
-      _productRefsTable(_$TodoDb db) => MultiTypedResultKey.fromTable(
-          db.product,
+      _productRefsTable(TodoDb db) => MultiTypedResultKey.fromTable(db.product,
           aliasName:
               $_aliasNameGenerator(db.department.id, db.product.department));
 
@@ -4923,7 +4922,7 @@ final class $$DepartmentTableReferences
 }
 
 class $$DepartmentTableFilterComposer
-    extends Composer<_$TodoDb, $DepartmentTable> {
+    extends Composer<TodoDb, $DepartmentTable> {
   $$DepartmentTableFilterComposer({
     required super.$db,
     required super.$table,
@@ -4960,7 +4959,7 @@ class $$DepartmentTableFilterComposer
 }
 
 class $$DepartmentTableOrderingComposer
-    extends Composer<_$TodoDb, $DepartmentTable> {
+    extends Composer<TodoDb, $DepartmentTable> {
   $$DepartmentTableOrderingComposer({
     required super.$db,
     required super.$table,
@@ -4976,7 +4975,7 @@ class $$DepartmentTableOrderingComposer
 }
 
 class $$DepartmentTableAnnotationComposer
-    extends Composer<_$TodoDb, $DepartmentTable> {
+    extends Composer<TodoDb, $DepartmentTable> {
   $$DepartmentTableAnnotationComposer({
     required super.$db,
     required super.$table,
@@ -5013,7 +5012,7 @@ class $$DepartmentTableAnnotationComposer
 }
 
 class $$DepartmentTableTableManager extends RootTableManager<
-    _$TodoDb,
+    TodoDb,
     $DepartmentTable,
     DepartmentData,
     $$DepartmentTableFilterComposer,
@@ -5024,7 +5023,7 @@ class $$DepartmentTableTableManager extends RootTableManager<
     (DepartmentData, $$DepartmentTableReferences),
     DepartmentData,
     PrefetchHooks Function({bool productRefs})> {
-  $$DepartmentTableTableManager(_$TodoDb db, $DepartmentTable table)
+  $$DepartmentTableTableManager(TodoDb db, $DepartmentTable table)
       : super(TableManagerState(
           db: db,
           table: table,
@@ -5083,7 +5082,7 @@ class $$DepartmentTableTableManager extends RootTableManager<
 }
 
 typedef $$DepartmentTableProcessedTableManager = ProcessedTableManager<
-    _$TodoDb,
+    TodoDb,
     $DepartmentTable,
     DepartmentData,
     $$DepartmentTableFilterComposer,
@@ -5108,10 +5107,10 @@ typedef $$ProductTableUpdateCompanionBuilder = ProductCompanion Function({
 });
 
 final class $$ProductTableReferences
-    extends BaseReferences<_$TodoDb, $ProductTable, ProductData> {
+    extends BaseReferences<TodoDb, $ProductTable, ProductData> {
   $$ProductTableReferences(super.$_db, super.$_table, super.$_typedResult);
 
-  static $DepartmentTable _departmentTable(_$TodoDb db) =>
+  static $DepartmentTable _departmentTable(TodoDb db) =>
       db.department.createAlias(
           $_aliasNameGenerator(db.product.department, db.department.id));
 
@@ -5126,7 +5125,7 @@ final class $$ProductTableReferences
   }
 
   static MultiTypedResultKey<$ListingTable, List<ListingData>> _listingsTable(
-          _$TodoDb db) =>
+          TodoDb db) =>
       MultiTypedResultKey.fromTable(db.listing,
           aliasName: $_aliasNameGenerator(db.product.sku, db.listing.product));
 
@@ -5140,7 +5139,7 @@ final class $$ProductTableReferences
   }
 }
 
-class $$ProductTableFilterComposer extends Composer<_$TodoDb, $ProductTable> {
+class $$ProductTableFilterComposer extends Composer<TodoDb, $ProductTable> {
   $$ProductTableFilterComposer({
     required super.$db,
     required super.$table,
@@ -5196,7 +5195,7 @@ class $$ProductTableFilterComposer extends Composer<_$TodoDb, $ProductTable> {
   }
 }
 
-class $$ProductTableOrderingComposer extends Composer<_$TodoDb, $ProductTable> {
+class $$ProductTableOrderingComposer extends Composer<TodoDb, $ProductTable> {
   $$ProductTableOrderingComposer({
     required super.$db,
     required super.$table,
@@ -5231,8 +5230,7 @@ class $$ProductTableOrderingComposer extends Composer<_$TodoDb, $ProductTable> {
   }
 }
 
-class $$ProductTableAnnotationComposer
-    extends Composer<_$TodoDb, $ProductTable> {
+class $$ProductTableAnnotationComposer extends Composer<TodoDb, $ProductTable> {
   $$ProductTableAnnotationComposer({
     required super.$db,
     required super.$table,
@@ -5289,7 +5287,7 @@ class $$ProductTableAnnotationComposer
 }
 
 class $$ProductTableTableManager extends RootTableManager<
-    _$TodoDb,
+    TodoDb,
     $ProductTable,
     ProductData,
     $$ProductTableFilterComposer,
@@ -5300,7 +5298,7 @@ class $$ProductTableTableManager extends RootTableManager<
     (ProductData, $$ProductTableReferences),
     ProductData,
     PrefetchHooks Function({bool department, bool listings})> {
-  $$ProductTableTableManager(_$TodoDb db, $ProductTable table)
+  $$ProductTableTableManager(TodoDb db, $ProductTable table)
       : super(TableManagerState(
           db: db,
           table: table,
@@ -5389,7 +5387,7 @@ class $$ProductTableTableManager extends RootTableManager<
 }
 
 typedef $$ProductTableProcessedTableManager = ProcessedTableManager<
-    _$TodoDb,
+    TodoDb,
     $ProductTable,
     ProductData,
     $$ProductTableFilterComposer,
@@ -5410,11 +5408,11 @@ typedef $$StoreTableUpdateCompanionBuilder = StoreCompanion Function({
 });
 
 final class $$StoreTableReferences
-    extends BaseReferences<_$TodoDb, $StoreTable, StoreData> {
+    extends BaseReferences<TodoDb, $StoreTable, StoreData> {
   $$StoreTableReferences(super.$_db, super.$_table, super.$_typedResult);
 
   static MultiTypedResultKey<$ListingTable, List<ListingData>> _listingsTable(
-          _$TodoDb db) =>
+          TodoDb db) =>
       MultiTypedResultKey.fromTable(db.listing,
           aliasName: $_aliasNameGenerator(db.store.id, db.listing.store));
 
@@ -5428,7 +5426,7 @@ final class $$StoreTableReferences
   }
 }
 
-class $$StoreTableFilterComposer extends Composer<_$TodoDb, $StoreTable> {
+class $$StoreTableFilterComposer extends Composer<TodoDb, $StoreTable> {
   $$StoreTableFilterComposer({
     required super.$db,
     required super.$table,
@@ -5464,7 +5462,7 @@ class $$StoreTableFilterComposer extends Composer<_$TodoDb, $StoreTable> {
   }
 }
 
-class $$StoreTableOrderingComposer extends Composer<_$TodoDb, $StoreTable> {
+class $$StoreTableOrderingComposer extends Composer<TodoDb, $StoreTable> {
   $$StoreTableOrderingComposer({
     required super.$db,
     required super.$table,
@@ -5479,7 +5477,7 @@ class $$StoreTableOrderingComposer extends Composer<_$TodoDb, $StoreTable> {
       column: $table.name, builder: (column) => ColumnOrderings(column));
 }
 
-class $$StoreTableAnnotationComposer extends Composer<_$TodoDb, $StoreTable> {
+class $$StoreTableAnnotationComposer extends Composer<TodoDb, $StoreTable> {
   $$StoreTableAnnotationComposer({
     required super.$db,
     required super.$table,
@@ -5516,7 +5514,7 @@ class $$StoreTableAnnotationComposer extends Composer<_$TodoDb, $StoreTable> {
 }
 
 class $$StoreTableTableManager extends RootTableManager<
-    _$TodoDb,
+    TodoDb,
     $StoreTable,
     StoreData,
     $$StoreTableFilterComposer,
@@ -5527,7 +5525,7 @@ class $$StoreTableTableManager extends RootTableManager<
     (StoreData, $$StoreTableReferences),
     StoreData,
     PrefetchHooks Function({bool listings})> {
-  $$StoreTableTableManager(_$TodoDb db, $StoreTable table)
+  $$StoreTableTableManager(TodoDb db, $StoreTable table)
       : super(TableManagerState(
           db: db,
           table: table,
@@ -5583,7 +5581,7 @@ class $$StoreTableTableManager extends RootTableManager<
 }
 
 typedef $$StoreTableProcessedTableManager = ProcessedTableManager<
-    _$TodoDb,
+    TodoDb,
     $StoreTable,
     StoreData,
     $$StoreTableFilterComposer,
@@ -5608,10 +5606,10 @@ typedef $$ListingTableUpdateCompanionBuilder = ListingCompanion Function({
 });
 
 final class $$ListingTableReferences
-    extends BaseReferences<_$TodoDb, $ListingTable, ListingData> {
+    extends BaseReferences<TodoDb, $ListingTable, ListingData> {
   $$ListingTableReferences(super.$_db, super.$_table, super.$_typedResult);
 
-  static $ProductTable _productTable(_$TodoDb db) => db.product
+  static $ProductTable _productTable(TodoDb db) => db.product
       .createAlias($_aliasNameGenerator(db.listing.product, db.product.sku));
 
   $$ProductTableProcessedTableManager? get product {
@@ -5624,7 +5622,7 @@ final class $$ListingTableReferences
         manager.$state.copyWith(prefetchedData: [item]));
   }
 
-  static $StoreTable _storeTable(_$TodoDb db) =>
+  static $StoreTable _storeTable(TodoDb db) =>
       db.store.createAlias($_aliasNameGenerator(db.listing.store, db.store.id));
 
   $$StoreTableProcessedTableManager? get store {
@@ -5638,7 +5636,7 @@ final class $$ListingTableReferences
   }
 }
 
-class $$ListingTableFilterComposer extends Composer<_$TodoDb, $ListingTable> {
+class $$ListingTableFilterComposer extends Composer<TodoDb, $ListingTable> {
   $$ListingTableFilterComposer({
     required super.$db,
     required super.$table,
@@ -5693,7 +5691,7 @@ class $$ListingTableFilterComposer extends Composer<_$TodoDb, $ListingTable> {
   }
 }
 
-class $$ListingTableOrderingComposer extends Composer<_$TodoDb, $ListingTable> {
+class $$ListingTableOrderingComposer extends Composer<TodoDb, $ListingTable> {
   $$ListingTableOrderingComposer({
     required super.$db,
     required super.$table,
@@ -5748,8 +5746,7 @@ class $$ListingTableOrderingComposer extends Composer<_$TodoDb, $ListingTable> {
   }
 }
 
-class $$ListingTableAnnotationComposer
-    extends Composer<_$TodoDb, $ListingTable> {
+class $$ListingTableAnnotationComposer extends Composer<TodoDb, $ListingTable> {
   $$ListingTableAnnotationComposer({
     required super.$db,
     required super.$table,
@@ -5805,7 +5802,7 @@ class $$ListingTableAnnotationComposer
 }
 
 class $$ListingTableTableManager extends RootTableManager<
-    _$TodoDb,
+    TodoDb,
     $ListingTable,
     ListingData,
     $$ListingTableFilterComposer,
@@ -5816,7 +5813,7 @@ class $$ListingTableTableManager extends RootTableManager<
     (ListingData, $$ListingTableReferences),
     ListingData,
     PrefetchHooks Function({bool product, bool store})> {
-  $$ListingTableTableManager(_$TodoDb db, $ListingTable table)
+  $$ListingTableTableManager(TodoDb db, $ListingTable table)
       : super(TableManagerState(
           db: db,
           table: table,
@@ -5901,7 +5898,7 @@ class $$ListingTableTableManager extends RootTableManager<
 }
 
 typedef $$ListingTableProcessedTableManager = ProcessedTableManager<
-    _$TodoDb,
+    TodoDb,
     $ListingTable,
     ListingData,
     $$ListingTableFilterComposer,
@@ -5913,9 +5910,9 @@ typedef $$ListingTableProcessedTableManager = ProcessedTableManager<
     ListingData,
     PrefetchHooks Function({bool product, bool store})>;
 
-class $TodoDbManager {
-  final _$TodoDb _db;
-  $TodoDbManager(this._db);
+class TodoDbManager {
+  final TodoDb _db;
+  TodoDbManager(this._db);
   $$CategoriesTableTableManager get categories =>
       $$CategoriesTableTableManager(_db, _db.categories);
   $$TodosTableTableTableManager get todosTable =>
@@ -5943,8 +5940,8 @@ class $TodoDbManager {
       $$ListingTableTableManager(_db, _db.listing);
 }
 
-extension $TodoDbManagerExt on _$TodoDb {
-  $TodoDbManager get managers => $TodoDbManager(this);
+extension TodoDbManagerExt on TodoDb {
+  TodoDbManager get managers => TodoDbManager(this);
 }
 
 class AllTodosWithCategoryResult extends CustomResultSet {

--- a/drift/test/generated/todos.g.dart
+++ b/drift/test/generated/todos.g.dart
@@ -3344,7 +3344,6 @@ class $TodoWithCategoryViewView
 
 abstract class _$TodoDb extends GeneratedDatabase {
   _$TodoDb(QueryExecutor e) : super(e);
-  $TodoDbManager get managers => $TodoDbManager(this);
   late final $CategoriesTable categories = $CategoriesTable(this);
   late final $TodosTableTable todosTable = $TodosTableTable(this);
   late final $UsersTable users = $UsersTable(this);
@@ -5942,6 +5941,10 @@ class $TodoDbManager {
       $$StoreTableTableManager(_db, _db.store);
   $$ListingTableTableManager get listing =>
       $$ListingTableTableManager(_db, _db.listing);
+}
+
+extension $TodoDbManagerExt on _$TodoDb {
+  $TodoDbManager get managers => $TodoDbManager(this);
 }
 
 class AllTodosWithCategoryResult extends CustomResultSet {

--- a/drift/test/generated/todos.mocks.dart
+++ b/drift/test/generated/todos.mocks.dart
@@ -207,20 +207,9 @@ class _FakeSomeDao_16 extends _i1.SmartFake implements _i3.SomeDao {
         );
 }
 
-class _Fake$TodoDbManager_17 extends _i1.SmartFake
-    implements _i3.$TodoDbManager {
-  _Fake$TodoDbManager_17(
-    Object parent,
-    Invocation parentInvocation,
-  ) : super(
-          parent,
-          parentInvocation,
-        );
-}
-
-class _FakeGeneratedDatabase_18 extends _i1.SmartFake
+class _FakeGeneratedDatabase_17 extends _i1.SmartFake
     implements _i2.GeneratedDatabase {
-  _FakeGeneratedDatabase_18(
+  _FakeGeneratedDatabase_17(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -229,9 +218,9 @@ class _FakeGeneratedDatabase_18 extends _i1.SmartFake
         );
 }
 
-class _FakeStreamQueryUpdateRules_19 extends _i1.SmartFake
+class _FakeStreamQueryUpdateRules_18 extends _i1.SmartFake
     implements _i2.StreamQueryUpdateRules {
-  _FakeStreamQueryUpdateRules_19(
+  _FakeStreamQueryUpdateRules_18(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -240,9 +229,9 @@ class _FakeStreamQueryUpdateRules_19 extends _i1.SmartFake
         );
 }
 
-class _FakeDatabaseConnection_20 extends _i1.SmartFake
+class _FakeDatabaseConnection_19 extends _i1.SmartFake
     implements _i2.DatabaseConnection {
-  _FakeDatabaseConnection_20(
+  _FakeDatabaseConnection_19(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -251,8 +240,8 @@ class _FakeDatabaseConnection_20 extends _i1.SmartFake
         );
 }
 
-class _FakeQueryExecutor_21 extends _i1.SmartFake implements _i2.QueryExecutor {
-  _FakeQueryExecutor_21(
+class _FakeQueryExecutor_20 extends _i1.SmartFake implements _i2.QueryExecutor {
+  _FakeQueryExecutor_20(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -261,9 +250,9 @@ class _FakeQueryExecutor_21 extends _i1.SmartFake implements _i2.QueryExecutor {
         );
 }
 
-class _FakeStreamQueryStore_22 extends _i1.SmartFake
+class _FakeStreamQueryStore_21 extends _i1.SmartFake
     implements _i4.StreamQueryStore {
-  _FakeStreamQueryStore_22(
+  _FakeStreamQueryStore_21(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -272,9 +261,9 @@ class _FakeStreamQueryStore_22 extends _i1.SmartFake
         );
 }
 
-class _FakeDatabaseConnectionUser_23 extends _i1.SmartFake
+class _FakeDatabaseConnectionUser_22 extends _i1.SmartFake
     implements _i2.DatabaseConnectionUser {
-  _FakeDatabaseConnectionUser_23(
+  _FakeDatabaseConnectionUser_22(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -283,8 +272,8 @@ class _FakeDatabaseConnectionUser_23 extends _i1.SmartFake
         );
 }
 
-class _FakeSelectable_24<T> extends _i1.SmartFake implements _i2.Selectable<T> {
-  _FakeSelectable_24(
+class _FakeSelectable_23<T> extends _i1.SmartFake implements _i2.Selectable<T> {
+  _FakeSelectable_23(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -293,8 +282,8 @@ class _FakeSelectable_24<T> extends _i1.SmartFake implements _i2.Selectable<T> {
         );
 }
 
-class _FakeMigrator_25 extends _i1.SmartFake implements _i2.Migrator {
-  _FakeMigrator_25(
+class _FakeMigrator_24 extends _i1.SmartFake implements _i2.Migrator {
+  _FakeMigrator_24(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -303,8 +292,8 @@ class _FakeMigrator_25 extends _i1.SmartFake implements _i2.Migrator {
         );
 }
 
-class _FakeFuture_26<T1> extends _i1.SmartFake implements _i5.Future<T1> {
-  _FakeFuture_26(
+class _FakeFuture_25<T1> extends _i1.SmartFake implements _i5.Future<T1> {
+  _FakeFuture_25(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -313,9 +302,9 @@ class _FakeFuture_26<T1> extends _i1.SmartFake implements _i5.Future<T1> {
         );
 }
 
-class _FakeInsertStatement_27<T1 extends _i2.Table, D1> extends _i1.SmartFake
+class _FakeInsertStatement_26<T1 extends _i2.Table, D1> extends _i1.SmartFake
     implements _i2.InsertStatement<T1, D1> {
-  _FakeInsertStatement_27(
+  _FakeInsertStatement_26(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -324,9 +313,9 @@ class _FakeInsertStatement_27<T1 extends _i2.Table, D1> extends _i1.SmartFake
         );
 }
 
-class _FakeUpdateStatement_28<T extends _i2.Table, D> extends _i1.SmartFake
+class _FakeUpdateStatement_27<T extends _i2.Table, D> extends _i1.SmartFake
     implements _i2.UpdateStatement<T, D> {
-  _FakeUpdateStatement_28(
+  _FakeUpdateStatement_27(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -335,9 +324,9 @@ class _FakeUpdateStatement_28<T extends _i2.Table, D> extends _i1.SmartFake
         );
 }
 
-class _FakeSimpleSelectStatement_29<T1 extends _i2.HasResultSet, D>
+class _FakeSimpleSelectStatement_28<T1 extends _i2.HasResultSet, D>
     extends _i1.SmartFake implements _i2.SimpleSelectStatement<T1, D> {
-  _FakeSimpleSelectStatement_29(
+  _FakeSimpleSelectStatement_28(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -346,9 +335,9 @@ class _FakeSimpleSelectStatement_29<T1 extends _i2.HasResultSet, D>
         );
 }
 
-class _FakeJoinedSelectStatement_30<FirstT extends _i2.HasResultSet, FirstD>
+class _FakeJoinedSelectStatement_29<FirstT extends _i2.HasResultSet, FirstD>
     extends _i1.SmartFake implements _i2.JoinedSelectStatement<FirstT, FirstD> {
-  _FakeJoinedSelectStatement_30(
+  _FakeJoinedSelectStatement_29(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -357,9 +346,9 @@ class _FakeJoinedSelectStatement_30<FirstT extends _i2.HasResultSet, FirstD>
         );
 }
 
-class _FakeDeleteStatement_31<T1 extends _i2.Table, D1> extends _i1.SmartFake
+class _FakeDeleteStatement_30<T1 extends _i2.Table, D1> extends _i1.SmartFake
     implements _i2.DeleteStatement<T1, D1> {
-  _FakeDeleteStatement_31(
+  _FakeDeleteStatement_30(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -368,9 +357,141 @@ class _FakeDeleteStatement_31<T1 extends _i2.Table, D1> extends _i1.SmartFake
         );
 }
 
-class _FakeGenerationContext_32 extends _i1.SmartFake
+class _FakeGenerationContext_31 extends _i1.SmartFake
     implements _i2.GenerationContext {
-  _FakeGenerationContext_32(
+  _FakeGenerationContext_31(
+    Object parent,
+    Invocation parentInvocation,
+  ) : super(
+          parent,
+          parentInvocation,
+        );
+}
+
+class _Fake$$CategoriesTableTableManager_32 extends _i1.SmartFake
+    implements _i3.$$CategoriesTableTableManager {
+  _Fake$$CategoriesTableTableManager_32(
+    Object parent,
+    Invocation parentInvocation,
+  ) : super(
+          parent,
+          parentInvocation,
+        );
+}
+
+class _Fake$$TodosTableTableTableManager_33 extends _i1.SmartFake
+    implements _i3.$$TodosTableTableTableManager {
+  _Fake$$TodosTableTableTableManager_33(
+    Object parent,
+    Invocation parentInvocation,
+  ) : super(
+          parent,
+          parentInvocation,
+        );
+}
+
+class _Fake$$UsersTableTableManager_34 extends _i1.SmartFake
+    implements _i3.$$UsersTableTableManager {
+  _Fake$$UsersTableTableManager_34(
+    Object parent,
+    Invocation parentInvocation,
+  ) : super(
+          parent,
+          parentInvocation,
+        );
+}
+
+class _Fake$$SharedTodosTableTableManager_35 extends _i1.SmartFake
+    implements _i3.$$SharedTodosTableTableManager {
+  _Fake$$SharedTodosTableTableManager_35(
+    Object parent,
+    Invocation parentInvocation,
+  ) : super(
+          parent,
+          parentInvocation,
+        );
+}
+
+class _Fake$$TableWithoutPKTableTableManager_36 extends _i1.SmartFake
+    implements _i3.$$TableWithoutPKTableTableManager {
+  _Fake$$TableWithoutPKTableTableManager_36(
+    Object parent,
+    Invocation parentInvocation,
+  ) : super(
+          parent,
+          parentInvocation,
+        );
+}
+
+class _Fake$$PureDefaultsTableTableManager_37 extends _i1.SmartFake
+    implements _i3.$$PureDefaultsTableTableManager {
+  _Fake$$PureDefaultsTableTableManager_37(
+    Object parent,
+    Invocation parentInvocation,
+  ) : super(
+          parent,
+          parentInvocation,
+        );
+}
+
+class _Fake$$WithCustomTypeTableTableManager_38 extends _i1.SmartFake
+    implements _i3.$$WithCustomTypeTableTableManager {
+  _Fake$$WithCustomTypeTableTableManager_38(
+    Object parent,
+    Invocation parentInvocation,
+  ) : super(
+          parent,
+          parentInvocation,
+        );
+}
+
+class _Fake$$TableWithEveryColumnTypeTableTableManager_39 extends _i1.SmartFake
+    implements _i3.$$TableWithEveryColumnTypeTableTableManager {
+  _Fake$$TableWithEveryColumnTypeTableTableManager_39(
+    Object parent,
+    Invocation parentInvocation,
+  ) : super(
+          parent,
+          parentInvocation,
+        );
+}
+
+class _Fake$$DepartmentTableTableManager_40 extends _i1.SmartFake
+    implements _i3.$$DepartmentTableTableManager {
+  _Fake$$DepartmentTableTableManager_40(
+    Object parent,
+    Invocation parentInvocation,
+  ) : super(
+          parent,
+          parentInvocation,
+        );
+}
+
+class _Fake$$ProductTableTableManager_41 extends _i1.SmartFake
+    implements _i3.$$ProductTableTableManager {
+  _Fake$$ProductTableTableManager_41(
+    Object parent,
+    Invocation parentInvocation,
+  ) : super(
+          parent,
+          parentInvocation,
+        );
+}
+
+class _Fake$$StoreTableTableManager_42 extends _i1.SmartFake
+    implements _i3.$$StoreTableTableManager {
+  _Fake$$StoreTableTableManager_42(
+    Object parent,
+    Invocation parentInvocation,
+  ) : super(
+          parent,
+          parentInvocation,
+        );
+}
+
+class _Fake$$ListingTableTableManager_43 extends _i1.SmartFake
+    implements _i3.$$ListingTableTableManager {
+  _Fake$$ListingTableTableManager_43(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -641,19 +762,6 @@ class MockTodoDb extends _i1.Mock implements _i3.TodoDb {
       ) as _i3.SomeDao);
 
   @override
-  _i3.$TodoDbManager get managers => (super.noSuchMethod(
-        Invocation.getter(#managers),
-        returnValue: _Fake$TodoDbManager_17(
-          this,
-          Invocation.getter(#managers),
-        ),
-        returnValueForMissingStub: _Fake$TodoDbManager_17(
-          this,
-          Invocation.getter(#managers),
-        ),
-      ) as _i3.$TodoDbManager);
-
-  @override
   Iterable<_i2.TableInfo<_i2.Table, Object?>> get allTables =>
       (super.noSuchMethod(
         Invocation.getter(#allTables),
@@ -671,11 +779,11 @@ class MockTodoDb extends _i1.Mock implements _i3.TodoDb {
   @override
   _i2.GeneratedDatabase get attachedDatabase => (super.noSuchMethod(
         Invocation.getter(#attachedDatabase),
-        returnValue: _FakeGeneratedDatabase_18(
+        returnValue: _FakeGeneratedDatabase_17(
           this,
           Invocation.getter(#attachedDatabase),
         ),
-        returnValueForMissingStub: _FakeGeneratedDatabase_18(
+        returnValueForMissingStub: _FakeGeneratedDatabase_17(
           this,
           Invocation.getter(#attachedDatabase),
         ),
@@ -684,11 +792,11 @@ class MockTodoDb extends _i1.Mock implements _i3.TodoDb {
   @override
   _i2.StreamQueryUpdateRules get streamUpdateRules => (super.noSuchMethod(
         Invocation.getter(#streamUpdateRules),
-        returnValue: _FakeStreamQueryUpdateRules_19(
+        returnValue: _FakeStreamQueryUpdateRules_18(
           this,
           Invocation.getter(#streamUpdateRules),
         ),
-        returnValueForMissingStub: _FakeStreamQueryUpdateRules_19(
+        returnValueForMissingStub: _FakeStreamQueryUpdateRules_18(
           this,
           Invocation.getter(#streamUpdateRules),
         ),
@@ -697,11 +805,11 @@ class MockTodoDb extends _i1.Mock implements _i3.TodoDb {
   @override
   _i2.DatabaseConnection get connection => (super.noSuchMethod(
         Invocation.getter(#connection),
-        returnValue: _FakeDatabaseConnection_20(
+        returnValue: _FakeDatabaseConnection_19(
           this,
           Invocation.getter(#connection),
         ),
-        returnValueForMissingStub: _FakeDatabaseConnection_20(
+        returnValueForMissingStub: _FakeDatabaseConnection_19(
           this,
           Invocation.getter(#connection),
         ),
@@ -723,11 +831,11 @@ class MockTodoDb extends _i1.Mock implements _i3.TodoDb {
   @override
   _i2.QueryExecutor get executor => (super.noSuchMethod(
         Invocation.getter(#executor),
-        returnValue: _FakeQueryExecutor_21(
+        returnValue: _FakeQueryExecutor_20(
           this,
           Invocation.getter(#executor),
         ),
-        returnValueForMissingStub: _FakeQueryExecutor_21(
+        returnValueForMissingStub: _FakeQueryExecutor_20(
           this,
           Invocation.getter(#executor),
         ),
@@ -736,11 +844,11 @@ class MockTodoDb extends _i1.Mock implements _i3.TodoDb {
   @override
   _i4.StreamQueryStore get streamQueries => (super.noSuchMethod(
         Invocation.getter(#streamQueries),
-        returnValue: _FakeStreamQueryStore_22(
+        returnValue: _FakeStreamQueryStore_21(
           this,
           Invocation.getter(#streamQueries),
         ),
-        returnValueForMissingStub: _FakeStreamQueryStore_22(
+        returnValueForMissingStub: _FakeStreamQueryStore_21(
           this,
           Invocation.getter(#streamQueries),
         ),
@@ -749,11 +857,11 @@ class MockTodoDb extends _i1.Mock implements _i3.TodoDb {
   @override
   _i2.DatabaseConnectionUser get resolvedEngine => (super.noSuchMethod(
         Invocation.getter(#resolvedEngine),
-        returnValue: _FakeDatabaseConnectionUser_23(
+        returnValue: _FakeDatabaseConnectionUser_22(
           this,
           Invocation.getter(#resolvedEngine),
         ),
-        returnValueForMissingStub: _FakeDatabaseConnectionUser_23(
+        returnValueForMissingStub: _FakeDatabaseConnectionUser_22(
           this,
           Invocation.getter(#resolvedEngine),
         ),
@@ -766,7 +874,7 @@ class MockTodoDb extends _i1.Mock implements _i3.TodoDb {
           #allTodosWithCategory,
           [],
         ),
-        returnValue: _FakeSelectable_24<_i3.AllTodosWithCategoryResult>(
+        returnValue: _FakeSelectable_23<_i3.AllTodosWithCategoryResult>(
           this,
           Invocation.method(
             #allTodosWithCategory,
@@ -774,7 +882,7 @@ class MockTodoDb extends _i1.Mock implements _i3.TodoDb {
           ),
         ),
         returnValueForMissingStub:
-            _FakeSelectable_24<_i3.AllTodosWithCategoryResult>(
+            _FakeSelectable_23<_i3.AllTodosWithCategoryResult>(
           this,
           Invocation.method(
             #allTodosWithCategory,
@@ -808,7 +916,7 @@ class MockTodoDb extends _i1.Mock implements _i3.TodoDb {
             var3,
           ],
         ),
-        returnValue: _FakeSelectable_24<_i3.TodoEntry>(
+        returnValue: _FakeSelectable_23<_i3.TodoEntry>(
           this,
           Invocation.method(
             #withIn,
@@ -819,7 +927,7 @@ class MockTodoDb extends _i1.Mock implements _i3.TodoDb {
             ],
           ),
         ),
-        returnValueForMissingStub: _FakeSelectable_24<_i3.TodoEntry>(
+        returnValueForMissingStub: _FakeSelectable_23<_i3.TodoEntry>(
           this,
           Invocation.method(
             #withIn,
@@ -840,7 +948,7 @@ class MockTodoDb extends _i1.Mock implements _i3.TodoDb {
           [],
           {#id: id},
         ),
-        returnValue: _FakeSelectable_24<_i3.TodoEntry>(
+        returnValue: _FakeSelectable_23<_i3.TodoEntry>(
           this,
           Invocation.method(
             #search,
@@ -848,7 +956,7 @@ class MockTodoDb extends _i1.Mock implements _i3.TodoDb {
             {#id: id},
           ),
         ),
-        returnValueForMissingStub: _FakeSelectable_24<_i3.TodoEntry>(
+        returnValueForMissingStub: _FakeSelectable_23<_i3.TodoEntry>(
           this,
           Invocation.method(
             #search,
@@ -864,14 +972,14 @@ class MockTodoDb extends _i1.Mock implements _i3.TodoDb {
           #findCustom,
           [],
         ),
-        returnValue: _FakeSelectable_24<_i3.MyCustomObject>(
+        returnValue: _FakeSelectable_23<_i3.MyCustomObject>(
           this,
           Invocation.method(
             #findCustom,
             [],
           ),
         ),
-        returnValueForMissingStub: _FakeSelectable_24<_i3.MyCustomObject>(
+        returnValueForMissingStub: _FakeSelectable_23<_i3.MyCustomObject>(
           this,
           Invocation.method(
             #findCustom,
@@ -886,14 +994,14 @@ class MockTodoDb extends _i1.Mock implements _i3.TodoDb {
           #createMigrator,
           [],
         ),
-        returnValue: _FakeMigrator_25(
+        returnValue: _FakeMigrator_24(
           this,
           Invocation.method(
             #createMigrator,
             [],
           ),
         ),
-        returnValueForMissingStub: _FakeMigrator_25(
+        returnValueForMissingStub: _FakeMigrator_24(
           this,
           Invocation.method(
             #createMigrator,
@@ -1025,7 +1133,7 @@ class MockTodoDb extends _i1.Mock implements _i3.TodoDb {
               ),
               (T v) => _i5.Future<T>.value(v),
             ) ??
-            _FakeFuture_26<T>(
+            _FakeFuture_25<T>(
               this,
               Invocation.method(
                 #doWhenOpened,
@@ -1042,7 +1150,7 @@ class MockTodoDb extends _i1.Mock implements _i3.TodoDb {
               ),
               (T v) => _i5.Future<T>.value(v),
             ) ??
-            _FakeFuture_26<T>(
+            _FakeFuture_25<T>(
               this,
               Invocation.method(
                 #doWhenOpened,
@@ -1059,14 +1167,14 @@ class MockTodoDb extends _i1.Mock implements _i3.TodoDb {
           #into,
           [table],
         ),
-        returnValue: _FakeInsertStatement_27<T, D>(
+        returnValue: _FakeInsertStatement_26<T, D>(
           this,
           Invocation.method(
             #into,
             [table],
           ),
         ),
-        returnValueForMissingStub: _FakeInsertStatement_27<T, D>(
+        returnValueForMissingStub: _FakeInsertStatement_26<T, D>(
           this,
           Invocation.method(
             #into,
@@ -1083,14 +1191,14 @@ class MockTodoDb extends _i1.Mock implements _i3.TodoDb {
           #update,
           [table],
         ),
-        returnValue: _FakeUpdateStatement_28<Tbl, R>(
+        returnValue: _FakeUpdateStatement_27<Tbl, R>(
           this,
           Invocation.method(
             #update,
             [table],
           ),
         ),
-        returnValueForMissingStub: _FakeUpdateStatement_28<Tbl, R>(
+        returnValueForMissingStub: _FakeUpdateStatement_27<Tbl, R>(
           this,
           Invocation.method(
             #update,
@@ -1110,7 +1218,7 @@ class MockTodoDb extends _i1.Mock implements _i3.TodoDb {
           [table],
           {#distinct: distinct},
         ),
-        returnValue: _FakeSimpleSelectStatement_29<T, R>(
+        returnValue: _FakeSimpleSelectStatement_28<T, R>(
           this,
           Invocation.method(
             #select,
@@ -1118,7 +1226,7 @@ class MockTodoDb extends _i1.Mock implements _i3.TodoDb {
             {#distinct: distinct},
           ),
         ),
-        returnValueForMissingStub: _FakeSimpleSelectStatement_29<T, R>(
+        returnValueForMissingStub: _FakeSimpleSelectStatement_28<T, R>(
           this,
           Invocation.method(
             #select,
@@ -1139,7 +1247,7 @@ class MockTodoDb extends _i1.Mock implements _i3.TodoDb {
           [table],
           {#distinct: distinct},
         ),
-        returnValue: _FakeJoinedSelectStatement_30<T, R>(
+        returnValue: _FakeJoinedSelectStatement_29<T, R>(
           this,
           Invocation.method(
             #selectOnly,
@@ -1147,7 +1255,7 @@ class MockTodoDb extends _i1.Mock implements _i3.TodoDb {
             {#distinct: distinct},
           ),
         ),
-        returnValueForMissingStub: _FakeJoinedSelectStatement_30<T, R>(
+        returnValueForMissingStub: _FakeJoinedSelectStatement_29<T, R>(
           this,
           Invocation.method(
             #selectOnly,
@@ -1165,14 +1273,14 @@ class MockTodoDb extends _i1.Mock implements _i3.TodoDb {
           #selectExpressions,
           [columns],
         ),
-        returnValue: _FakeSelectable_24<_i2.TypedResult>(
+        returnValue: _FakeSelectable_23<_i2.TypedResult>(
           this,
           Invocation.method(
             #selectExpressions,
             [columns],
           ),
         ),
-        returnValueForMissingStub: _FakeSelectable_24<_i2.TypedResult>(
+        returnValueForMissingStub: _FakeSelectable_23<_i2.TypedResult>(
           this,
           Invocation.method(
             #selectExpressions,
@@ -1189,14 +1297,14 @@ class MockTodoDb extends _i1.Mock implements _i3.TodoDb {
           #delete,
           [table],
         ),
-        returnValue: _FakeDeleteStatement_31<T, D>(
+        returnValue: _FakeDeleteStatement_30<T, D>(
           this,
           Invocation.method(
             #delete,
             [table],
           ),
         ),
-        returnValueForMissingStub: _FakeDeleteStatement_31<T, D>(
+        returnValueForMissingStub: _FakeDeleteStatement_30<T, D>(
           this,
           Invocation.method(
             #delete,
@@ -1282,7 +1390,7 @@ class MockTodoDb extends _i1.Mock implements _i3.TodoDb {
             #readsFrom: readsFrom,
           },
         ),
-        returnValue: _FakeSelectable_24<_i2.QueryRow>(
+        returnValue: _FakeSelectable_23<_i2.QueryRow>(
           this,
           Invocation.method(
             #customSelect,
@@ -1293,7 +1401,7 @@ class MockTodoDb extends _i1.Mock implements _i3.TodoDb {
             },
           ),
         ),
-        returnValueForMissingStub: _FakeSelectable_24<_i2.QueryRow>(
+        returnValueForMissingStub: _FakeSelectable_23<_i2.QueryRow>(
           this,
           Invocation.method(
             #customSelect,
@@ -1321,7 +1429,7 @@ class MockTodoDb extends _i1.Mock implements _i3.TodoDb {
             #readsFrom: readsFrom,
           },
         ),
-        returnValue: _FakeSelectable_24<_i2.QueryRow>(
+        returnValue: _FakeSelectable_23<_i2.QueryRow>(
           this,
           Invocation.method(
             #customSelectQuery,
@@ -1332,7 +1440,7 @@ class MockTodoDb extends _i1.Mock implements _i3.TodoDb {
             },
           ),
         ),
-        returnValueForMissingStub: _FakeSelectable_24<_i2.QueryRow>(
+        returnValueForMissingStub: _FakeSelectable_23<_i2.QueryRow>(
           this,
           Invocation.method(
             #customSelectQuery,
@@ -1384,7 +1492,7 @@ class MockTodoDb extends _i1.Mock implements _i3.TodoDb {
               ),
               (T v) => _i5.Future<T>.value(v),
             ) ??
-            _FakeFuture_26<T>(
+            _FakeFuture_25<T>(
               this,
               Invocation.method(
                 #transaction,
@@ -1403,7 +1511,7 @@ class MockTodoDb extends _i1.Mock implements _i3.TodoDb {
               ),
               (T v) => _i5.Future<T>.value(v),
             ) ??
-            _FakeFuture_26<T>(
+            _FakeFuture_25<T>(
               this,
               Invocation.method(
                 #transaction,
@@ -1430,7 +1538,7 @@ class MockTodoDb extends _i1.Mock implements _i3.TodoDb {
               ),
               (T v) => _i5.Future<T>.value(v),
             ) ??
-            _FakeFuture_26<T>(
+            _FakeFuture_25<T>(
               this,
               Invocation.method(
                 #exclusively,
@@ -1447,7 +1555,7 @@ class MockTodoDb extends _i1.Mock implements _i3.TodoDb {
               ),
               (T v) => _i5.Future<T>.value(v),
             ) ??
-            _FakeFuture_26<T>(
+            _FakeFuture_25<T>(
               this,
               Invocation.method(
                 #exclusively,
@@ -1482,7 +1590,7 @@ class MockTodoDb extends _i1.Mock implements _i3.TodoDb {
             #startIndex: startIndex,
           },
         ),
-        returnValue: _FakeGenerationContext_32(
+        returnValue: _FakeGenerationContext_31(
           this,
           Invocation.method(
             #$write,
@@ -1493,7 +1601,7 @@ class MockTodoDb extends _i1.Mock implements _i3.TodoDb {
             },
           ),
         ),
-        returnValueForMissingStub: _FakeGenerationContext_32(
+        returnValueForMissingStub: _FakeGenerationContext_31(
           this,
           Invocation.method(
             #$write,
@@ -1521,7 +1629,7 @@ class MockTodoDb extends _i1.Mock implements _i3.TodoDb {
           ],
           {#startIndex: startIndex},
         ),
-        returnValue: _FakeGenerationContext_32(
+        returnValue: _FakeGenerationContext_31(
           this,
           Invocation.method(
             #$writeInsertable,
@@ -1532,7 +1640,7 @@ class MockTodoDb extends _i1.Mock implements _i3.TodoDb {
             {#startIndex: startIndex},
           ),
         ),
-        returnValueForMissingStub: _FakeGenerationContext_32(
+        returnValueForMissingStub: _FakeGenerationContext_31(
           this,
           Invocation.method(
             #$writeInsertable,
@@ -1579,4 +1687,169 @@ class MockTodoDb extends _i1.Mock implements _i3.TodoDb {
           ),
         ),
       ) as String);
+}
+
+/// A class which mocks [$TodoDbManager].
+///
+/// See the documentation for Mockito's code generation for more information.
+class Mock$TodoDbManager extends _i1.Mock implements _i3.$TodoDbManager {
+  @override
+  _i3.$$CategoriesTableTableManager get categories => (super.noSuchMethod(
+        Invocation.getter(#categories),
+        returnValue: _Fake$$CategoriesTableTableManager_32(
+          this,
+          Invocation.getter(#categories),
+        ),
+        returnValueForMissingStub: _Fake$$CategoriesTableTableManager_32(
+          this,
+          Invocation.getter(#categories),
+        ),
+      ) as _i3.$$CategoriesTableTableManager);
+
+  @override
+  _i3.$$TodosTableTableTableManager get todosTable => (super.noSuchMethod(
+        Invocation.getter(#todosTable),
+        returnValue: _Fake$$TodosTableTableTableManager_33(
+          this,
+          Invocation.getter(#todosTable),
+        ),
+        returnValueForMissingStub: _Fake$$TodosTableTableTableManager_33(
+          this,
+          Invocation.getter(#todosTable),
+        ),
+      ) as _i3.$$TodosTableTableTableManager);
+
+  @override
+  _i3.$$UsersTableTableManager get users => (super.noSuchMethod(
+        Invocation.getter(#users),
+        returnValue: _Fake$$UsersTableTableManager_34(
+          this,
+          Invocation.getter(#users),
+        ),
+        returnValueForMissingStub: _Fake$$UsersTableTableManager_34(
+          this,
+          Invocation.getter(#users),
+        ),
+      ) as _i3.$$UsersTableTableManager);
+
+  @override
+  _i3.$$SharedTodosTableTableManager get sharedTodos => (super.noSuchMethod(
+        Invocation.getter(#sharedTodos),
+        returnValue: _Fake$$SharedTodosTableTableManager_35(
+          this,
+          Invocation.getter(#sharedTodos),
+        ),
+        returnValueForMissingStub: _Fake$$SharedTodosTableTableManager_35(
+          this,
+          Invocation.getter(#sharedTodos),
+        ),
+      ) as _i3.$$SharedTodosTableTableManager);
+
+  @override
+  _i3.$$TableWithoutPKTableTableManager get tableWithoutPK =>
+      (super.noSuchMethod(
+        Invocation.getter(#tableWithoutPK),
+        returnValue: _Fake$$TableWithoutPKTableTableManager_36(
+          this,
+          Invocation.getter(#tableWithoutPK),
+        ),
+        returnValueForMissingStub: _Fake$$TableWithoutPKTableTableManager_36(
+          this,
+          Invocation.getter(#tableWithoutPK),
+        ),
+      ) as _i3.$$TableWithoutPKTableTableManager);
+
+  @override
+  _i3.$$PureDefaultsTableTableManager get pureDefaults => (super.noSuchMethod(
+        Invocation.getter(#pureDefaults),
+        returnValue: _Fake$$PureDefaultsTableTableManager_37(
+          this,
+          Invocation.getter(#pureDefaults),
+        ),
+        returnValueForMissingStub: _Fake$$PureDefaultsTableTableManager_37(
+          this,
+          Invocation.getter(#pureDefaults),
+        ),
+      ) as _i3.$$PureDefaultsTableTableManager);
+
+  @override
+  _i3.$$WithCustomTypeTableTableManager get withCustomType =>
+      (super.noSuchMethod(
+        Invocation.getter(#withCustomType),
+        returnValue: _Fake$$WithCustomTypeTableTableManager_38(
+          this,
+          Invocation.getter(#withCustomType),
+        ),
+        returnValueForMissingStub: _Fake$$WithCustomTypeTableTableManager_38(
+          this,
+          Invocation.getter(#withCustomType),
+        ),
+      ) as _i3.$$WithCustomTypeTableTableManager);
+
+  @override
+  _i3.$$TableWithEveryColumnTypeTableTableManager
+      get tableWithEveryColumnType => (super.noSuchMethod(
+            Invocation.getter(#tableWithEveryColumnType),
+            returnValue: _Fake$$TableWithEveryColumnTypeTableTableManager_39(
+              this,
+              Invocation.getter(#tableWithEveryColumnType),
+            ),
+            returnValueForMissingStub:
+                _Fake$$TableWithEveryColumnTypeTableTableManager_39(
+              this,
+              Invocation.getter(#tableWithEveryColumnType),
+            ),
+          ) as _i3.$$TableWithEveryColumnTypeTableTableManager);
+
+  @override
+  _i3.$$DepartmentTableTableManager get department => (super.noSuchMethod(
+        Invocation.getter(#department),
+        returnValue: _Fake$$DepartmentTableTableManager_40(
+          this,
+          Invocation.getter(#department),
+        ),
+        returnValueForMissingStub: _Fake$$DepartmentTableTableManager_40(
+          this,
+          Invocation.getter(#department),
+        ),
+      ) as _i3.$$DepartmentTableTableManager);
+
+  @override
+  _i3.$$ProductTableTableManager get product => (super.noSuchMethod(
+        Invocation.getter(#product),
+        returnValue: _Fake$$ProductTableTableManager_41(
+          this,
+          Invocation.getter(#product),
+        ),
+        returnValueForMissingStub: _Fake$$ProductTableTableManager_41(
+          this,
+          Invocation.getter(#product),
+        ),
+      ) as _i3.$$ProductTableTableManager);
+
+  @override
+  _i3.$$StoreTableTableManager get store => (super.noSuchMethod(
+        Invocation.getter(#store),
+        returnValue: _Fake$$StoreTableTableManager_42(
+          this,
+          Invocation.getter(#store),
+        ),
+        returnValueForMissingStub: _Fake$$StoreTableTableManager_42(
+          this,
+          Invocation.getter(#store),
+        ),
+      ) as _i3.$$StoreTableTableManager);
+
+  @override
+  _i3.$$ListingTableTableManager get listing => (super.noSuchMethod(
+        Invocation.getter(#listing),
+        returnValue: _Fake$$ListingTableTableManager_43(
+          this,
+          Invocation.getter(#listing),
+        ),
+        returnValueForMissingStub: _Fake$$ListingTableTableManager_43(
+          this,
+          Invocation.getter(#listing),
+        ),
+      ) as _i3.$$ListingTableTableManager);
 }

--- a/drift/test/generated/todos.mocks.dart
+++ b/drift/test/generated/todos.mocks.dart
@@ -1689,10 +1689,10 @@ class MockTodoDb extends _i1.Mock implements _i3.TodoDb {
       ) as String);
 }
 
-/// A class which mocks [$TodoDbManager].
+/// A class which mocks [TodoDbManager].
 ///
 /// See the documentation for Mockito's code generation for more information.
-class Mock$TodoDbManager extends _i1.Mock implements _i3.$TodoDbManager {
+class MockTodoDbManager extends _i1.Mock implements _i3.TodoDbManager {
   @override
   _i3.$$CategoriesTableTableManager get categories => (super.noSuchMethod(
         Invocation.getter(#categories),

--- a/drift/test/integration_tests/regress_2166_test.g.dart
+++ b/drift/test/integration_tests/regress_2166_test.g.dart
@@ -191,7 +191,6 @@ class _SomeTableCompanion extends UpdateCompanion<_SomeTableData> {
 
 abstract class _$_SomeDb extends GeneratedDatabase {
   _$_SomeDb(QueryExecutor e) : super(e);
-  $_SomeDbManager get managers => $_SomeDbManager(this);
   late final $_SomeTableTable someTable = $_SomeTableTable(this);
   @override
   Iterable<TableInfo<Table, Object?>> get allTables =>
@@ -326,4 +325,8 @@ class $_SomeDbManager {
   $_SomeDbManager(this._db);
   $$_SomeTableTableTableManager get someTable =>
       $$_SomeTableTableTableManager(_db, _db.someTable);
+}
+
+extension $_SomeDbManagerExt on _$_SomeDb {
+  $_SomeDbManager get managers => $_SomeDbManager(this);
 }

--- a/drift/test/integration_tests/regress_2166_test.g.dart
+++ b/drift/test/integration_tests/regress_2166_test.g.dart
@@ -209,7 +209,7 @@ typedef $$_SomeTableTableUpdateCompanionBuilder = _SomeTableCompanion Function({
 });
 
 class $$_SomeTableTableFilterComposer
-    extends Composer<_$_SomeDb, $_SomeTableTable> {
+    extends Composer<_SomeDb, $_SomeTableTable> {
   $$_SomeTableTableFilterComposer({
     required super.$db,
     required super.$table,
@@ -225,7 +225,7 @@ class $$_SomeTableTableFilterComposer
 }
 
 class $$_SomeTableTableOrderingComposer
-    extends Composer<_$_SomeDb, $_SomeTableTable> {
+    extends Composer<_SomeDb, $_SomeTableTable> {
   $$_SomeTableTableOrderingComposer({
     required super.$db,
     required super.$table,
@@ -241,7 +241,7 @@ class $$_SomeTableTableOrderingComposer
 }
 
 class $$_SomeTableTableAnnotationComposer
-    extends Composer<_$_SomeDb, $_SomeTableTable> {
+    extends Composer<_SomeDb, $_SomeTableTable> {
   $$_SomeTableTableAnnotationComposer({
     required super.$db,
     required super.$table,
@@ -257,7 +257,7 @@ class $$_SomeTableTableAnnotationComposer
 }
 
 class $$_SomeTableTableTableManager extends RootTableManager<
-    _$_SomeDb,
+    _SomeDb,
     $_SomeTableTable,
     _SomeTableData,
     $$_SomeTableTableFilterComposer,
@@ -265,13 +265,10 @@ class $$_SomeTableTableTableManager extends RootTableManager<
     $$_SomeTableTableAnnotationComposer,
     $$_SomeTableTableCreateCompanionBuilder,
     $$_SomeTableTableUpdateCompanionBuilder,
-    (
-      _SomeTableData,
-      BaseReferences<_$_SomeDb, $_SomeTableTable, _SomeTableData>
-    ),
+    (_SomeTableData, BaseReferences<_SomeDb, $_SomeTableTable, _SomeTableData>),
     _SomeTableData,
     PrefetchHooks Function()> {
-  $$_SomeTableTableTableManager(_$_SomeDb db, $_SomeTableTable table)
+  $$_SomeTableTableTableManager(_SomeDb db, $_SomeTableTable table)
       : super(TableManagerState(
           db: db,
           table: table,
@@ -305,7 +302,7 @@ class $$_SomeTableTableTableManager extends RootTableManager<
 }
 
 typedef $$_SomeTableTableProcessedTableManager = ProcessedTableManager<
-    _$_SomeDb,
+    _SomeDb,
     $_SomeTableTable,
     _SomeTableData,
     $$_SomeTableTableFilterComposer,
@@ -313,20 +310,17 @@ typedef $$_SomeTableTableProcessedTableManager = ProcessedTableManager<
     $$_SomeTableTableAnnotationComposer,
     $$_SomeTableTableCreateCompanionBuilder,
     $$_SomeTableTableUpdateCompanionBuilder,
-    (
-      _SomeTableData,
-      BaseReferences<_$_SomeDb, $_SomeTableTable, _SomeTableData>
-    ),
+    (_SomeTableData, BaseReferences<_SomeDb, $_SomeTableTable, _SomeTableData>),
     _SomeTableData,
     PrefetchHooks Function()>;
 
-class $_SomeDbManager {
-  final _$_SomeDb _db;
-  $_SomeDbManager(this._db);
+class SomeDbManager {
+  final _SomeDb _db;
+  SomeDbManager(this._db);
   $$_SomeTableTableTableManager get someTable =>
       $$_SomeTableTableTableManager(_db, _db.someTable);
 }
 
-extension $_SomeDbManagerExt on _$_SomeDb {
-  $_SomeDbManager get managers => $_SomeDbManager(this);
+extension SomeDbManagerExt on _SomeDb {
+  SomeDbManager get managers => SomeDbManager(this);
 }

--- a/drift_dev/lib/src/writer/database_writer.dart
+++ b/drift_dev/lib/src/writer/database_writer.dart
@@ -151,7 +151,12 @@ class DatabaseWriter {
     // Write the main database manager and, if we're doing a monolithic build,
     // the manager classes for involved tables.
     if (scope.options.generateManager) {
-      final managerWriter = DatabaseManagerWriter(scope.child(), dbClassName);
+      // Managers try to use the public database class. If we're generating a
+      // public class (e.g. not for schema generation), we use the users class
+      // in the manager. Otherwise, we use the generated class.
+      final managerDbClassName = isAbstract ? className : db.id.name;
+      final managerWriter =
+          DatabaseManagerWriter(scope.child(), managerDbClassName);
       for (var table in elements.whereType<DriftTable>()) {
         managerWriter.addTable(table);
       }
@@ -162,7 +167,6 @@ class DatabaseWriter {
       // Write main class for managers and reference it in a getter from the
       // database class.
       managerWriter.writeDatabaseManager();
-      firstLeaf.writeln(managerWriter.databaseManagerGetter);
     }
 
     // Write implementation for query methods

--- a/drift_dev/lib/src/writer/database_writer.dart
+++ b/drift_dev/lib/src/writer/database_writer.dart
@@ -154,7 +154,8 @@ class DatabaseWriter {
       // Managers try to use the public database class. If we're generating a
       // public class (e.g. not for schema generation), we use the users class
       // in the manager. Otherwise, we use the generated class.
-      final managerDbClassName = isAbstract ? className : db.id.name;
+      final managerDbClassName =
+          className.startsWith("_") ? db.id.name : className;
       final managerWriter =
           DatabaseManagerWriter(scope.child(), managerDbClassName);
       for (var table in elements.whereType<DriftTable>()) {

--- a/drift_dev/lib/src/writer/manager/database_manager_writer.dart
+++ b/drift_dev/lib/src/writer/manager/database_manager_writer.dart
@@ -8,6 +8,7 @@ part 'table_manager_writer.dart';
 
 class DatabaseManagerWriter {
   final Scope _scope;
+  // The original name of the database class without any the `_$` prefixes
   final String _dbClassName;
   final List<DriftTable> _addedTables;
 
@@ -41,12 +42,6 @@ class DatabaseManagerWriter {
     }
   }
 
-  /// The code for the database manager getter which will be added to the main database class
-  ///
-  /// E.g. `AppDatabase get managers => AppDatabaseManager(this);`
-  String get databaseManagerGetter =>
-      '${_templates.databaseManagerName(_dbClassName)} get managers => ${_templates.databaseManagerName(_dbClassName)}(this);';
-
   /// Write the database manager class
   void writeDatabaseManager() {
     final leaf = _scope.leaf();
@@ -67,5 +62,14 @@ class DatabaseManagerWriter {
           '$rootTableManagerClass get ${table.dbGetterName} => $rootTableManagerClass(_db, _db.${table.dbGetterName});');
     }
     leaf.writeln('}');
+
+    // Write the extension for the database class
+    if (!_scope.generationOptions.isModular) {
+      leaf.write("""
+extension ${_templates.databaseManagerName(_dbClassName)}Ext on $_dbClassName {
+  ${_templates.databaseManagerName(_dbClassName)} get managers => ${_templates.databaseManagerName(_dbClassName)}(this);
+}
+""");
+    }
   }
 }

--- a/drift_flutter/example/main.g.dart
+++ b/drift_flutter/example/main.g.dart
@@ -189,7 +189,6 @@ class ExampleTableCompanion extends UpdateCompanion<ExampleTableData> {
 
 abstract class _$ExampleDatabase extends GeneratedDatabase {
   _$ExampleDatabase(QueryExecutor e) : super(e);
-  $ExampleDatabaseManager get managers => $ExampleDatabaseManager(this);
   late final $ExampleTableTable exampleTable = $ExampleTableTable(this);
   @override
   Iterable<TableInfo<Table, Object?>> get allTables =>
@@ -327,4 +326,8 @@ class $ExampleDatabaseManager {
   $ExampleDatabaseManager(this._db);
   $$ExampleTableTableTableManager get exampleTable =>
       $$ExampleTableTableTableManager(_db, _db.exampleTable);
+}
+
+extension $ExampleDatabaseManagerExt on _$ExampleDatabase {
+  $ExampleDatabaseManager get managers => $ExampleDatabaseManager(this);
 }

--- a/drift_flutter/example/main.g.dart
+++ b/drift_flutter/example/main.g.dart
@@ -209,7 +209,7 @@ typedef $$ExampleTableTableUpdateCompanionBuilder = ExampleTableCompanion
 });
 
 class $$ExampleTableTableFilterComposer
-    extends Composer<_$ExampleDatabase, $ExampleTableTable> {
+    extends Composer<ExampleDatabase, $ExampleTableTable> {
   $$ExampleTableTableFilterComposer({
     required super.$db,
     required super.$table,
@@ -225,7 +225,7 @@ class $$ExampleTableTableFilterComposer
 }
 
 class $$ExampleTableTableOrderingComposer
-    extends Composer<_$ExampleDatabase, $ExampleTableTable> {
+    extends Composer<ExampleDatabase, $ExampleTableTable> {
   $$ExampleTableTableOrderingComposer({
     required super.$db,
     required super.$table,
@@ -241,7 +241,7 @@ class $$ExampleTableTableOrderingComposer
 }
 
 class $$ExampleTableTableAnnotationComposer
-    extends Composer<_$ExampleDatabase, $ExampleTableTable> {
+    extends Composer<ExampleDatabase, $ExampleTableTable> {
   $$ExampleTableTableAnnotationComposer({
     required super.$db,
     required super.$table,
@@ -257,7 +257,7 @@ class $$ExampleTableTableAnnotationComposer
 }
 
 class $$ExampleTableTableTableManager extends RootTableManager<
-    _$ExampleDatabase,
+    ExampleDatabase,
     $ExampleTableTable,
     ExampleTableData,
     $$ExampleTableTableFilterComposer,
@@ -267,12 +267,11 @@ class $$ExampleTableTableTableManager extends RootTableManager<
     $$ExampleTableTableUpdateCompanionBuilder,
     (
       ExampleTableData,
-      BaseReferences<_$ExampleDatabase, $ExampleTableTable, ExampleTableData>
+      BaseReferences<ExampleDatabase, $ExampleTableTable, ExampleTableData>
     ),
     ExampleTableData,
     PrefetchHooks Function()> {
-  $$ExampleTableTableTableManager(
-      _$ExampleDatabase db, $ExampleTableTable table)
+  $$ExampleTableTableTableManager(ExampleDatabase db, $ExampleTableTable table)
       : super(TableManagerState(
           db: db,
           table: table,
@@ -306,7 +305,7 @@ class $$ExampleTableTableTableManager extends RootTableManager<
 }
 
 typedef $$ExampleTableTableProcessedTableManager = ProcessedTableManager<
-    _$ExampleDatabase,
+    ExampleDatabase,
     $ExampleTableTable,
     ExampleTableData,
     $$ExampleTableTableFilterComposer,
@@ -316,18 +315,18 @@ typedef $$ExampleTableTableProcessedTableManager = ProcessedTableManager<
     $$ExampleTableTableUpdateCompanionBuilder,
     (
       ExampleTableData,
-      BaseReferences<_$ExampleDatabase, $ExampleTableTable, ExampleTableData>
+      BaseReferences<ExampleDatabase, $ExampleTableTable, ExampleTableData>
     ),
     ExampleTableData,
     PrefetchHooks Function()>;
 
-class $ExampleDatabaseManager {
-  final _$ExampleDatabase _db;
-  $ExampleDatabaseManager(this._db);
+class ExampleDatabaseManager {
+  final ExampleDatabase _db;
+  ExampleDatabaseManager(this._db);
   $$ExampleTableTableTableManager get exampleTable =>
       $$ExampleTableTableTableManager(_db, _db.exampleTable);
 }
 
-extension $ExampleDatabaseManagerExt on _$ExampleDatabase {
-  $ExampleDatabaseManager get managers => $ExampleDatabaseManager(this);
+extension ExampleDatabaseManagerExt on ExampleDatabase {
+  ExampleDatabaseManager get managers => ExampleDatabaseManager(this);
 }

--- a/examples/app/lib/database/database.g.dart
+++ b/examples/app/lib/database/database.g.dart
@@ -659,7 +659,6 @@ class TextEntriesCompanion extends UpdateCompanion<TextEntry> {
 
 abstract class _$AppDatabase extends GeneratedDatabase {
   _$AppDatabase(QueryExecutor e) : super(e);
-  $AppDatabaseManager get managers => $AppDatabaseManager(this);
   late final $CategoriesTable categories = $CategoriesTable(this);
   late final $TodoEntriesTable todoEntries = $TodoEntriesTable(this);
   late final TextEntries textEntries = TextEntries(this);
@@ -1329,6 +1328,10 @@ class $AppDatabaseManager {
       $$TodoEntriesTableTableManager(_db, _db.todoEntries);
   $TextEntriesTableManager get textEntries =>
       $TextEntriesTableManager(_db, _db.textEntries);
+}
+
+extension $AppDatabaseManagerExt on _$AppDatabase {
+  $AppDatabaseManager get managers => $AppDatabaseManager(this);
 }
 
 class CategoriesWithCountResult {

--- a/examples/app/lib/database/database.g.dart
+++ b/examples/app/lib/database/database.g.dart
@@ -755,11 +755,11 @@ typedef $$CategoriesTableUpdateCompanionBuilder = CategoriesCompanion Function({
 });
 
 final class $$CategoriesTableReferences
-    extends BaseReferences<_$AppDatabase, $CategoriesTable, Category> {
+    extends BaseReferences<AppDatabase, $CategoriesTable, Category> {
   $$CategoriesTableReferences(super.$_db, super.$_table, super.$_typedResult);
 
   static MultiTypedResultKey<$TodoEntriesTable, List<TodoEntry>>
-      _todoEntriesRefsTable(_$AppDatabase db) => MultiTypedResultKey.fromTable(
+      _todoEntriesRefsTable(AppDatabase db) => MultiTypedResultKey.fromTable(
           db.todoEntries,
           aliasName:
               $_aliasNameGenerator(db.categories.id, db.todoEntries.category));
@@ -775,7 +775,7 @@ final class $$CategoriesTableReferences
 }
 
 class $$CategoriesTableFilterComposer
-    extends Composer<_$AppDatabase, $CategoriesTable> {
+    extends Composer<AppDatabase, $CategoriesTable> {
   $$CategoriesTableFilterComposer({
     required super.$db,
     required super.$table,
@@ -817,7 +817,7 @@ class $$CategoriesTableFilterComposer
 }
 
 class $$CategoriesTableOrderingComposer
-    extends Composer<_$AppDatabase, $CategoriesTable> {
+    extends Composer<AppDatabase, $CategoriesTable> {
   $$CategoriesTableOrderingComposer({
     required super.$db,
     required super.$table,
@@ -836,7 +836,7 @@ class $$CategoriesTableOrderingComposer
 }
 
 class $$CategoriesTableAnnotationComposer
-    extends Composer<_$AppDatabase, $CategoriesTable> {
+    extends Composer<AppDatabase, $CategoriesTable> {
   $$CategoriesTableAnnotationComposer({
     required super.$db,
     required super.$table,
@@ -876,7 +876,7 @@ class $$CategoriesTableAnnotationComposer
 }
 
 class $$CategoriesTableTableManager extends RootTableManager<
-    _$AppDatabase,
+    AppDatabase,
     $CategoriesTable,
     Category,
     $$CategoriesTableFilterComposer,
@@ -887,7 +887,7 @@ class $$CategoriesTableTableManager extends RootTableManager<
     (Category, $$CategoriesTableReferences),
     Category,
     PrefetchHooks Function({bool todoEntriesRefs})> {
-  $$CategoriesTableTableManager(_$AppDatabase db, $CategoriesTable table)
+  $$CategoriesTableTableManager(AppDatabase db, $CategoriesTable table)
       : super(TableManagerState(
           db: db,
           table: table,
@@ -950,7 +950,7 @@ class $$CategoriesTableTableManager extends RootTableManager<
 }
 
 typedef $$CategoriesTableProcessedTableManager = ProcessedTableManager<
-    _$AppDatabase,
+    AppDatabase,
     $CategoriesTable,
     Category,
     $$CategoriesTableFilterComposer,
@@ -977,10 +977,10 @@ typedef $$TodoEntriesTableUpdateCompanionBuilder = TodoEntriesCompanion
 });
 
 final class $$TodoEntriesTableReferences
-    extends BaseReferences<_$AppDatabase, $TodoEntriesTable, TodoEntry> {
+    extends BaseReferences<AppDatabase, $TodoEntriesTable, TodoEntry> {
   $$TodoEntriesTableReferences(super.$_db, super.$_table, super.$_typedResult);
 
-  static $CategoriesTable _categoryTable(_$AppDatabase db) =>
+  static $CategoriesTable _categoryTable(AppDatabase db) =>
       db.categories.createAlias(
           $_aliasNameGenerator(db.todoEntries.category, db.categories.id));
 
@@ -996,7 +996,7 @@ final class $$TodoEntriesTableReferences
 }
 
 class $$TodoEntriesTableFilterComposer
-    extends Composer<_$AppDatabase, $TodoEntriesTable> {
+    extends Composer<AppDatabase, $TodoEntriesTable> {
   $$TodoEntriesTableFilterComposer({
     required super.$db,
     required super.$table,
@@ -1035,7 +1035,7 @@ class $$TodoEntriesTableFilterComposer
 }
 
 class $$TodoEntriesTableOrderingComposer
-    extends Composer<_$AppDatabase, $TodoEntriesTable> {
+    extends Composer<AppDatabase, $TodoEntriesTable> {
   $$TodoEntriesTableOrderingComposer({
     required super.$db,
     required super.$table,
@@ -1074,7 +1074,7 @@ class $$TodoEntriesTableOrderingComposer
 }
 
 class $$TodoEntriesTableAnnotationComposer
-    extends Composer<_$AppDatabase, $TodoEntriesTable> {
+    extends Composer<AppDatabase, $TodoEntriesTable> {
   $$TodoEntriesTableAnnotationComposer({
     required super.$db,
     required super.$table,
@@ -1113,7 +1113,7 @@ class $$TodoEntriesTableAnnotationComposer
 }
 
 class $$TodoEntriesTableTableManager extends RootTableManager<
-    _$AppDatabase,
+    AppDatabase,
     $TodoEntriesTable,
     TodoEntry,
     $$TodoEntriesTableFilterComposer,
@@ -1124,7 +1124,7 @@ class $$TodoEntriesTableTableManager extends RootTableManager<
     (TodoEntry, $$TodoEntriesTableReferences),
     TodoEntry,
     PrefetchHooks Function({bool category})> {
-  $$TodoEntriesTableTableManager(_$AppDatabase db, $TodoEntriesTable table)
+  $$TodoEntriesTableTableManager(AppDatabase db, $TodoEntriesTable table)
       : super(TableManagerState(
           db: db,
           table: table,
@@ -1203,7 +1203,7 @@ class $$TodoEntriesTableTableManager extends RootTableManager<
 }
 
 typedef $$TodoEntriesTableProcessedTableManager = ProcessedTableManager<
-    _$AppDatabase,
+    AppDatabase,
     $TodoEntriesTable,
     TodoEntry,
     $$TodoEntriesTableFilterComposer,
@@ -1223,7 +1223,7 @@ typedef $TextEntriesUpdateCompanionBuilder = TextEntriesCompanion Function({
   Value<int> rowid,
 });
 
-class $TextEntriesFilterComposer extends Composer<_$AppDatabase, TextEntries> {
+class $TextEntriesFilterComposer extends Composer<AppDatabase, TextEntries> {
   $TextEntriesFilterComposer({
     required super.$db,
     required super.$table,
@@ -1235,8 +1235,7 @@ class $TextEntriesFilterComposer extends Composer<_$AppDatabase, TextEntries> {
       column: $table.description, builder: (column) => ColumnFilters(column));
 }
 
-class $TextEntriesOrderingComposer
-    extends Composer<_$AppDatabase, TextEntries> {
+class $TextEntriesOrderingComposer extends Composer<AppDatabase, TextEntries> {
   $TextEntriesOrderingComposer({
     required super.$db,
     required super.$table,
@@ -1249,7 +1248,7 @@ class $TextEntriesOrderingComposer
 }
 
 class $TextEntriesAnnotationComposer
-    extends Composer<_$AppDatabase, TextEntries> {
+    extends Composer<AppDatabase, TextEntries> {
   $TextEntriesAnnotationComposer({
     required super.$db,
     required super.$table,
@@ -1262,7 +1261,7 @@ class $TextEntriesAnnotationComposer
 }
 
 class $TextEntriesTableManager extends RootTableManager<
-    _$AppDatabase,
+    AppDatabase,
     TextEntries,
     TextEntry,
     $TextEntriesFilterComposer,
@@ -1270,10 +1269,10 @@ class $TextEntriesTableManager extends RootTableManager<
     $TextEntriesAnnotationComposer,
     $TextEntriesCreateCompanionBuilder,
     $TextEntriesUpdateCompanionBuilder,
-    (TextEntry, BaseReferences<_$AppDatabase, TextEntries, TextEntry>),
+    (TextEntry, BaseReferences<AppDatabase, TextEntries, TextEntry>),
     TextEntry,
     PrefetchHooks Function()> {
-  $TextEntriesTableManager(_$AppDatabase db, TextEntries table)
+  $TextEntriesTableManager(AppDatabase db, TextEntries table)
       : super(TableManagerState(
           db: db,
           table: table,
@@ -1307,7 +1306,7 @@ class $TextEntriesTableManager extends RootTableManager<
 }
 
 typedef $TextEntriesProcessedTableManager = ProcessedTableManager<
-    _$AppDatabase,
+    AppDatabase,
     TextEntries,
     TextEntry,
     $TextEntriesFilterComposer,
@@ -1315,13 +1314,13 @@ typedef $TextEntriesProcessedTableManager = ProcessedTableManager<
     $TextEntriesAnnotationComposer,
     $TextEntriesCreateCompanionBuilder,
     $TextEntriesUpdateCompanionBuilder,
-    (TextEntry, BaseReferences<_$AppDatabase, TextEntries, TextEntry>),
+    (TextEntry, BaseReferences<AppDatabase, TextEntries, TextEntry>),
     TextEntry,
     PrefetchHooks Function()>;
 
-class $AppDatabaseManager {
-  final _$AppDatabase _db;
-  $AppDatabaseManager(this._db);
+class AppDatabaseManager {
+  final AppDatabase _db;
+  AppDatabaseManager(this._db);
   $$CategoriesTableTableManager get categories =>
       $$CategoriesTableTableManager(_db, _db.categories);
   $$TodoEntriesTableTableManager get todoEntries =>
@@ -1330,8 +1329,8 @@ class $AppDatabaseManager {
       $TextEntriesTableManager(_db, _db.textEntries);
 }
 
-extension $AppDatabaseManagerExt on _$AppDatabase {
-  $AppDatabaseManager get managers => $AppDatabaseManager(this);
+extension AppDatabaseManagerExt on AppDatabase {
+  AppDatabaseManager get managers => AppDatabaseManager(this);
 }
 
 class CategoriesWithCountResult {

--- a/examples/encryption/lib/database.g.dart
+++ b/examples/encryption/lib/database.g.dart
@@ -200,7 +200,7 @@ typedef $$NotesTableUpdateCompanionBuilder = NotesCompanion Function({
 });
 
 class $$NotesTableFilterComposer
-    extends Composer<_$MyEncryptedDatabase, $NotesTable> {
+    extends Composer<MyEncryptedDatabase, $NotesTable> {
   $$NotesTableFilterComposer({
     required super.$db,
     required super.$table,
@@ -216,7 +216,7 @@ class $$NotesTableFilterComposer
 }
 
 class $$NotesTableOrderingComposer
-    extends Composer<_$MyEncryptedDatabase, $NotesTable> {
+    extends Composer<MyEncryptedDatabase, $NotesTable> {
   $$NotesTableOrderingComposer({
     required super.$db,
     required super.$table,
@@ -232,7 +232,7 @@ class $$NotesTableOrderingComposer
 }
 
 class $$NotesTableAnnotationComposer
-    extends Composer<_$MyEncryptedDatabase, $NotesTable> {
+    extends Composer<MyEncryptedDatabase, $NotesTable> {
   $$NotesTableAnnotationComposer({
     required super.$db,
     required super.$table,
@@ -248,7 +248,7 @@ class $$NotesTableAnnotationComposer
 }
 
 class $$NotesTableTableManager extends RootTableManager<
-    _$MyEncryptedDatabase,
+    MyEncryptedDatabase,
     $NotesTable,
     Note,
     $$NotesTableFilterComposer,
@@ -256,10 +256,10 @@ class $$NotesTableTableManager extends RootTableManager<
     $$NotesTableAnnotationComposer,
     $$NotesTableCreateCompanionBuilder,
     $$NotesTableUpdateCompanionBuilder,
-    (Note, BaseReferences<_$MyEncryptedDatabase, $NotesTable, Note>),
+    (Note, BaseReferences<MyEncryptedDatabase, $NotesTable, Note>),
     Note,
     PrefetchHooks Function()> {
-  $$NotesTableTableManager(_$MyEncryptedDatabase db, $NotesTable table)
+  $$NotesTableTableManager(MyEncryptedDatabase db, $NotesTable table)
       : super(TableManagerState(
           db: db,
           table: table,
@@ -293,7 +293,7 @@ class $$NotesTableTableManager extends RootTableManager<
 }
 
 typedef $$NotesTableProcessedTableManager = ProcessedTableManager<
-    _$MyEncryptedDatabase,
+    MyEncryptedDatabase,
     $NotesTable,
     Note,
     $$NotesTableFilterComposer,
@@ -301,17 +301,17 @@ typedef $$NotesTableProcessedTableManager = ProcessedTableManager<
     $$NotesTableAnnotationComposer,
     $$NotesTableCreateCompanionBuilder,
     $$NotesTableUpdateCompanionBuilder,
-    (Note, BaseReferences<_$MyEncryptedDatabase, $NotesTable, Note>),
+    (Note, BaseReferences<MyEncryptedDatabase, $NotesTable, Note>),
     Note,
     PrefetchHooks Function()>;
 
-class $MyEncryptedDatabaseManager {
-  final _$MyEncryptedDatabase _db;
-  $MyEncryptedDatabaseManager(this._db);
+class MyEncryptedDatabaseManager {
+  final MyEncryptedDatabase _db;
+  MyEncryptedDatabaseManager(this._db);
   $$NotesTableTableManager get notes =>
       $$NotesTableTableManager(_db, _db.notes);
 }
 
-extension $MyEncryptedDatabaseManagerExt on _$MyEncryptedDatabase {
-  $MyEncryptedDatabaseManager get managers => $MyEncryptedDatabaseManager(this);
+extension MyEncryptedDatabaseManagerExt on MyEncryptedDatabase {
+  MyEncryptedDatabaseManager get managers => MyEncryptedDatabaseManager(this);
 }

--- a/examples/encryption/lib/database.g.dart
+++ b/examples/encryption/lib/database.g.dart
@@ -182,7 +182,6 @@ class NotesCompanion extends UpdateCompanion<Note> {
 
 abstract class _$MyEncryptedDatabase extends GeneratedDatabase {
   _$MyEncryptedDatabase(QueryExecutor e) : super(e);
-  $MyEncryptedDatabaseManager get managers => $MyEncryptedDatabaseManager(this);
   late final $NotesTable notes = $NotesTable(this);
   @override
   Iterable<TableInfo<Table, Object?>> get allTables =>
@@ -311,4 +310,8 @@ class $MyEncryptedDatabaseManager {
   $MyEncryptedDatabaseManager(this._db);
   $$NotesTableTableManager get notes =>
       $$NotesTableTableManager(_db, _db.notes);
+}
+
+extension $MyEncryptedDatabaseManagerExt on _$MyEncryptedDatabase {
+  $MyEncryptedDatabaseManager get managers => $MyEncryptedDatabaseManager(this);
 }

--- a/examples/flutter_web_worker_example/lib/src/database/database.g.dart
+++ b/examples/flutter_web_worker_example/lib/src/database/database.g.dart
@@ -182,7 +182,6 @@ class EntriesCompanion extends UpdateCompanion<Entry> {
 
 abstract class _$MyDatabase extends GeneratedDatabase {
   _$MyDatabase(QueryExecutor e) : super(e);
-  $MyDatabaseManager get managers => $MyDatabaseManager(this);
   late final Entries entries = Entries(this);
   Selectable<Entry> allEntries() {
     return customSelect('SELECT * FROM entries', variables: [], readsFrom: {
@@ -330,4 +329,8 @@ class $MyDatabaseManager {
   final _$MyDatabase _db;
   $MyDatabaseManager(this._db);
   $EntriesTableManager get entries => $EntriesTableManager(_db, _db.entries);
+}
+
+extension $MyDatabaseManagerExt on _$MyDatabase {
+  $MyDatabaseManager get managers => $MyDatabaseManager(this);
 }

--- a/examples/flutter_web_worker_example/lib/src/database/database.g.dart
+++ b/examples/flutter_web_worker_example/lib/src/database/database.g.dart
@@ -222,7 +222,7 @@ typedef $EntriesUpdateCompanionBuilder = EntriesCompanion Function({
   Value<String> value,
 });
 
-class $EntriesFilterComposer extends Composer<_$MyDatabase, Entries> {
+class $EntriesFilterComposer extends Composer<MyDatabase, Entries> {
   $EntriesFilterComposer({
     required super.$db,
     required super.$table,
@@ -237,7 +237,7 @@ class $EntriesFilterComposer extends Composer<_$MyDatabase, Entries> {
       column: $table.value, builder: (column) => ColumnFilters(column));
 }
 
-class $EntriesOrderingComposer extends Composer<_$MyDatabase, Entries> {
+class $EntriesOrderingComposer extends Composer<MyDatabase, Entries> {
   $EntriesOrderingComposer({
     required super.$db,
     required super.$table,
@@ -252,7 +252,7 @@ class $EntriesOrderingComposer extends Composer<_$MyDatabase, Entries> {
       column: $table.value, builder: (column) => ColumnOrderings(column));
 }
 
-class $EntriesAnnotationComposer extends Composer<_$MyDatabase, Entries> {
+class $EntriesAnnotationComposer extends Composer<MyDatabase, Entries> {
   $EntriesAnnotationComposer({
     required super.$db,
     required super.$table,
@@ -268,7 +268,7 @@ class $EntriesAnnotationComposer extends Composer<_$MyDatabase, Entries> {
 }
 
 class $EntriesTableManager extends RootTableManager<
-    _$MyDatabase,
+    MyDatabase,
     Entries,
     Entry,
     $EntriesFilterComposer,
@@ -276,10 +276,10 @@ class $EntriesTableManager extends RootTableManager<
     $EntriesAnnotationComposer,
     $EntriesCreateCompanionBuilder,
     $EntriesUpdateCompanionBuilder,
-    (Entry, BaseReferences<_$MyDatabase, Entries, Entry>),
+    (Entry, BaseReferences<MyDatabase, Entries, Entry>),
     Entry,
     PrefetchHooks Function()> {
-  $EntriesTableManager(_$MyDatabase db, Entries table)
+  $EntriesTableManager(MyDatabase db, Entries table)
       : super(TableManagerState(
           db: db,
           table: table,
@@ -313,7 +313,7 @@ class $EntriesTableManager extends RootTableManager<
 }
 
 typedef $EntriesProcessedTableManager = ProcessedTableManager<
-    _$MyDatabase,
+    MyDatabase,
     Entries,
     Entry,
     $EntriesFilterComposer,
@@ -321,16 +321,16 @@ typedef $EntriesProcessedTableManager = ProcessedTableManager<
     $EntriesAnnotationComposer,
     $EntriesCreateCompanionBuilder,
     $EntriesUpdateCompanionBuilder,
-    (Entry, BaseReferences<_$MyDatabase, Entries, Entry>),
+    (Entry, BaseReferences<MyDatabase, Entries, Entry>),
     Entry,
     PrefetchHooks Function()>;
 
-class $MyDatabaseManager {
-  final _$MyDatabase _db;
-  $MyDatabaseManager(this._db);
+class MyDatabaseManager {
+  final MyDatabase _db;
+  MyDatabaseManager(this._db);
   $EntriesTableManager get entries => $EntriesTableManager(_db, _db.entries);
 }
 
-extension $MyDatabaseManagerExt on _$MyDatabase {
-  $MyDatabaseManager get managers => $MyDatabaseManager(this);
+extension MyDatabaseManagerExt on MyDatabase {
+  MyDatabaseManager get managers => MyDatabaseManager(this);
 }

--- a/examples/migrations_example/lib/database.g.dart
+++ b/examples/migrations_example/lib/database.g.dart
@@ -914,7 +914,6 @@ class GroupCount extends ViewInfo<GroupCount, GroupCountData>
 
 abstract class _$Database extends GeneratedDatabase {
   _$Database(QueryExecutor e) : super(e);
-  $DatabaseManager get managers => $DatabaseManager(this);
   late final $UsersTable users = $UsersTable(this);
   late final Groups groups = Groups(this);
   late final Notes notes = Notes(this);
@@ -1626,4 +1625,8 @@ class $DatabaseManager {
       $$UsersTableTableManager(_db, _db.users);
   $GroupsTableManager get groups => $GroupsTableManager(_db, _db.groups);
   $NotesTableManager get notes => $NotesTableManager(_db, _db.notes);
+}
+
+extension $DatabaseManagerExt on _$Database {
+  $DatabaseManager get managers => $DatabaseManager(this);
 }

--- a/examples/migrations_example/lib/database.g.dart
+++ b/examples/migrations_example/lib/database.g.dart
@@ -945,10 +945,10 @@ typedef $$UsersTableUpdateCompanionBuilder = UsersCompanion Function({
 });
 
 final class $$UsersTableReferences
-    extends BaseReferences<_$Database, $UsersTable, User> {
+    extends BaseReferences<Database, $UsersTable, User> {
   $$UsersTableReferences(super.$_db, super.$_table, super.$_typedResult);
 
-  static $UsersTable _nextUserTable(_$Database db) => db.users
+  static $UsersTable _nextUserTable(Database db) => db.users
       .createAlias($_aliasNameGenerator(db.users.nextUser, db.users.id));
 
   $$UsersTableProcessedTableManager? get nextUser {
@@ -962,7 +962,7 @@ final class $$UsersTableReferences
   }
 
   static MultiTypedResultKey<Groups, List<Group>> _groupsRefsTable(
-          _$Database db) =>
+          Database db) =>
       MultiTypedResultKey.fromTable(db.groups,
           aliasName: $_aliasNameGenerator(db.users.id, db.groups.owner));
 
@@ -976,7 +976,7 @@ final class $$UsersTableReferences
   }
 }
 
-class $$UsersTableFilterComposer extends Composer<_$Database, $UsersTable> {
+class $$UsersTableFilterComposer extends Composer<Database, $UsersTable> {
   $$UsersTableFilterComposer({
     required super.$db,
     required super.$table,
@@ -1035,7 +1035,7 @@ class $$UsersTableFilterComposer extends Composer<_$Database, $UsersTable> {
   }
 }
 
-class $$UsersTableOrderingComposer extends Composer<_$Database, $UsersTable> {
+class $$UsersTableOrderingComposer extends Composer<Database, $UsersTable> {
   $$UsersTableOrderingComposer({
     required super.$db,
     required super.$table,
@@ -1073,7 +1073,7 @@ class $$UsersTableOrderingComposer extends Composer<_$Database, $UsersTable> {
   }
 }
 
-class $$UsersTableAnnotationComposer extends Composer<_$Database, $UsersTable> {
+class $$UsersTableAnnotationComposer extends Composer<Database, $UsersTable> {
   $$UsersTableAnnotationComposer({
     required super.$db,
     required super.$table,
@@ -1133,7 +1133,7 @@ class $$UsersTableAnnotationComposer extends Composer<_$Database, $UsersTable> {
 }
 
 class $$UsersTableTableManager extends RootTableManager<
-    _$Database,
+    Database,
     $UsersTable,
     User,
     $$UsersTableFilterComposer,
@@ -1144,7 +1144,7 @@ class $$UsersTableTableManager extends RootTableManager<
     (User, $$UsersTableReferences),
     User,
     PrefetchHooks Function({bool nextUser, bool groupsRefs})> {
-  $$UsersTableTableManager(_$Database db, $UsersTable table)
+  $$UsersTableTableManager(Database db, $UsersTable table)
       : super(TableManagerState(
           db: db,
           table: table,
@@ -1232,7 +1232,7 @@ class $$UsersTableTableManager extends RootTableManager<
 }
 
 typedef $$UsersTableProcessedTableManager = ProcessedTableManager<
-    _$Database,
+    Database,
     $UsersTable,
     User,
     $$UsersTableFilterComposer,
@@ -1256,11 +1256,10 @@ typedef $GroupsUpdateCompanionBuilder = GroupsCompanion Function({
   Value<int> owner,
 });
 
-final class $GroupsReferences
-    extends BaseReferences<_$Database, Groups, Group> {
+final class $GroupsReferences extends BaseReferences<Database, Groups, Group> {
   $GroupsReferences(super.$_db, super.$_table, super.$_typedResult);
 
-  static $UsersTable _ownerTable(_$Database db) =>
+  static $UsersTable _ownerTable(Database db) =>
       db.users.createAlias($_aliasNameGenerator(db.groups.owner, db.users.id));
 
   $$UsersTableProcessedTableManager? get owner {
@@ -1274,7 +1273,7 @@ final class $GroupsReferences
   }
 }
 
-class $GroupsFilterComposer extends Composer<_$Database, Groups> {
+class $GroupsFilterComposer extends Composer<Database, Groups> {
   $GroupsFilterComposer({
     required super.$db,
     required super.$table,
@@ -1312,7 +1311,7 @@ class $GroupsFilterComposer extends Composer<_$Database, Groups> {
   }
 }
 
-class $GroupsOrderingComposer extends Composer<_$Database, Groups> {
+class $GroupsOrderingComposer extends Composer<Database, Groups> {
   $GroupsOrderingComposer({
     required super.$db,
     required super.$table,
@@ -1350,7 +1349,7 @@ class $GroupsOrderingComposer extends Composer<_$Database, Groups> {
   }
 }
 
-class $GroupsAnnotationComposer extends Composer<_$Database, Groups> {
+class $GroupsAnnotationComposer extends Composer<Database, Groups> {
   $GroupsAnnotationComposer({
     required super.$db,
     required super.$table,
@@ -1389,7 +1388,7 @@ class $GroupsAnnotationComposer extends Composer<_$Database, Groups> {
 }
 
 class $GroupsTableManager extends RootTableManager<
-    _$Database,
+    Database,
     Groups,
     Group,
     $GroupsFilterComposer,
@@ -1400,7 +1399,7 @@ class $GroupsTableManager extends RootTableManager<
     (Group, $GroupsReferences),
     Group,
     PrefetchHooks Function({bool owner})> {
-  $GroupsTableManager(_$Database db, Groups table)
+  $GroupsTableManager(Database db, Groups table)
       : super(TableManagerState(
           db: db,
           table: table,
@@ -1474,7 +1473,7 @@ class $GroupsTableManager extends RootTableManager<
 }
 
 typedef $GroupsProcessedTableManager = ProcessedTableManager<
-    _$Database,
+    Database,
     Groups,
     Group,
     $GroupsFilterComposer,
@@ -1498,7 +1497,7 @@ typedef $NotesUpdateCompanionBuilder = NotesCompanion Function({
   Value<int> rowid,
 });
 
-class $NotesFilterComposer extends Composer<_$Database, Notes> {
+class $NotesFilterComposer extends Composer<Database, Notes> {
   $NotesFilterComposer({
     required super.$db,
     required super.$table,
@@ -1516,7 +1515,7 @@ class $NotesFilterComposer extends Composer<_$Database, Notes> {
       column: $table.searchTerms, builder: (column) => ColumnFilters(column));
 }
 
-class $NotesOrderingComposer extends Composer<_$Database, Notes> {
+class $NotesOrderingComposer extends Composer<Database, Notes> {
   $NotesOrderingComposer({
     required super.$db,
     required super.$table,
@@ -1534,7 +1533,7 @@ class $NotesOrderingComposer extends Composer<_$Database, Notes> {
       column: $table.searchTerms, builder: (column) => ColumnOrderings(column));
 }
 
-class $NotesAnnotationComposer extends Composer<_$Database, Notes> {
+class $NotesAnnotationComposer extends Composer<Database, Notes> {
   $NotesAnnotationComposer({
     required super.$db,
     required super.$table,
@@ -1553,7 +1552,7 @@ class $NotesAnnotationComposer extends Composer<_$Database, Notes> {
 }
 
 class $NotesTableManager extends RootTableManager<
-    _$Database,
+    Database,
     Notes,
     Note,
     $NotesFilterComposer,
@@ -1561,10 +1560,10 @@ class $NotesTableManager extends RootTableManager<
     $NotesAnnotationComposer,
     $NotesCreateCompanionBuilder,
     $NotesUpdateCompanionBuilder,
-    (Note, BaseReferences<_$Database, Notes, Note>),
+    (Note, BaseReferences<Database, Notes, Note>),
     Note,
     PrefetchHooks Function()> {
-  $NotesTableManager(_$Database db, Notes table)
+  $NotesTableManager(Database db, Notes table)
       : super(TableManagerState(
           db: db,
           table: table,
@@ -1606,7 +1605,7 @@ class $NotesTableManager extends RootTableManager<
 }
 
 typedef $NotesProcessedTableManager = ProcessedTableManager<
-    _$Database,
+    Database,
     Notes,
     Note,
     $NotesFilterComposer,
@@ -1614,19 +1613,19 @@ typedef $NotesProcessedTableManager = ProcessedTableManager<
     $NotesAnnotationComposer,
     $NotesCreateCompanionBuilder,
     $NotesUpdateCompanionBuilder,
-    (Note, BaseReferences<_$Database, Notes, Note>),
+    (Note, BaseReferences<Database, Notes, Note>),
     Note,
     PrefetchHooks Function()>;
 
-class $DatabaseManager {
-  final _$Database _db;
-  $DatabaseManager(this._db);
+class DatabaseManager {
+  final Database _db;
+  DatabaseManager(this._db);
   $$UsersTableTableManager get users =>
       $$UsersTableTableManager(_db, _db.users);
   $GroupsTableManager get groups => $GroupsTableManager(_db, _db.groups);
   $NotesTableManager get notes => $NotesTableManager(_db, _db.notes);
 }
 
-extension $DatabaseManagerExt on _$Database {
-  $DatabaseManager get managers => $DatabaseManager(this);
+extension DatabaseManagerExt on Database {
+  DatabaseManager get managers => DatabaseManager(this);
 }

--- a/examples/modular/lib/database.drift.dart
+++ b/examples/modular/lib/database.drift.dart
@@ -11,7 +11,6 @@ import 'package:drift/internal/modular.dart' as i7;
 
 abstract class $Database extends i0.GeneratedDatabase {
   $Database(i0.QueryExecutor e) : super(e);
-  $DatabaseManager get managers => $DatabaseManager(this);
   late final i1.Users users = i1.Users(this);
   late final i2.Posts posts = i2.Posts(this);
   late final i3.SearchInPosts searchInPosts = i3.SearchInPosts(this);

--- a/examples/multi_package/client/lib/database.drift.dart
+++ b/examples/multi_package/client/lib/database.drift.dart
@@ -8,7 +8,6 @@ import 'package:drift/internal/modular.dart' as i4;
 
 abstract class $ClientDatabase extends i0.GeneratedDatabase {
   $ClientDatabase(i0.QueryExecutor e) : super(e);
-  $ClientDatabaseManager get managers => $ClientDatabaseManager(this);
   late final i1.$UsersTable users = i1.$UsersTable(this);
   late final i2.Posts posts = i2.Posts(this);
   i3.SharedDrift get sharedDrift => i4.ReadDatabaseContainer(this)

--- a/examples/multi_package/server/lib/database.drift.dart
+++ b/examples/multi_package/server/lib/database.drift.dart
@@ -201,7 +201,6 @@ typedef $$ActiveSessionsTableProcessedTableManager = i0.ProcessedTableManager<
 
 abstract class $ServerDatabase extends i0.GeneratedDatabase {
   $ServerDatabase(i0.QueryExecutor e) : super(e);
-  $ServerDatabaseManager get managers => $ServerDatabaseManager(this);
   late final i1.$UsersTable users = i1.$UsersTable(this);
   late final i2.Posts posts = i2.Posts(this);
   late final i3.$ActiveSessionsTable activeSessions =

--- a/examples/with_built_value/lib/database.drift.dart
+++ b/examples/with_built_value/lib/database.drift.dart
@@ -5,7 +5,6 @@ import 'package:with_built_value/tables.drift.dart' as i1;
 
 abstract class $Database extends i0.GeneratedDatabase {
   $Database(i0.QueryExecutor e) : super(e);
-  $DatabaseManager get managers => $DatabaseManager(this);
   late final i1.Users users = i1.Users(this);
   @override
   Iterable<i0.TableInfo<i0.Table, Object?>> get allTables =>

--- a/extras/drift_postgres/example/main.g.dart
+++ b/extras/drift_postgres/example/main.g.dart
@@ -210,7 +210,7 @@ typedef $$UsersTableUpdateCompanionBuilder = UsersCompanion Function({
 });
 
 class $$UsersTableFilterComposer
-    extends Composer<_$DriftPostgresDatabase, $UsersTable> {
+    extends Composer<DriftPostgresDatabase, $UsersTable> {
   $$UsersTableFilterComposer({
     required super.$db,
     required super.$table,
@@ -226,7 +226,7 @@ class $$UsersTableFilterComposer
 }
 
 class $$UsersTableOrderingComposer
-    extends Composer<_$DriftPostgresDatabase, $UsersTable> {
+    extends Composer<DriftPostgresDatabase, $UsersTable> {
   $$UsersTableOrderingComposer({
     required super.$db,
     required super.$table,
@@ -242,7 +242,7 @@ class $$UsersTableOrderingComposer
 }
 
 class $$UsersTableAnnotationComposer
-    extends Composer<_$DriftPostgresDatabase, $UsersTable> {
+    extends Composer<DriftPostgresDatabase, $UsersTable> {
   $$UsersTableAnnotationComposer({
     required super.$db,
     required super.$table,
@@ -258,7 +258,7 @@ class $$UsersTableAnnotationComposer
 }
 
 class $$UsersTableTableManager extends RootTableManager<
-    _$DriftPostgresDatabase,
+    DriftPostgresDatabase,
     $UsersTable,
     User,
     $$UsersTableFilterComposer,
@@ -266,10 +266,10 @@ class $$UsersTableTableManager extends RootTableManager<
     $$UsersTableAnnotationComposer,
     $$UsersTableCreateCompanionBuilder,
     $$UsersTableUpdateCompanionBuilder,
-    (User, BaseReferences<_$DriftPostgresDatabase, $UsersTable, User>),
+    (User, BaseReferences<DriftPostgresDatabase, $UsersTable, User>),
     User,
     PrefetchHooks Function()> {
-  $$UsersTableTableManager(_$DriftPostgresDatabase db, $UsersTable table)
+  $$UsersTableTableManager(DriftPostgresDatabase db, $UsersTable table)
       : super(TableManagerState(
           db: db,
           table: table,
@@ -307,7 +307,7 @@ class $$UsersTableTableManager extends RootTableManager<
 }
 
 typedef $$UsersTableProcessedTableManager = ProcessedTableManager<
-    _$DriftPostgresDatabase,
+    DriftPostgresDatabase,
     $UsersTable,
     User,
     $$UsersTableFilterComposer,
@@ -315,18 +315,18 @@ typedef $$UsersTableProcessedTableManager = ProcessedTableManager<
     $$UsersTableAnnotationComposer,
     $$UsersTableCreateCompanionBuilder,
     $$UsersTableUpdateCompanionBuilder,
-    (User, BaseReferences<_$DriftPostgresDatabase, $UsersTable, User>),
+    (User, BaseReferences<DriftPostgresDatabase, $UsersTable, User>),
     User,
     PrefetchHooks Function()>;
 
-class $DriftPostgresDatabaseManager {
-  final _$DriftPostgresDatabase _db;
-  $DriftPostgresDatabaseManager(this._db);
+class DriftPostgresDatabaseManager {
+  final DriftPostgresDatabase _db;
+  DriftPostgresDatabaseManager(this._db);
   $$UsersTableTableManager get users =>
       $$UsersTableTableManager(_db, _db.users);
 }
 
-extension $DriftPostgresDatabaseManagerExt on _$DriftPostgresDatabase {
-  $DriftPostgresDatabaseManager get managers =>
-      $DriftPostgresDatabaseManager(this);
+extension DriftPostgresDatabaseManagerExt on DriftPostgresDatabase {
+  DriftPostgresDatabaseManager get managers =>
+      DriftPostgresDatabaseManager(this);
 }

--- a/extras/drift_postgres/example/main.g.dart
+++ b/extras/drift_postgres/example/main.g.dart
@@ -190,8 +190,6 @@ class UsersCompanion extends UpdateCompanion<User> {
 
 abstract class _$DriftPostgresDatabase extends GeneratedDatabase {
   _$DriftPostgresDatabase(QueryExecutor e) : super(e);
-  $DriftPostgresDatabaseManager get managers =>
-      $DriftPostgresDatabaseManager(this);
   late final $UsersTable users = $UsersTable(this);
   @override
   Iterable<TableInfo<Table, Object?>> get allTables =>
@@ -326,4 +324,9 @@ class $DriftPostgresDatabaseManager {
   $DriftPostgresDatabaseManager(this._db);
   $$UsersTableTableManager get users =>
       $$UsersTableTableManager(_db, _db.users);
+}
+
+extension $DriftPostgresDatabaseManagerExt on _$DriftPostgresDatabase {
+  $DriftPostgresDatabaseManager get managers =>
+      $DriftPostgresDatabaseManager(this);
 }

--- a/extras/integration_tests/drift_testcases/lib/database/database.g.dart
+++ b/extras/integration_tests/drift_testcases/lib/database/database.g.dart
@@ -579,7 +579,6 @@ class FriendshipsCompanion extends UpdateCompanion<Friendship> {
 
 abstract class _$Database extends GeneratedDatabase {
   _$Database(QueryExecutor e) : super(e);
-  $DatabaseManager get managers => $DatabaseManager(this);
   late final $UsersTable users = $UsersTable(this);
   late final $FriendshipsTable friendships = $FriendshipsTable(this);
   Selectable<User> mostPopularUsers(int amount) {
@@ -1026,6 +1025,10 @@ class $DatabaseManager {
       $$UsersTableTableManager(_db, _db.users);
   $$FriendshipsTableTableManager get friendships =>
       $$FriendshipsTableTableManager(_db, _db.friendships);
+}
+
+extension $DatabaseManagerExt on _$Database {
+  $DatabaseManager get managers => $DatabaseManager(this);
 }
 
 class FriendshipsOfResult {

--- a/extras/integration_tests/drift_testcases/lib/database/database.g.dart
+++ b/extras/integration_tests/drift_testcases/lib/database/database.g.dart
@@ -732,7 +732,7 @@ typedef $$UsersTableUpdateCompanionBuilder = UsersCompanion Function({
   Value<Preferences?> preferences,
 });
 
-class $$UsersTableFilterComposer extends Composer<_$Database, $UsersTable> {
+class $$UsersTableFilterComposer extends Composer<Database, $UsersTable> {
   $$UsersTableFilterComposer({
     required super.$db,
     required super.$table,
@@ -759,7 +759,7 @@ class $$UsersTableFilterComposer extends Composer<_$Database, $UsersTable> {
           builder: (column) => ColumnWithTypeConverterFilters(column));
 }
 
-class $$UsersTableOrderingComposer extends Composer<_$Database, $UsersTable> {
+class $$UsersTableOrderingComposer extends Composer<Database, $UsersTable> {
   $$UsersTableOrderingComposer({
     required super.$db,
     required super.$table,
@@ -784,7 +784,7 @@ class $$UsersTableOrderingComposer extends Composer<_$Database, $UsersTable> {
       column: $table.preferences, builder: (column) => ColumnOrderings(column));
 }
 
-class $$UsersTableAnnotationComposer extends Composer<_$Database, $UsersTable> {
+class $$UsersTableAnnotationComposer extends Composer<Database, $UsersTable> {
   $$UsersTableAnnotationComposer({
     required super.$db,
     required super.$table,
@@ -810,7 +810,7 @@ class $$UsersTableAnnotationComposer extends Composer<_$Database, $UsersTable> {
 }
 
 class $$UsersTableTableManager extends RootTableManager<
-    _$Database,
+    Database,
     $UsersTable,
     User,
     $$UsersTableFilterComposer,
@@ -818,10 +818,10 @@ class $$UsersTableTableManager extends RootTableManager<
     $$UsersTableAnnotationComposer,
     $$UsersTableCreateCompanionBuilder,
     $$UsersTableUpdateCompanionBuilder,
-    (User, BaseReferences<_$Database, $UsersTable, User>),
+    (User, BaseReferences<Database, $UsersTable, User>),
     User,
     PrefetchHooks Function()> {
-  $$UsersTableTableManager(_$Database db, $UsersTable table)
+  $$UsersTableTableManager(Database db, $UsersTable table)
       : super(TableManagerState(
           db: db,
           table: table,
@@ -867,7 +867,7 @@ class $$UsersTableTableManager extends RootTableManager<
 }
 
 typedef $$UsersTableProcessedTableManager = ProcessedTableManager<
-    _$Database,
+    Database,
     $UsersTable,
     User,
     $$UsersTableFilterComposer,
@@ -875,7 +875,7 @@ typedef $$UsersTableProcessedTableManager = ProcessedTableManager<
     $$UsersTableAnnotationComposer,
     $$UsersTableCreateCompanionBuilder,
     $$UsersTableUpdateCompanionBuilder,
-    (User, BaseReferences<_$Database, $UsersTable, User>),
+    (User, BaseReferences<Database, $UsersTable, User>),
     User,
     PrefetchHooks Function()>;
 typedef $$FriendshipsTableCreateCompanionBuilder = FriendshipsCompanion
@@ -894,7 +894,7 @@ typedef $$FriendshipsTableUpdateCompanionBuilder = FriendshipsCompanion
 });
 
 class $$FriendshipsTableFilterComposer
-    extends Composer<_$Database, $FriendshipsTable> {
+    extends Composer<Database, $FriendshipsTable> {
   $$FriendshipsTableFilterComposer({
     required super.$db,
     required super.$table,
@@ -914,7 +914,7 @@ class $$FriendshipsTableFilterComposer
 }
 
 class $$FriendshipsTableOrderingComposer
-    extends Composer<_$Database, $FriendshipsTable> {
+    extends Composer<Database, $FriendshipsTable> {
   $$FriendshipsTableOrderingComposer({
     required super.$db,
     required super.$table,
@@ -934,7 +934,7 @@ class $$FriendshipsTableOrderingComposer
 }
 
 class $$FriendshipsTableAnnotationComposer
-    extends Composer<_$Database, $FriendshipsTable> {
+    extends Composer<Database, $FriendshipsTable> {
   $$FriendshipsTableAnnotationComposer({
     required super.$db,
     required super.$table,
@@ -953,7 +953,7 @@ class $$FriendshipsTableAnnotationComposer
 }
 
 class $$FriendshipsTableTableManager extends RootTableManager<
-    _$Database,
+    Database,
     $FriendshipsTable,
     Friendship,
     $$FriendshipsTableFilterComposer,
@@ -961,10 +961,10 @@ class $$FriendshipsTableTableManager extends RootTableManager<
     $$FriendshipsTableAnnotationComposer,
     $$FriendshipsTableCreateCompanionBuilder,
     $$FriendshipsTableUpdateCompanionBuilder,
-    (Friendship, BaseReferences<_$Database, $FriendshipsTable, Friendship>),
+    (Friendship, BaseReferences<Database, $FriendshipsTable, Friendship>),
     Friendship,
     PrefetchHooks Function()> {
-  $$FriendshipsTableTableManager(_$Database db, $FriendshipsTable table)
+  $$FriendshipsTableTableManager(Database db, $FriendshipsTable table)
       : super(TableManagerState(
           db: db,
           table: table,
@@ -1006,7 +1006,7 @@ class $$FriendshipsTableTableManager extends RootTableManager<
 }
 
 typedef $$FriendshipsTableProcessedTableManager = ProcessedTableManager<
-    _$Database,
+    Database,
     $FriendshipsTable,
     Friendship,
     $$FriendshipsTableFilterComposer,
@@ -1014,21 +1014,21 @@ typedef $$FriendshipsTableProcessedTableManager = ProcessedTableManager<
     $$FriendshipsTableAnnotationComposer,
     $$FriendshipsTableCreateCompanionBuilder,
     $$FriendshipsTableUpdateCompanionBuilder,
-    (Friendship, BaseReferences<_$Database, $FriendshipsTable, Friendship>),
+    (Friendship, BaseReferences<Database, $FriendshipsTable, Friendship>),
     Friendship,
     PrefetchHooks Function()>;
 
-class $DatabaseManager {
-  final _$Database _db;
-  $DatabaseManager(this._db);
+class DatabaseManager {
+  final Database _db;
+  DatabaseManager(this._db);
   $$UsersTableTableManager get users =>
       $$UsersTableTableManager(_db, _db.users);
   $$FriendshipsTableTableManager get friendships =>
       $$FriendshipsTableTableManager(_db, _db.friendships);
 }
 
-extension $DatabaseManagerExt on _$Database {
-  $DatabaseManager get managers => $DatabaseManager(this);
+extension DatabaseManagerExt on Database {
+  DatabaseManager get managers => DatabaseManager(this);
 }
 
 class FriendshipsOfResult {

--- a/extras/integration_tests/web_wasm/lib/src/database.g.dart
+++ b/extras/integration_tests/web_wasm/lib/src/database.g.dart
@@ -203,7 +203,7 @@ typedef $$TestTableTableUpdateCompanionBuilder = TestTableCompanion Function({
 });
 
 class $$TestTableTableFilterComposer
-    extends Composer<_$TestDatabase, $TestTableTable> {
+    extends Composer<TestDatabase, $TestTableTable> {
   $$TestTableTableFilterComposer({
     required super.$db,
     required super.$table,
@@ -219,7 +219,7 @@ class $$TestTableTableFilterComposer
 }
 
 class $$TestTableTableOrderingComposer
-    extends Composer<_$TestDatabase, $TestTableTable> {
+    extends Composer<TestDatabase, $TestTableTable> {
   $$TestTableTableOrderingComposer({
     required super.$db,
     required super.$table,
@@ -235,7 +235,7 @@ class $$TestTableTableOrderingComposer
 }
 
 class $$TestTableTableAnnotationComposer
-    extends Composer<_$TestDatabase, $TestTableTable> {
+    extends Composer<TestDatabase, $TestTableTable> {
   $$TestTableTableAnnotationComposer({
     required super.$db,
     required super.$table,
@@ -251,7 +251,7 @@ class $$TestTableTableAnnotationComposer
 }
 
 class $$TestTableTableTableManager extends RootTableManager<
-    _$TestDatabase,
+    TestDatabase,
     $TestTableTable,
     TestTableData,
     $$TestTableTableFilterComposer,
@@ -261,11 +261,11 @@ class $$TestTableTableTableManager extends RootTableManager<
     $$TestTableTableUpdateCompanionBuilder,
     (
       TestTableData,
-      BaseReferences<_$TestDatabase, $TestTableTable, TestTableData>
+      BaseReferences<TestDatabase, $TestTableTable, TestTableData>
     ),
     TestTableData,
     PrefetchHooks Function()> {
-  $$TestTableTableTableManager(_$TestDatabase db, $TestTableTable table)
+  $$TestTableTableTableManager(TestDatabase db, $TestTableTable table)
       : super(TableManagerState(
           db: db,
           table: table,
@@ -299,7 +299,7 @@ class $$TestTableTableTableManager extends RootTableManager<
 }
 
 typedef $$TestTableTableProcessedTableManager = ProcessedTableManager<
-    _$TestDatabase,
+    TestDatabase,
     $TestTableTable,
     TestTableData,
     $$TestTableTableFilterComposer,
@@ -309,18 +309,18 @@ typedef $$TestTableTableProcessedTableManager = ProcessedTableManager<
     $$TestTableTableUpdateCompanionBuilder,
     (
       TestTableData,
-      BaseReferences<_$TestDatabase, $TestTableTable, TestTableData>
+      BaseReferences<TestDatabase, $TestTableTable, TestTableData>
     ),
     TestTableData,
     PrefetchHooks Function()>;
 
-class $TestDatabaseManager {
-  final _$TestDatabase _db;
-  $TestDatabaseManager(this._db);
+class TestDatabaseManager {
+  final TestDatabase _db;
+  TestDatabaseManager(this._db);
   $$TestTableTableTableManager get testTable =>
       $$TestTableTableTableManager(_db, _db.testTable);
 }
 
-extension $TestDatabaseManagerExt on _$TestDatabase {
-  $TestDatabaseManager get managers => $TestDatabaseManager(this);
+extension TestDatabaseManagerExt on TestDatabase {
+  TestDatabaseManager get managers => TestDatabaseManager(this);
 }

--- a/extras/integration_tests/web_wasm/lib/src/database.g.dart
+++ b/extras/integration_tests/web_wasm/lib/src/database.g.dart
@@ -185,7 +185,6 @@ class TestTableCompanion extends UpdateCompanion<TestTableData> {
 
 abstract class _$TestDatabase extends GeneratedDatabase {
   _$TestDatabase(QueryExecutor e) : super(e);
-  $TestDatabaseManager get managers => $TestDatabaseManager(this);
   late final $TestTableTable testTable = $TestTableTable(this);
   @override
   Iterable<TableInfo<Table, Object?>> get allTables =>
@@ -320,4 +319,8 @@ class $TestDatabaseManager {
   $TestDatabaseManager(this._db);
   $$TestTableTableTableManager get testTable =>
       $$TestTableTableTableManager(_db, _db.testTable);
+}
+
+extension $TestDatabaseManagerExt on _$TestDatabase {
+  $TestDatabaseManager get managers => $TestDatabaseManager(this);
 }


### PR DESCRIPTION
Instead of managers being fields on private classes:
```dart
class _Database extends GeneratedDatabase {
  Managers get managers => Managers(this);
}
Managers {
  // Private: Bad for Mockito
  final _Database db;
}

```
We now have them on extension on the public class:
```dart
class _Database extends GeneratedDatabase {
  ...
}
Managers {
  // Public
  final Database db;
}

extension DatabaseManagersExt on Database {
  Managers get managers => Managers(this);
}
```

This will allow mockito to do whatever it wants as Manager doesn't rely on a private class
closes https://github.com/simolus3/drift/issues/3015