### PR TITLE
SQLite Window Function Expression

### DIFF
--- a/docs/docs/dart_api/expressions.md
+++ b/docs/docs/dart_api/expressions.md
@@ -146,7 +146,7 @@ Support for common JSON operators is provided through `package:drift/extensions/
 This provides things like `jsonExtract` to extract fields from JSON or `jsonEach` to query
 nested JSON structures. For more details, see the [JSON support](select.md#json-support) section on the page about selects or [this more complex example](../Examples/relationships.md#with-json-functions).
 
-## Aggregate functions (like count and sum) 
+## Aggregate functions (like count and sum)
 
 [Aggregate functions](https://www.sqlite.org/lang_aggfunc.html) are available
 from the Dart api. Unlike regular functions, aggregate functions operate on multiple rows at
@@ -224,6 +224,21 @@ Stream<String> allTodoContent() {
 
 The separator defaults to a comma without surrounding whitespace, but it can be changed
 with the `separator` argument on `groupConcat`.
+
+### Window functions
+
+In addition to aggregate expressions and `groupBy`, drift supports [window functions](https://en.wikipedia.org/wiki/Window_function_(SQL)).
+Unlike regular aggregates, which collapse a group of rows into a single value, window functions allow
+running aggregations over a subset of rows related to the current one.
+For instance, you could use this to track a running total of values:
+
+{{ load_snippet('window','lib/snippets/dart_api/expressions.dart.excerpt.json') }}
+
+An interesting use for window function is to determine the rank a row would have if rows were
+sorted by some column (without actually returning all rows, or sorting them by that column).
+This ranking can be attached to each row:
+
+{{ load_snippet('window2','lib/snippets/dart_api/expressions.dart.excerpt.json') }}
 
 ## Mathematical functions and regexp
 

--- a/docs/lib/snippets/dart_api/expressions.dart
+++ b/docs/lib/snippets/dart_api/expressions.dart
@@ -34,6 +34,40 @@ extension Snippets on CanUseCommonTables {
     await update(todoItems).write(change);
   }
   // #enddocregion date3
+
+  // #docregion window
+  /// Returns all todo items, associating each item with the total length of all
+  /// titles up until (and including) each todo item.
+  Selectable<(TodoItem, int)> todosWithRunningLength() {
+    final runningTitleLength = WindowFunctionExpression(
+      todoItems.title.length.sum(),
+      orderBy: [OrderingTerm.asc(todoItems.id)],
+    );
+    final query = select(todoItems).addColumns([runningTitleLength]);
+    query.orderBy([OrderingTerm.asc(todoItems.id)]);
+
+    return query.map((row) {
+      return (row.readTable(todoItems)!, row.read(runningTitleLength)!);
+    });
+  }
+  // #enddocregion window
+
+  // #docregion window2
+  /// Returns all todo items, also reporting the index (counting from 1) each
+  /// todo item would have if all items were sorted by descending content
+  /// length.
+  Selectable<(TodoItem, int)> todosWithLengthRanking() {
+    final lengthRanking = WindowFunctionExpression(
+      todoItems.id.count(),
+      orderBy: [OrderingTerm.desc(todoItems.content.length)],
+    );
+    final query = select(todoItems).addColumns([lengthRanking]);
+
+    return query.map((row) {
+      return (row.readTable(todoItems)!, row.read(lengthRanking)!);
+    });
+  }
+  // #enddocregion window2
 }
 
 // #docregion bitwise

--- a/drift/CHANGELOG.md
+++ b/drift/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 2.16.0-dev
+
+- Add support for window functions with `WindowFunctionExpression`.
+
 ## 2.25.0
 
 - Report `SqliteException`s occurring on workers as `SqliteException`

--- a/drift/lib/src/runtime/query_builder/expressions/window.dart
+++ b/drift/lib/src/runtime/query_builder/expressions/window.dart
@@ -5,6 +5,8 @@ part of '../query_builder.dart';
 /// Window functions perform calculations across a set of table rows that are somehow
 /// related to the current row. This expression class allows you to construct window
 /// function queries with partitioning, ordering, and frame specifications.
+///
+/// More information at [Window Functions](https://www.sqlite.org/windowfunctions.html) documentation.
 class WindowFunctionExpression<T extends Object> extends Expression<T> {
   /// The aggregate or window function to apply (e.g., SUM, AVG).
   final Expression<T> function;
@@ -54,6 +56,8 @@ class WindowFunctionExpression<T extends Object> extends Expression<T> {
   /// EXCLUDE clause, GROUPS frame types, window chaining, and
   /// support for `<expr> PRECEDING` and `<expr> FOLLOWING` boundaries in RANGE frames
   /// are only available from sqlite 3.28.0, released on 2019-04-16.
+  ///
+  /// More information at [Window Functions](https://www.sqlite.org/windowfunctions.html) documentation.
   ///
   /// # Basic Usage
   ///
@@ -248,11 +252,25 @@ enum _FrameType {
 /// Zero indicates the current row
 ///
 /// {@endtemplate}
+///
+/// More information at [FrameBoundary](https://www.sqlite.org/windowfunctions.html#frame_boundaries) documentation.
 sealed class FrameBoundary extends Component {
-  /// The start of the frame boundary.
+  /// The start of the frame boundary, relative to the current row.
+  ///
+  /// A value of [null] indicates that frame includes all prior rows, groups or range bounds.
+  /// A value of 0 indicates that frame starts at the current row.
+  ///
+  /// A negative or positive value indicates that frame starts at the specified offset
+  /// before or after the current row.
   final num? start;
 
-  /// The end of the frame boundary.
+  /// The end of the frame boundary, relative to the current row.
+  ///
+  /// A value of [null] indicates that frame includes all following rows, groups or range bounds.
+  /// A value of 0 indicates that frame ends at the current row.
+  ///
+  /// A negative or positive value indicates that frame ends at the specified offset
+  /// before or after the current row.
   final num? end;
 
   /// The type of frame for the boundary.
@@ -338,7 +356,7 @@ class GroupsFrameBoundary extends FrameBoundary {
   /// Note that GROUPS Frame Type is only available from sqlite 3.28.0, released on 2019-04-16.
   /// Most devices will use an older sqlite version.
   ///
-  /// {@macro boundary}
+  /// {@macro drift_window_boundary}
   const GroupsFrameBoundary({
     int? start,
     int? end = 0,
@@ -357,7 +375,7 @@ class RangeFrameBoundary extends FrameBoundary {
   /// If multiple rows have the same value in the `ORDER BY` column, they
   /// are all included in the frame.
   ///
-  /// {@macro boundary}
+  /// {@macro drift_window_boundary}
   ///
   /// Note that passing value except 0 (CURRENT ROW) or null (UNBOUNDED) to [start] or [end] in RANGE Frame is only available from sqlite 3.28.0, released on 2019-04-16.
   /// Most devices will use an older sqlite version.

--- a/drift/lib/src/runtime/query_builder/expressions/window.dart
+++ b/drift/lib/src/runtime/query_builder/expressions/window.dart
@@ -1,0 +1,371 @@
+part of '../query_builder.dart';
+
+/// Represents a window function expression in SQL.
+///
+/// Window functions perform calculations across a set of table rows that are somehow
+/// related to the current row. This expression class allows you to construct window
+/// function queries with partitioning, ordering, and frame specifications.
+class WindowFunctionExpression<T extends Object> extends Expression<T> {
+  /// The aggregate or window function to apply (e.g., SUM, AVG).
+  final Expression<T> function;
+
+  /// The ordering terms that define how rows are sorted within each partition.
+  /// Must not be empty as window functions require an ORDER BY clause.
+  final List<OrderingTerm> orderBy;
+
+  /// Optional list of expressions to partition the rows by.
+  ///
+  /// When specified, the window function calculations are performed separately
+  /// for each distinct combination of the partition values.
+  final List<Expression>? partitionBy;
+
+  /// Optional frame boundary that defines which rows to include in the
+  /// window calculations relative to the current row.
+  ///
+  /// If not specified, defaults to a RANGE BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW.
+  ///
+  /// Usage:
+  ///
+  /// ```dart
+  /// // RANGE Boundary
+  ///  boundary: RangeFrameBoundary(),
+  ///
+  /// // ROWS Boundary
+  ///  boundary: RowsFrameBoundary(),
+  ///
+  /// // GROUPS Boundary
+  ///  boundary: GroupFrameBoundary(),
+  /// ```
+  final FrameBoundary boundary;
+
+  /// Creates a new window function expression.
+  ///
+  /// Parameters:
+  /// - [function]: The window or aggregate function to apply
+  /// - [orderBy]: How to sort rows within each partition (required, must not be empty)
+  /// - [partitionBy]: Optional expressions to partition rows by
+  /// - [boundary]: Optional specification of which rows to include in calculations
+  ///
+  /// Throws [ArgumentError] if [orderBy] is empty.
+  ///
+  /// Note that Window Function is only available from sqlite 3.25.0, released on 2018-09-15.
+  /// Most devices will use an older sqlite version.
+  ///
+  /// EXCLUDE clause, GROUPS frame types, window chaining, and
+  /// support for `<expr> PRECEDING` and `<expr> FOLLOWING` boundaries in RANGE frames
+  /// are only available from sqlite 3.28.0, released on 2019-04-16.
+  ///
+  /// # Basic Usage
+  ///
+  /// ```dart
+  /// // Simple running total example
+  /// final runningTotal = WindowFunctionExpression<double>(
+  ///   items.price.sum(), // aggregate function
+  ///   orderBy: [OrderingTerm.asc(items.date)],
+  /// );
+  ///
+  /// // Use in a query
+  /// final query = select(items).addColumns([runningTotal]);
+  /// ```
+  ///
+  /// # Partitioning
+  ///
+  /// Partition data into groups before applying the window function:
+  ///
+  /// ```dart
+  /// // Running total per category
+  /// final runningTotalByCategory = WindowFunctionExpression<int>(
+  ///   items.price.sum(),
+  ///   orderBy: [OrderingTerm.asc(items.date)],
+  ///   partitionBy: [items.categoryId],
+  /// );
+  /// ```
+  ///
+  /// # Frame Boundaries
+  ///
+  /// ## Rows Frame
+  /// Operates on physical rows:
+  ///
+  /// ```dart
+  /// // Moving average of previous 3 rows and current row
+  /// final movingAverage = WindowFunctionExpression<double>(
+  ///   items.price.avg(),
+  ///   orderBy: [OrderingTerm.asc(items.date)],
+  ///   boundary: RowsFrameBoundary(
+  ///     start: -3, // 3 rows preceding
+  ///     end: 0,    // current row
+  ///   ),
+  /// );
+  /// ```
+  ///
+  /// ## Groups Frame
+  /// Operates on groups of rows with same ORDER BY values:
+  ///
+  /// ```dart
+  /// // Include current group and one group before
+  /// final groupFrame = WindowFunctionExpression<int>(
+  ///   items.quantity.sum(),
+  ///   orderBy: [OrderingTerm.asc(items.category)],
+  ///   boundary: GroupsFrameBoundary(
+  ///     start: null, // Unbounded preceding groups
+  ///     end: 0,    // current group
+  ///   ),
+  /// );
+  /// ```
+  ///
+  /// ## Range Frame
+  /// Operates on value ranges (default):
+  ///
+  /// ```dart
+  /// // Sum of items within price range of ±10 from current row
+  /// final rangeFrame = WindowFunctionExpression<int>(
+  ///   items.quantity.sum(),
+  ///   orderBy: [OrderingTerm.asc(items.price)],
+  ///   boundary: RangeFrameBoundary(
+  ///     start: -10, // 10 units less than current value
+  ///     end: 10,    // 10 units more than current value
+  ///   ),
+  /// );
+  /// ```
+  ///
+  WindowFunctionExpression(
+    this.function, {
+    required this.orderBy,
+    this.partitionBy,
+    this.boundary = const RangeFrameBoundary(),
+  }) {
+    if (orderBy.isEmpty) {
+      throw ArgumentError.value(
+        orderBy,
+        'orderBy',
+        'Must not be empty',
+      );
+    }
+  }
+
+  @override
+  void writeInto(GenerationContext context) {
+    function.writeInto(context);
+    context.buffer.write(' OVER (');
+    if (partitionBy case final partitionBy? when partitionBy.isNotEmpty) {
+      PartitionBy(partitionBy).writeInto(context);
+      context.writeWhitespace();
+    }
+    OrderBy(orderBy).writeInto(context);
+    context.writeWhitespace();
+    boundary.writeInto(context);
+    context.buffer.write(')');
+  }
+}
+
+/// A partition-by clause as part of a window function statement. The clause can consist
+/// of multiple [Expression]s, with the first terms being primary partition and
+/// the later terms will work as a nested partition for the previous partition and so on.
+class PartitionBy extends Component {
+  /// The list of expressions to partition by.
+  final List<Expression> expressions;
+
+  /// Constructs a partition by clause by the [expressions].
+  const PartitionBy(this.expressions);
+
+  @override
+  void writeInto(GenerationContext context) {
+    if (expressions.isEmpty) return;
+
+    context.buffer.write('PARTITION BY ');
+    _writeCommaSeparated(context, expressions);
+  }
+}
+
+/// Specifies how to exclude rows from the window frame.
+enum FrameExclude {
+  /// No rows are excluded from the window frame.
+  ///
+  /// This is the default behavior
+  noOthers._('NO OTHERS'),
+
+  /// Excludes the current row from the window frame.
+  currentRow._('CURRENT ROW'),
+
+  /// Excludes the current row and its peers from the window frame.
+  ///
+  /// Peers are rows that are considered equivalent to the current row based on
+  /// the window's ORDER BY clause.
+  group._('GROUP'),
+
+  /// Excludes the peers of the current row from the window frame, but keeps the current row.
+  ///
+  /// Only rows that have exactly the same values for the ORDER BY columns as the
+  /// current row are excluded, while the current row itself remains in the frame.
+  ties._('TIES');
+
+  /// The string representation of the exclude clause.
+  final String _exclude;
+
+  const FrameExclude._(this._exclude);
+}
+
+/// Describes the type of frame for a window function.
+enum _FrameType {
+  /// A frame that considers a range of values for the provided boundary.
+  ///
+  /// `RANGE` frames operate based on the values in the `ORDER BY` clause,
+  /// not row positions. It includes all rows that fall within the specified
+  /// value range relative to the current row.
+  ///
+  /// If multiple rows have the same value in the `ORDER BY` column, they
+  /// are all included in the frame.
+  range._('RANGE'),
+
+  /// A frame that considers a number of rows for the provided boundary.
+  ///
+  /// Each row is treated as a separate entity, and the frame is defined
+  /// by a specific number of rows before or after the current row.
+  rows._('ROWS'),
+
+  /// A frame that considers a number of groups for the provided boundary.
+  ///
+  /// A group is a set of rows that share the same values for every term
+  /// in the `ORDER BY` clause. The frame includes a specified number of
+  /// groups before or after the current group.
+  groups._('GROUPS');
+
+  /// The string representation of the frame type.
+  final String _type;
+
+  const _FrameType._(this._type);
+}
+
+/// Base Class for Boundary in a window frame.
+///
+/// {@template drift_window_boundary}
+/// If null, the boundary is unbounded.
+///
+/// Negative value indicates a preceding boundary
+///
+/// Positive value indicates a following boundary
+///
+/// Zero indicates the current row
+///
+/// {@endtemplate}
+abstract class FrameBoundary<T extends num> extends Expression<num> {
+  /// The start of the frame boundary.
+  final T? start;
+
+  /// The end of the frame boundary.
+  final T? end;
+
+  /// The type of frame for the boundary.
+  final _FrameType _frameType;
+
+  /// Specifies which rows to exclude from the frame
+  ///
+  /// If not specified, defaults to [FrameExclude.noOthers].
+  ///
+  /// Note that [exclude] is only available from sqlite 3.28.0, released on 2019-04-16.
+  /// Most devices will use an older sqlite version.
+  ///
+  /// If you want to use [FrameExclude.noOthers] then keeping [exclude] as null will give you the same behaviour.
+  final FrameExclude? exclude;
+
+  const FrameBoundary._(
+    this.start,
+    this.end,
+    this._frameType, {
+    this.exclude,
+  }) : assert(
+          start == null || start <= 0 || (end == null || end > 0),
+          'Invalid frame specification. A FOLLOWING boundary must have an end boundary as FOLLOWING or UNBOUNDED.',
+        );
+
+  @override
+  void writeInto(GenerationContext context) {
+    context.buffer.write(_frameType._type);
+    context.buffer.write(' BETWEEN ');
+    if (start case final start?) {
+      _writeBoundary(context, start);
+    } else {
+      context.buffer.write('UNBOUNDED PRECEDING');
+    }
+    context.buffer.write(' AND ');
+    if (end case final end?) {
+      _writeBoundary(context, end);
+    } else {
+      context.buffer.write('UNBOUNDED FOLLOWING');
+    }
+    if (exclude case final exclude?) {
+      context.buffer.write(' EXCLUDE ');
+      context.buffer.write(exclude._exclude);
+    }
+  }
+
+  void _writeBoundary(GenerationContext context, T exp) {
+    if (exp == 0) {
+      context.buffer.write('CURRENT ROW');
+    } else if (exp < 0) {
+      Constant(exp.abs()).writeInto(context);
+      context.buffer.write(' PRECEDING');
+    } else {
+      Constant(exp.abs()).writeInto(context);
+      context.buffer.write(' FOLLOWING');
+    }
+  }
+}
+
+/// Rows boundary for the window frame.
+class RowsFrameBoundary extends FrameBoundary<int> {
+  /// Constructs a ROWS frame with the given [start] and [end] boundaries.
+  ///
+  /// A ROWS frame operates on physical rows. The [start] and [end] parameter specifies how
+  /// many rows before and/or after the current row should be included in the frame.
+  ///
+  /// {@macro drift_window_boundary}
+  const RowsFrameBoundary({
+    int? start,
+    int? end = 0,
+    super.exclude,
+  }) : super._(start, end, _FrameType.rows);
+}
+
+/// Groups boundary for the window frame.
+class GroupsFrameBoundary extends FrameBoundary<int> {
+  /// Constructs a GROUPS frame with the given [start] and [end] boundaries.
+  ///
+  /// A GROUPS frame operates on groups of rows that share the same values in the
+  /// ORDER BY columns. The [start] and [end] parameter specifies how many groups before
+  /// and/or after the current row's group should be included.
+  ///
+  /// Note that GROUPS Frame Type is only available from sqlite 3.28.0, released on 2019-04-16.
+  /// Most devices will use an older sqlite version.
+  ///
+  /// {@macro boundary}
+  const GroupsFrameBoundary({
+    int? start,
+    int? end = 0,
+    super.exclude,
+  }) : super._(start, end, _FrameType.groups);
+}
+
+/// Range boundary for the window frame.
+class RangeFrameBoundary extends FrameBoundary<num> {
+  /// Constructs a range boundary with the given [start] and [end].
+  ///
+  /// A RANGE frame operates on logical ranges of values based on the ORDER BY columns.
+  /// The [start] and [end] parameter specifies the range of values to include relative to
+  /// the current row's values.
+  ///
+  /// If multiple rows have the same value in the `ORDER BY` column, they
+  /// are all included in the frame.
+  ///
+  /// {@macro boundary}
+  ///
+  /// Note that passing value except 0 (CURRENT ROW) or null (UNBOUNDED) to [start] or [end] in RANGE Frame is only available from sqlite 3.28.0, released on 2019-04-16.
+  /// Most devices will use an older sqlite version.
+  ///
+  /// 0 (CURRENT ROW) and null (UNBOUNDED) are supported from sqlite 3.25.0, released on 2018-09-15.
+  const RangeFrameBoundary({
+    num? start,
+    num? end = 0,
+    super.exclude,
+  }) : super._(start, end, _FrameType.range);
+}

