### PR TITLE
fix: use dart.tool.dart2wasm in connect.dart conditional import

### DIFF
--- a/drift_flutter/lib/src/connect.dart
+++ b/drift_flutter/lib/src/connect.dart
@@ -1,5 +1,6 @@
 export 'unsupported.dart'
     if (dart.library.js) 'web.dart'
+    if (dart.tool.dart2wasm) 'web.dart'
     if (dart.library.ffi) 'native.dart';
 
 export 'package:drift/src/web/wasm_setup/types.dart';


### PR DESCRIPTION
Potential fix for https://github.com/simolus3/drift/issues/3381.

Is still unclear to me from the research made what's the "migration" steps from the Dart team given the deprecation discussed in https://github.com/dart-lang/sdk/issues/55266 for these conditional imports.