### PR TITLE
Fix typo that refers to an non-existent internal table

### DIFF
--- a/drift_dev/lib/src/services/schema/verifier_common.dart
+++ b/drift_dev/lib/src/services/schema/verifier_common.dart
@@ -7,7 +7,7 @@ import 'package:sqlite3/common.dart';
 import 'find_differences.dart';
 
 /// Attempts to recognize whether [name] is likely the name of an internal
-/// sqlite3 table (like `sqlite3_sequence`) that we should not consider when
+/// sqlite3 table (like `sqlite_sequence`) that we should not consider when
 /// comparing schemas.
 bool isInternalElement(String name, List<String> virtualTables) {
   // Skip sqlite-internal tables, https://www.sqlite.org/fileformat2.html#intschema


### PR DESCRIPTION
This was slightly misleading as the implementation suggests that 'sqlite_' is the prefix for these tables.

This was brought up here:
  https://github.com/zulip/zulip-flutter/pull/1248#discussion_r1961002211