### PR TITLE
Add file path to error message in make-migrations script

### DIFF
--- a/drift_dev/lib/src/cli/commands/make_migrations.dart
+++ b/drift_dev/lib/src/cli/commands/make_migrations.dart
@@ -323,7 +323,7 @@ class _MigrationTestEmitter {
     } else if (schemaFile.readAsStringSync() != content) {
       cli.exit(
           "A schema for version $schemaVersion of the $dbName database already exists and differs from the current schema."
-          " Either delete the existing schema file or update the schema version in the database file.");
+          " Either delete the existing schema file (${schemaFile.path}) or update the schema version in the database file.");
     }
   }
 


### PR DESCRIPTION
During development, migrations may need to be built repeatedly for the same schema version. `dart run drift_dev make-migrations` fails if a schema file with different content already exists for a schema version and suggests deleting it. However, it is not clear which exact file needs to be deleted.

This change adds the schema file path to the error message.