### PR TITLE
Fix range error in page caching

### DIFF
--- a/docs/lib/src/search/database.dart
+++ b/docs/lib/src/search/database.dart
@@ -289,7 +289,7 @@ final class _BlockCache {
 
     // Trim the range from page, endPageInclusive to remove pages at both ends
     // that have already been cached.
-    while (cachedPages[page] != null && page < endPageExclusive) {
+    while (page < endPageExclusive && cachedPages[page] != null) {
       page++;
     }
     while (cachedPages[endPageExclusive - 1] != null &&


### PR DESCRIPTION
When I search for "conflict" on the drift documentation page, I get an SqliteException.

It looks like the `cachedPages` array is accessed in the if condition before the bounds are checked.