### PR TITLE
Adapt to renamed methods in source_gen.

### DIFF
--- a/drift_dev/lib/src/analysis/driver/error.dart
+++ b/drift_dev/lib/src/analysis/driver/error.dart
@@ -11,11 +11,10 @@ class DriftAnalysisError {
   DriftAnalysisError(this.span, this.message);
 
   factory DriftAnalysisError.forDartElement(
-      dart.Element2 element, String message) {
-    return DriftAnalysisError(
-      spanForElement2(element),
-      message,
-    );
+    dart.Element2 element,
+    String message,
+  ) {
+    return DriftAnalysisError(spanForElement(element), message);
   }
 
   factory DriftAnalysisError.inDartAst(
@@ -51,8 +50,10 @@ class DriftAnalysisError {
   }
 
   static FileSpan dartAstSpan(
-      dart.Element2 element, dart.SyntacticEntity entity) {
-    final span = spanForElement2(element) as FileSpan;
+    dart.Element2 element,
+    dart.SyntacticEntity entity,
+  ) {
+    final span = spanForElement(element) as FileSpan;
     return span.file.span(entity.offset, entity.end);
   }
 }

--- a/drift_dev/lib/src/analysis/resolver/discover.dart
+++ b/drift_dev/lib/src/analysis/resolver/discover.dart
@@ -200,16 +200,16 @@ class _FindDartElements extends RecursiveElementVisitor2<void> {
     // weird errors for the Table class itself. In weird cases where we iterate
     // over generated code (standalone tool), don't report existing
     // implementations as tables.
-    return _isTable.isAssignableFrom2(element) &&
-        !_isTable.isExactly2(element) &&
-        !_isTableInfo.isAssignableFrom2(element) &&
+    return _isTable.isAssignableFrom(element) &&
+        !_isTable.isExactly(element) &&
+        !_isTableInfo.isAssignableFrom(element) &&
         // Temporary workaround until https://github.com/dart-lang/source_gen/pull/628
         // gets merged.
         !element.mixins.any((e) => e.nameIfInterfaceType == 'TableInfo');
   }
 
   bool _isDslView(ClassElement2 element) {
-    return _isView.isAssignableFrom2(element) && !_isView.isExactly2(element);
+    return _isView.isAssignableFrom(element) && !_isView.isExactly(element);
   }
 
   @override
@@ -245,8 +245,8 @@ class _FindDartElements extends RecursiveElementVisitor2<void> {
     } else {
       // Check if this class declares a database or a database accessor.
 
-      final firstDb = _isDatabase.firstAnnotationOf2(element);
-      final firstDao = _isDao.firstAnnotationOf2(element);
+      final firstDb = _isDatabase.firstAnnotationOf(element);
+      final firstDao = _isDao.firstAnnotationOf(element);
       final id = _discoverStep._id(element.name3!);
 
       if (firstDb != null) {


### PR DESCRIPTION
When a version of the `source_gen` package is published that works with the new analyzer element model, it will not use `2` suffixes on the methods `spanForElement`, `isAssignableFrom`, and `isExactly`. (See
https://github.com/dart-lang/source_gen/pull/750). Accordingly, `drift_dev` need to refer to these methods without the `2` suffix.