### PR TITLE
[Web] Fix Shared Worker Probe

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -159,7 +159,8 @@ jobs:
         working-directory: drift
     strategy:
       matrix:
-        browser: [chrome, firefox]
+        browser: [chrome] # Dart 3.7 unfortunately broke tests with dart2wasm on Firefox
+        # browser: [chrome, firefox]
     name: "Drift web unit tests, dart2wasm, ${{ matrix.browser }}"
     steps:
       # setup

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -371,7 +371,7 @@ jobs:
         working-directory: .
       - name: Test
         working-directory: extras/integration_tests/web_wasm
-        run: dart test
+        run: dart test -P gh_actions
 #  upload_coverage:
 #    runs-on: ubuntu-20.04
 #    needs: [moor, sqlparser]

--- a/drift/lib/src/web/channel_legacy.dart
+++ b/drift/lib/src/web/channel_legacy.dart
@@ -1,4 +1,4 @@
-import 'dart:html';
+import 'dart:html'; // ignore: deprecated_member_use
 
 import 'package:stream_channel/stream_channel.dart';
 

--- a/drift/lib/src/web/wasm_setup/protocol.dart
+++ b/drift/lib/src/web/wasm_setup/protocol.dart
@@ -3,8 +3,8 @@
 import 'dart:js_interop';
 import 'dart:js_interop_unsafe';
 
-import 'package:web/web.dart' hide WorkerOptions;
 import 'package:sqlite3/wasm.dart';
+import 'package:web/web.dart' hide WorkerOptions;
 
 import 'types.dart';
 
