### PR TITLE
Use const for the generated `versions`

### DIFF
--- a/drift_dev/lib/src/cli/commands/make_migrations.dart
+++ b/drift_dev/lib/src/cli/commands/make_migrations.dart
@@ -402,7 +402,7 @@ void main() {
     // These simple tests verify all possible schema updates with a simple (no
     // data) migration. This is a quick way to ensure that written database
     // migrations properly alter the schema.
-    final versions = GeneratedHelper.versions;
+    const versions = GeneratedHelper.versions;
     for (final (i, fromVersion) in versions.indexed) {
       group('from \$fromVersion', () {
         for (final toVersion in versions.skip(i + 1)) {


### PR DESCRIPTION
This fixes the lint complaint about [prefer_const_declarations](https://dart.dev/tools/diagnostic-messages?utm_source=dartdev&utm_medium=redir&utm_id=diagcode&utm_content=prefer_const_declarations#prefer_const_declarations)