### PR TITLE
FTS5 highlight/snippet nullable

### DIFF
--- a/sqlparser/lib/src/engine/module/fts5.dart
+++ b/sqlparser/lib/src/engine/module/fts5.dart
@@ -189,7 +189,8 @@ class _Fts5Functions with ArgumentCountLinter implements FunctionHandler {
         return const ResolveResult(ResolvedType(type: BasicType.real));
       case 'highlight':
       case 'snippet':
-        return const ResolveResult(ResolvedType(type: BasicType.text));
+        return const ResolveResult(
+            ResolvedType(type: BasicType.text, nullable: true));
     }
     return const ResolveResult.unknown();
   }


### PR DESCRIPTION
In case the indexed value is null (e.g. multiple columns in the FTS5 table) highlight and snippet also return null.