### PR TITLE
Fix manager references around custom row classes

### DIFF
--- a/docs/lib/snippets/_shared/todo_tables.drift.dart
+++ b/docs/lib/snippets/_shared/todo_tables.drift.dart
@@ -38,13 +38,14 @@ final class $$TodoItemsTableReferences extends i0
                   .id));
 
   i1.$$CategoriesTableProcessedTableManager? get category {
-    if ($_item.category == null) return null;
+    final $_column = $_itemColumn<int>('category');
+    if ($_column == null) return null;
     final manager = i1
         .$$CategoriesTableTableManager(
             $_db,
             i3.ReadDatabaseContainer($_db)
                 .resultSet<i1.$CategoriesTable>('categories'))
-        .filter((f) => f.id($_item.category!));
+        .filter((f) => f.id.sqlEquals($_column));
     final item = $_typedResult.readTableOrNull(_categoryTable($_db));
     if (item == null) return manager;
     return i0.ProcessedTableManager(
@@ -325,7 +326,7 @@ final class $$CategoriesTableReferences extends i0
             $_db,
             i3.ReadDatabaseContainer($_db)
                 .resultSet<i1.$TodoItemsTable>('todo_items'))
-        .filter((f) => f.category.id($_item.id));
+        .filter((f) => f.category.id.sqlEquals($_itemColumn<int>('id')!));
 
     final cache = $_typedResult.readTableOrNull(_todoItemsRefsTable($_db));
     return i0.ProcessedTableManager(

--- a/docs/lib/snippets/modular/drift/example.drift.dart
+++ b/docs/lib/snippets/modular/drift/example.drift.dart
@@ -33,13 +33,14 @@ final class $TodosReferences
                   .id));
 
   i1.$CategoriesProcessedTableManager? get category {
-    if ($_item.category == null) return null;
+    final $_column = $_itemColumn<int>('category');
+    if ($_column == null) return null;
     final manager = i1
         .$CategoriesTableManager(
             $_db,
             i2.ReadDatabaseContainer($_db)
                 .resultSet<i1.Categories>('categories'))
-        .filter((f) => f.id($_item.category!));
+        .filter((f) => f.id.sqlEquals($_column));
     final item = $_typedResult.readTableOrNull(_categoryTable($_db));
     if (item == null) return manager;
     return i0.ProcessedTableManager(
@@ -296,7 +297,7 @@ final class $CategoriesReferences extends i0
     final manager = i1
         .$TodosTableManager(
             $_db, i2.ReadDatabaseContainer($_db).resultSet<i1.Todos>('todos'))
-        .filter((f) => f.category.id($_item.id));
+        .filter((f) => f.category.id.sqlEquals($_itemColumn<int>('id')!));
 
     final cache = $_typedResult.readTableOrNull(_todosRefsTable($_db));
     return i0.ProcessedTableManager(

--- a/docs/lib/snippets/modular/drift/with_existing.drift.dart
+++ b/docs/lib/snippets/modular/drift/with_existing.drift.dart
@@ -143,10 +143,12 @@ final class $FriendsReferences
               i3.ReadDatabaseContainer(db).resultSet<i2.Users>('users').id));
 
   i2.$UsersProcessedTableManager get userA {
+    final $_column = $_itemColumn<int>('user_a')!;
+
     final manager = i2
         .$UsersTableManager(
             $_db, i3.ReadDatabaseContainer($_db).resultSet<i2.Users>('users'))
-        .filter((f) => f.id($_item.userA));
+        .filter((f) => f.id.sqlEquals($_column));
     final item = $_typedResult.readTableOrNull(_userATable($_db));
     if (item == null) return manager;
     return i0.ProcessedTableManager(
@@ -162,10 +164,12 @@ final class $FriendsReferences
               i3.ReadDatabaseContainer(db).resultSet<i2.Users>('users').id));
 
   i2.$UsersProcessedTableManager get userB {
+    final $_column = $_itemColumn<int>('user_b')!;
+
     final manager = i2
         .$UsersTableManager(
             $_db, i3.ReadDatabaseContainer($_db).resultSet<i2.Users>('users'))
-        .filter((f) => f.id($_item.userB));
+        .filter((f) => f.id.sqlEquals($_column));
     final item = $_typedResult.readTableOrNull(_userBTable($_db));
     if (item == null) return manager;
     return i0.ProcessedTableManager(

--- a/docs/lib/snippets/modular/many_to_many/relational.drift.dart
+++ b/docs/lib/snippets/modular/many_to_many/relational.drift.dart
@@ -44,7 +44,7 @@ final class $$ShoppingCartsTableReferences extends i0.BaseReferences<
             i4.ReadDatabaseContainer($_db)
                 .resultSet<i2.$ShoppingCartEntriesTable>(
                     'shopping_cart_entries'))
-        .filter((f) => f.shoppingCart.id($_item.id));
+        .filter((f) => f.shoppingCart.id.sqlEquals($_itemColumn<int>('id')!));
 
     final cache =
         $_typedResult.readTableOrNull(_shoppingCartEntriesRefsTable($_db));
@@ -263,12 +263,14 @@ final class $$ShoppingCartEntriesTableReferences extends i0.BaseReferences<
                   .id));
 
   i2.$$ShoppingCartsTableProcessedTableManager get shoppingCart {
+    final $_column = $_itemColumn<int>('shopping_cart')!;
+
     final manager = i2
         .$$ShoppingCartsTableTableManager(
             $_db,
             i4.ReadDatabaseContainer($_db)
                 .resultSet<i2.$ShoppingCartsTable>('shopping_carts'))
-        .filter((f) => f.id($_item.shoppingCart));
+        .filter((f) => f.id.sqlEquals($_column));
     final item = $_typedResult.readTableOrNull(_shoppingCartTable($_db));
     if (item == null) return manager;
     return i0.ProcessedTableManager(
@@ -288,12 +290,14 @@ final class $$ShoppingCartEntriesTableReferences extends i0.BaseReferences<
                   .id));
 
   i1.$$BuyableItemsTableProcessedTableManager get item {
+    final $_column = $_itemColumn<int>('item')!;
+
     final manager = i1
         .$$BuyableItemsTableTableManager(
             $_db,
             i4.ReadDatabaseContainer($_db)
                 .resultSet<i1.$BuyableItemsTable>('buyable_items'))
-        .filter((f) => f.id($_item.item));
+        .filter((f) => f.id.sqlEquals($_column));
     final item = $_typedResult.readTableOrNull(_itemTable($_db));
     if (item == null) return manager;
     return i0.ProcessedTableManager(

--- a/drift/example/main.g.dart
+++ b/drift/example/main.g.dart
@@ -738,7 +738,7 @@ final class $$TodoCategoriesTableReferences
 
   $$TodoItemsTableProcessedTableManager get todoItemsRefs {
     final manager = $$TodoItemsTableTableManager($_db, $_db.todoItems)
-        .filter((f) => f.categoryId.id($_item.id));
+        .filter((f) => f.categoryId.id.sqlEquals($_itemColumn<int>('id')!));
 
     final cache = $_typedResult.readTableOrNull(_todoItemsRefsTable($_db));
     return ProcessedTableManager(
@@ -940,8 +940,10 @@ final class $$TodoItemsTableReferences
           $_aliasNameGenerator(db.todoItems.categoryId, db.todoCategories.id));
 
   $$TodoCategoriesTableProcessedTableManager get categoryId {
+    final $_column = $_itemColumn<int>('category_id')!;
+
     final manager = $$TodoCategoriesTableTableManager($_db, $_db.todoCategories)
-        .filter((f) => f.id($_item.categoryId));
+        .filter((f) => f.id.sqlEquals($_column));
     final item = $_typedResult.readTableOrNull(_categoryIdTable($_db));
     if (item == null) return manager;
     return ProcessedTableManager(

--- a/drift/lib/src/runtime/manager/filter.dart
+++ b/drift/lib/src/runtime/manager/filter.dart
@@ -16,6 +16,15 @@ abstract class _BaseColumnFilters<T extends Object> {
     return inverted ? expression.not() : expression;
   }
 
+  /// Creates a filter that checks whether the column is equal to the [value].
+  ///
+  /// On columns with type converters, the filter operations invoked with
+  /// `call` or `equals` apply the type converter. This method will always
+  /// bypass any type converter that might be set on the column.
+  Expression<bool> sqlEquals(T value) {
+    return $composableFilter(column.equals(value));
+  }
+
   /// Create a filter that checks if the column is null.
   Expression<bool> isNull() => $composableFilter(column.isNull());
 
@@ -95,11 +104,17 @@ class ColumnWithTypeConverterFilters<CustomType, CustomTypeNonNullable,
   }
 
   /// Create a filter that checks if the column equals a value.
+  ///
+  /// This generates an equals operator in SQL after applying the type converter
+  /// on [value]. To compare a raw SQL value, use [sqlEquals].
   Expression<bool> equals(CustomTypeNonNullable value) {
-    return $composableFilter(column.equals(_customTypeToSql(value)));
+    return sqlEquals(_customTypeToSql(value));
   }
 
-  /// Shortcut for [equals]
+  /// Shortcut for [equals].
+  ///
+  /// This generates an equals operator in SQL after applying the type converter
+  /// on [value]. To compare a raw SQL value, use [sqlEquals].
   Expression<bool> call(CustomTypeNonNullable value) => equals(value);
 
   /// Create a filter that checks if the column is in a list of values.

--- a/drift/lib/src/runtime/manager/references.dart
+++ b/drift/lib/src/runtime/manager/references.dart
@@ -267,13 +267,26 @@ base class BaseReferences<$Database extends GeneratedDatabase,
   // ignore: non_constant_identifier_names
   final TypedResult $_typedResult;
 
-  // The item these references are for
+  /// The item these references are for.
+  ///
+  /// Drift used to use getters on this class to extract columns when building
+  /// subsequent joins or queries to resolve reference.
+  /// This was broken around custom row classes that might not expose all
+  /// columns.
+  @Deprecated(r'Please re-generate code, should be replaced with $_itemColumn')
   // ignore: public_member_api_docs, non_constant_identifier_names
   late final $Dataclass $_item = $_typedResult.readTable($_table);
 
   /// Create a [BaseReferences] class
   // ignore: non_constant_identifier_names
   BaseReferences(this.$_db, this.$_table, this.$_typedResult);
+
+  /// Extracts the value of a column with the given [name] in the
+  /// [$_typedResult] row.
+  // ignore: non_constant_identifier_names
+  C? $_itemColumn<C extends Object>(String name) {
+    return $_typedResult.read($_table.columnsByName[name]! as Expression<C>);
+  }
 }
 
 /// Type definition for a function that transforms the state of a manager

--- a/drift/test/generated/todos.g.dart
+++ b/drift/test/generated/todos.g.dart
@@ -3469,7 +3469,7 @@ final class $$CategoriesTableReferences
 
   $$TodosTableTableProcessedTableManager get todos {
     final manager = $$TodosTableTableTableManager($_db, $_db.todosTable)
-        .filter((f) => f.category.id($_item.id));
+        .filter((f) => f.category.id.sqlEquals($_itemColumn<int>('id')!));
 
     final cache = $_typedResult.readTableOrNull(_todosTable($_db));
     return ProcessedTableManager(
@@ -3702,9 +3702,10 @@ final class $$TodosTableTableReferences
           $_aliasNameGenerator(db.todosTable.category, db.categories.id));
 
   $$CategoriesTableProcessedTableManager? get category {
-    if ($_item.category == null) return null;
+    final $_column = $_itemColumn<int>('category');
+    if ($_column == null) return null;
     final manager = $$CategoriesTableTableManager($_db, $_db.categories)
-        .filter((f) => f.id($_item.category!));
+        .filter((f) => f.id.sqlEquals($_column));
     final item = $_typedResult.readTableOrNull(_categoryTable($_db));
     if (item == null) return manager;
     return ProcessedTableManager(
@@ -4905,7 +4906,7 @@ final class $$DepartmentTableReferences
 
   $$ProductTableProcessedTableManager get productRefs {
     final manager = $$ProductTableTableManager($_db, $_db.product)
-        .filter((f) => f.department.id($_item.id));
+        .filter((f) => f.department.id.sqlEquals($_itemColumn<int>('id')!));
 
     final cache = $_typedResult.readTableOrNull(_productRefsTable($_db));
     return ProcessedTableManager(
@@ -5107,9 +5108,10 @@ final class $$ProductTableReferences
           $_aliasNameGenerator(db.product.department, db.department.id));
 
   $$DepartmentTableProcessedTableManager? get department {
-    if ($_item.department == null) return null;
+    final $_column = $_itemColumn<int>('department');
+    if ($_column == null) return null;
     final manager = $$DepartmentTableTableManager($_db, $_db.department)
-        .filter((f) => f.id($_item.department!));
+        .filter((f) => f.id.sqlEquals($_column));
     final item = $_typedResult.readTableOrNull(_departmentTable($_db));
     if (item == null) return manager;
     return ProcessedTableManager(
@@ -5123,7 +5125,7 @@ final class $$ProductTableReferences
 
   $$ListingTableProcessedTableManager get listings {
     final manager = $$ListingTableTableManager($_db, $_db.listing)
-        .filter((f) => f.product.sku($_item.sku));
+        .filter((f) => f.product.sku.sqlEquals($_itemColumn<String>('sku')!));
 
     final cache = $_typedResult.readTableOrNull(_listingsTable($_db));
     return ProcessedTableManager(
@@ -5411,7 +5413,7 @@ final class $$StoreTableReferences
 
   $$ListingTableProcessedTableManager get listings {
     final manager = $$ListingTableTableManager($_db, $_db.listing)
-        .filter((f) => f.store.id($_item.id));
+        .filter((f) => f.store.id.sqlEquals($_itemColumn<int>('id')!));
 
     final cache = $_typedResult.readTableOrNull(_listingsTable($_db));
     return ProcessedTableManager(
@@ -5606,8 +5608,10 @@ final class $$ListingTableReferences
       .createAlias($_aliasNameGenerator(db.listing.product, db.product.sku));
 
   $$ProductTableProcessedTableManager get product {
+    final $_column = $_itemColumn<String>('product')!;
+
     final manager = $$ProductTableTableManager($_db, $_db.product)
-        .filter((f) => f.sku($_item.product));
+        .filter((f) => f.sku.sqlEquals($_column));
     final item = $_typedResult.readTableOrNull(_productTable($_db));
     if (item == null) return manager;
     return ProcessedTableManager(
@@ -5618,9 +5622,10 @@ final class $$ListingTableReferences
       db.store.createAlias($_aliasNameGenerator(db.listing.store, db.store.id));
 
   $$StoreTableProcessedTableManager? get store {
-    if ($_item.store == null) return null;
+    final $_column = $_itemColumn<int>('store');
+    if ($_column == null) return null;
     final manager = $$StoreTableTableManager($_db, $_db.store)
-        .filter((f) => f.id($_item.store!));
+        .filter((f) => f.id.sqlEquals($_column));
     final item = $_typedResult.readTableOrNull(_storeTable($_db));
     if (item == null) return manager;
     return ProcessedTableManager(

--- a/drift_dev/CHANGELOG.md
+++ b/drift_dev/CHANGELOG.md
@@ -3,6 +3,7 @@
 - Generate typed reference-resolving queries through the manager API when
   modular code-generation is enabled. Previously, this feature was only enabled
   for monolithic generation modes.
+- Fix generating manager code around references when custom row classes are involved.
 
 ## 2.23.0
 

--- a/drift_dev/lib/src/writer/manager/database_manager_writer.dart
+++ b/drift_dev/lib/src/writer/manager/database_manager_writer.dart
@@ -1,5 +1,6 @@
 import 'package:collection/collection.dart';
 import 'package:drift_dev/src/analysis/results/results.dart';
+import 'package:drift_dev/src/utils/string_escaper.dart';
 import 'package:drift_dev/src/writer/tables/update_companion_writer.dart';
 import 'package:drift_dev/src/writer/writer.dart';
 

--- a/examples/app/lib/database/database.g.dart
+++ b/examples/app/lib/database/database.g.dart
@@ -767,7 +767,7 @@ final class $$CategoriesTableReferences
 
   $$TodoEntriesTableProcessedTableManager get todoEntriesRefs {
     final manager = $$TodoEntriesTableTableManager($_db, $_db.todoEntries)
-        .filter((f) => f.category.id($_item.id));
+        .filter((f) => f.category.id.sqlEquals($_itemColumn<int>('id')!));
 
     final cache = $_typedResult.readTableOrNull(_todoEntriesRefsTable($_db));
     return ProcessedTableManager(
@@ -986,9 +986,10 @@ final class $$TodoEntriesTableReferences
           $_aliasNameGenerator(db.todoEntries.category, db.categories.id));
 
   $$CategoriesTableProcessedTableManager? get category {
-    if ($_item.category == null) return null;
+    final $_column = $_itemColumn<int>('category');
+    if ($_column == null) return null;
     final manager = $$CategoriesTableTableManager($_db, $_db.categories)
-        .filter((f) => f.id($_item.category!));
+        .filter((f) => f.id.sqlEquals($_column));
     final item = $_typedResult.readTableOrNull(_categoryTable($_db));
     if (item == null) return manager;
     return ProcessedTableManager(

--- a/examples/migrations_example/lib/database.g.dart
+++ b/examples/migrations_example/lib/database.g.dart
@@ -953,9 +953,10 @@ final class $$UsersTableReferences
       .createAlias($_aliasNameGenerator(db.users.nextUser, db.users.id));
 
   $$UsersTableProcessedTableManager? get nextUser {
-    if ($_item.nextUser == null) return null;
+    final $_column = $_itemColumn<int>('next_user');
+    if ($_column == null) return null;
     final manager = $$UsersTableTableManager($_db, $_db.users)
-        .filter((f) => f.id($_item.nextUser!));
+        .filter((f) => f.id.sqlEquals($_column));
     final item = $_typedResult.readTableOrNull(_nextUserTable($_db));
     if (item == null) return manager;
     return ProcessedTableManager(
@@ -969,7 +970,7 @@ final class $$UsersTableReferences
 
   $GroupsProcessedTableManager get groupsRefs {
     final manager = $GroupsTableManager($_db, $_db.groups)
-        .filter((f) => f.owner.id($_item.id));
+        .filter((f) => f.owner.id.sqlEquals($_itemColumn<int>('id')!));
 
     final cache = $_typedResult.readTableOrNull(_groupsRefsTable($_db));
     return ProcessedTableManager(
@@ -1265,8 +1266,10 @@ final class $GroupsReferences
       db.users.createAlias($_aliasNameGenerator(db.groups.owner, db.users.id));
 
   $$UsersTableProcessedTableManager get owner {
+    final $_column = $_itemColumn<int>('owner')!;
+
     final manager = $$UsersTableTableManager($_db, $_db.users)
-        .filter((f) => f.id($_item.owner));
+        .filter((f) => f.id.sqlEquals($_column));
     final item = $_typedResult.readTableOrNull(_ownerTable($_db));
     if (item == null) return manager;
     return ProcessedTableManager(

--- a/examples/modular/lib/src/posts.drift.dart
+++ b/examples/modular/lib/src/posts.drift.dart
@@ -27,10 +27,12 @@ final class $PostsReferences
               i3.ReadDatabaseContainer(db).resultSet<i2.Users>('users').id));
 
   i2.$UsersProcessedTableManager get author {
+    final $_column = $_itemColumn<int>('author')!;
+
     final manager = i2
         .$UsersTableManager(
             $_db, i3.ReadDatabaseContainer($_db).resultSet<i2.Users>('users'))
-        .filter((f) => f.id($_item.author));
+        .filter((f) => f.id.sqlEquals($_column));
     final item = $_typedResult.readTableOrNull(_authorTable($_db));
     if (item == null) return manager;
     return i0.ProcessedTableManager(
@@ -49,7 +51,7 @@ final class $PostsReferences
     final manager = i1
         .$LikesTableManager(
             $_db, i3.ReadDatabaseContainer($_db).resultSet<i1.Likes>('likes'))
-        .filter((f) => f.post.id($_item.id));
+        .filter((f) => f.post.id.sqlEquals($_itemColumn<int>('id')!));
 
     final cache = $_typedResult.readTableOrNull(_likesRefsTable($_db));
     return i0.ProcessedTableManager(
@@ -347,10 +349,12 @@ final class $LikesReferences
               i3.ReadDatabaseContainer(db).resultSet<i1.Posts>('posts').id));
 
   i1.$PostsProcessedTableManager get post {
+    final $_column = $_itemColumn<int>('post')!;
+
     final manager = i1
         .$PostsTableManager(
             $_db, i3.ReadDatabaseContainer($_db).resultSet<i1.Posts>('posts'))
-        .filter((f) => f.id($_item.post));
+        .filter((f) => f.id.sqlEquals($_column));
     final item = $_typedResult.readTableOrNull(_postTable($_db));
     if (item == null) return manager;
     return i0.ProcessedTableManager(
@@ -364,10 +368,12 @@ final class $LikesReferences
               i3.ReadDatabaseContainer(db).resultSet<i2.Users>('users').id));
 
   i2.$UsersProcessedTableManager get likedBy {
+    final $_column = $_itemColumn<int>('liked_by')!;
+
     final manager = i2
         .$UsersTableManager(
             $_db, i3.ReadDatabaseContainer($_db).resultSet<i2.Users>('users'))
-        .filter((f) => f.id($_item.likedBy));
+        .filter((f) => f.id.sqlEquals($_column));
     final item = $_typedResult.readTableOrNull(_likedByTable($_db));
     if (item == null) return manager;
     return i0.ProcessedTableManager(

--- a/examples/modular/lib/src/users.drift.dart
+++ b/examples/modular/lib/src/users.drift.dart
@@ -195,10 +195,12 @@ final class $FollowsReferences
               i4.ReadDatabaseContainer(db).resultSet<i1.Users>('users').id));
 
   i1.$UsersProcessedTableManager get followed {
+    final $_column = $_itemColumn<int>('followed')!;
+
     final manager = i1
         .$UsersTableManager(
             $_db, i4.ReadDatabaseContainer($_db).resultSet<i1.Users>('users'))
-        .filter((f) => f.id($_item.followed));
+        .filter((f) => f.id.sqlEquals($_column));
     final item = $_typedResult.readTableOrNull(_followedTable($_db));
     if (item == null) return manager;
     return i0.ProcessedTableManager(
@@ -214,10 +216,12 @@ final class $FollowsReferences
               i4.ReadDatabaseContainer(db).resultSet<i1.Users>('users').id));
 
   i1.$UsersProcessedTableManager get follower {
+    final $_column = $_itemColumn<int>('follower')!;
+
     final manager = i1
         .$UsersTableManager(
             $_db, i4.ReadDatabaseContainer($_db).resultSet<i1.Users>('users'))
-        .filter((f) => f.id($_item.follower));
+        .filter((f) => f.id.sqlEquals($_column));
     final item = $_typedResult.readTableOrNull(_followerTable($_db));
     if (item == null) return manager;
     return i0.ProcessedTableManager(

--- a/examples/multi_package/server/lib/database.drift.dart
+++ b/examples/multi_package/server/lib/database.drift.dart
@@ -38,10 +38,12 @@ final class $$ActiveSessionsTableReferences extends i0.BaseReferences<
                   .id));
 
   i1.$$UsersTableProcessedTableManager get user {
+    final $_column = $_itemColumn<int>('user')!;
+
     final manager = i1
         .$$UsersTableTableManager($_db,
             i5.ReadDatabaseContainer($_db).resultSet<i1.$UsersTable>('users'))
-        .filter((f) => f.id($_item.user));
+        .filter((f) => f.id.sqlEquals($_column));
     final item = $_typedResult.readTableOrNull(_userTable($_db));
     if (item == null) return manager;
     return i0.ProcessedTableManager(
@@ -205,7 +207,41 @@ class $$ActiveSessionsTableTableManager extends i0.RootTableManager<
                     i3.$$ActiveSessionsTableReferences(db, table, e)
                   ))
               .toList(),
-          prefetchHooksCallback: null,
+          prefetchHooksCallback: ({user = false}) {
+            return i0.PrefetchHooks(
+              db: db,
+              explicitlyWatchedTables: [],
+              addJoins: <
+                  T extends i0.TableManagerState<
+                      dynamic,
+                      dynamic,
+                      dynamic,
+                      dynamic,
+                      dynamic,
+                      dynamic,
+                      dynamic,
+                      dynamic,
+                      dynamic,
+                      dynamic,
+                      dynamic>>(state) {
+                if (user) {
+                  state = state.withJoin(
+                    currentTable: table,
+                    currentColumn: table.user,
+                    referencedTable:
+                        i3.$$ActiveSessionsTableReferences._userTable(db),
+                    referencedColumn:
+                        i3.$$ActiveSessionsTableReferences._userTable(db).id,
+                  ) as T;
+                }
+
+                return state;
+              },
+              getPrefetchedDataCallback: (items) async {
+                return [];
+              },
+            );
+          },
         ));
 }
 

--- a/examples/multi_package/shared/lib/src/posts.drift.dart
+++ b/examples/multi_package/shared/lib/src/posts.drift.dart
@@ -30,10 +30,12 @@ final class $PostsReferences
                   .id));
 
   i2.$$UsersTableProcessedTableManager get author {
+    final $_column = $_itemColumn<int>('author')!;
+
     final manager = i2
         .$$UsersTableTableManager($_db,
             i3.ReadDatabaseContainer($_db).resultSet<i2.$UsersTable>('users'))
-        .filter((f) => f.id($_item.author));
+        .filter((f) => f.id.sqlEquals($_column));
     final item = $_typedResult.readTableOrNull(_authorTable($_db));
     if (item == null) return manager;
     return i0.ProcessedTableManager(
@@ -191,7 +193,39 @@ class $PostsTableManager extends i0.RootTableManager<
               .map((e) =>
                   (e.readTable(table), i1.$PostsReferences(db, table, e)))
               .toList(),
-          prefetchHooksCallback: null,
+          prefetchHooksCallback: ({author = false}) {
+            return i0.PrefetchHooks(
+              db: db,
+              explicitlyWatchedTables: [],
+              addJoins: <
+                  T extends i0.TableManagerState<
+                      dynamic,
+                      dynamic,
+                      dynamic,
+                      dynamic,
+                      dynamic,
+                      dynamic,
+                      dynamic,
+                      dynamic,
+                      dynamic,
+                      dynamic,
+                      dynamic>>(state) {
+                if (author) {
+                  state = state.withJoin(
+                    currentTable: table,
+                    currentColumn: table.author,
+                    referencedTable: i1.$PostsReferences._authorTable(db),
+                    referencedColumn: i1.$PostsReferences._authorTable(db).id,
+                  ) as T;
+                }
+
+                return state;
+              },
+              getPrefetchedDataCallback: (items) async {
+                return [];
+              },
+            );
+          },
         ));
 }
 

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -13,34 +13,34 @@ packages:
     dependency: transitive
     description:
       name: args
-      sha256: "7cf60b9f0cc88203c5a190b4cd62a99feea42759a7fa695010eb5de1c0b2252a"
+      sha256: bf9f5caeea8d8fe6721a9c358dd8a5c1947b27f1cfaa18b39c301273594919e6
       url: "https://pub.dev"
     source: hosted
-    version: "2.5.0"
+    version: "2.6.0"
   async:
     dependency: transitive
     description:
       name: async
-      sha256: "947bfcf187f74dbc5e146c9eb9c0f10c9f8b30743e341481c1e2ed3ecc18c20c"
+      sha256: d2872f9c19731c2e5f10444b14686eb7cc85c76274bd6c16e1816bff9a3bab63
       url: "https://pub.dev"
     source: hosted
-    version: "2.11.0"
-  boolean_selector:
-    dependency: transitive
-    description:
-      name: boolean_selector
-      sha256: "6cfb5af12253eaf2b368f07bacc5a80d1301a071c73360d746b7f2e32d762c66"
-      url: "https://pub.dev"
-    source: hosted
-    version: "2.1.1"
+    version: "2.12.0"
   charcode:
     dependency: transitive
     description:
       name: charcode
-      sha256: fb98c0f6d12c920a02ee2d998da788bca066ca5f148492b7085ee23372b12306
+      sha256: fb0f1107cac15a5ea6ef0a6ef71a807b9e4267c713bb93e00e92d737cc8dbd8a
       url: "https://pub.dev"
     source: hosted
-    version: "1.3.1"
+    version: "1.4.0"
+  checked_yaml:
+    dependency: transitive
+    description:
+      name: checked_yaml
+      sha256: feb6bed21949061731a7a75fc5d2aa727cf160b91af9a3e464c5e3a32e28b5ff
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.0.3"
   cli_launcher:
     dependency: transitive
     description:
@@ -53,18 +53,26 @@ packages:
     dependency: transitive
     description:
       name: cli_util
-      sha256: c05b7406fdabc7a49a3929d4af76bcaccbbffcbcdcf185b082e1ae07da323d19
+      sha256: ff6785f7e9e3c38ac98b2fb035701789de90154024a75b6cb926445e83197d1c
       url: "https://pub.dev"
     source: hosted
-    version: "0.4.1"
+    version: "0.4.2"
+  clock:
+    dependency: transitive
+    description:
+      name: clock
+      sha256: fddb70d9b5277016c77a80201021d40a2247104d9f4aa7bab7157b7e3f05b84b
+      url: "https://pub.dev"
+    source: hosted
+    version: "1.1.2"
   collection:
     dependency: transitive
     description:
       name: collection
-      sha256: a1ace0a119f20aabc852d165077c036cd864315bd99b7eaa10a60100341941bf
+      sha256: "2f5709ae4d3d59dd8f7cd309b4e023046b57d8a6c82130785d2b0e5868084e76"
       url: "https://pub.dev"
     source: hosted
-    version: "1.19.0"
+    version: "1.19.1"
   conventional_commit:
     dependency: transitive
     description:
@@ -77,10 +85,10 @@ packages:
     dependency: transitive
     description:
       name: file
-      sha256: "1b92bec4fc2a72f59a8e15af5f52cd441e4a7860b49499d69dfa817af20e925d"
+      sha256: a3b4f84adafef897088c160faf7dfffb7696046cb13ae90b508c2cbc95d3b8d4
       url: "https://pub.dev"
     source: hosted
-    version: "6.1.4"
+    version: "7.0.1"
   glob:
     dependency: transitive
     description:
@@ -109,18 +117,26 @@ packages:
     dependency: transitive
     description:
       name: http_parser
-      sha256: "40f592dd352890c3b60fec1b68e786cefb9603e05ff303dbc4dda49b304ecdf4"
+      sha256: "178d74305e7866013777bab2c3d8726205dc5a4dd935297175b19a23a2e66571"
       url: "https://pub.dev"
     source: hosted
-    version: "4.1.0"
+    version: "4.1.2"
+  intl:
+    dependency: transitive
+    description:
+      name: intl
+      sha256: d6f56758b7d3014a48af9701c085700aac781a92a87a62b1333b46d8879661cf
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.19.0"
   io:
     dependency: transitive
     description:
       name: io
-      sha256: "2ec25704aba361659e10e3e5f5d672068d332fc8ac516421d483a11e5cbd061e"
+      sha256: dfd5a80599cf0165756e3181807ed3e77daf6dd4137caaad72d0b7931597650b
       url: "https://pub.dev"
     source: hosted
-    version: "1.0.4"
+    version: "1.0.5"
   json_annotation:
     dependency: transitive
     description:
@@ -129,30 +145,22 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "4.9.0"
-  matcher:
-    dependency: transitive
-    description:
-      name: matcher
-      sha256: d2323aa2060500f906aa31a895b4030b6da3ebdcc5619d14ce1aada65cd161cb
-      url: "https://pub.dev"
-    source: hosted
-    version: "0.12.16+1"
   melos:
     dependency: "direct dev"
     description:
       name: melos
-      sha256: "96e64bbade5712c3f010137e195bca9f1b351fac34ab1f322af492ae34032067"
+      sha256: "3f3ab3f902843d1e5a1b1a4dd39a4aca8ba1056f2d32fd8995210fa2843f646f"
       url: "https://pub.dev"
     source: hosted
-    version: "3.4.0"
+    version: "6.3.2"
   meta:
     dependency: transitive
     description:
       name: meta
-      sha256: bdb68674043280c3428e9ec998512fb681678676b3c54e773629ffe74419f8c7
+      sha256: e3641ec5d63ebf0d9b41bd43201a66e3fc79a65db5f61fc181f04cd27aab950c
       url: "https://pub.dev"
     source: hosted
-    version: "1.15.0"
+    version: "1.16.0"
   mustache_template:
     dependency: transitive
     description:
@@ -165,18 +173,18 @@ packages:
     dependency: transitive
     description:
       name: path
-      sha256: "087ce49c3f0dc39180befefc60fdb4acd8f8620e5682fe2476afd0b3688bb4af"
+      sha256: "75cca69d1490965be98c73ceaea117e8a04dd21217b37b292c9ddbec0d955bc5"
       url: "https://pub.dev"
     source: hosted
-    version: "1.9.0"
+    version: "1.9.1"
   platform:
     dependency: transitive
     description:
       name: platform
-      sha256: "9b71283fc13df574056616011fb138fd3b793ea47cc509c189a6c3fa5f8a1a65"
+      sha256: "5d6b1b0036a5f331ebc77c850ebc8506cbc1e9416c27e59b439f917a902a4984"
       url: "https://pub.dev"
     source: hosted
-    version: "3.1.5"
+    version: "3.1.6"
   pool:
     dependency: transitive
     description:
@@ -189,10 +197,10 @@ packages:
     dependency: transitive
     description:
       name: process
-      sha256: "53fd8db9cec1d37b0574e12f07520d582019cb6c44abf5479a01505099a34a09"
+      sha256: "107d8be718f120bbba9dcd1e95e3bd325b1b4a4f07db64154635ba03f2567a0d"
       url: "https://pub.dev"
     source: hosted
-    version: "4.2.4"
+    version: "5.0.3"
   prompts:
     dependency: transitive
     description:
@@ -205,121 +213,89 @@ packages:
     dependency: transitive
     description:
       name: pub_semver
-      sha256: "40d3ab1bbd474c4c2328c91e3a7df8c6dd629b79ece4c4bd04bee496a224fb0c"
+      sha256: "7b3cfbf654f3edd0c6298ecd5be782ce997ddf0e00531b9464b55245185bbbbd"
       url: "https://pub.dev"
     source: hosted
-    version: "2.1.4"
+    version: "2.1.5"
   pub_updater:
     dependency: transitive
     description:
       name: pub_updater
-      sha256: b06600619c8c219065a548f8f7c192b3e080beff95488ed692780f48f69c0625
+      sha256: "54e8dc865349059ebe7f163d6acce7c89eb958b8047e6d6e80ce93b13d7c9e60"
       url: "https://pub.dev"
     source: hosted
-    version: "0.3.1"
-  pubspec:
+    version: "0.4.0"
+  pubspec_parse:
     dependency: transitive
     description:
-      name: pubspec
-      sha256: f534a50a2b4d48dc3bc0ec147c8bd7c304280fff23b153f3f11803c4d49d927e
+      name: pubspec_parse
+      sha256: "0560ba233314abbed0a48a2956f7f022cce7c3e1e73df540277da7544cad4082"
       url: "https://pub.dev"
     source: hosted
-    version: "2.3.0"
-  quiver:
-    dependency: transitive
-    description:
-      name: quiver
-      sha256: ea0b925899e64ecdfbf9c7becb60d5b50e706ade44a85b2363be2a22d88117d2
-      url: "https://pub.dev"
-    source: hosted
-    version: "3.2.2"
+    version: "1.5.0"
   source_span:
     dependency: transitive
     description:
       name: source_span
-      sha256: "53e943d4206a5e30df338fd4c6e7a077e02254531b138a15aec3bd143c1a8b3c"
+      sha256: "254ee5351d6cb365c859e20ee823c3bb479bf4a293c22d17a9f1bf144ce86f7c"
       url: "https://pub.dev"
     source: hosted
-    version: "1.10.0"
+    version: "1.10.1"
   stack_trace:
     dependency: transitive
     description:
       name: stack_trace
-      sha256: "73713990125a6d93122541237550ee3352a2d84baad52d375a4cad2eb9b7ce0b"
+      sha256: "8b27215b45d22309b5cddda1aa2b19bdfec9df0e765f2de506401c071d38d1b1"
       url: "https://pub.dev"
     source: hosted
-    version: "1.11.1"
-  stream_channel:
-    dependency: transitive
-    description:
-      name: stream_channel
-      sha256: ba2aa5d8cc609d96bbb2899c28934f9e1af5cddbd60a827822ea467161eb54e7
-      url: "https://pub.dev"
-    source: hosted
-    version: "2.1.2"
+    version: "1.12.1"
   string_scanner:
     dependency: transitive
     description:
       name: string_scanner
-      sha256: "688af5ed3402a4bde5b3a6c15fd768dbf2621a614950b17f04626c431ab3c4c3"
+      sha256: "921cd31725b72fe181906c6a94d987c78e3b98c2e205b397ea399d4054872b43"
       url: "https://pub.dev"
     source: hosted
-    version: "1.3.0"
+    version: "1.4.1"
   term_glyph:
     dependency: transitive
     description:
       name: term_glyph
-      sha256: a29248a84fbb7c79282b40b8c72a1209db169a2e0542bce341da992fe1bc7e84
+      sha256: "7f554798625ea768a7518313e58f83891c7f5024f88e46e7182a4558850a4b8e"
       url: "https://pub.dev"
     source: hosted
-    version: "1.2.1"
-  test_api:
-    dependency: transitive
-    description:
-      name: test_api
-      sha256: "664d3a9a64782fcdeb83ce9c6b39e78fd2971d4e37827b9b06c3aa1edc5e760c"
-      url: "https://pub.dev"
-    source: hosted
-    version: "0.7.3"
+    version: "1.2.2"
   typed_data:
     dependency: transitive
     description:
       name: typed_data
-      sha256: facc8d6582f16042dd49f2463ff1bd6e2c9ef9f3d5da3d9b087e244a7b564b3c
+      sha256: f9049c039ebfeb4cf7a7104a675823cd72dba8297f264b6637062516699fa006
       url: "https://pub.dev"
     source: hosted
-    version: "1.3.2"
-  uri:
-    dependency: transitive
-    description:
-      name: uri
-      sha256: "889eea21e953187c6099802b7b4cf5219ba8f3518f604a1033064d45b1b8268a"
-      url: "https://pub.dev"
-    source: hosted
-    version: "1.0.0"
+    version: "1.4.0"
   web:
     dependency: transitive
     description:
       name: web
-      sha256: d43c1d6b787bf0afad444700ae7f4db8827f701bc61c255ac8d328c6f4d52062
+      sha256: cd3543bd5798f6ad290ea73d210f423502e71900302dde696f8bff84bf89a1cb
       url: "https://pub.dev"
     source: hosted
-    version: "1.0.0"
+    version: "1.1.0"
   yaml:
     dependency: transitive
     description:
       name: yaml
-      sha256: "75769501ea3489fca56601ff33454fe45507ea3bfb014161abc3b43ae25989d5"
+      sha256: b9da305ac7c39faa3f030eccd175340f968459dae4af175130b3fc47e40d76ce
       url: "https://pub.dev"
     source: hosted
-    version: "3.1.2"
+    version: "3.1.3"
   yaml_edit:
     dependency: transitive
     description:
       name: yaml_edit
-      sha256: e9c1a3543d2da0db3e90270dbb1e4eebc985ee5e3ffe468d83224472b2194a5f
+      sha256: fb38626579fb345ad00e674e2af3a5c9b0cc4b9bfb8fd7f7ff322c7c9e62aef5
       url: "https://pub.dev"
     source: hosted
-    version: "2.2.1"
+    version: "2.2.2"
 sdks:
-  dart: ">=3.4.0 <4.0.0"
+  dart: ">=3.6.0 <4.0.0"

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -5,4 +5,4 @@ environment:
   sdk: ">=3.3.0 <4.0.0"
 
 dev_dependencies:
-  melos: ^3.0.0
+  melos: ^6.3.2


### PR DESCRIPTION
In the manager classes responsible for resolving references, our approach for generating subsequent queries was to:

1. Map the row for the original query into the row class for the source table.
2. Extract the foreign key by fetching the field from the row class.
3. Using that to build the subsequent query.

Especially around custom row classes, step 2 can be broken because these classes are not guaranteed to contain fields for all columns. Luckily, we have access to the raw result set and can use that to resolve a specific column regardless of whether it is exposed through a field.
@dickermoshe, let me know if I missed something in the changed templates. But this also seems to be covered quite well by existing tests. So I'm confident this didn't break anything.

Closes https://github.com/simolus3/drift/issues/3335