### PR TITLE
Prepare for upcoming element2 release of package:build.

### DIFF
--- a/drift_dev/lib/src/backends/build/backend.dart
+++ b/drift_dev/lib/src/backends/build/backend.dart
@@ -34,7 +34,7 @@ class DriftBuildBackend extends DriftBackend {
 
   @override
   Future<Uri> uriOfDart(Element2 element) async {
-    final id = await _buildStep.resolver.assetIdForElement2(element);
+    final id = await _buildStep.resolver.assetIdForElement(element);
     return id.uri;
   }
 
@@ -45,7 +45,7 @@ class DriftBuildBackend extends DriftBackend {
   Future<LibraryElement2> readDart(Uri uri) async {
     if (uri.scheme == 'dart') {
       final name = 'dart.${uri.path}';
-      final library = await _buildStep.resolver.findLibraryByName2(name);
+      final library = await _buildStep.resolver.findLibraryByName(name);
 
       if (library == null) {
         throw NotALibraryException(uri);
@@ -55,7 +55,7 @@ class DriftBuildBackend extends DriftBackend {
     }
 
     try {
-      return await _buildStep.resolver.libraryFor2(AssetId.resolve(uri));
+      return await _buildStep.resolver.libraryFor(AssetId.resolve(uri));
     } on NonLibraryAssetException {
       throw NotALibraryException(uri);
     }
@@ -63,7 +63,7 @@ class DriftBuildBackend extends DriftBackend {
 
   @override
   Future<AstNode?> loadElementDeclaration(Element2 element) {
-    return _buildStep.resolver.astNodeFor2(
+    return _buildStep.resolver.astNodeFor(
       element.firstFragment,
       resolve: true,
     );
@@ -95,10 +95,10 @@ class DriftBuildBackend extends DriftBackend {
       throw CannotReadExpressionException('No field for $dartExpression');
     }
 
-    final library = await _buildStep.resolver.libraryFor2(tempDart);
+    final library = await _buildStep.resolver.libraryFor(tempDart);
     final field = library.firstFragment.topLevelVariables2
         .firstWhere((element) => element.name2 == getter);
-    final fieldAst = await _buildStep.resolver.astNodeFor2(
+    final fieldAst = await _buildStep.resolver.astNodeFor(
       field,
       resolve: true,
     );
@@ -118,7 +118,7 @@ class DriftBuildBackend extends DriftBackend {
     final tempDart = original.changeExtension('.expr.temp.dart');
 
     if (await _buildStep.canRead(tempDart)) {
-      final library = await _buildStep.resolver.libraryFor2(tempDart);
+      final library = await _buildStep.resolver.libraryFor(tempDart);
       return library.firstFragment.scope.lookup(reference).getter2;
     } else {
       // If there's no temporary file whose imports we can use, then that means
@@ -127,7 +127,7 @@ class DriftBuildBackend extends DriftBackend {
       // For that, resolve a library we know exists and likely has been resolved
       // already.
       final libraryWeKnowExists = await _buildStep.resolver
-          .libraryFor2(AssetId.resolve(KnownDriftTypes.uri));
+          .libraryFor(AssetId.resolve(KnownDriftTypes.uri));
       final dartCore = libraryWeKnowExists.typeProvider.objectElement2.library2;
 
       return dartCore.exportNamespace.get2(reference);
@@ -197,7 +197,7 @@ class BuildCacheReader implements AnalysisResultCacheReader {
   Future<LibraryElement2?> readTypeHelperFor(Uri uri) async {
     final assetId = AssetId.resolve(uri).addExtension('.types.temp.dart');
     if (await _buildStep.canRead(assetId)) {
-      return _buildStep.resolver.libraryFor2(assetId, allowSyntaxErrors: true);
+      return _buildStep.resolver.libraryFor(assetId, allowSyntaxErrors: true);
     }
 
     return null;

--- a/drift_dev/lib/src/backends/build/drift_builder.dart
+++ b/drift_dev/lib/src/backends/build/drift_builder.dart
@@ -278,7 +278,7 @@ class _DriftBuildRun {
   /// minimal version constraints.
   Future<void> _checkForLanguageVersions() async {
     if (mode.isPartFile) {
-      final library = await buildStep.inputLibrary2;
+      final library = await buildStep.inputLibrary;
       overriddenLanguageVersion = library.languageVersion.override;
 
       final effectiveVersion =
@@ -467,7 +467,7 @@ class _DriftBuildRun {
   Future<void> _createWriter() async {
     if (mode.isMonolithic) {
       final generationOptions = GenerationOptions(
-        imports: ImportManagerForPartFiles(await buildStep.inputLibrary2),
+        imports: ImportManagerForPartFiles(await buildStep.inputLibrary),
       );
       writer = Writer(options, generationOptions: generationOptions);
     } else {

--- a/drift_dev/pubspec.yaml
+++ b/drift_dev/pubspec.yaml
@@ -63,5 +63,39 @@ dev_dependencies:
   crypto: ^3.0.3
   glob: ^2.1.2
 
+dependency_overrides:
+  analyzer: ^7.3.0
+  # package:build with element2 APIs is not released yet.
+  build:
+    git:
+      url: https://github.com/dart-lang/build.git
+      path: build
+      ref: resolver-2-methods
+  build_resolvers:
+    git:
+      url: https://github.com/dart-lang/build.git
+      path: build_resolvers
+      ref: resolver-2-methods
+  build_runner:
+    git:
+      url: https://github.com/dart-lang/build.git
+      path: build_runner
+      ref: resolver-2-methods
+  build_runner_core:
+    git:
+      url: https://github.com/dart-lang/build.git
+      path: build_runner_core
+      ref: resolver-2-methods
+  build_test:
+    git:
+      url: https://github.com/dart-lang/build.git
+      path: build_test
+      ref: resolver-2-methods
+  source_gen:
+    git:
+      url: https://github.com/dart-lang/source_gen.git
+      path: source_gen
+      ref: analyzer-element2
+
 executables:
   drift_dev:


### PR DESCRIPTION
The "build" packages will be released, like source_gen, with element2 APIs under the same names as the current element1 APIs.

This should now be approximately the final state that will work after source_gen+build are released for element2.

I added some dependency overrides so it's actually possible to analyze against the work-in-progress releases.