### PR TITLE
Fine-grained query intercepting

### DIFF
--- a/docs/docs/Examples/tracing.md
+++ b/docs/docs/Examples/tracing.md
@@ -5,8 +5,6 @@ description: Using the `QueryInterceptor` API to log details about database oper
 
 ---
 
-
-
 Drift provides the relatively simple `logStatements` option to print the statements it
 executes.
 The `QueryInterceptor` API can be used to extend this logging to provide more information,
@@ -18,6 +16,11 @@ Interceptors can be applied with the `interceptWith` extension on `QueryExecutor
 `DatabaseConnection`:
 
 {{ load_snippet('use','lib/snippets/log_interceptor.dart.excerpt.json') }}
+
+If you only want to apply an interceptor on a certain block instead of on the whole database,
+that's possible too:
+
+{{ load_snippet('runWithInterceptor','lib/snippets/log_interceptor.dart.excerpt.json') }}
 
 The `QueryInterceptor` class is pretty powerful, as it allows you to fully control the underlying
 database connection. You could also use it to retry some failing statements or to aggregate

--- a/docs/lib/snippets/log_interceptor.dart
+++ b/docs/lib/snippets/log_interceptor.dart
@@ -4,6 +4,8 @@ import 'dart:io';
 import 'package:drift/drift.dart';
 import 'package:drift/native.dart';
 
+import 'setup/database.dart';
+
 // #docregion class
 class LogInterceptor extends QueryInterceptor {
   Future<T> _run<T>(
@@ -89,4 +91,15 @@ void use() {
     myDatabaseFile,
   ).interceptWith(LogInterceptor());
   // #enddocregion use
+}
+
+void useScoped() async {
+  final database = AppDatabase();
+
+  // #docregion runWithInterceptor
+  final interceptor = LogInterceptor();
+  await database.runWithInterceptor(interceptor: interceptor, () async {
+    // Only database operations in this block will reach the interceptor.
+  });
+  // #enddocregion runWithInterceptor
 }

--- a/docs/lib/snippets/log_interceptor.dart
+++ b/docs/lib/snippets/log_interceptor.dart
@@ -4,7 +4,7 @@ import 'dart:io';
 import 'package:drift/drift.dart';
 import 'package:drift/native.dart';
 
-import 'setup/database.dart';
+import 'dart_api/manager.dart';
 
 // #docregion class
 class LogInterceptor extends QueryInterceptor {
@@ -94,7 +94,7 @@ void use() {
 }
 
 void useScoped() async {
-  final database = AppDatabase();
+  final database = AppDatabase(NativeDatabase.memory());
 
   // #docregion runWithInterceptor
   final interceptor = LogInterceptor();

--- a/drift/CHANGELOG.md
+++ b/drift/CHANGELOG.md
@@ -5,6 +5,8 @@
 - Deprecate `TypeConverter.json` utility in favor of `TypeConverter.json2`. The
   new method avoids encoding values twice when mapping drift row classes to
   JSON.
+- Add `runWithInterceptor` method to databases to only apply interceptors in
+  a restricted block.
 
 ## 2.23.1
 

--- a/drift/lib/src/runtime/api/connection_user.dart
+++ b/drift/lib/src/runtime/api/connection_user.dart
@@ -471,7 +471,7 @@ abstract class DatabaseConnectionUser {
   /// See also:
   ///  - the docs on [transactions](https://drift.simonbinder.eu/docs/transactions/)
   Future<T> transaction<T>(Future<T> Function() action,
-      {bool requireNew = false}) async {
+      {bool requireNew = false, QueryInterceptor? interceptor}) async {
     final resolved = resolvedEngine;
 
     // Are we about to start a nested transaction?
@@ -489,6 +489,9 @@ abstract class DatabaseConnectionUser {
     }
 
     return await resolved.doWhenOpened((executor) {
+      if (interceptor != null) {
+        executor = executor.interceptWith(interceptor);
+      }
       final transactionExecutor = executor.beginTransaction();
       final transaction = Transaction(this, transactionExecutor);
 

--- a/drift/lib/src/runtime/api/connection_user.dart
+++ b/drift/lib/src/runtime/api/connection_user.dart
@@ -468,6 +468,12 @@ abstract class DatabaseConnectionUser {
   ///   transaction can continue to run if it catched the exception thrown by
   ///   the inner transaction when it aborted.
   ///
+  /// The optional [interceptor] can be used to apply a [QueryInterceptor] on
+  /// the opened transaction. This is useful to modify the behavior of the
+  /// executor for this specific transaction only. Note that lifecycle methods
+  /// will be called starting with [QueryInterceptor.beginTransaction] for the
+  /// transaction that is about to begin.
+  ///
   /// See also:
   ///  - the docs on [transactions](https://drift.simonbinder.eu/docs/transactions/)
   Future<T> transaction<T>(Future<T> Function() action,

--- a/drift/test/generated/todos.mocks.dart
+++ b/drift/test/generated/todos.mocks.dart
@@ -1479,6 +1479,57 @@ class MockTodoDb extends _i1.Mock implements _i3.TodoDb {
       ) as _i5.Future<void>);
 
   @override
+  _i5.Future<T> runWithInterceptor<T>(
+    _i5.Future<T> Function()? action, {
+    required _i2.QueryInterceptor? interceptor,
+  }) =>
+      (super.noSuchMethod(
+        Invocation.method(
+          #runWithInterceptor,
+          [action],
+          {#interceptor: interceptor},
+        ),
+        returnValue: _i6.ifNotNull(
+              _i6.dummyValueOrNull<T>(
+                this,
+                Invocation.method(
+                  #runWithInterceptor,
+                  [action],
+                  {#interceptor: interceptor},
+                ),
+              ),
+              (T v) => _i5.Future<T>.value(v),
+            ) ??
+            _FakeFuture_26<T>(
+              this,
+              Invocation.method(
+                #runWithInterceptor,
+                [action],
+                {#interceptor: interceptor},
+              ),
+            ),
+        returnValueForMissingStub: _i6.ifNotNull(
+              _i6.dummyValueOrNull<T>(
+                this,
+                Invocation.method(
+                  #runWithInterceptor,
+                  [action],
+                  {#interceptor: interceptor},
+                ),
+              ),
+              (T v) => _i5.Future<T>.value(v),
+            ) ??
+            _FakeFuture_26<T>(
+              this,
+              Invocation.method(
+                #runWithInterceptor,
+                [action],
+                {#interceptor: interceptor},
+              ),
+            ),
+      ) as _i5.Future<T>);
+
+  @override
   _i2.GenerationContext $write(
     _i2.Component? component, {
     bool? hasMultipleTables,


### PR DESCRIPTION
I want to be able to intercept queries executed only in certain transaction contexts, and I couldn't find another/easier way.

I thought of filing an issue for this, but it just seemed easier to do.