### PR TITLE
Feature: Add dispose method to DatabaseTracker for resource management

### DIFF
--- a/drift/CHANGELOG.md
+++ b/drift/CHANGELOG.md
@@ -7,6 +7,7 @@
   JSON.
 - Add `runWithInterceptor` method to databases to only apply interceptors in
   a restricted block.
+- Add `dispose()` method to `DatabaseTracker` to explicitly release in-memory SQLite resources.
 
 ## 2.23.1
 

--- a/drift/lib/src/sqlite3/database_tracker.dart
+++ b/drift/lib/src/sqlite3/database_tracker.dart
@@ -27,6 +27,9 @@ class DatabaseTracker {
   /// Whether this [DatabaseTracker] has been disposed.
   bool _isDisposed = false;
 
+  /// Public getter to check if this tracker has been disposed.
+  bool get isDisposed => _isDisposed;
+
   /// Creates a new tracker with necessary tables.
   DatabaseTracker()
       : _db = sqlite3.open(

--- a/drift/test/database/database_tracker_test.dart
+++ b/drift/test/database/database_tracker_test.dart
@@ -61,5 +61,12 @@ void main() {
       expect(() => tracker.dispose(), returnsNormally);
       expect(() => tracker.dispose(), returnsNormally);
     });
+
+    test('isDisposed reflects tracker state', () {
+      expect(tracker.isDisposed, isFalse);
+
+      tracker.dispose();
+      expect(tracker.isDisposed, isTrue);
+    });
   });
 }

--- a/drift/test/database/database_tracker_test.dart
+++ b/drift/test/database/database_tracker_test.dart
@@ -1,0 +1,65 @@
+import 'package:test/test.dart';
+import 'package:sqlite3/sqlite3.dart';
+import 'package:drift/src/sqlite3/database_tracker.dart';
+
+void main() {
+  group('DatabaseTracker', () {
+    late DatabaseTracker tracker;
+
+    setUp(() {
+      // Create a fresh DatabaseTracker instance before each test.
+      tracker = DatabaseTracker();
+    });
+
+    tearDown(() {
+      // Clean up resources by disposing of the tracker.
+      // Multiple dispose calls should be safe.
+      tracker.dispose();
+    });
+
+    test('tracks and closes existing database connections', () {
+      // Open two in-memory SQLite databases.
+      final db1 = sqlite3.openInMemory();
+      final db2 = sqlite3.openInMemory();
+
+      // Register each database with the tracker.
+      tracker.markOpened('db1_path', db1);
+      tracker.markOpened('db2_path', db2);
+
+      // Optionally perform some queries to confirm the databases are working.
+      db1.execute('CREATE TABLE test1 (id INTEGER NOT NULL PRIMARY KEY)');
+      db2.execute('CREATE TABLE test2 (id INTEGER NOT NULL PRIMARY KEY)');
+
+      // Use the tracker to close all tracked connections.
+      tracker.closeExisting();
+
+      // After closing, further queries should throw an error.
+      expect(
+            () => db1.execute('INSERT INTO test1 (id) VALUES (1)'),
+        throwsA(anything),
+      );
+      expect(
+            () => db2.execute('INSERT INTO test2 (id) VALUES (2)'),
+        throwsA(anything),
+      );
+    });
+
+    test('throws StateError after disposal', () {
+      // Dispose immediately
+      tracker.dispose();
+
+      // Any usage of the tracker after dispose should throw a StateError.
+      expect(
+            () => tracker.markOpened('test', sqlite3.openInMemory()),
+        throwsStateError,
+      );
+      expect(() => tracker.closeExisting(), throwsStateError);
+    });
+
+    test('multiple calls to dispose are safe', () {
+      // Dispose can be called multiple times without throwing errors.
+      expect(() => tracker.dispose(), returnsNormally);
+      expect(() => tracker.dispose(), returnsNormally);
+    });
+  });
+}


### PR DESCRIPTION
### Summary
This pull request introduces a `dispose()` method to the `DatabaseTracker` class to address potential resource leaks. The dispose method ensures proper cleanup of in-memory SQLite databases and tracked resources.

### Changes
- Added a `dispose()` method in `DatabaseTracker` to explicitly release tracked database connections.
- Introduced an `_isDisposed` flag to prevent method calls after disposal, ensuring safe resource management.
- Updated the `closeExisting()` method to work in conjunction with `dispose()` for complete cleanup.
- Added new tests in `database_tracker_test.dart` to validate:
  - Successful cleanup of database resources using `dispose()`.
  - Throwing of `StateError` when methods are called after disposal.
  - Safe handling of multiple calls to `dispose()`.

### Motivation
The lack of a `dispose()` method in `DatabaseTracker` can lead to unclosed SQLite connections, especially in long-running applications or during hot restarts in Flutter. This implementation ensures proper resource management and avoids potential deadlocks or memory leaks.

### Related Issue
- Fixes #3419 
