### PR TITLE
Preserve multi-line comment order

### DIFF
--- a/drift_dev/lib/src/analysis/resolver/drift/table.dart
+++ b/drift_dev/lib/src/analysis/resolver/drift/table.dart
@@ -360,7 +360,7 @@ extension on ColumnDefinition {
     final tokens = <CommentToken>[];
 
     while (lastBefore is CommentToken) {
-      tokens.add(lastBefore);
+      tokens.insert(0, lastBefore);
       lastBefore = lastBefore.previous;
     }
 


### PR DESCRIPTION
### Description

This PR fixes an issue where multi-line comments in SQL were reversed in the generated Dart models. For example:

```sql
-- First comment.
-- Second comment.
title TEXT NOT NULL
```

Previously generated:
```dart
/// Second comment.
/// First comment.
final String title;
```

Now generates:
```dart
/// First comment.
/// Second comment.
final String title;
```

The fix updates the comment collection logic to preserve the correct order. A test case has been added to verify this behavior.

While this change addresses the issue for column comments, I’m not entirely sure if it might affect other parts of the system. Feedback or additional testing suggestions would be appreciated!