### PR TITLE
Add Insert From Select to Batch API

### DIFF
--- a/drift/CHANGELOG.md
+++ b/drift/CHANGELOG.md
@@ -3,6 +3,7 @@
 - Allow specifying ordering for columns in `@TableIndex` annotation.
 - Add `DelegatedDatabase.externalExecutor`, allowing transactions started
   externally to be used with drift.
+- Add `Batch.insertFromSelect` to insert rows from a select statement in a batch.
 
 ## 2.28.2
 

--- a/drift/lib/src/runtime/api/batch.dart
+++ b/drift/lib/src/runtime/api/batch.dart
@@ -53,6 +53,32 @@ class Batch {
     _addContext(context);
   }
 
+  /// Inserts rows from the [select] statement.
+  ///
+  /// This method creates an `INSERT INTO SELECT` statement in SQL which will
+  /// insert a row into this table for each row returned by the [select]
+  /// statement.
+  ///
+  /// The [columns] map describes which column from the select statement should
+  /// be written into which column of the table. The keys of the map are the
+  /// target column, and values are expressions added to the select statement.
+  ///
+  /// See also:
+  ///  - [InsertStatement.insertFromSelect], which would be used outside a
+  ///  [Batch].
+  void insertFromSelect<T extends Table, D>(
+      TableInfo<T, D> table, BaseSelectStatement select,
+      {required Map<Column, Expression> columns,
+      InsertMode? mode,
+      UpsertClause<T, D>? onConflict}) {
+    _addUpdate(table, UpdateKind.insert);
+    final actualMode = mode ?? InsertMode.insert;
+    final context = InsertStatement<T, D>(_user, table).createContextFromSelect(
+        select, columns, actualMode,
+        onConflict: onConflict);
+    _addContext(context);
+  }
+
   /// Inserts all [rows] into the [table].
   ///
   /// All fields in a row that don't have a default value or auto-increment

--- a/drift/lib/src/runtime/query_builder/statements/insert.dart
+++ b/drift/lib/src/runtime/query_builder/statements/insert.dart
@@ -95,45 +95,8 @@ class InsertStatement<T extends Table, D> {
     InsertMode mode = InsertMode.insert,
     UpsertClause<T, D>? onConflict,
   }) async {
-    // To be able to reference columns by names instead of by their index like
-    // normally done with `INSERT INTO SELECT`, we use a CTE. The final SQL
-    // statement will look like this:
-    // WITH source AS $select INSERT INTO $table (...) SELECT ... FROM source
-    final ctx = GenerationContext.fromDb(database);
-    const sourceCte = '_source';
-
-    ctx.buffer.write('WITH $sourceCte AS (');
-    select.writeInto(ctx);
-    ctx.buffer.write(') ');
-
-    final columnNameToSelectColumnName = <String, String>{};
-    columns.forEach((key, value) {
-      final name = select._nameForColumn(value);
-      if (name == null) {
-        throw ArgumentError.value(
-            value,
-            'column',
-            'This column passd to insertFromSelect() was not added to the '
-                'source select statement.');
-      }
-
-      columnNameToSelectColumnName[key.name] = name;
-    });
-
-    mode.writeInto(ctx);
-    ctx.buffer
-      ..write(' INTO ${ctx.identifier(table.aliasedName)} (')
-      ..write(columnNameToSelectColumnName.keys.map(ctx.identifier).join(', '))
-      ..write(') SELECT ')
-      ..write(
-          columnNameToSelectColumnName.values.map(ctx.identifier).join(', '))
-      ..write(' FROM $sourceCte');
-    if (onConflict != null) {
-      // Resolve parsing ambiguity (a `ON` from the conflict clause could also
-      // be parsed as a join).
-      ctx.buffer.write(' WHERE TRUE');
-      _writeOnConflict(ctx, mode, null, onConflict);
-    }
+    final ctx =
+        createContextFromSelect(select, columns, mode, onConflict: onConflict);
 
     return await database.withCurrentExecutor((e) async {
       await e.runInsert(ctx.sql, ctx.boundVariables);
@@ -271,6 +234,57 @@ class InsertStatement<T extends Table, D> {
           ctx.buffer.write(' RETURNING ${id.name}');
         }
       }
+    }
+
+    return ctx;
+  }
+
+  /// Creates a [GenerationContext] which contains the sql necessary to run an
+  /// insert from the [select] statement with the [mode].
+  ///
+  /// This method is used internally by drift. Consider using [insertFromSelect]
+  /// instead.
+  GenerationContext createContextFromSelect(BaseSelectStatement select,
+      Map<Column, Expression> columns, InsertMode mode,
+      {UpsertClause<T, D>? onConflict}) {
+    // To be able to reference columns by names instead of by their index like
+    // normally done with `INSERT INTO SELECT`, we use a CTE. The final SQL
+    // statement will look like this:
+    // WITH source AS $select INSERT INTO $table (...) SELECT ... FROM source
+    final ctx = GenerationContext.fromDb(database);
+    const sourceCte = '_source';
+
+    ctx.buffer.write('WITH $sourceCte AS (');
+    select.writeInto(ctx);
+    ctx.buffer.write(') ');
+
+    final columnNameToSelectColumnName = <String, String>{};
+    columns.forEach((key, value) {
+      final name = select._nameForColumn(value);
+      if (name == null) {
+        throw ArgumentError.value(
+            value,
+            'column',
+            'This column passd to insertFromSelect() was not added to the '
+                'source select statement.');
+      }
+
+      columnNameToSelectColumnName[key.name] = name;
+    });
+
+    mode.writeInto(ctx);
+    ctx.buffer
+      ..write(' INTO ${ctx.identifier(table.aliasedName)} (')
+      ..write(columnNameToSelectColumnName.keys.map(ctx.identifier).join(', '))
+      ..write(') SELECT ')
+      ..write(
+          columnNameToSelectColumnName.values.map(ctx.identifier).join(', '))
+      ..write(' FROM $sourceCte');
+    if (onConflict != null) {
+      // Resolve parsing ambiguity (a `ON` from the conflict clause could also
+      // be parsed as a join).
+      ctx.buffer.write(' WHERE TRUE');
+      _writeOnConflict(ctx, mode, null, onConflict);
     }
 
     return ctx;

--- a/drift/test/database/batch_test.dart
+++ b/drift/test/database/batch_test.dart
@@ -241,4 +241,91 @@ void main() {
 
     verify(executor.beginTransaction()).called(1);
   });