@@ -177,7 +177,7 @@ final class SharedWorkerCompatibilityResult extends CompatibilityResult {
 
   factory SharedWorkerCompatibilityResult.fromJsPayload(JSArray payload) {
     final asList = payload.toDart;
-    final asBooleans = asList.cast<bool>();
+    bool asBoolean(int index) => (asList[index] as JSBoolean).toDart;
 
     final List<ExistingDatabase> existingDatabases;
     var version = ProtocolVersion.legacy;
@@ -193,11 +193,11 @@ final class SharedWorkerCompatibilityResult extends CompatibilityResult {
     }
 
     return SharedWorkerCompatibilityResult(
-      canSpawnDedicatedWorkers: asBooleans[0],
-      dedicatedWorkersCanUseOpfs: asBooleans[1],
-      canUseIndexedDb: asBooleans[2],
-      indexedDbExists: asBooleans[3],
-      opfsExists: asBooleans[4],
+      canSpawnDedicatedWorkers: asBoolean(0),
+      dedicatedWorkersCanUseOpfs: asBoolean(1),
+      canUseIndexedDb: asBoolean(2),
+      indexedDbExists: asBoolean(3),
+      opfsExists: asBoolean(4),
       existingDatabases: existingDatabases,
       version: version,
     );

--- a/extras/integration_tests/web_wasm/build.yaml
+++ b/extras/integration_tests/web_wasm/build.yaml
@@ -1,8 +1,38 @@
 targets:
+  dart2js_archives:
+    auto_apply_builders: false
+    dependencies: [":$default", ":worker"]
+    builders:
+      build_web_compilers:dart2js_archive_extractor:
+        enabled: true
+  worker:
+    auto_apply_builders: false
+    dependencies: [":$default"]
+    builders:
+      build_web_compilers:entrypoint:
+        enabled: true
+        generate_for:
+          - web/worker.dart
+        options:
+          compiler: dart2js
+      build_web_compilers:dart2js_archive_extractor:
+        enabled: false
+
   $default:
     builders:
       build_web_compilers:entrypoint:
         generate_for:
-          - web/**
+          include:
+            - "example/**"
+            - web/**
+          # This one is compiled in the other target
+          exclude:
+            - web/worker.dart
         options:
-          compiler: dart2js
+          compilers:
+            dart2js:
+            dart2wasm:
+          loader: # We're using our own loader to test dart2js + dart2wasm separately
+      # We have a designated target for this step.
+      build_web_compilers:dart2js_archive_extractor:
+        enabled: false

--- a/extras/integration_tests/web_wasm/dart_test.yaml
+++ b/extras/integration_tests/web_wasm/dart_test.yaml
@@ -1,0 +1,10 @@
+tags:
+  firefox:
+  chrome:
+  dart2js:
+  dart2wasm:
+
+presets:
+  gh_actions:
+    # Firefox tests with dart2wasm are currently broken
+    exclude_tags: firefox && dart2wasm

--- a/extras/integration_tests/web_wasm/lib/driver.dart
+++ b/extras/integration_tests/web_wasm/lib/driver.dart
@@ -15,6 +15,7 @@ import 'package:web_wasm/initialization_mode.dart';
 import 'package:webdriver/async_io.dart';
 // ignore: implementation_imports
 import 'package:drift/src/web/wasm_setup/types.dart';
+import 'package:webdriver/support/async.dart';
 
 class TestAssetServer {
   final BuildDaemonClient buildRunner;
@@ -107,6 +108,12 @@ class DriftWebDriver {
 
   DriftWebDriver(this.server, this.driver);
 
+  /// Wait for the Dart code on the test page to finish its main method, which
+  /// it signals by creating an element.
+  Future<void> waitReady() async {
+    await waitFor(() => driver.findElement(By.id('ready')));
+  }
+
   Future<
       ({
         Set<WasmStorageImplementation> storages,
@@ -194,5 +201,9 @@ class DriftWebDriver {
     await driver.executeAsync('delete_database(arguments[0], arguments[1])', [
       json.encode([storageApi.name, name]),
     ]);
+  }
+
+  Future<bool> isDart2wasm() async {
+    return await driver.executeAsync('isDart2wasm("", arguments[0])', []);
   }
 }

--- a/extras/integration_tests/web_wasm/pubspec.yaml
+++ b/extras/integration_tests/web_wasm/pubspec.yaml
@@ -18,10 +18,11 @@ dependencies:
   async: ^2.11.0
   http: ^1.0.0
   sqlite3: ^2.0.0
+  web: ^1.1.0
 
 dev_dependencies:
   build_runner: ^2.4.5
-  build_web_compilers: ^4.0.0
+  build_web_compilers: ^4.1.0
   drift_dev:
   lints: ^4.0.0
   test: ^1.24.3

--- a/extras/integration_tests/web_wasm/test/drift_wasm_test.dart
+++ b/extras/integration_tests/web_wasm/test/drift_wasm_test.dart
@@ -1,4 +1,5 @@
 // ignore: implementation_imports
+import 'dart:async';
 import 'dart:io';
 
 import 'package:drift/src/web/wasm_setup/types.dart';
@@ -62,13 +63,57 @@ void main() {
   for (final browser in Browser.values) {
     group(browser.name, () {
       late Process driverProcess;
-      late DriftWebDriver driver;
+      var isStoppingProcess = false;
+      final processStopped = Completer<void>();
 
-      setUpAll(() async => driverProcess = await browser.spawnDriver());
-      tearDownAll(() => driverProcess.kill());
+      setUpAll(() async {
+        final process = driverProcess = await browser.spawnDriver();
+        process.exitCode.then((code) {
+          if (!isStoppingProcess) {
+            throw 'Webdriver stopped (code $code) before tearing down tests.';
+          }
 
-      setUp(() async {
-        final rawDriver = await createDriver(
+          processStopped.complete();
+        });
+      });
+      tearDownAll(() {
+        isStoppingProcess = true;
+        driverProcess.kill();
+        return processStopped.future;
+      });
+
+      for (final wasm in [false, true]) {
+        group(wasm ? 'dart2wasm' : 'dart2js', () {
+          final config = _TestConfiguration(browser, () => server, wasm);
+
+          setUp(() async {
+            await config.setUp();
+          });
+          tearDown(() => config.tearDown());
+
+          config.declareTests();
+        });
+      }
+    });
+  }
+}
+
+final class _TestConfiguration {
+  final Browser browser;
+  final TestAssetServer Function() _server;
+  final bool isDart2Wasm;
+
+  late DriftWebDriver driver;
+
+  _TestConfiguration(this.browser, this._server, this.isDart2Wasm);
+
+  TestAssetServer get server => _server();
+
+  Future<void> setUp() async {
+    late WebDriver rawDriver;
+    for (var i = 0; i < 3; i++) {
+      try {
+        rawDriver = await createDriver(
           spec: browser.isChromium ? WebDriverSpec.JsonWire : WebDriverSpec.W3c,
           uri: browser.driverUri,
           desired: {
@@ -83,217 +128,245 @@ void main() {
             },
           },
         );
+        break;
+      } on SocketException {
+        // webdriver server taking a bit longer to start up...
+        if (i == 2) {
+          rethrow;
+        }
 
-        driver = DriftWebDriver(server, rawDriver);
-        await driver.driver.get('http://localhost:${server.server.port}/');
+        await Future.delayed(const Duration(milliseconds: 500));
+      }
+    }
+
+    // logs.get() isn't supported on Firefox
+    if (browser != Browser.firefox) {
+      rawDriver.logs.get(LogType.browser).listen((entry) {
+        print('[console]: ${entry.message}');
       });
+    }
 
-      tearDown(() => driver.driver.quit());
+    driver = DriftWebDriver(server, rawDriver);
+    final port = server.server.port;
+    await driver.driver.get(isDart2Wasm
+        ? 'http://localhost:$port/?wasm=1'
+        : 'http://localhost:$port/');
+    await driver.waitReady();
+  }
 
-      test('compatibility check', () async {
-        final result = await driver.probeImplementations();
+  Future<void> tearDown() async {
+    await driver.driver.quit();
+  }
 
-        final expectedImplementations = WasmStorageImplementation.values.toSet()
-          ..removeAll(browser.unsupportedImplementations);
+  void declareTests() {
+    test('compatibility check', () async {
+      // Make sure we're not testing the same compiler twice due to e.g. bugs in
+      // the loader script.
+      expect(await driver.isDart2wasm(), isDart2Wasm);
 
-        expect(result.missingFeatures, browser.missingFeatures);
-        expect(result.storages, expectedImplementations);
-      });
+      final result = await driver.probeImplementations();
 
-      test('reports worker error for wrong URI', () async {
-        final result =
-            await driver.probeImplementations(withWrongWorkerUri: true);
+      final expectedImplementations = WasmStorageImplementation.values.toSet()
+        ..removeAll(browser.unsupportedImplementations);
 
-        expect(result.missingFeatures,
-            contains(MissingBrowserFeature.workerError));
-      });
+      expect(result.missingFeatures, browser.missingFeatures);
+      expect(result.storages, expectedImplementations);
+    });
 
-      test('via regular open', () async {
-        await driver.openDatabase();
-        expect(await driver.amountOfRows, 0);
+    test('reports worker error for wrong URI', () async {
+      final result =
+          await driver.probeImplementations(withWrongWorkerUri: true);
 
-        await driver.insertIntoDatabase();
-        await driver.waitForTableUpdate();
-        expect(await driver.amountOfRows, 1);
-      });
+      expect(
+          result.missingFeatures, contains(MissingBrowserFeature.workerError));
+    });
 
-      test('regular open with initializaton', () async {
-        await driver.enableInitialization(InitializationMode.loadAsset);
-        await driver.openDatabase();
+    test('via regular open', () async {
+      await driver.openDatabase();
+      expect(await driver.amountOfRows, 0);
 
-        expect(await driver.amountOfRows, 1);
-      });
+      await driver.insertIntoDatabase();
+      await driver.waitForTableUpdate();
+      expect(await driver.amountOfRows, 1);
+    });
 
-      test('disable migrations', () async {
-        await driver
-            .enableInitialization(InitializationMode.noneAndDisableMigrations);
-        await driver.openDatabase();
+    test('regular open with initializaton', () async {
+      await driver.enableInitialization(InitializationMode.loadAsset);
+      await driver.openDatabase();
 
-        expect(await driver.hasTable, isFalse);
-      });
+      expect(await driver.amountOfRows, 1);
+    });
 
-      for (final entry in browser.availableImplementations) {
-        group(entry.name, () {
-          test('basic', () async {
+    test('disable migrations', () async {
+      await driver
+          .enableInitialization(InitializationMode.noneAndDisableMigrations);
+      await driver.openDatabase();
+
+      expect(await driver.hasTable, isFalse);
+    });
+
+    for (final entry in browser.availableImplementations) {
+      group(entry.name, () {
+        test('basic', () async {
+          await driver.openDatabase(entry);
+          expect(await driver.amountOfRows, 0);
+
+          await driver.insertIntoDatabase();
+          await driver.waitForTableUpdate();
+          expect(await driver.amountOfRows, 1);
+
+          if (entry != WasmStorageImplementation.unsafeIndexedDb &&
+              entry != WasmStorageImplementation.inMemory) {
+            // Test stream query updates across tabs
+            final newTabLink = await driver.driver.findElement(By.id('newtab'));
+            await newTabLink.click();
+
+            final windows = await driver.driver.windows.toList();
+            expect(windows, hasLength(2));
+            // Firefox does crazy things when setAsActive is called without
+            // this delay. I don't really understand why, Chrome works...
+            await Future.delayed(const Duration(seconds: 1));
+            await windows.last.setAsActive();
+
             await driver.openDatabase(entry);
-            expect(await driver.amountOfRows, 0);
+            expect(await driver.amountOfRows, 1);
+            await driver.insertIntoDatabase();
+            await windows.last.close();
 
+            await windows.first.setAsActive();
+            await driver.waitForTableUpdate();
+          }
+        });
+
+        if (entry != WasmStorageImplementation.inMemory) {
+          test('delete', () async {
+            final impl = await driver.probeImplementations();
+            expect(impl.existing, isEmpty);
+
+            await driver.openDatabase(entry);
             await driver.insertIntoDatabase();
             await driver.waitForTableUpdate();
-            expect(await driver.amountOfRows, 1);
 
-            if (entry != WasmStorageImplementation.unsafeIndexedDb &&
-                entry != WasmStorageImplementation.inMemory) {
-              // Test stream query updates across tabs
-              final newTabLink =
-                  await driver.driver.findElement(By.id('newtab'));
-              await newTabLink.click();
+            await driver.closeDatabase();
 
-              final windows = await driver.driver.windows.toList();
-              expect(windows, hasLength(2));
-              // Firefox does crazy things when setAsActive is called without
-              // this delay. I don't really understand why, Chrome works...
-              await Future.delayed(const Duration(seconds: 1));
-              await windows.last.setAsActive();
+            final newImpls = await driver.probeImplementations();
+            expect(newImpls.existing, hasLength(1));
+            final existing = newImpls.existing[0];
+            await driver.deleteDatabase(existing.$1, existing.$2);
 
-              await driver.openDatabase(entry);
-              expect(await driver.amountOfRows, 1);
-              await driver.insertIntoDatabase();
-              await windows.last.close();
+            await driver.driver.refresh();
+            await driver.waitReady();
 
-              await windows.first.setAsActive();
-              await driver.waitForTableUpdate();
-            }
+            final finalImpls = await driver.probeImplementations();
+            expect(finalImpls.existing, isEmpty);
           });
 
-          if (entry != WasmStorageImplementation.inMemory) {
-            test('delete', () async {
-              final impl = await driver.probeImplementations();
-              expect(impl.existing, isEmpty);
-
-              await driver.openDatabase(entry);
-              await driver.insertIntoDatabase();
-              await driver.waitForTableUpdate();
-
-              await driver.closeDatabase();
-
-              final newImpls = await driver.probeImplementations();
-              expect(newImpls.existing, hasLength(1));
-              final existing = newImpls.existing[0];
-              await driver.deleteDatabase(existing.$1, existing.$2);
-
-              await driver.driver.refresh();
-
-              final finalImpls = await driver.probeImplementations();
-              expect(finalImpls.existing, isEmpty);
-            });
-
-            test('migrations', () async {
-              await driver.openDatabase(entry);
-              await driver.insertIntoDatabase();
-              await driver.waitForTableUpdate();
-
-              await driver.closeDatabase();
-              await driver.driver.refresh();
-
-              await driver.setSchemaVersion(2);
-              await driver.openDatabase(entry);
-              // The migration adds a row
-              expect(await driver.amountOfRows, 2);
-            });
-
-            test('disabling migrations', () async {
-              await driver.enableInitialization(
-                  InitializationMode.noneAndDisableMigrations);
-              await driver.openDatabase();
-              expect(await driver.hasTable, isFalse);
-            });
-          }
-
-          group(
-            'initialization from',
-            () {
-              test('static blob', () async {
-                await driver.enableInitialization(InitializationMode.loadAsset);
-                await driver.openDatabase(entry);
-
-                expect(await driver.amountOfRows, 1);
-                await driver.insertIntoDatabase();
-                expect(await driver.amountOfRows, 2);
-
-                if (entry != WasmStorageImplementation.inMemory) {
-                  await Future.delayed(const Duration(seconds: 1));
-                  await driver.driver.refresh();
-
-                  await driver
-                      .enableInitialization(InitializationMode.loadAsset);
-                  await driver.openDatabase();
-                  expect(await driver.amountOfRows, 2);
-                }
-              });
-
-              test('custom wasmdatabase', () async {
-                await driver.enableInitialization(
-                    InitializationMode.migrateCustomWasmDatabase);
-                await driver.openDatabase(entry);
-
-                expect(await driver.amountOfRows, 1);
-              });
-            },
-            skip: browser == Browser.firefox &&
-                    entry == WasmStorageImplementation.opfsLocks
-                ? "This configuration fails, but the failure can't be "
-                    'reproduced by manually running the steps of this test.'
-                : null,
-          );
-        });
-      }
-
-      if (browser.supports(WasmStorageImplementation.unsafeIndexedDb) &&
-          browser.supports(WasmStorageImplementation.opfsLocks)) {
-        test(
-          'keep existing IndexedDB database after OPFS becomes available',
-          () async {
-            // Open an IndexedDB database first
-            await driver
-                .openDatabase(WasmStorageImplementation.unsafeIndexedDb);
+          test('migrations', () async {
+            await driver.openDatabase(entry);
             await driver.insertIntoDatabase();
-            await Future.delayed(const Duration(seconds: 2));
-            await driver.driver.refresh(); // Reset JS state
+            await driver.waitForTableUpdate();
 
-            // Open the database again, this time without specifying a fixed
-            // implementation. Despite OPFS being available (and preferred),
-            // the existing database should be used.
+            await driver.closeDatabase();
+            await driver.driver.refresh();
+            await driver.waitReady();
+
+            await driver.setSchemaVersion(2);
+            await driver.openDatabase(entry);
+            // The migration adds a row
+            expect(await driver.amountOfRows, 2);
+          });
+
+          test('disabling migrations', () async {
+            await driver.enableInitialization(
+                InitializationMode.noneAndDisableMigrations);
             await driver.openDatabase();
-            expect(await driver.amountOfRows, 1);
-          },
-        );
-
-        if (!browser.supports(WasmStorageImplementation.opfsShared)) {
-          test('uses indexeddb after OPFS becomes unavailable', () async {
-            // This browser only supports OPFS with the right headers. If they
-            // are ever removed, data is lost (nothing we could do about that),
-            // but drift should continue to work.
-            await driver.openDatabase(WasmStorageImplementation.opfsLocks);
-            await driver.insertIntoDatabase();
-            expect(await driver.amountOfRows, 1);
-            await Future.delayed(const Duration(seconds: 2));
-
-            await driver.driver
-                .get('http://localhost:${server.server.port}/no-coep');
-            await driver.openDatabase();
-            expect(await driver.amountOfRows, isZero);
+            expect(await driver.hasTable, isFalse);
           });
         }
-      }
 
-      test('supports exclusively API', () async {
-        await driver.openDatabase();
-        expect(await driver.amountOfRows, 0);
+        group(
+          'initialization from',
+          () {
+            test('static blob', () async {
+              await driver.enableInitialization(InitializationMode.loadAsset);
+              await driver.openDatabase(entry);
 
-        await driver.runExclusiveBlock();
-        expect(await driver.amountOfRows, 1);
+              expect(await driver.amountOfRows, 1);
+              await driver.insertIntoDatabase();
+              expect(await driver.amountOfRows, 2);
+
+              if (entry != WasmStorageImplementation.inMemory) {
+                await Future.delayed(const Duration(seconds: 1));
+                await driver.driver.refresh();
+                await driver.waitReady();
+
+                await driver.enableInitialization(InitializationMode.loadAsset);
+                await driver.openDatabase();
+                expect(await driver.amountOfRows, 2);
+              }
+            });
+
+            test('custom wasmdatabase', () async {
+              await driver.enableInitialization(
+                  InitializationMode.migrateCustomWasmDatabase);
+              await driver.openDatabase(entry);
+
+              expect(await driver.amountOfRows, 1);
+            });
+          },
+          skip: browser == Browser.firefox &&
+                  entry == WasmStorageImplementation.opfsLocks
+              ? "This configuration fails, but the failure can't be "
+                  'reproduced by manually running the steps of this test.'
+              : null,
+        );
       });
+    }
+
+    if (browser.supports(WasmStorageImplementation.unsafeIndexedDb) &&
+        browser.supports(WasmStorageImplementation.opfsLocks)) {
+      test(
+        'keep existing IndexedDB database after OPFS becomes available',
+        () async {
+          // Open an IndexedDB database first
+          await driver.openDatabase(WasmStorageImplementation.unsafeIndexedDb);
+          await driver.insertIntoDatabase();
+          await Future.delayed(const Duration(seconds: 2));
+          await driver.driver.refresh(); // Reset JS state
+          await driver.waitReady();
+
+          // Open the database again, this time without specifying a fixed
+          // implementation. Despite OPFS being available (and preferred),
+          // the existing database should be used.
+          await driver.openDatabase();
+          expect(await driver.amountOfRows, 1);
+        },
+      );
+
+      if (!browser.supports(WasmStorageImplementation.opfsShared)) {
+        test('uses indexeddb after OPFS becomes unavailable', () async {
+          // This browser only supports OPFS with the right headers. If they
+          // are ever removed, data is lost (nothing we could do about that),
+          // but drift should continue to work.
+          await driver.openDatabase(WasmStorageImplementation.opfsLocks);
+          await driver.insertIntoDatabase();
+          expect(await driver.amountOfRows, 1);
+          await Future.delayed(const Duration(seconds: 2));
+
+          await driver.driver
+              .get('http://localhost:${server.server.port}/no-coep');
+          await driver.openDatabase();
+          expect(await driver.amountOfRows, isZero);
+        });
+      }
+    }
+
+    test('supports exclusively API', () async {
+      await driver.openDatabase();
+      expect(await driver.amountOfRows, 0);
+
+      await driver.runExclusiveBlock();
+      expect(await driver.amountOfRows, 1);
     });
   }
 }

--- a/extras/integration_tests/web_wasm/test/drift_wasm_test.dart
+++ b/extras/integration_tests/web_wasm/test/drift_wasm_test.dart
@@ -83,7 +83,9 @@ void main() {
       });
 
       for (final wasm in [false, true]) {
-        group(wasm ? 'dart2wasm' : 'dart2js', () {
+        final compiler = wasm ? 'dart2wasm' : 'dart2js';
+
+        group(compiler, () {
           final config = _TestConfiguration(browser, () => server, wasm);
 
           setUp(() async {
@@ -92,7 +94,7 @@ void main() {
           tearDown(() => config.tearDown());
 
           config.declareTests();
-        });
+        }, tags: [browser.name, compiler]);
       }
     });
   }

--- a/extras/integration_tests/web_wasm/web/index.html
+++ b/extras/integration_tests/web_wasm/web/index.html
@@ -7,7 +7,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <meta name="scaffolded-by" content="https://github.com/dart-lang/sdk">
     <title>web_wasm</title>
-    <script defer src="main.dart.js"></script>
+    <script defer src="main.js"></script>
 </head>
 
 <body>

--- a/extras/integration_tests/web_wasm/web/main.js
+++ b/extras/integration_tests/web_wasm/web/main.js
@@ -1,0 +1,23 @@
+(async () => {
+    const thisScript = document.currentScript;
+    const params = new URL(document.location.toString()).searchParams;
+    const wasmOption = params.get("wasm");
+
+    function relativeURL(ref) {
+      const base = thisScript?.src ?? document.baseURI;
+      return new URL(ref, base).toString();
+    }
+
+    if (wasmOption == "1") {
+        let { compileStreaming } = await import("./main.mjs");
+
+        let app = await compileStreaming(fetch(relativeURL("main.wasm")));
+        let module = await app.instantiate({});
+        module.invokeMain();
+    } else {
+        const scriptTag = document.createElement("script");
+        scriptTag.type = "application/javascript";
+        scriptTag.src = relativeURL("./main.dart2js.js");
+        document.head.append(scriptTag);
+    }
+})();


### PR DESCRIPTION
The sharedWorker probe fails due to a incorrect type castings. You cannot cast a JSBoolean to a `bool` value directly, you must go through the `toDart` conversion.

This failure leads drift to exclude the shared IndexedDb implementation from being used, falling back to the unsafe implementation.

This PR fixes the casts, allowing the probe to properly read the data and include `sharedIndexedDb` as the correct chosen implementation.