### PR TITLE
add isolateDebugLog to DriftNativeOptions

### DIFF
--- a/drift/lib/native.dart
+++ b/drift/lib/native.dart
@@ -187,6 +187,7 @@ class NativeDatabase extends DelegatedDatabase {
   static DatabaseConnection createBackgroundConnection(
     File file, {
     bool logStatements = false,
+    bool isolateDebugLog = false,
     DatabaseSetup? setup,
     SqliteResolver sqlite3 = _NativeDelegate._defaultResolver,
     IsolateSetup? isolateSetup,
@@ -204,14 +205,14 @@ class NativeDatabase extends DelegatedDatabase {
         await Isolate.spawn(
           _NativeIsolateStartup.start,
           _NativeIsolateStartup(
-            file.absolute.path,
-            logStatements,
-            cachePreparedStatements,
-            enableMigrations,
-            setup,
-            isolateSetup,
-            sqlite3,
-            receiveIsolate.sendPort,
+            path: file.absolute.path,
+            enableLogs: logStatements,
+            cachePreparedStatements: cachePreparedStatements,
+            enableMigrations: enableMigrations,
+            setup: setup,
+            isolateSetup: isolateSetup,
+            sqlite3: sqlite3,
+            sendServer: receiveIsolate.sendPort,
           ),
           debugName: 'Drift isolate $kind for ${file.path}',
         );
@@ -220,7 +221,8 @@ class NativeDatabase extends DelegatedDatabase {
       await spawnIsolate('worker');
       final driftIsolate = await receive.next;
 
-      var connection = await driftIsolate.connect(singleClientMode: true);
+      var connection = await driftIsolate.connect(
+          singleClientMode: true, isolateDebugLog: isolateDebugLog);
       if (readPool != 0) {
         final readers = <QueryExecutor>[];
 
@@ -230,7 +232,10 @@ class NativeDatabase extends DelegatedDatabase {
 
         for (var i = 0; i < readPool; i++) {
           final spawned = await receive.next;
-          readers.add(await spawned.connect(singleClientMode: true));
+          readers.add(await spawned.connect(
+            singleClientMode: true,
+            isolateDebugLog: isolateDebugLog,
+          ));
         }
 
         connection = DatabaseConnection(
@@ -466,16 +471,16 @@ class _NativeIsolateStartup {
   final SqliteResolver sqlite3;
   final SendPort sendServer;
 
-  _NativeIsolateStartup(
-    this.path,
-    this.enableLogs,
-    this.cachePreparedStatements,
-    this.enableMigrations,
-    this.setup,
-    this.isolateSetup,
-    this.sqlite3,
-    this.sendServer,
-  );
+  _NativeIsolateStartup({
+    required this.path,
+    required this.enableLogs,
+    required this.cachePreparedStatements,
+    required this.enableMigrations,
+    required this.setup,
+    required this.isolateSetup,
+    required this.sqlite3,
+    required this.sendServer,
+  });
 
   static Future<void> start(_NativeIsolateStartup startup) async {
     await startup.isolateSetup?.call();

--- a/drift_flutter/CHANGELOG.md
+++ b/drift_flutter/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.2.7-dev
+
+- Add `isolateDebugLog` parameter to `DriftNativeOptions` to debug internal messages between isolates.
+
 ## 0.2.6
 
 - Add `initializeDatabase` parameter to `DriftWebOptions` to enable loading initial database.

--- a/drift_flutter/lib/src/connect.dart
+++ b/drift_flutter/lib/src/connect.dart
@@ -39,12 +39,12 @@ final class DriftWebOptions {
   final FutureOr<Uint8List?> Function()? initializeDatabase;
 
   /// Create web-specific drift options.
-  DriftWebOptions(
-      {required this.sqlite3Wasm,
-      required this.driftWorker,
-      this.onResult,
-      this.initializeDatabase,
-      });
+  DriftWebOptions({
+    required this.sqlite3Wasm,
+    required this.driftWorker,
+    this.onResult,
+    this.initializeDatabase,
+  });
 }
 
 /// Options used to open drift databases on native platforms (outside of the
@@ -66,6 +66,10 @@ final class DriftNativeOptions {
   /// This option is not enabled by default, but recommended if a drift database
   /// may be used on multiple isolates.
   final bool shareAcrossIsolates;
+
+  /// Setting the [isolateDebugLog] is only helpful when debugging drift itself.
+  /// It will print messages exchanged between the Drift server and the client.
+  final bool isolateDebugLog;
 
   /// An optional callback returning a custom database path to be used by drift.
   ///
@@ -129,6 +133,7 @@ final class DriftNativeOptions {
   /// platforms.
   const DriftNativeOptions({
     this.shareAcrossIsolates = false,
+    this.isolateDebugLog = false,
     this.databasePath,
     this.databaseDirectory,
     this.tempDirectoryPath,

--- a/drift_flutter/lib/src/connect.dart
+++ b/drift_flutter/lib/src/connect.dart
@@ -68,7 +68,8 @@ final class DriftNativeOptions {
   final bool shareAcrossIsolates;
 
   /// Setting the [isolateDebugLog] is only helpful when debugging drift itself.
-  /// It will print messages exchanged between the Drift server and the client.
+  /// It will print messages exchanged between the drift isolate server and the
+  /// client.
   final bool isolateDebugLog;
 
   /// An optional callback returning a custom database path to be used by drift.

--- a/drift_flutter/lib/src/native.dart
+++ b/drift_flutter/lib/src/native.dart
@@ -138,6 +138,7 @@ QueryExecutor driftDatabase({
     return NativeDatabase.createBackgroundConnection(
       await databaseFile(),
       setup: native?.setup,
+      isolateDebugLog: native?.isolateDebugLog ?? false,
     );
   }));
 }

--- a/drift_flutter/lib/src/native.dart
+++ b/drift_flutter/lib/src/native.dart
@@ -7,8 +7,8 @@ import 'package:drift/drift.dart';
 import 'package:drift/isolate.dart';
 import 'package:drift/native.dart';
 import 'package:meta/meta.dart';
-import 'package:path_provider/path_provider.dart';
 import 'package:path/path.dart' as p;
+import 'package:path_provider/path_provider.dart';
 import 'package:sqlite3/sqlite3.dart';
 import 'package:sqlite3_flutter_libs/sqlite3_flutter_libs.dart';
 
@@ -82,7 +82,10 @@ QueryExecutor driftDatabase({
             case final port?) {
           final isolate = DriftIsolate.fromConnectPort(port);
           try {
-            return await isolate.connect(connectTimeout: connectTimeout);
+            return await isolate.connect(
+              connectTimeout: connectTimeout,
+              isolateDebugLog: native.isolateDebugLog,
+            );
           } on TimeoutException {
             // Isolate has stopped shortly after the register call. It should
             // also remove the port mapping, so we can just try again in another
@@ -124,7 +127,9 @@ QueryExecutor driftDatabase({
           // due to a race condition (in which case it exits).
           final first = await firstMessage;
           if (first case SendPort port) {
-            return await DriftIsolate.fromConnectPort(port).connect();
+            return await DriftIsolate.fromConnectPort(port).connect(
+              isolateDebugLog: native.isolateDebugLog,
+            );
           }
         }
       }


### PR DESCRIPTION
### Description

- Adds the `isolateDebugLog` flag to `DriftNativeOptions` which is then passed on to the connect method of the underlying `DriftIsolate`


### Note
- The other changes in the file were made automatically by the formatter. Let me know if you want me to remove those