+
+  group('insert from select', () {
+    test('with simple select statement', () async {
+      final query = db.select(db.categories);
+      await db.batch((b) {
+        b.insertFromSelect(db.categories, query, columns: {
+          db.categories.description: db.categories.description,
+          db.categories.priority: db.categories.priority,
+        });
+      });
+
+      verify(executor.transactions.runBatched(BatchedStatements(
+        [
+          ('WITH _source AS (SELECT * FROM "categories") INSERT INTO "categories" '
+              '("desc", "priority") SELECT "desc", "priority" FROM _source')
+        ],
+        [
+          ArgumentsForBatchedStatement(0, []),
+        ],
+      )));
+    });
+
+    test('with join', () async {
+      final amountOfTodos = db.todosTable.id.count();
+      final newDescription = db.categories.description + amountOfTodos.cast();
+      final query = db.selectOnly(db.todosTable)
+        ..join([
+          innerJoin(
+              db.categories, db.categories.id.equalsExp(db.todosTable.category))
+        ])
+        ..groupBy([db.categories.id])
+        ..addColumns([newDescription, db.categories.priority]);
+
+      await db.batch((b) {
+        b.insertFromSelect(db.categories, query, columns: {
+          db.categories.description: newDescription,
+          db.categories.priority: db.categories.priority,
+        });
+      });
+
+      verify(executor.transactions.runBatched(BatchedStatements(
+        [
+          ('WITH _source AS (SELECT '
+              '"categories"."desc" || CAST(COUNT("todos"."id") AS TEXT) AS "c0", '
+              '"categories"."priority" AS "categories.priority" '
+              'FROM "todos" '
+              'INNER JOIN "categories" ON "categories"."id" = "todos"."category" '
+              'GROUP BY "categories"."id") '
+              'INSERT INTO "categories" ("desc", "priority") '
+              'SELECT "c0", "categories.priority" FROM _source')
+        ],
+        [
+          ArgumentsForBatchedStatement(0, []),
+        ],
+      )));
+    });
+
+    test('with on conflict clause', () async {
+      final query = db.select(db.categories);
+      await db.batch((b) {
+        b.insertFromSelect(
+          db.categories,
+          query,
+          columns: {
+            db.categories.description: db.categories.description,
+            db.categories.priority: db.categories.priority,
+          },
+          onConflict: DoUpdate<$CategoriesTable, Category>(
+            (old) => CategoriesCompanion.custom(
+              description: old.description,
+            ),
+          ),
+        );
+      });
+
+      verify(executor.transactions.runBatched(BatchedStatements(
+        [
+          ('WITH _source AS (SELECT * FROM "categories") INSERT INTO "categories" '
+              '("desc", "priority") SELECT "desc", "priority" FROM _source WHERE TRUE'
+              ' ON CONFLICT("id") DO UPDATE SET "desc" = "desc"')
+        ],
+        [
+          ArgumentsForBatchedStatement(0, []),
+        ],
+      )));
+    });
+  });
 }


### PR DESCRIPTION
Test cases were copied from `drift/test/database/statements/insert_test.dart` and adapted to Batch verify flow.