### PR TITLE
Migrate database if prefered option is available

### DIFF
--- a/drift/lib/wasm.dart
+++ b/drift/lib/wasm.dart
@@ -145,7 +145,7 @@ class WasmDatabase extends DelegatedDatabase {
     required Uri driftWorkerUri,
     FutureOr<Uint8List?> Function()? initializeDatabase,
     WasmDatabaseSetup? localSetup,
-    bool migrateToBestImplementation = false,
+    WasmStorageImplementation? preferedImplemetation,
     bool enableMigrations = true,
   }) async {
     final probed = await probe(
@@ -164,7 +164,8 @@ class WasmDatabase extends DelegatedDatabase {
     // left.
     availableImplementations.sortBy<num>((element) => element.index);
 
-    final bestAvailableImplementation = availableImplementations.first;
+    final preferedAvailable =
+        availableImplementations.contains(preferedImplemetation);
     ExistingDatabase? currentDatabase;
 
     checkExisting:
@@ -192,17 +193,15 @@ class WasmDatabase extends DelegatedDatabase {
       }
     }
 
-    final bestCurrentImplementation = availableImplementations.firstOrNull ??
+    final bestImplementation = availableImplementations.firstOrNull ??
         WasmStorageImplementation.inMemory;
 
-    final needsMigration = migrateToBestImplementation &&
+    final needsMigration = preferedAvailable &&
         currentDatabase != null &&
-        bestCurrentImplementation != bestAvailableImplementation;
+        bestImplementation != preferedImplemetation;
 
     final connection = await probed.open(
-      migrateToBestImplementation
-          ? bestAvailableImplementation
-          : bestCurrentImplementation,
+      needsMigration ? preferedImplemetation! : bestImplementation,
       databaseName,
       localSetup: localSetup,
       initializeDatabase: needsMigration
@@ -212,7 +211,7 @@ class WasmDatabase extends DelegatedDatabase {
     );
 
     return WasmDatabaseResult(
-        connection, bestCurrentImplementation, probed.missingFeatures);
+        connection, bestImplementation, probed.missingFeatures);
   }
 
   /// Probes for:

--- a/drift/lib/wasm.dart
+++ b/drift/lib/wasm.dart
@@ -138,6 +138,9 @@ class WasmDatabase extends DelegatedDatabase {
   /// When [enableMigrations] is set to `false`, drift will not check the
   /// `user_version` pragma when opening the database or run migrations.
   ///
+  /// If a [preferedImplemetation] is defined and available in the browser the
+  /// data will automatically be migrated to it.
+  ///
   /// For more detailed information, see https://drift.simonbinder.eu/web.
   static Future<WasmDatabaseResult> open({
     required String databaseName,

--- a/drift/lib/wasm.dart
+++ b/drift/lib/wasm.dart
@@ -159,66 +159,77 @@ class WasmDatabase extends DelegatedDatabase {
 
     // If we have an existing database in storage, we want to keep using that
     // format to avoid data loss (e.g. after a browser update that enables a
-    // otherwise preferred storage implementation). In the future, we might want
-    // to consider migrating between storage implementations as well.
+    // otherwise preferred storage implementation).
     final availableImplementations = probed.availableStorages.toList();
-
     // Enum values are ordered by preferrability, so just pick the best option
     // left.
-    availableImplementations.sortBy<num>((element) => element.index);
+    availableImplementations.sortBy<num>((e) => e.index);
 
-    final preferedAvailable =
+    final preferredIsAvailable =
         availableImplementations.contains(preferredImplementation);
-    ExistingDatabase? currentDatabase;
 
-    checkExisting:
-    for (final (location, name) in probed.existingDatabases) {
-      if (name == databaseName) {
-        final implementationsForStorage = switch (location) {
-          WebStorageApi.indexedDb => const [
-              WasmStorageImplementation.sharedIndexedDb,
-              WasmStorageImplementation.unsafeIndexedDb
-            ],
-          WebStorageApi.opfs => const [
-              WasmStorageImplementation.opfsShared,
-              WasmStorageImplementation.opfsLocks,
-            ],
-        };
-
-        // If any of the implementations for this location is still availalable,
-        // we want to use it instead of another location.
-        if (implementationsForStorage.any(availableImplementations.contains)) {
-          availableImplementations
-              .removeWhere((i) => !implementationsForStorage.contains(i));
-          currentDatabase = (location, name);
-          break checkExisting;
-        }
-      }
-    }
+    // Check if there is an existing DB and restrict implementations to its storage.
+    final currentDb = _selectExistingDatabase(
+      databaseName,
+      availableImplementations,
+      probed.existingDatabases,
+    );
 
     final bestImplementation = availableImplementations.firstOrNull ??
         WasmStorageImplementation.inMemory;
 
-    final needsMigration = preferedAvailable &&
-        currentDatabase != null &&
+    final needsMigration = preferredIsAvailable &&
+        currentDb != null &&
         bestImplementation != preferredImplementation;
 
+    // Determine which implementation to open with
+    final implementationToOpen = needsMigration
+        ? preferredImplementation!
+        : preferredIsAvailable
+            ? preferredImplementation!
+            : bestImplementation;
+
     final connection = await probed.open(
-      needsMigration
-          ? preferredImplementation!
-          : preferedAvailable
-              ? preferredImplementation!
-              : bestImplementation,
+      implementationToOpen,
       databaseName,
       localSetup: localSetup,
       initializeDatabase: needsMigration
-          ? () => probed.exportDatabase(currentDatabase!)
+          ? () => probed.exportDatabase(currentDb)
           : initializeDatabase,
       enableMigrations: enableMigrations,
     );
 
     return WasmDatabaseResult(
         connection, bestImplementation, probed.missingFeatures);
+  }
+
+  static ExistingDatabase? _selectExistingDatabase(
+    String databaseName,
+    List<WasmStorageImplementation> available,
+    List<ExistingDatabase> existingDatabases,
+  ) {
+    for (final (location, name) in existingDatabases) {
+      if (name != databaseName) continue;
+
+      final implementationsForStorage = switch (location) {
+        WebStorageApi.indexedDb => const [
+            WasmStorageImplementation.sharedIndexedDb,
+            WasmStorageImplementation.unsafeIndexedDb,
+          ],
+        WebStorageApi.opfs => const [
+            WasmStorageImplementation.opfsShared,
+            WasmStorageImplementation.opfsLocks,
+          ],
+      };
+
+      // If storage still supported → restrict available implementations
+      if (implementationsForStorage.any(available.contains)) {
+        available.removeWhere((i) => !implementationsForStorage.contains(i));
+        return (location, name);
+      }
+    }
+
+    return null;
   }
 
   /// Probes for:

--- a/drift/lib/wasm.dart
+++ b/drift/lib/wasm.dart
@@ -138,7 +138,7 @@ class WasmDatabase extends DelegatedDatabase {
   /// When [enableMigrations] is set to `false`, drift will not check the
   /// `user_version` pragma when opening the database or run migrations.
   ///
-  /// If a [preferedImplemetation] is defined and available in the browser the
+  /// If a [preferredImplementation] is defined and available in the browser the
   /// data will automatically be migrated to it.
   ///
   /// For more detailed information, see https://drift.simonbinder.eu/web.
@@ -148,7 +148,7 @@ class WasmDatabase extends DelegatedDatabase {
     required Uri driftWorkerUri,
     FutureOr<Uint8List?> Function()? initializeDatabase,
     WasmDatabaseSetup? localSetup,
-    WasmStorageImplementation? preferedImplemetation,
+    WasmStorageImplementation? preferredImplementation,
     bool enableMigrations = true,
   }) async {
     final probed = await probe(
@@ -168,7 +168,7 @@ class WasmDatabase extends DelegatedDatabase {
     availableImplementations.sortBy<num>((element) => element.index);
 
     final preferedAvailable =
-        availableImplementations.contains(preferedImplemetation);
+        availableImplementations.contains(preferredImplementation);
     ExistingDatabase? currentDatabase;
 
     checkExisting:
@@ -201,10 +201,14 @@ class WasmDatabase extends DelegatedDatabase {
 
     final needsMigration = preferedAvailable &&
         currentDatabase != null &&
-        bestImplementation != preferedImplemetation;
+        bestImplementation != preferredImplementation;
 
     final connection = await probed.open(
-      needsMigration ? preferedImplemetation! : bestImplementation,
+      needsMigration
+          ? preferredImplementation!
+          : preferedAvailable
+              ? preferredImplementation!
+              : bestImplementation,
       databaseName,
       localSetup: localSetup,
       initializeDatabase: needsMigration

--- a/drift/lib/wasm.dart
+++ b/drift/lib/wasm.dart
@@ -8,12 +8,12 @@ library;
 
 import 'dart:async';
 import 'dart:js_interop';
-import 'dart:typed_data';
 
 import 'package:collection/collection.dart';
+import 'package:drift/drift.dart';
+import 'package:sqlite3/wasm.dart';
 import 'package:web/web.dart'
     show DedicatedWorkerGlobalScope, SharedWorkerGlobalScope;
-import 'package:sqlite3/wasm.dart';
 
 import 'backends.dart';
 import 'src/sqlite3/database.dart';
@@ -145,6 +145,7 @@ class WasmDatabase extends DelegatedDatabase {
     required Uri driftWorkerUri,
     FutureOr<Uint8List?> Function()? initializeDatabase,
     WasmDatabaseSetup? localSetup,
+    bool migrateToBestImplementation = false,
     bool enableMigrations = true,
   }) async {
     final probed = await probe(
@@ -158,6 +159,13 @@ class WasmDatabase extends DelegatedDatabase {
     // otherwise preferred storage implementation). In the future, we might want
     // to consider migrating between storage implementations as well.
     final availableImplementations = probed.availableStorages.toList();
+
+    // Enum values are ordered by preferrability, so just pick the best option
+    // left.
+    availableImplementations.sortBy<num>((element) => element.index);
+
+    final bestAvailableImplementation = availableImplementations.first;
+    ExistingDatabase? currentDatabase;
 
     checkExisting:
     for (final (location, name) in probed.existingDatabases) {
@@ -178,27 +186,33 @@ class WasmDatabase extends DelegatedDatabase {
         if (implementationsForStorage.any(availableImplementations.contains)) {
           availableImplementations
               .removeWhere((i) => !implementationsForStorage.contains(i));
+          currentDatabase = (location, name);
           break checkExisting;
         }
       }
     }
 
-    // Enum values are ordered by preferrability, so just pick the best option
-    // left.
-    availableImplementations.sortBy<num>((element) => element.index);
-
-    final bestImplementation = availableImplementations.firstOrNull ??
+    final bestCurrentImplementation = availableImplementations.firstOrNull ??
         WasmStorageImplementation.inMemory;
+
+    final needsMigration = migrateToBestImplementation &&
+        currentDatabase != null &&
+        bestCurrentImplementation != bestAvailableImplementation;
+
     final connection = await probed.open(
-      bestImplementation,
+      migrateToBestImplementation
+          ? bestAvailableImplementation
+          : bestCurrentImplementation,
       databaseName,
       localSetup: localSetup,
-      initializeDatabase: initializeDatabase,
+      initializeDatabase: needsMigration
+          ? () => probed.exportDatabase(currentDatabase!)
+          : initializeDatabase,
       enableMigrations: enableMigrations,
     );
 
     return WasmDatabaseResult(
-        connection, bestImplementation, probed.missingFeatures);
+        connection, bestCurrentImplementation, probed.missingFeatures);
   }
 
   /// Probes for:

--- a/extras/integration_tests/web_wasm/README.md
+++ b/extras/integration_tests/web_wasm/README.md
@@ -5,3 +5,5 @@ To run the tests automatically (with us managing a browser driver), just run `da
 To manually debug issues, it might make sense to trigger some functionality manually.
 You can run `dart run tool/serve_manually.dart` to start a web server hosting the test
 content on <http://localhost:8080>.
+
+Make sure to install [chromedriver](https://googlechromelabs.github.io/chrome-for-testing) and [geckodriver](https://github.com/mozilla/geckodriver/releases) for the test to use.

--- a/extras/integration_tests/web_wasm/lib/driver.dart
+++ b/extras/integration_tests/web_wasm/lib/driver.dart
@@ -148,9 +148,9 @@ class DriftWebDriver {
 
   Future<void> openDatabase(
       [WasmStorageImplementation? implementation,
-      WasmStorageImplementation? preferedImplemetation]) async {
+      WasmStorageImplementation? preferredImplementation]) async {
     await driver.executeAsync('open(arguments[0], arguments[1])', [
-      json.encode([implementation?.name, preferedImplemetation?.name])
+      json.encode([implementation?.name, preferredImplementation?.name])
     ]);
   }
 

--- a/extras/integration_tests/web_wasm/lib/driver.dart
+++ b/extras/integration_tests/web_wasm/lib/driver.dart
@@ -7,14 +7,14 @@ import 'package:build_daemon/constants.dart';
 import 'package:build_daemon/data/build_status.dart';
 import 'package:build_daemon/data/build_target.dart';
 import 'package:collection/collection.dart';
+// ignore: implementation_imports
+import 'package:drift/src/web/wasm_setup/types.dart';
 import 'package:package_config/package_config.dart';
 import 'package:path/path.dart' as p;
 import 'package:shelf/shelf_io.dart';
 import 'package:shelf_proxy/shelf_proxy.dart';
 import 'package:web_wasm/initialization_mode.dart';
 import 'package:webdriver/async_io.dart';
-// ignore: implementation_imports
-import 'package:drift/src/web/wasm_setup/types.dart';
 import 'package:webdriver/support/async.dart';
 
 class TestAssetServer {
@@ -36,7 +36,7 @@ class TestAssetServer {
         await loadPackageConfigUri((await Isolate.packageConfig)!);
     final ownPackage = packageConfig['web_wasm']!.root;
     var packageDir = ownPackage.toFilePath(windows: Platform.isWindows);
-    if (packageDir.endsWith('/')) {
+    if (packageDir.endsWith('/') || packageDir.endsWith('\\')) {
       packageDir = packageDir.substring(0, packageDir.length - 1);
     }
 

--- a/extras/integration_tests/web_wasm/lib/driver.dart
+++ b/extras/integration_tests/web_wasm/lib/driver.dart
@@ -146,9 +146,12 @@ class DriftWebDriver {
     );
   }
 
-  Future<void> openDatabase([WasmStorageImplementation? implementation]) async {
-    await driver.executeAsync(
-        'open(arguments[0], arguments[1])', [implementation?.name]);
+  Future<void> openDatabase(
+      [WasmStorageImplementation? implementation,
+      WasmStorageImplementation? preferedImplemetation]) async {
+    await driver.executeAsync('open(arguments[0], arguments[1])', [
+      json.encode([implementation?.name, preferedImplemetation?.name])
+    ]);
   }
 
   Future<void> closeDatabase() async {

--- a/extras/integration_tests/web_wasm/test/drift_wasm_test.dart
+++ b/extras/integration_tests/web_wasm/test/drift_wasm_test.dart
@@ -352,6 +352,25 @@ final class _TestConfiguration {
       );
 
       test(
+        'use preferred implementation if available when initializing',
+        () async {
+          // Open with preferred IndexedDB database first
+          await driver.openDatabase(
+              null, WasmStorageImplementation.unsafeIndexedDb);
+          await driver.insertIntoDatabase();
+          await Future.delayed(const Duration(seconds: 2));
+          await driver.driver.refresh(); // Reset JS state
+          await driver.waitReady();
+
+          // Open the database again, this time without specifying a fixed
+          // implementation. Despite OPFS being available (and preferred),
+          // the existing database should be used.
+          await driver.openDatabase();
+          expect(await driver.amountOfRows, 1);
+        },
+      );
+
+      test(
         'switch from IndexedDB database to OPFS if it is the preferred implementation',
         () async {
           // Open an IndexedDB database first

--- a/extras/integration_tests/web_wasm/test/drift_wasm_test.dart
+++ b/extras/integration_tests/web_wasm/test/drift_wasm_test.dart
@@ -351,6 +351,29 @@ final class _TestConfiguration {
         },
       );
 
+      test(
+        'switch from IndexedDB database to OPFS if it is the prefered implementation',
+        () async {
+          // Open an IndexedDB database first
+          await driver.openDatabase(WasmStorageImplementation.unsafeIndexedDb);
+          await driver.insertIntoDatabase();
+          await Future.delayed(const Duration(seconds: 2));
+          await driver.driver.refresh(); // Reset JS state
+          await driver.waitReady();
+
+          // Open the database again, this time specifying opfs as the
+          // preferred implementation.
+          await driver.openDatabase(null, WasmStorageImplementation.opfsLocks);
+          expect(await driver.amountOfRows, 1);
+          await Future.delayed(const Duration(seconds: 2));
+          await driver.driver.refresh(); // Reset JS state
+          await driver.waitReady();
+
+          await driver.openDatabase(WasmStorageImplementation.opfsLocks);
+          expect(await driver.amountOfRows, 1);
+        },
+      );
+
       if (!browser.supports(WasmStorageImplementation.opfsShared)) {
         test('uses indexeddb after OPFS becomes unavailable', () async {
           // This browser only supports OPFS with the right headers. If they

--- a/extras/integration_tests/web_wasm/test/drift_wasm_test.dart
+++ b/extras/integration_tests/web_wasm/test/drift_wasm_test.dart
@@ -352,7 +352,7 @@ final class _TestConfiguration {
       );
 
       test(
-        'switch from IndexedDB database to OPFS if it is the prefered implementation',
+        'switch from IndexedDB database to OPFS if it is the preferred implementation',
         () async {
           // Open an IndexedDB database first
           await driver.openDatabase(WasmStorageImplementation.unsafeIndexedDb);

--- a/extras/integration_tests/web_wasm/web/main.dart
+++ b/extras/integration_tests/web_wasm/web/main.dart
@@ -182,7 +182,7 @@ Future<JSString> _detectImplementations(String? _) async {
 }
 
 Future<JSAny?> _open(
-    String? implementationName, String? preferedImplemetationName) async {
+    String? implementationName, String? preferredImplementationName) async {
   DatabaseConnection connection;
 
   if (implementationName != null) {
@@ -205,8 +205,8 @@ Future<JSAny?> _open(
       initializeDatabase: _initializeDatabase,
       enableMigrations:
           initializationMode != InitializationMode.noneAndDisableMigrations,
-      preferedImplemetation: WasmStorageImplementation.values
-          .asNameMap()[preferedImplemetationName],
+      preferredImplementation: WasmStorageImplementation.values
+          .asNameMap()[preferredImplementationName],
       localSetup: (db) {
         // The worker has a similar setup call that will make database_host
         // return `worker` instead.

--- a/extras/integration_tests/web_wasm/web/main.dart
+++ b/extras/integration_tests/web_wasm/web/main.dart
@@ -6,11 +6,11 @@ import 'package:async/async.dart';
 import 'package:drift/drift.dart';
 import 'package:drift/wasm.dart';
 import 'package:http/http.dart' as http;
+import 'package:sqlite3/wasm.dart';
 import 'package:web/web.dart'
     show document, EventStreamProviders, HTMLDivElement;
 import 'package:web_wasm/initialization_mode.dart';
 import 'package:web_wasm/src/database.dart';
-import 'package:sqlite3/wasm.dart';
 
 const dbName = 'drift_test';
 final sqlite3WasmUri = Uri.parse('sqlite3.wasm');
@@ -32,7 +32,10 @@ void main() {
     driftWorkerUri = Uri.parse('wrong.js');
     return _detectImplementations(arg);
   });
-  _addCallbackForWebDriver('open', _open);
+  _addCallbackForWebDriver('open', (arg) {
+    final decoded = json.decode(arg!);
+    return _open(decoded[0] as String?, decoded[1] as String?);
+  });
   _addCallbackForWebDriver('close', (arg) async {
     await tableUpdates?.cancel();
     await openedDatabase?.close();
@@ -178,7 +181,8 @@ Future<JSString> _detectImplementations(String? _) async {
   }).toJS;
 }
 
-Future<JSAny?> _open(String? implementationName) async {
+Future<JSAny?> _open(
+    String? implementationName, String? preferedImplemetationName) async {
   DatabaseConnection connection;
 
   if (implementationName != null) {
@@ -201,6 +205,8 @@ Future<JSAny?> _open(String? implementationName) async {
       initializeDatabase: _initializeDatabase,
       enableMigrations:
           initializationMode != InitializationMode.noneAndDisableMigrations,
+      preferedImplemetation: WasmStorageImplementation.values
+          .asNameMap()[preferedImplemetationName],
       localSetup: (db) {
         // The worker has a similar setup call that will make database_host
         // return `worker` instead.


### PR DESCRIPTION
Created this PR to simplify migrating an existing Flutter app using Drift from one storage implementation to another.

The new implementation allows developers to specify a `preferredImplementation`. If this implementation is available, the current database will be exported and used to initialize the new database via the `initializeDatabase` function.

This change should improve developer experience and make it easier to take advantage of the benefits of OPFS.