### PR TITLE
Avoid incorrect cast in sql_js in wasm builds

### DIFF
--- a/drift/lib/src/web/sql_js.dart
+++ b/drift/lib/src/web/sql_js.dart
@@ -114,7 +114,7 @@ class SqlJsDatabase {
 
   /// Returns the `user_version` pragma from sqlite.
   int get userVersion {
-    return (_selectSingleRowAndColumn('PRAGMA user_version;') as double)
+    return (_selectSingleRowAndColumn('PRAGMA user_version;') as num)
         .toInt();
   }
 
@@ -153,7 +153,7 @@ class SqlJsDatabase {
   /// [export].
   int lastInsertId() {
     // load insert id. Will return [{columns: [...], values: [[id]]}]
-    return (_selectSingleRowAndColumn('SELECT last_insert_rowid();') as double)
+    return (_selectSingleRowAndColumn('SELECT last_insert_rowid();') as num)
         .toInt();
   }
 

--- a/drift/lib/src/web/sql_js.dart
+++ b/drift/lib/src/web/sql_js.dart
@@ -114,7 +114,8 @@ class SqlJsDatabase {
 
   /// Returns the `user_version` pragma from sqlite.
   int get userVersion {
-    return _selectSingleRowAndColumn('PRAGMA user_version;') as int;
+    return (_selectSingleRowAndColumn('PRAGMA user_version;') as double)
+        .toInt();
   }
 
   /// Sets sqlite's `user_version` pragma to the specified [version].
@@ -152,7 +153,8 @@ class SqlJsDatabase {
   /// [export].
   int lastInsertId() {
     // load insert id. Will return [{columns: [...], values: [[id]]}]
-    return _selectSingleRowAndColumn('SELECT last_insert_rowid();') as int;
+    return (_selectSingleRowAndColumn('SELECT last_insert_rowid();') as double)
+        .toInt();
   }
 
   dynamic _selectSingleRowAndColumn(String sql) {

--- a/drift/lib/src/web/sql_js.dart
+++ b/drift/lib/src/web/sql_js.dart
@@ -1,7 +1,7 @@
 import 'dart:async';
-import 'dart:typed_data';
 import 'dart:js_interop';
 import 'dart:js_interop_unsafe';
+import 'dart:typed_data';
 
 @JS('initSqlJs')
 external JSPromise<_SqlJs> _initSqlJs();


### PR DESCRIPTION
In order to avoid:

    Type 'double' is not a subtype of type 'int' in type cast

Raised when drift is built with `flutter run -d chrome --wasm` it's needed to first cast the value to double then turn it into int and it does makes sense as int isn't native type in JS while double is the default numeric type in JS.

Fixing this make these errors in an external project (stream-chat) go:

<img width="518" height="140" alt="image" src="https://github.com/user-attachments/assets/d6325b13-d63b-4078-8a2d-68e32428b5df" />