--- a/drift/lib/src/runtime/query_builder/expressions/window.dart
+++ b/drift/lib/src/runtime/query_builder/expressions/window.dart
@@ -248,12 +248,12 @@ enum _FrameType {
 /// Zero indicates the current row
 ///
 /// {@endtemplate}
-abstract class FrameBoundary<T extends num> extends Expression<num> {
+sealed class FrameBoundary extends Component {
   /// The start of the frame boundary.
-  final T? start;
+  final num? start;
 
   /// The end of the frame boundary.
-  final T? end;
+  final num? end;
 
   /// The type of frame for the boundary.
   final _FrameType _frameType;
@@ -275,7 +275,7 @@ abstract class FrameBoundary<T extends num> extends Expression<num> {
     this.exclude,
   }) : assert(
           start == null || start <= 0 || (end == null || end > 0),
-          'Invalid frame specification. A FOLLOWING boundary must have an end boundary as FOLLOWING or UNBOUNDED.',
+          'Invalid frame specification. A FOLLOWING start boundary must have an end boundary as FOLLOWING or UNBOUNDED.',
         );
 
   @override
@@ -299,7 +299,7 @@ abstract class FrameBoundary<T extends num> extends Expression<num> {
     }
   }
 
-  void _writeBoundary(GenerationContext context, T exp) {
+  void _writeBoundary(GenerationContext context, num exp) {
     if (exp == 0) {
       context.buffer.write('CURRENT ROW');
     } else if (exp < 0) {
@@ -313,7 +313,7 @@ abstract class FrameBoundary<T extends num> extends Expression<num> {
 }
 
 /// Rows boundary for the window frame.
-class RowsFrameBoundary extends FrameBoundary<int> {
+class RowsFrameBoundary extends FrameBoundary {
   /// Constructs a ROWS frame with the given [start] and [end] boundaries.
   ///
   /// A ROWS frame operates on physical rows. The [start] and [end] parameter specifies how
@@ -328,7 +328,7 @@ class RowsFrameBoundary extends FrameBoundary<int> {
 }
 
 /// Groups boundary for the window frame.
-class GroupsFrameBoundary extends FrameBoundary<int> {
+class GroupsFrameBoundary extends FrameBoundary {
   /// Constructs a GROUPS frame with the given [start] and [end] boundaries.
   ///
   /// A GROUPS frame operates on groups of rows that share the same values in the
@@ -347,7 +347,7 @@ class GroupsFrameBoundary extends FrameBoundary<int> {
 }
 
 /// Range boundary for the window frame.
-class RangeFrameBoundary extends FrameBoundary<num> {
+class RangeFrameBoundary extends FrameBoundary {
   /// Constructs a range boundary with the given [start] and [end].
   ///
   /// A RANGE frame operates on logical ranges of values based on the ORDER BY columns.

--- a/drift/lib/src/runtime/query_builder/expressions/window.dart
+++ b/drift/lib/src/runtime/query_builder/expressions/window.dart
@@ -30,10 +30,10 @@ class WindowFunctionExpression<T extends Object> extends Expression<T> {
   ///
   /// ```dart
   /// // RANGE Boundary
-  ///  boundary: RangeFrameBoundary(),
+  ///  boundary: FrameBoundary.range(),
   ///
   /// // ROWS Boundary
-  ///  boundary: RowsFrameBoundary(),
+  ///  boundary: FrameBoundary.rows(),
   ///
   /// // GROUPS Boundary
   ///  boundary: GroupFrameBoundary(),
@@ -95,7 +95,7 @@ class WindowFunctionExpression<T extends Object> extends Expression<T> {
   /// final movingAverage = WindowFunctionExpression<double>(
   ///   items.price.avg(),
   ///   orderBy: [OrderingTerm.asc(items.date)],
-  ///   boundary: RowsFrameBoundary(
+  ///   boundary: FrameBoundary.rows(
   ///     start: -3, // 3 rows preceding
   ///     end: 0,    // current row
   ///   ),
@@ -110,7 +110,7 @@ class WindowFunctionExpression<T extends Object> extends Expression<T> {
   /// final groupFrame = WindowFunctionExpression<int>(
   ///   items.quantity.sum(),
   ///   orderBy: [OrderingTerm.asc(items.category)],
-  ///   boundary: GroupsFrameBoundary(
+  ///   boundary: FrameBoundary.groups(
   ///     start: null, // Unbounded preceding groups
   ///     end: 0,    // current group
   ///   ),
@@ -125,7 +125,7 @@ class WindowFunctionExpression<T extends Object> extends Expression<T> {
   /// final rangeFrame = WindowFunctionExpression<int>(
   ///   items.quantity.sum(),
   ///   orderBy: [OrderingTerm.asc(items.price)],
-  ///   boundary: RangeFrameBoundary(
+  ///   boundary: FrameBoundary.range(
   ///     start: -10, // 10 units less than current value
   ///     end: 10,    // 10 units more than current value
   ///   ),

--- a/drift/lib/src/runtime/query_builder/query_builder.dart
+++ b/drift/lib/src/runtime/query_builder/query_builder.dart
@@ -52,6 +52,7 @@ part 'expressions/in.dart';
 part 'expressions/null_check.dart';
 part 'expressions/text.dart';
 part 'expressions/variables.dart';
+part 'expressions/window.dart';
 part 'generation_context.dart';
 part 'migration.dart';
 part 'schema/column_impl.dart';

--- a/drift/test/database/expressions/window_test.dart
+++ b/drift/test/database/expressions/window_test.dart
@@ -133,6 +133,13 @@ void main() {
         ),
         generates("ROWS BETWEEN 6 FOLLOWING AND UNBOUNDED FOLLOWING"),
       );
+      expect(
+        RangeFrameBoundary(
+          start: -6.78,
+          end: 57,
+        ),
+        generates("RANGE BETWEEN 6.78 PRECEDING AND 57 FOLLOWING"),
+      );
     });
 
     test('allows reverse boundary of same type', () {

--- a/drift/test/database/expressions/window_test.dart
+++ b/drift/test/database/expressions/window_test.dart
@@ -1,0 +1,204 @@
+import 'package:drift/drift.dart';
+import 'package:test/test.dart';
+
+import '../../test_utils/test_utils.dart';
+
+void main() {
+  const foo = CustomExpression<int>('foo', precedence: Precedence.primary);
+  const x = CustomExpression<String>('x');
+  const y = CustomExpression<int>('y');
+
+  group('WINDOW FUNCTION', () {
+    test('with single Order By', () {
+      expect(
+        WindowFunctionExpression<int>(
+          foo.sum(),
+          orderBy: [OrderingTerm.asc(foo)],
+        ),
+        generates(
+            "SUM(foo) OVER (ORDER BY foo ASC RANGE BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW)"),
+      );
+    });
+
+    test('with multiple Order By', () {
+      expect(
+        WindowFunctionExpression<int>(
+          foo.sum(),
+          orderBy: [OrderingTerm.asc(foo), OrderingTerm.desc(x)],
+        ),
+        generates(
+            "SUM(foo) OVER (ORDER BY foo ASC, x DESC RANGE BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW)"),
+      );
+    });
+
+    test('with Partition By', () {
+      expect(
+        WindowFunctionExpression<double>(
+          foo.avg(),
+          orderBy: [OrderingTerm.desc(foo)],
+          partitionBy: [x, y],
+        ),
+        generates(
+            "AVG(foo) OVER (PARTITION BY x, y ORDER BY foo DESC RANGE BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW)"),
+      );
+    });
+
+    test('with Filter', () {
+      expect(
+        WindowFunctionExpression(
+          countAll(filter: foo.isBiggerOrEqualValue(3)),
+          orderBy: [OrderingTerm.desc(foo)],
+          partitionBy: [x, y],
+        ),
+        generates(
+            "COUNT(*) FILTER (WHERE foo >= ?) OVER (PARTITION BY x, y ORDER BY foo DESC RANGE BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW)",
+            [3]),
+      );
+    });
+
+    test('does not allow empty Order By', () {
+      expect(
+          () => WindowFunctionExpression<double>(
+                foo.avg(),
+                orderBy: [],
+              ),
+          throwsA(isA<ArgumentError>()));
+    });
+  });
+
+  group('WINDOW FUNCTION Frame Spec', () {
+    test('between unbounded preceding and current row', () {
+      expect(
+        RowsFrameBoundary(),
+        generates("ROWS BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW"),
+      );
+      expect(
+        GroupsFrameBoundary(),
+        generates("GROUPS BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW"),
+      );
+      expect(
+        RangeFrameBoundary(),
+        generates("RANGE BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW"),
+      );
+    });
+
+    test('between unbounded preceding and unbounded following', () {
+      expect(
+        RowsFrameBoundary(start: null, end: null),
+        generates("ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING"),
+      );
+      expect(
+        GroupsFrameBoundary(start: null, end: null),
+        generates("GROUPS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING"),
+      );
+      expect(
+        RangeFrameBoundary(start: null, end: null),
+        generates("RANGE BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING"),
+      );
+    });
+
+    test('between expr preceding and/or expr following', () {
+      expect(
+        RangeFrameBoundary(
+          start: -2,
+          end: 0,
+        ),
+        generates("RANGE BETWEEN 2 PRECEDING AND CURRENT ROW"),
+      );
+      expect(
+        RowsFrameBoundary(
+          start: -4,
+          end: 6,
+        ),
+        generates("ROWS BETWEEN 4 PRECEDING AND 6 FOLLOWING"),
+      );
+      expect(
+        GroupsFrameBoundary(
+          start: null,
+          end: -4,
+        ),
+        generates("GROUPS BETWEEN UNBOUNDED PRECEDING AND 4 PRECEDING"),
+      );
+      expect(
+        RowsFrameBoundary(
+          start: 0,
+          end: null,
+        ),
+        generates("ROWS BETWEEN CURRENT ROW AND UNBOUNDED FOLLOWING"),
+      );
+      expect(
+        RowsFrameBoundary(
+          start: 6,
+          end: null,
+        ),
+        generates("ROWS BETWEEN 6 FOLLOWING AND UNBOUNDED FOLLOWING"),
+      );
+    });
+
+    test('allows reverse boundary of same type', () {
+      expect(
+        RangeFrameBoundary(
+          start: -6,
+          end: -1,
+        ),
+        generates("RANGE BETWEEN 6 PRECEDING AND 1 PRECEDING"),
+      );
+
+      expect(
+        GroupsFrameBoundary(
+          start: 4,
+          end: 1,
+        ),
+        generates("GROUPS BETWEEN 4 FOLLOWING AND 1 FOLLOWING"),
+      );
+    });
+
+    test(
+        'does not allow reverse boundary of different type (start with FOLLOWING and end with PRECEDING or CURRENT ROW)',
+        () {
+      expect(
+          () => RangeFrameBoundary(
+                start: 6,
+                end: 0,
+              ),
+          throwsA(isA<AssertionError>()));
+      expect(
+          () => RangeFrameBoundary(
+                start: 6,
+                end: -3,
+              ),
+          throwsA(isA<AssertionError>()));
+    });
+
+    test('Exclude boundary', () {
+      expect(
+        RangeFrameBoundary(
+          exclude: FrameExclude.noOthers,
+        ),
+        generates(
+            "RANGE BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW EXCLUDE NO OTHERS"),
+      );
+      expect(
+        RowsFrameBoundary(
+          exclude: FrameExclude.currentRow,
+        ),
+        generates(
+            "ROWS BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW EXCLUDE CURRENT ROW"),
+      );
+      expect(
+        GroupsFrameBoundary(
+          exclude: FrameExclude.group,
+        ),
+        generates(
+            "GROUPS BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW EXCLUDE GROUP"),
+      );
+      expect(
+        RangeFrameBoundary(
+          exclude: FrameExclude.ties,
+        ),
+        generates(
+            "RANGE BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW EXCLUDE TIES"),
+      );
+    });
+  });
+}

--- a/drift/test/database/expressions/window_test.dart
+++ b/drift/test/database/expressions/window_test.dart
@@ -69,72 +69,72 @@ void main() {
   group('WINDOW FUNCTION Frame Spec', () {
     test('between unbounded preceding and current row', () {
       expect(
-        RowsFrameBoundary(),
+        FrameBoundary.rows(),
         generates("ROWS BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW"),
       );
       expect(
-        GroupsFrameBoundary(),
+        FrameBoundary.groups(),
         generates("GROUPS BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW"),
       );
       expect(
-        RangeFrameBoundary(),
+        FrameBoundary.range(),
         generates("RANGE BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW"),
       );
     });
 
     test('between unbounded preceding and unbounded following', () {
       expect(
-        RowsFrameBoundary(start: null, end: null),
+        FrameBoundary.rows(start: null, end: null),
         generates("ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING"),
       );
       expect(
-        GroupsFrameBoundary(start: null, end: null),
+        FrameBoundary.groups(start: null, end: null),
         generates("GROUPS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING"),
       );
       expect(
-        RangeFrameBoundary(start: null, end: null),
+        FrameBoundary.range(start: null, end: null),
         generates("RANGE BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING"),
       );
     });
 
     test('between expr preceding and/or expr following', () {
       expect(
-        RangeFrameBoundary(
+        FrameBoundary.range(
           start: -2,
           end: 0,
         ),
         generates("RANGE BETWEEN 2 PRECEDING AND CURRENT ROW"),
       );
       expect(
-        RowsFrameBoundary(
+        FrameBoundary.rows(
           start: -4,
           end: 6,
         ),
         generates("ROWS BETWEEN 4 PRECEDING AND 6 FOLLOWING"),
       );
       expect(
-        GroupsFrameBoundary(
+        FrameBoundary.groups(
           start: null,
           end: -4,
         ),
         generates("GROUPS BETWEEN UNBOUNDED PRECEDING AND 4 PRECEDING"),
       );
       expect(
-        RowsFrameBoundary(
+        FrameBoundary.rows(
           start: 0,
           end: null,
         ),
         generates("ROWS BETWEEN CURRENT ROW AND UNBOUNDED FOLLOWING"),
       );
       expect(
-        RowsFrameBoundary(
+        FrameBoundary.rows(
           start: 6,
           end: null,
         ),
         generates("ROWS BETWEEN 6 FOLLOWING AND UNBOUNDED FOLLOWING"),
       );
       expect(
-        RangeFrameBoundary(
+        FrameBoundary.range(
           start: -6.78,
           end: 57,
         ),
@@ -144,7 +144,7 @@ void main() {
 
     test('allows reverse boundary of same type', () {
       expect(
-        RangeFrameBoundary(
+        FrameBoundary.range(
           start: -6,
           end: -1,
         ),
@@ -152,7 +152,7 @@ void main() {
       );
 
       expect(
-        GroupsFrameBoundary(
+        FrameBoundary.groups(
           start: 4,
           end: 1,
         ),
@@ -164,13 +164,13 @@ void main() {
         'does not allow reverse boundary of different type (start with FOLLOWING and end with PRECEDING or CURRENT ROW)',
         () {
       expect(
-          () => RangeFrameBoundary(
+          () => FrameBoundary.range(
                 start: 6,
                 end: 0,
               ),
           throwsA(isA<AssertionError>()));
       expect(
-          () => RangeFrameBoundary(
+          () => FrameBoundary.range(
                 start: 6,
                 end: -3,
               ),
@@ -179,28 +179,28 @@ void main() {
 
     test('Exclude boundary', () {
       expect(
-        RangeFrameBoundary(
+        FrameBoundary.range(
           exclude: FrameExclude.noOthers,
         ),
         generates(
             "RANGE BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW EXCLUDE NO OTHERS"),
       );
       expect(
-        RowsFrameBoundary(
+        FrameBoundary.rows(
           exclude: FrameExclude.currentRow,
         ),
         generates(
             "ROWS BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW EXCLUDE CURRENT ROW"),
       );
       expect(
-        GroupsFrameBoundary(
+        FrameBoundary.groups(
           exclude: FrameExclude.group,
         ),
         generates(
             "GROUPS BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW EXCLUDE GROUP"),
       );
       expect(
-        RangeFrameBoundary(
+        FrameBoundary.range(
           exclude: FrameExclude.ties,
         ),
         generates(


### PR DESCRIPTION
The PR adds support for Window Function Expression as per specification on [SQLite Window Functions](https://www.sqlite.org/windowfunctions.html)

Currently using it in personal project. Thought it would be a good addition to the plugin.

# Basic Usage
 ```dart
 // Simple running total example
 final runningTotal = WindowFunctionExpression<double>(
   items.price.sum(), // aggregate function
   orderBy: [OrderingTerm.asc(items.date)],
 );

 // Use in a query
 final query = select(items).addColumns([runningTotal]);
 ```

 # Partitioning

 Partition data into groups before applying the window function:

 ```dart
 // Running total per category
 final runningTotalByCategory = WindowFunctionExpression<int>(
   items.price.sum(),
   orderBy: [OrderingTerm.asc(items.date)],
   partitionBy: [items.categoryId],
 );
 ```

 # Frame Boundaries

 ## Rows Frame
 Operates on physical rows:

 ```dart
 // Moving average of previous 3 rows and current row
 final movingAverage = WindowFunctionExpression<double>(
   items.price.avg(),
   orderBy: [OrderingTerm.asc(items.date)],
   boundary: RowsFrameBoundary(
     start: -3, // 3 rows preceding
     end: 0,    // current row
   ),
 );
 ```

 ## Groups Frame
 Operates on groups of rows with same ORDER BY values:

 ```dart
 // Include current group and one group before
 final groupFrame = WindowFunctionExpression<int>(
   items.quantity.sum(),
   orderBy: [OrderingTerm.asc(items.category)],
   boundary: GroupsFrameBoundary(
     start: null, // Unbounded preceding groups
     end: 0,    // current group
   ),
 );
 ```

 ## Range Frame
 Operates on value ranges (default):

 ```dart
 // Sum of items within price range of ±10 from current row
 final rangeFrame = WindowFunctionExpression<int>(
   items.quantity.sum(),
   orderBy: [OrderingTerm.asc(items.price)],
   boundary: RangeFrameBoundary(
     start: -10, // 10 units less than current value
     end: 10,    // 10 units more than current value
   ),
 );
 ```

