### PR TITLE
Fixed spelling of `commend`

### DIFF
--- a/drift_dev/lib/src/cli/commands/schema/dump.dart
+++ b/drift_dev/lib/src/cli/commands/schema/dump.dart
@@ -29,7 +29,7 @@ class DumpSchemaCommand extends Command {
 
   DumpSchemaCommand(this.cli) {
     argParser.registerExportSchemaStartupCodeOption();
-    argParser.addSeparator("It's recommended to run this commend from the "
+    argParser.addSeparator("It's recommended to run this command from the "
         'directory containing your pubspec.yaml so that compiler options '
         'are respected.');
   }


### PR DESCRIPTION
Not exactly a critical issue, but noticed it when running the tool for the first time. :-)