### PR TITLE
Prefer using single quotes for the generated test description

### DIFF
--- a/drift_dev/lib/src/cli/commands/make_migrations.dart
+++ b/drift_dev/lib/src/cli/commands/make_migrations.dart
@@ -510,7 +510,7 @@ class _MigrationTestWriter {
   /// It will also import the validation models to test data integrity
   String testStepByStepMigrationCode(String dbName, String dbClassName) {
     return """
-test("migration from v$from to v$to does not corrupt data",
+test('migration from v$from to v$to does not corrupt data',
       () async {
   // Add data to insert into the old database, and the expected rows after the
   // migration.


### PR DESCRIPTION
This fixes the lint complaint about [prefer_single_quotes](https://dart.dev/tools/diagnostic-messages?utm_source=dartdev&utm_medium=redir&utm_id=diagcode&utm_content=prefer_single_quotes#prefer_single_quotes)