### PR TITLE
fix: Add conditional export to support --wasm build

### DIFF
--- a/drift/lib/src/web/channel_legacy_dummy.dart
+++ b/drift/lib/src/web/channel_legacy_dummy.dart
@@ -1,0 +1,27 @@
+import 'package:stream_channel/stream_channel.dart';
+
+/// Extension to transform a raw `MessagePort` from web workers into a Dart
+/// [StreamChannel].
+extension PortToChannel on dynamic {
+  /// Converts this port to a two-way communication channel, exposed as a
+  /// [StreamChannel].
+  ///
+  /// This can be used to implement a remote database connection over service
+  /// workers.
+  ///
+  /// The [explicitClose] parameter can be used to control whether a close
+  /// message should be sent through the channel when it is closed. This will
+  /// cause it to be closed on the other end as well. Note that this is not a
+  /// reliable way of determining channel closures though, as there is no event
+  /// for channels being closed due to a tab or worker being closed.
+  /// Both "ends" of a JS channel calling [channel] on their part must use the
+  /// value for [explicitClose].
+  @Deprecated(
+    'Please use MessagePorts from package:web instead of those from dart:html. '
+    'This extension will be removed from drift once `dart:html` is removed '
+    'from the SDK.',
+  )
+  StreamChannel<Object?> channel({bool explicitClose = false}) {
+    throw 'If this import was resolved, dart:html is not available.';
+  }
+}

--- a/drift/lib/web.dart
+++ b/drift/lib/web.dart
@@ -12,5 +12,6 @@ library drift.web;
 export 'src/web/sql_js.dart';
 export 'src/web/storage.dart' hide CustomSchemaVersionSave;
 export 'src/web/web_db.dart';
-export 'src/web/channel_legacy.dart';
+export 'src/web/channel_legacy_dummy.dart'
+    if (dart.library.html) 'src/web/channel_legacy.dart';
 export 'src/web/channel_new.dart';


### PR DESCRIPTION
Added `if (dart.library.html)` to `src/web/channel_legacy.dart` export.

With this change, `src/web/channel_legacy.dart` will only be referenced if `dart:html` is available, and builds with the `--wasm` option will succeed.

---

If we write the following migration code from IndexedDB to WasmDB, we need to do two imports, `drift/wasm.dart` and `drift/web.dart`.

```dart
import 'package:drift/drift.dart';
import 'package:drift/wasm.dart';
import 'package:drift/web.dart';

const _databaseName = 'nice_db';

LazyDatabase getDatabase() => LazyDatabase(() async {
      final result = await WasmDatabase.open(
        databaseName: _databaseName,
        sqlite3Uri: Uri.parse('sqlite3.wasm'),
        driftWorkerUri: Uri.parse('drift_worker.dart.js'),
        initializeDatabase: () async {
          final storage = await DriftWebStorage.indexedDbIfSupported(
            _databaseName,
          );
          await storage.open();

          final blob = await storage.restore();
          await storage.close();

          return blob;
        },
      );

      return result.resolvedExecutor;
    });
```

In a build targeting the web, the current code work. (`flutter run -d chrome`)
However, in builds with the `--wasm` option, code using `dart:html` is not available. (`flutter run -d chrome --wasm`)

```
$ flutter run -d chrome --wasm
Launching lib/main.dart on Chrome in debug mode...
Target dart2wasm failed: ProcessException: Process exited abnormally with exit code 64:
../../../../.pub-cache/hosted/pub.dev/drift-2.22.0/lib/src/web/channel_legacy.dart:1:8: Error: Dart library 'dart:html' is not available on this platform.
import 'dart:html';
       ^
Context: The unavailable library 'dart:html' is imported through these packages:

    main.dart => package:example => package:encrypt_file_loader => package:drift => dart:html
```