### PR TITLE
Fix scanner if source ends with an unterminated string

### DIFF
--- a/sqlparser/lib/src/reader/tokenizer/scanner.dart
+++ b/sqlparser/lib/src/reader/tokenizer/scanner.dart
@@ -313,7 +313,10 @@ class Scanner {
     }
 
     final value = source
-        .substring(_startOffset + (binary ? 2 : 1), _currentOffset - 1)
+        .substring(
+          _startOffset + (binary ? 2 : 1),
+          _currentOffset - (properlyClosed ? 1 : 0),
+        )
         .replaceAll("''", "'");
     tokens.add(StringLiteralToken(value, _currentSpan, binary: binary));
   }

--- a/sqlparser/test/scanner/single_token_test.dart
+++ b/sqlparser/test/scanner/single_token_test.dart
@@ -74,14 +74,32 @@ void main() {
     expect(scanner.tokens[1].type, TokenType.eof);
   });
 
-  test('issues error for unterminated string literals', () {
-    final scanner = Scanner("'unterminated")..scanTokens();
+  group("parse unterminated string literals", () {
+    test('issues error', () {
+      final scanner = Scanner("'unterminated")..scanTokens();
 
-    expect(
-      scanner.errors,
-      contains(const TypeMatcher<TokenizerError>()
-          .having((e) => e.message, 'message', 'Unterminated string')),
-    );
+      expect(
+        scanner.errors,
+        contains(const TypeMatcher<TokenizerError>()
+            .having((e) => e.message, 'message', 'Unterminated string')),
+      );
+
+      expect(scanner.tokens, [
+        isA<StringLiteralToken>()
+            .having((e) => e.value, 'value', 'unterminated'),
+        isA<Token>().having((e) => e.type, 'type', TokenType.eof),
+      ]);
+    });
+
+    test('does not crash if the input ends with apostrophe', () {
+      final scanner = Scanner("'")..scanTokens();
+
+      expect(
+        scanner.errors,
+        contains(const TypeMatcher<TokenizerError>()
+            .having((e) => e.message, 'message', 'Unterminated string')),
+      );
+    });
   });
 
   test('binary string literal', () {


### PR DESCRIPTION
Fixed range error if the scanner input ended with a single apostrophe.
Returned value when parsing unterminated string literal was one character short.