### PR TITLE
Migrate IndexedDB databases to OPFS

### DIFF
--- a/drift/CHANGELOG.md
+++ b/drift/CHANGELOG.md
@@ -1,6 +1,9 @@
 ## 2.30.0-wip
 
 - Add `rightOuterJoin` and `fullOuterJoin`.
+- Wasm: Add the `WasmProbeResult.moveFromIndexedDBToOpfs()` method and the
+  `moveExistingIndexedDbToOpfs` parameter on `WasmDatabase.open`. They can be
+  used to move an existing database stored in IndexedDB to OPFS.
 
 ## 2.29.0
 

--- a/drift/lib/src/web/wasm_setup.dart
+++ b/drift/lib/src/web/wasm_setup.dart
@@ -24,6 +24,7 @@ import 'package:web/web.dart' as web;
 
 import 'broadcast_stream_queries.dart';
 import 'channel_new.dart';
+import 'wasm_setup/indexeddb_to_opfs.dart';
 import 'wasm_setup/shared.dart';
 import 'wasm_setup/protocol.dart';
 
@@ -397,6 +398,11 @@ final class _ProbeResult implements WasmProbeResult {
 
         return contents.toDart.asUint8List();
     }
+  }
+
+  @override
+  Future<void> moveFromIndexedDBToOpfs(String databaseName) {
+    return moveIndexedDBDatabaseToOpfs(databaseName);
   }
 }
 

--- a/drift/lib/src/web/wasm_setup/indexeddb_to_opfs.dart
+++ b/drift/lib/src/web/wasm_setup/indexeddb_to_opfs.dart
@@ -10,7 +10,7 @@ import 'shared.dart';
 ///
 /// Because this only uses asynchronous web file system APIs, it can run in the
 /// main tab and doesn't have to run in a worker.
-Future<void> moveIndexedDbDatabaseToOpfs(String databaseName) async {
+Future<void> moveIndexedDBDatabaseToOpfs(String databaseName) async {
   final existingVfs = await IndexedDbFileSystem.open(dbName: databaseName);
   final createDirectory = FileSystemGetDirectoryOptions(create: true);
   final createFile = FileSystemGetFileOptions(create: true);

--- a/drift/lib/src/web/wasm_setup/indexeddb_to_opfs.dart
+++ b/drift/lib/src/web/wasm_setup/indexeddb_to_opfs.dart
@@ -1,0 +1,90 @@
+import 'dart:js_interop';
+import 'dart:typed_data';
+
+import 'package:sqlite3/wasm.dart';
+import 'package:web/web.dart';
+
+import 'shared.dart';
+
+/// Moves a SQLite database stored in IndexedDB to OPFS.
+///
+/// Because this only uses asynchronous web file system APIs, it can run in the
+/// main tab and doesn't have to run in a worker.
+Future<void> moveIndexedDbDatabaseToOpfs(String databaseName) async {
+  final existingVfs = await IndexedDbFileSystem.open(dbName: databaseName);
+  final createDirectory = FileSystemGetDirectoryOptions(create: true);
+  final createFile = FileSystemGetFileOptions(create: true);
+
+  final driftDbRoot = await opfsDriftDirectoryHandle(createDirectory);
+  if (driftDbRoot == null) {
+    throw MoveIndexedDbToOpfsException._(
+        databaseName, 'OPFS does not appear to be available.');
+  }
+  final dbRoot = await driftDbRoot
+      .getDirectoryHandle(databaseName, createDirectory)
+      .toDart;
+
+  Future<bool> copyFile(String file) async {
+    VirtualFileSystemFile old;
+    try {
+      old = existingVfs.xOpen(Sqlite3Filename('/$file'), 0).file;
+    } on VfsException {
+      // Doesn't exist.
+      return false;
+    }
+
+    final buffer = Uint8List(old.xFileSize());
+    old.xRead(buffer, 0);
+    old.xClose();
+
+    final target = await dbRoot.getFileHandle(file, createFile).toDart;
+    final writable = await target
+        .createWritable(
+            FileSystemCreateWritableOptions(keepExistingData: false))
+        .toDart;
+    await writable.write(buffer.toJS).toDart;
+    await writable.close().toDart;
+    return true;
+  }
+
+  final journalExists = await copyFile('database-journal');
+  final mainFileExists = await copyFile('database');
+
+  {
+    // We use a meta file storing two bytes representing whether the database
+    // file exist. For details, see SimpleOpfsFileSystem in package:sqlite3.
+    final metaTarget = await dbRoot.getFileHandle('meta', createFile).toDart;
+    final metaWriter = await metaTarget
+        .createWritable(
+            FileSystemCreateWritableOptions(keepExistingData: false))
+        .toDart;
+    final buffer = Uint8List(2);
+    buffer[0] = mainFileExists ? 1 : 0;
+    buffer[1] = journalExists ? 1 : 0;
+    await metaWriter.write(buffer.toJS).toDart;
+    await metaWriter.close().toDart;
+  }
+
+  try {
+    await existingVfs.close();
+    await IndexedDbFileSystem.deleteDatabase(databaseName);
+  } catch (e) {
+    // At this point, drift would still use the new OPFS database because it
+    // would be detected as existing. Deleting the old one saves space, but is
+    // not strictly required either.
+  }
+}
+
+/// An exception thrown by [moveIndexedDbDatabaseToOpfs] if an unexpected error
+/// occurs.
+final class MoveIndexedDbToOpfsException implements Exception {
+  final String _databaseName;
+  final String _message;
+
+  MoveIndexedDbToOpfsException._(this._databaseName, this._message);
+
+  @override
+  String toString() {
+    return 'Could not move $_databaseName from IndexedDB to OPFS: $_message';
+  }
+}

--- a/drift/lib/src/web/wasm_setup/shared.dart
+++ b/drift/lib/src/web/wasm_setup/shared.dart
@@ -21,7 +21,8 @@ import 'package:web/web.dart'
         FileSystemHandle,
         FileSystemSyncAccessHandle,
         FileSystemGetFileOptions,
-        FileSystemRemoveOptions;
+        FileSystemRemoveOptions,
+        FileSystemGetDirectoryOptions;
 // ignore: implementation_imports
 import 'package:sqlite3/src/wasm/js_interop/core.dart';
 import 'package:sqlite3/wasm.dart';
@@ -33,7 +34,8 @@ import 'protocol.dart';
 @JS('navigator')
 external Navigator get _navigator;
 
-StorageManager? get _storageManager {
+/// The web [StorageManager], if available.
+StorageManager? get storageManager {
   final navigator = _navigator;
 
   if (navigator.has('storage')) {
@@ -49,7 +51,7 @@ StorageManager? get _storageManager {
 /// Since OPFS uses the synchronous file system access API, this method can only
 /// return true when called in a dedicated worker.
 Future<bool> checkOpfsSupport() async {
-  final storage = _storageManager;
+  final storage = storageManager;
   if (storage == null) return false;
 
   const testFileName = '_drift_feature_detection';
@@ -166,6 +168,9 @@ Future<void> deleteDatabaseInIndexedDb(String databaseName) async {
   }
 }
 
+/// The directory under the OPFS root used to store drift databases.
+const driftOpfsRoot = 'drift_db';
+
 /// Constructs the path used by drift to store a database in the origin-private
 /// section of the agent's file system.
 String pathForOpfs(String databaseName) {
@@ -174,13 +179,17 @@ String pathForOpfs(String databaseName) {
 
 /// returns the [FileSystemDirectoryHandle] containing all drift databases, or
 /// null if it doesn't exist.
-Future<FileSystemDirectoryHandle?> opfsDriftDirectoryHandle() async {
-  final storage = _storageManager;
+Future<FileSystemDirectoryHandle?> opfsDriftDirectoryHandle(
+    [FileSystemGetDirectoryOptions? options]) async {
+  final storage = storageManager;
   if (storage == null) return null;
 
   var directory = await storage.getDirectory().toDart;
   try {
-    return await directory.getDirectoryHandle('drift_db').toDart;
+    return await directory
+        .getDirectoryHandle(
+            'drift_db', options ?? FileSystemGetDirectoryOptions())
+        .toDart;
   } on Object {
     // fine, an error probably means that the database didn't exist in the first
     // place.
@@ -198,16 +207,28 @@ Future<List<String>> opfsDatabases() async {
   final entries = AsyncJavaScriptIteratable<JSArray>(directory)
       .map((data) => data.toDart[1] as FileSystemHandle);
 
-  return [
-    await for (final entry in entries)
-      if (entry.kind == 'directory') entry.name,
-  ];
+  final found = <String>[];
+  await for (final entry in entries) {
+    if (entry.kind == 'directory') {
+      // Check if there's a database file in the directory as well.
+      try {
+        await (entry as FileSystemDirectoryHandle)
+            .getFileHandle('database')
+            .toDart;
+        found.add(entry.name);
+      } catch (e) {
+        // Can't access database file, ignore this directory.
+      }
+    }
+  }
+
+  return found;
 }
 
 /// Deletes the OPFS folder storing a database with the given [databaseName] if
 /// such folder exists.
 Future<void> deleteDatabaseInOpfs(String databaseName) async {
-  final storage = _storageManager;
+  final storage = storageManager;
   if (storage == null) return;
 
   var directory = await storage.getDirectory().toDart;

--- a/drift/lib/src/web/wasm_setup/types.dart
+++ b/drift/lib/src/web/wasm_setup/types.dart
@@ -216,6 +216,20 @@ abstract interface class WasmProbeResult {
 
   /// Attempts to read an [ExistingDatabase] from storage.
   Future<Uint8List?> exportDatabase(ExistingDatabase database);
+
+  /// Moves an existing database stored in IndexedDB to OPFS.
+  ///
+  /// This may be convenient if this result indicates that an OPFS-based
+  /// implementation is available ([availableStorages]) while an existing copy
+  /// of the database is stored in IndexedDB.
+  ///
+  /// Note that this function does not check whether an IndexedDB database with
+  /// the given name exists, or that an OPFS directory with the name does not
+  /// exist already.
+  ///
+  /// It unconditionally copies files stored in IndexedDB to OPFS, and then
+  /// deletes the old IndexedDB database.
+  Future<void> moveFromIndexedDBToOpfs(String databaseName);
 }
 
 /// The result of opening a WASM database with default options.

--- a/drift/lib/src/web/wasm_setup/types.dart
+++ b/drift/lib/src/web/wasm_setup/types.dart
@@ -44,7 +44,7 @@ enum WasmStorageImplementation {
   /// Chrome (https://crbug.com/1088481) and Safari don't support this yet.
   ///
   /// [OPFS]: https://developer.mozilla.org/en-US/docs/Web/API/File_System_Access_API#origin_private_file_system
-  opfsShared,
+  opfsShared(WebStorageApi.opfs),
 
   /// Uses the [Origin private file system APIs][OPFS] provided my modern
   /// browsers to persist data.
@@ -70,24 +70,30 @@ enum WasmStorageImplementation {
   ///
   /// [OPFS]: https://developer.mozilla.org/en-US/docs/Web/API/File_System_Access_API#origin_private_file_system´
   /// [cross-origin isolation]: https://developer.mozilla.org/en-US/docs/Web/API/crossOriginIsolated
-  opfsLocks,
+  opfsLocks(WebStorageApi.opfs),
 
   /// Emulates a file system over `IndexedDB` in a shared worker.
-  sharedIndexedDb,
+  sharedIndexedDb(WebStorageApi.indexedDb),
 
   /// Uses the asynchronous IndexedDB API outside of any worker to persist data.
   ///
   /// Unlike [opfsShared], [opfsLocks] or [sharedIndexedDb], this storage
   /// implementation can't prevent data races if your app is opened in multiple
   /// tabs at the same time, which is why it's declared as as unsafe.
-  unsafeIndexedDb,
+  unsafeIndexedDb(WebStorageApi.indexedDb),
 
   /// A fallback storage implementation that doesn't store anything.
   ///
   /// This implementation is chosen when none of the features needed for other
   /// storage implementations are supported by the current browser. In this case,
   /// [WasmDatabaseResult.missingFeatures] enumerates missing browser features.
-  inMemory,
+  inMemory(null);
+
+  /// The [WebStorageApi] used to persist data with this storage implementation,
+  /// or `null` for [inMemory].
+  final WebStorageApi? storageApi;
+
+  const WasmStorageImplementation(this.storageApi);
 }
 
 /// The storage API used by drift to store a database.

--- a/drift/lib/wasm.dart
+++ b/drift/lib/wasm.dart
@@ -145,7 +145,7 @@ class WasmDatabase extends DelegatedDatabase {
     required Uri driftWorkerUri,
     FutureOr<Uint8List?> Function()? initializeDatabase,
     WasmDatabaseSetup? localSetup,
-    bool migrateToBestImplementation = false,
+    WasmStorageImplementation? preferedImplemetation,
     bool enableMigrations = true,
   }) async {
     final probed = await probe(
@@ -164,7 +164,8 @@ class WasmDatabase extends DelegatedDatabase {
     // left.
     availableImplementations.sortBy<num>((element) => element.index);
 
-    final bestAvailableImplementation = availableImplementations.first;
+    final preferedAvailable =
+        availableImplementations.contains(preferedImplemetation);
     ExistingDatabase? currentDatabase;
 
     checkExisting:
@@ -192,17 +193,15 @@ class WasmDatabase extends DelegatedDatabase {
       }
     }
 
-    final bestCurrentImplementation = availableImplementations.firstOrNull ??
+    final bestImplementation = availableImplementations.firstOrNull ??
         WasmStorageImplementation.inMemory;
 
-    final needsMigration = migrateToBestImplementation &&
+    final needsMigration = preferedAvailable &&
         currentDatabase != null &&
-        bestCurrentImplementation != bestAvailableImplementation;
+        bestImplementation != preferedImplemetation;
 
     final connection = await probed.open(
-      migrateToBestImplementation
-          ? bestAvailableImplementation
-          : bestCurrentImplementation,
+      needsMigration ? preferedImplemetation! : bestImplementation,
       databaseName,
       localSetup: localSetup,
       initializeDatabase: needsMigration
@@ -212,7 +211,7 @@ class WasmDatabase extends DelegatedDatabase {
     );
 
     return WasmDatabaseResult(
-        connection, bestCurrentImplementation, probed.missingFeatures);
+        connection, bestImplementation, probed.missingFeatures);
   }
 
   /// Probes for:

--- a/drift/lib/wasm.dart
+++ b/drift/lib/wasm.dart
@@ -19,7 +19,6 @@ import 'backends.dart';
 import 'src/sqlite3/database.dart';
 import 'src/web/wasm_setup.dart';
 import 'src/web/wasm_setup/dedicated_worker.dart';
-import 'src/web/wasm_setup/indexeddb_to_opfs.dart';
 import 'src/web/wasm_setup/shared_worker.dart';
 import 'src/web/wasm_setup/types.dart';
 
@@ -184,7 +183,7 @@ class WasmDatabase extends DelegatedDatabase {
       if (currentDb == WebStorageApi.indexedDb &&
           selectedImplementation.storageApi == WebStorageApi.opfs) {
         try {
-          await moveIndexedDbDatabaseToOpfs(databaseName);
+          await probed.moveFromIndexedDBToOpfs(databaseName);
           didMove = true;
         } catch (e) {
           // Ok, we'll keep using the old database then.

--- a/drift/lib/wasm.dart
+++ b/drift/lib/wasm.dart
@@ -138,6 +138,9 @@ class WasmDatabase extends DelegatedDatabase {
   /// When [enableMigrations] is set to `false`, drift will not check the
   /// `user_version` pragma when opening the database or run migrations.
   ///
+  /// If a [preferedImplemetation] is defined and available in the browser the
+  /// data will automatically be migrated to it.
+  ///
   /// For more detailed information, see https://drift.simonbinder.eu/web.
   static Future<WasmDatabaseResult> open({
     required String databaseName,

--- a/drift/lib/wasm.dart
+++ b/drift/lib/wasm.dart
@@ -19,6 +19,7 @@ import 'backends.dart';
 import 'src/sqlite3/database.dart';
 import 'src/web/wasm_setup.dart';
 import 'src/web/wasm_setup/dedicated_worker.dart';
+import 'src/web/wasm_setup/indexeddb_to_opfs.dart';
 import 'src/web/wasm_setup/shared_worker.dart';
 import 'src/web/wasm_setup/types.dart';
 
@@ -138,8 +139,10 @@ class WasmDatabase extends DelegatedDatabase {
   /// When [enableMigrations] is set to `false`, drift will not check the
   /// `user_version` pragma when opening the database or run migrations.
   ///
-  /// If a [preferredImplementation] is defined and available in the browser the
-  /// data will automatically be migrated to it.
+  /// If [moveExistingIndexedDbToOpfs] is enabled (it is currently disabled by
+  /// default), drift will attempt to move existing databases from IndexedDB to
+  /// OPFS. This may be useful if previous versions of browsers or your app
+  /// didn't support OPFS.
   ///
   /// For more detailed information, see https://drift.simonbinder.eu/web.
   static Future<WasmDatabaseResult> open({
@@ -148,7 +151,7 @@ class WasmDatabase extends DelegatedDatabase {
     required Uri driftWorkerUri,
     FutureOr<Uint8List?> Function()? initializeDatabase,
     WasmDatabaseSetup? localSetup,
-    WasmStorageImplementation? preferredImplementation,
+    bool moveExistingIndexedDbToOpfs = false,
     bool enableMigrations = true,
   }) async {
     final probed = await probe(
@@ -161,12 +164,10 @@ class WasmDatabase extends DelegatedDatabase {
     // format to avoid data loss (e.g. after a browser update that enables a
     // otherwise preferred storage implementation).
     final availableImplementations = probed.availableStorages.toList();
-    // Enum values are ordered by preferrability, so just pick the best option
-    // left.
+    // Enum values are ordered by preferrability, so just pick the best option.
     availableImplementations.sortBy<num>((e) => e.index);
-
-    final preferredIsAvailable =
-        availableImplementations.contains(preferredImplementation);
+    var selectedImplementation = availableImplementations.firstOrNull ??
+        WasmStorageImplementation.inMemory;
 
     // Check if there is an existing DB and restrict implementations to its storage.
     final currentDb = _selectExistingDatabase(
@@ -175,35 +176,40 @@ class WasmDatabase extends DelegatedDatabase {
       probed.existingDatabases,
     );
 
-    final bestImplementation = availableImplementations.firstOrNull ??
-        WasmStorageImplementation.inMemory;
+    // If we have an existing database, we need to use its storage API instead
+    // of starting from scratch.
+    if (currentDb != null && currentDb != selectedImplementation.storageApi) {
+      // ... except if we want to move from IndexedDB to OPFS
+      var didMove = false;
+      if (currentDb == WebStorageApi.indexedDb &&
+          selectedImplementation.storageApi == WebStorageApi.opfs) {
+        try {
+          await moveIndexedDbDatabaseToOpfs(databaseName);
+          didMove = true;
+        } catch (e) {
+          // Ok, we'll keep using the old database then.
+        }
+      }
 
-    final needsMigration = preferredIsAvailable &&
-        currentDb != null &&
-        bestImplementation != preferredImplementation;
-
-    // Determine which implementation to open with
-    final implementationToOpen = needsMigration
-        ? preferredImplementation!
-        : preferredIsAvailable
-            ? preferredImplementation!
-            : bestImplementation;
+      if (!didMove) {
+        selectedImplementation = availableImplementations
+            .firstWhere((e) => e.storageApi == currentDb);
+      }
+    }
 
     final connection = await probed.open(
-      implementationToOpen,
+      selectedImplementation,
       databaseName,
       localSetup: localSetup,
-      initializeDatabase: needsMigration
-          ? () => probed.exportDatabase(currentDb)
-          : initializeDatabase,
+      initializeDatabase: initializeDatabase,
       enableMigrations: enableMigrations,
     );
 
     return WasmDatabaseResult(
-        connection, bestImplementation, probed.missingFeatures);
+        connection, selectedImplementation, probed.missingFeatures);
   }
 
-  static ExistingDatabase? _selectExistingDatabase(
+  static WebStorageApi? _selectExistingDatabase(
     String databaseName,
     List<WasmStorageImplementation> available,
     List<ExistingDatabase> existingDatabases,
@@ -222,10 +228,8 @@ class WasmDatabase extends DelegatedDatabase {
           ],
       };
 
-      // If storage still supported → restrict available implementations
       if (implementationsForStorage.any(available.contains)) {
-        available.removeWhere((i) => !implementationsForStorage.contains(i));
-        return (location, name);
+        return location;
       }
     }
 

--- a/drift/lib/wasm.dart
+++ b/drift/lib/wasm.dart
@@ -159,66 +159,77 @@ class WasmDatabase extends DelegatedDatabase {
 
     // If we have an existing database in storage, we want to keep using that
     // format to avoid data loss (e.g. after a browser update that enables a
-    // otherwise preferred storage implementation). In the future, we might want
-    // to consider migrating between storage implementations as well.
+    // otherwise preferred storage implementation).
     final availableImplementations = probed.availableStorages.toList();
-
     // Enum values are ordered by preferrability, so just pick the best option
     // left.
-    availableImplementations.sortBy<num>((element) => element.index);
+    availableImplementations.sortBy<num>((e) => e.index);
 
-    final preferedAvailable =
+    final preferredIsAvailable =
         availableImplementations.contains(preferredImplementation);
-    ExistingDatabase? currentDatabase;
 
-    checkExisting:
-    for (final (location, name) in probed.existingDatabases) {
-      if (name == databaseName) {
-        final implementationsForStorage = switch (location) {
-          WebStorageApi.indexedDb => const [
-              WasmStorageImplementation.sharedIndexedDb,
-              WasmStorageImplementation.unsafeIndexedDb
-            ],
-          WebStorageApi.opfs => const [
-              WasmStorageImplementation.opfsShared,
-              WasmStorageImplementation.opfsLocks,
-            ],
-        };
-
-        // If any of the implementations for this location is still availalable,
-        // we want to use it instead of another location.
-        if (implementationsForStorage.any(availableImplementations.contains)) {
-          availableImplementations
-              .removeWhere((i) => !implementationsForStorage.contains(i));
-          currentDatabase = (location, name);
-          break checkExisting;
-        }
-      }
-    }
+    // Check if there is an existing DB and restrict implementations to its storage.
+    final currentDb = _selectExistingDatabase(
+      databaseName,
+      availableImplementations,
+      probed.existingDatabases,
+    );
 
     final bestImplementation = availableImplementations.firstOrNull ??
         WasmStorageImplementation.inMemory;
 
-    final needsMigration = preferedAvailable &&
-        currentDatabase != null &&
+    final needsMigration = preferredIsAvailable &&
+        currentDb != null &&
         bestImplementation != preferredImplementation;
 
+    // Determine which implementation to open with
+    final implementationToOpen = needsMigration
+        ? preferredImplementation!
+        : preferredIsAvailable
+            ? preferredImplementation!
+            : bestImplementation;
+
     final connection = await probed.open(
-      needsMigration
-          ? preferredImplementation!
-          : preferedAvailable
-              ? preferredImplementation!
-              : bestImplementation,
+      implementationToOpen,
       databaseName,
       localSetup: localSetup,
       initializeDatabase: needsMigration
-          ? () => probed.exportDatabase(currentDatabase!)
+          ? () => probed.exportDatabase(currentDb)
           : initializeDatabase,
       enableMigrations: enableMigrations,
     );
 
     return WasmDatabaseResult(
         connection, bestImplementation, probed.missingFeatures);
+  }
+
+  static ExistingDatabase? _selectExistingDatabase(
+    String databaseName,
+    List<WasmStorageImplementation> available,
+    List<ExistingDatabase> existingDatabases,
+  ) {
+    for (final (location, name) in existingDatabases) {
+      if (name != databaseName) continue;
+
+      final implementationsForStorage = switch (location) {
+        WebStorageApi.indexedDb => const [
+            WasmStorageImplementation.sharedIndexedDb,
+            WasmStorageImplementation.unsafeIndexedDb,
+          ],
+        WebStorageApi.opfs => const [
+            WasmStorageImplementation.opfsShared,
+            WasmStorageImplementation.opfsLocks,
+          ],
+      };
+
+      // If storage still supported → restrict available implementations
+      if (implementationsForStorage.any(available.contains)) {
+        available.removeWhere((i) => !implementationsForStorage.contains(i));
+        return (location, name);
+      }
+    }
+
+    return null;
   }
 
   /// Probes for:

--- a/drift/lib/wasm.dart
+++ b/drift/lib/wasm.dart
@@ -138,7 +138,7 @@ class WasmDatabase extends DelegatedDatabase {
   /// When [enableMigrations] is set to `false`, drift will not check the
   /// `user_version` pragma when opening the database or run migrations.
   ///
-  /// If a [preferedImplemetation] is defined and available in the browser the
+  /// If a [preferredImplementation] is defined and available in the browser the
   /// data will automatically be migrated to it.
   ///
   /// For more detailed information, see https://drift.simonbinder.eu/web.
@@ -148,7 +148,7 @@ class WasmDatabase extends DelegatedDatabase {
     required Uri driftWorkerUri,
     FutureOr<Uint8List?> Function()? initializeDatabase,
     WasmDatabaseSetup? localSetup,
-    WasmStorageImplementation? preferedImplemetation,
+    WasmStorageImplementation? preferredImplementation,
     bool enableMigrations = true,
   }) async {
     final probed = await probe(
@@ -168,7 +168,7 @@ class WasmDatabase extends DelegatedDatabase {
     availableImplementations.sortBy<num>((element) => element.index);
 
     final preferedAvailable =
-        availableImplementations.contains(preferedImplemetation);
+        availableImplementations.contains(preferredImplementation);
     ExistingDatabase? currentDatabase;
 
     checkExisting:
@@ -201,10 +201,14 @@ class WasmDatabase extends DelegatedDatabase {
 
     final needsMigration = preferedAvailable &&
         currentDatabase != null &&
-        bestImplementation != preferedImplemetation;
+        bestImplementation != preferredImplementation;
 
     final connection = await probed.open(
-      needsMigration ? preferedImplemetation! : bestImplementation,
+      needsMigration
+          ? preferredImplementation!
+          : preferedAvailable
+              ? preferredImplementation!
+              : bestImplementation,
       databaseName,
       localSetup: localSetup,
       initializeDatabase: needsMigration

--- a/drift/lib/wasm.dart
+++ b/drift/lib/wasm.dart
@@ -8,12 +8,12 @@ library;
 
 import 'dart:async';
 import 'dart:js_interop';
-import 'dart:typed_data';
 
 import 'package:collection/collection.dart';
+import 'package:drift/drift.dart';
+import 'package:sqlite3/wasm.dart';
 import 'package:web/web.dart'
     show DedicatedWorkerGlobalScope, SharedWorkerGlobalScope;
-import 'package:sqlite3/wasm.dart';
 
 import 'backends.dart';
 import 'src/sqlite3/database.dart';
@@ -145,6 +145,7 @@ class WasmDatabase extends DelegatedDatabase {
     required Uri driftWorkerUri,
     FutureOr<Uint8List?> Function()? initializeDatabase,
     WasmDatabaseSetup? localSetup,
+    bool migrateToBestImplementation = false,
     bool enableMigrations = true,
   }) async {
     final probed = await probe(
@@ -158,6 +159,13 @@ class WasmDatabase extends DelegatedDatabase {
     // otherwise preferred storage implementation). In the future, we might want
     // to consider migrating between storage implementations as well.
     final availableImplementations = probed.availableStorages.toList();
+
+    // Enum values are ordered by preferrability, so just pick the best option
+    // left.
+    availableImplementations.sortBy<num>((element) => element.index);
+
+    final bestAvailableImplementation = availableImplementations.first;
+    ExistingDatabase? currentDatabase;
 
     checkExisting:
     for (final (location, name) in probed.existingDatabases) {
@@ -178,27 +186,33 @@ class WasmDatabase extends DelegatedDatabase {
         if (implementationsForStorage.any(availableImplementations.contains)) {
           availableImplementations
               .removeWhere((i) => !implementationsForStorage.contains(i));
+          currentDatabase = (location, name);
           break checkExisting;
         }
       }
     }
 
-    // Enum values are ordered by preferrability, so just pick the best option
-    // left.
-    availableImplementations.sortBy<num>((element) => element.index);
-
-    final bestImplementation = availableImplementations.firstOrNull ??
+    final bestCurrentImplementation = availableImplementations.firstOrNull ??
         WasmStorageImplementation.inMemory;
+
+    final needsMigration = migrateToBestImplementation &&
+        currentDatabase != null &&
+        bestCurrentImplementation != bestAvailableImplementation;
+
     final connection = await probed.open(
-      bestImplementation,
+      migrateToBestImplementation
+          ? bestAvailableImplementation
+          : bestCurrentImplementation,
       databaseName,
       localSetup: localSetup,
-      initializeDatabase: initializeDatabase,
+      initializeDatabase: needsMigration
+          ? () => probed.exportDatabase(currentDatabase!)
+          : initializeDatabase,
       enableMigrations: enableMigrations,
     );
 
     return WasmDatabaseResult(
-        connection, bestImplementation, probed.missingFeatures);
+        connection, bestCurrentImplementation, probed.missingFeatures);
   }
 
   /// Probes for:

--- a/drift/test/platforms/web/wasm_database_test.dart
+++ b/drift/test/platforms/web/wasm_database_test.dart
@@ -47,7 +47,7 @@ void main() {
     db.dispose();
     await indexedDb.close();
 
-    await moveIndexedDbDatabaseToOpfs('test_move');
+    await moveIndexedDBDatabaseToOpfs('test_move');
 
     expect(await opfsDatabases(), ['test_move']);
     expect(await checkIndexedDbExists('test_move'), isFalse);

--- a/drift/test/platforms/web/wasm_database_test.dart
+++ b/drift/test/platforms/web/wasm_database_test.dart
@@ -2,6 +2,8 @@
 library;
 
 import 'package:drift/drift.dart';
+import 'package:drift/src/web/wasm_setup/indexeddb_to_opfs.dart';
+import 'package:drift/src/web/wasm_setup/shared.dart';
 import 'package:drift/wasm.dart';
 import 'package:sqlite3/wasm.dart';
 import 'package:test/test.dart';
@@ -35,6 +37,20 @@ void main() {
       expect(() => underlying.execute('SELECT 1'), isNot(throwsA(anything)));
       underlying.dispose();
     });
+  });
+
+  test('moveIndexedDbDatabaseToOpfs', () async {
+    final indexedDb = await IndexedDbFileSystem.open(dbName: 'test_move');
+    sqlite3.registerVirtualFileSystem(indexedDb);
+    final db = sqlite3.open('/database', vfs: indexedDb.name);
+    db.execute('CREATE TABLE foo (bar TEXT);');
+    db.dispose();
+    await indexedDb.close();
+
+    await moveIndexedDbDatabaseToOpfs('test_move');
+
+    expect(await opfsDatabases(), ['test_move']);
+    expect(await checkIndexedDbExists('test_move'), isFalse);
   });
 }
 

--- a/extras/integration_tests/web_wasm/README.md
+++ b/extras/integration_tests/web_wasm/README.md
@@ -5,3 +5,5 @@ To run the tests automatically (with us managing a browser driver), just run `da
 To manually debug issues, it might make sense to trigger some functionality manually.
 You can run `dart run tool/serve_manually.dart` to start a web server hosting the test
 content on <http://localhost:8080>.
+
+Make sure to install [chromedriver](https://googlechromelabs.github.io/chrome-for-testing) and [geckodriver](https://github.com/mozilla/geckodriver/releases) for the test to use.

--- a/extras/integration_tests/web_wasm/lib/driver.dart
+++ b/extras/integration_tests/web_wasm/lib/driver.dart
@@ -148,9 +148,9 @@ class DriftWebDriver {
 
   Future<void> openDatabase(
       [WasmStorageImplementation? implementation,
-      WasmStorageImplementation? preferedImplemetation]) async {
+      WasmStorageImplementation? preferredImplementation]) async {
     await driver.executeAsync('open(arguments[0], arguments[1])', [
-      json.encode([implementation?.name, preferedImplemetation?.name])
+      json.encode([implementation?.name, preferredImplementation?.name])
     ]);
   }
 

--- a/extras/integration_tests/web_wasm/lib/driver.dart
+++ b/extras/integration_tests/web_wasm/lib/driver.dart
@@ -7,14 +7,14 @@ import 'package:build_daemon/constants.dart';
 import 'package:build_daemon/data/build_status.dart';
 import 'package:build_daemon/data/build_target.dart';
 import 'package:collection/collection.dart';
+// ignore: implementation_imports
+import 'package:drift/src/web/wasm_setup/types.dart';
 import 'package:package_config/package_config.dart';
 import 'package:path/path.dart' as p;
 import 'package:shelf/shelf_io.dart';
 import 'package:shelf_proxy/shelf_proxy.dart';
 import 'package:web_wasm/initialization_mode.dart';
 import 'package:webdriver/async_io.dart';
-// ignore: implementation_imports
-import 'package:drift/src/web/wasm_setup/types.dart';
 import 'package:webdriver/support/async.dart';
 
 class TestAssetServer {
@@ -36,7 +36,7 @@ class TestAssetServer {
         await loadPackageConfigUri((await Isolate.packageConfig)!);
     final ownPackage = packageConfig['web_wasm']!.root;
     var packageDir = ownPackage.toFilePath(windows: Platform.isWindows);
-    if (packageDir.endsWith('/')) {
+    if (packageDir.endsWith('/') || packageDir.endsWith('\\')) {
       packageDir = packageDir.substring(0, packageDir.length - 1);
     }
 

--- a/extras/integration_tests/web_wasm/lib/driver.dart
+++ b/extras/integration_tests/web_wasm/lib/driver.dart
@@ -146,11 +146,15 @@ class DriftWebDriver {
     );
   }
 
-  Future<void> openDatabase(
-      [WasmStorageImplementation? implementation,
-      WasmStorageImplementation? preferredImplementation]) async {
+  Future<void> openDatabase({
+    WasmStorageImplementation? implementation,
+    bool moveIndexedDbToOpfs = false,
+  }) async {
     await driver.executeAsync('open(arguments[0], arguments[1])', [
-      json.encode([implementation?.name, preferredImplementation?.name])
+      json.encode({
+        'implementation': implementation?.name,
+        'moveToOpfs': moveIndexedDbToOpfs,
+      }),
     ]);
   }
 

--- a/extras/integration_tests/web_wasm/lib/driver.dart
+++ b/extras/integration_tests/web_wasm/lib/driver.dart
@@ -146,9 +146,12 @@ class DriftWebDriver {
     );
   }
 
-  Future<void> openDatabase([WasmStorageImplementation? implementation]) async {
-    await driver.executeAsync(
-        'open(arguments[0], arguments[1])', [implementation?.name]);
+  Future<void> openDatabase(
+      [WasmStorageImplementation? implementation,
+      WasmStorageImplementation? preferedImplemetation]) async {
+    await driver.executeAsync('open(arguments[0], arguments[1])', [
+      json.encode([implementation?.name, preferedImplemetation?.name])
+    ]);
   }
 
   Future<void> closeDatabase() async {

--- a/extras/integration_tests/web_wasm/test/drift_wasm_test.dart
+++ b/extras/integration_tests/web_wasm/test/drift_wasm_test.dart
@@ -352,6 +352,25 @@ final class _TestConfiguration {
       );
 
       test(
+        'use preferred implementation if available when initializing',
+        () async {
+          // Open with preferred IndexedDB database first
+          await driver.openDatabase(
+              null, WasmStorageImplementation.unsafeIndexedDb);
+          await driver.insertIntoDatabase();
+          await Future.delayed(const Duration(seconds: 2));
+          await driver.driver.refresh(); // Reset JS state
+          await driver.waitReady();
+
+          // Open the database again, this time without specifying a fixed
+          // implementation. Despite OPFS being available (and preferred),
+          // the existing database should be used.
+          await driver.openDatabase();
+          expect(await driver.amountOfRows, 1);
+        },
+      );
+
+      test(
         'switch from IndexedDB database to OPFS if it is the preferred implementation',
         () async {
           // Open an IndexedDB database first

--- a/extras/integration_tests/web_wasm/test/drift_wasm_test.dart
+++ b/extras/integration_tests/web_wasm/test/drift_wasm_test.dart
@@ -351,6 +351,29 @@ final class _TestConfiguration {
         },
       );
 
+      test(
+        'switch from IndexedDB database to OPFS if it is the prefered implementation',
+        () async {
+          // Open an IndexedDB database first
+          await driver.openDatabase(WasmStorageImplementation.unsafeIndexedDb);
+          await driver.insertIntoDatabase();
+          await Future.delayed(const Duration(seconds: 2));
+          await driver.driver.refresh(); // Reset JS state
+          await driver.waitReady();
+
+          // Open the database again, this time specifying opfs as the
+          // preferred implementation.
+          await driver.openDatabase(null, WasmStorageImplementation.opfsLocks);
+          expect(await driver.amountOfRows, 1);
+          await Future.delayed(const Duration(seconds: 2));
+          await driver.driver.refresh(); // Reset JS state
+          await driver.waitReady();
+
+          await driver.openDatabase(WasmStorageImplementation.opfsLocks);
+          expect(await driver.amountOfRows, 1);
+        },
+      );
+
       if (!browser.supports(WasmStorageImplementation.opfsShared)) {
         test('uses indexeddb after OPFS becomes unavailable', () async {
           // This browser only supports OPFS with the right headers. If they

--- a/extras/integration_tests/web_wasm/test/drift_wasm_test.dart
+++ b/extras/integration_tests/web_wasm/test/drift_wasm_test.dart
@@ -213,7 +213,7 @@ final class _TestConfiguration {
     for (final entry in browser.availableImplementations) {
       group(entry.name, () {
         test('basic', () async {
-          await driver.openDatabase(entry);
+          await driver.openDatabase(implementation: entry);
           expect(await driver.amountOfRows, 0);
 
           await driver.insertIntoDatabase();
@@ -233,7 +233,7 @@ final class _TestConfiguration {
             await Future.delayed(const Duration(seconds: 1));
             await windows.last.setAsActive();
 
-            await driver.openDatabase(entry);
+            await driver.openDatabase(implementation: entry);
             expect(await driver.amountOfRows, 1);
             await driver.insertIntoDatabase();
             await windows.last.close();
@@ -248,7 +248,7 @@ final class _TestConfiguration {
             final impl = await driver.probeImplementations();
             expect(impl.existing, isEmpty);
 
-            await driver.openDatabase(entry);
+            await driver.openDatabase(implementation: entry);
             await driver.insertIntoDatabase();
             await driver.waitForTableUpdate();
 
@@ -270,7 +270,7 @@ final class _TestConfiguration {
           });
 
           test('migrations', () async {
-            await driver.openDatabase(entry);
+            await driver.openDatabase(implementation: entry);
             await driver.insertIntoDatabase();
             await driver.waitForTableUpdate();
 
@@ -279,7 +279,7 @@ final class _TestConfiguration {
             await driver.waitReady();
 
             await driver.setSchemaVersion(2);
-            await driver.openDatabase(entry);
+            await driver.openDatabase(implementation: entry);
             // The migration adds a row
             expect(await driver.amountOfRows, 2);
           });
@@ -297,7 +297,7 @@ final class _TestConfiguration {
           () {
             test('static blob', () async {
               await driver.enableInitialization(InitializationMode.loadAsset);
-              await driver.openDatabase(entry);
+              await driver.openDatabase(implementation: entry);
 
               expect(await driver.amountOfRows, 1);
               await driver.insertIntoDatabase();
@@ -317,7 +317,7 @@ final class _TestConfiguration {
             test('custom wasmdatabase', () async {
               await driver.enableInitialization(
                   InitializationMode.migrateCustomWasmDatabase);
-              await driver.openDatabase(entry);
+              await driver.openDatabase(implementation: entry);
 
               expect(await driver.amountOfRows, 1);
             });
@@ -337,26 +337,8 @@ final class _TestConfiguration {
         'keep existing IndexedDB database after OPFS becomes available',
         () async {
           // Open an IndexedDB database first
-          await driver.openDatabase(WasmStorageImplementation.unsafeIndexedDb);
-          await driver.insertIntoDatabase();
-          await Future.delayed(const Duration(seconds: 2));
-          await driver.driver.refresh(); // Reset JS state
-          await driver.waitReady();
-
-          // Open the database again, this time without specifying a fixed
-          // implementation. Despite OPFS being available (and preferred),
-          // the existing database should be used.
-          await driver.openDatabase();
-          expect(await driver.amountOfRows, 1);
-        },
-      );
-
-      test(
-        'use preferred implementation if available when initializing',
-        () async {
-          // Open with preferred IndexedDB database first
           await driver.openDatabase(
-              null, WasmStorageImplementation.unsafeIndexedDb);
+              implementation: WasmStorageImplementation.unsafeIndexedDb);
           await driver.insertIntoDatabase();
           await Future.delayed(const Duration(seconds: 2));
           await driver.driver.refresh(); // Reset JS state
@@ -371,24 +353,25 @@ final class _TestConfiguration {
       );
 
       test(
-        'switch from IndexedDB database to OPFS if it is the preferred implementation',
+        'can migrate from IndexedDB to OPFS',
         () async {
           // Open an IndexedDB database first
-          await driver.openDatabase(WasmStorageImplementation.unsafeIndexedDb);
+          await driver.openDatabase(
+              implementation: WasmStorageImplementation.unsafeIndexedDb);
           await driver.insertIntoDatabase();
           await Future.delayed(const Duration(seconds: 2));
           await driver.driver.refresh(); // Reset JS state
           await driver.waitReady();
 
-          // Open the database again, this time specifying opfs as the
-          // preferred implementation.
-          await driver.openDatabase(null, WasmStorageImplementation.opfsLocks);
+          // Open the database again, preferring a migration.
+          await driver.openDatabase(moveIndexedDbToOpfs: true);
           expect(await driver.amountOfRows, 1);
           await Future.delayed(const Duration(seconds: 2));
           await driver.driver.refresh(); // Reset JS state
           await driver.waitReady();
 
-          await driver.openDatabase(WasmStorageImplementation.opfsLocks);
+          await driver.openDatabase(
+              implementation: WasmStorageImplementation.opfsLocks);
           expect(await driver.amountOfRows, 1);
         },
       );
@@ -398,7 +381,8 @@ final class _TestConfiguration {
           // This browser only supports OPFS with the right headers. If they
           // are ever removed, data is lost (nothing we could do about that),
           // but drift should continue to work.
-          await driver.openDatabase(WasmStorageImplementation.opfsLocks);
+          await driver.openDatabase(
+              implementation: WasmStorageImplementation.opfsLocks);
           await driver.insertIntoDatabase();
           expect(await driver.amountOfRows, 1);
           await Future.delayed(const Duration(seconds: 2));

--- a/extras/integration_tests/web_wasm/test/drift_wasm_test.dart
+++ b/extras/integration_tests/web_wasm/test/drift_wasm_test.dart
@@ -352,7 +352,7 @@ final class _TestConfiguration {
       );
 
       test(
-        'switch from IndexedDB database to OPFS if it is the prefered implementation',
+        'switch from IndexedDB database to OPFS if it is the preferred implementation',
         () async {
           // Open an IndexedDB database first
           await driver.openDatabase(WasmStorageImplementation.unsafeIndexedDb);

--- a/extras/integration_tests/web_wasm/web/main.dart
+++ b/extras/integration_tests/web_wasm/web/main.dart
@@ -33,8 +33,16 @@ void main() {
     return _detectImplementations(arg);
   });
   _addCallbackForWebDriver('open', (arg) {
-    final decoded = json.decode(arg!);
-    return _open(decoded[0] as String?, decoded[1] as String?);
+    if (arg == null || !arg.startsWith('{')) {
+      return _open(arg, false);
+    } else {
+      final {
+        'implementation': implementation as String?,
+        'moveToOpfs': moveToOpfs as bool
+      } = json.decode(arg);
+
+      return _open(implementation, moveToOpfs);
+    }
   });
   _addCallbackForWebDriver('close', (arg) async {
     await tableUpdates?.cancel();
@@ -182,7 +190,7 @@ Future<JSString> _detectImplementations(String? _) async {
 }
 
 Future<JSAny?> _open(
-    String? implementationName, String? preferredImplementationName) async {
+    String? implementationName, bool moveIndexedDbToOps) async {
   DatabaseConnection connection;
 
   if (implementationName != null) {
@@ -205,8 +213,7 @@ Future<JSAny?> _open(
       initializeDatabase: _initializeDatabase,
       enableMigrations:
           initializationMode != InitializationMode.noneAndDisableMigrations,
-      preferredImplementation: WasmStorageImplementation.values
-          .asNameMap()[preferredImplementationName],
+      moveExistingIndexedDbToOpfs: moveIndexedDbToOps,
       localSetup: (db) {
         // The worker has a similar setup call that will make database_host
         // return `worker` instead.

--- a/extras/integration_tests/web_wasm/web/main.dart
+++ b/extras/integration_tests/web_wasm/web/main.dart
@@ -182,7 +182,7 @@ Future<JSString> _detectImplementations(String? _) async {
 }
 
 Future<JSAny?> _open(
-    String? implementationName, String? preferedImplemetationName) async {
+    String? implementationName, String? preferredImplementationName) async {
   DatabaseConnection connection;
 
   if (implementationName != null) {
@@ -205,8 +205,8 @@ Future<JSAny?> _open(
       initializeDatabase: _initializeDatabase,
       enableMigrations:
           initializationMode != InitializationMode.noneAndDisableMigrations,
-      preferedImplemetation: WasmStorageImplementation.values
-          .asNameMap()[preferedImplemetationName],
+      preferredImplementation: WasmStorageImplementation.values
+          .asNameMap()[preferredImplementationName],
       localSetup: (db) {
         // The worker has a similar setup call that will make database_host
         // return `worker` instead.

--- a/extras/integration_tests/web_wasm/web/main.dart
+++ b/extras/integration_tests/web_wasm/web/main.dart
@@ -6,11 +6,11 @@ import 'package:async/async.dart';
 import 'package:drift/drift.dart';
 import 'package:drift/wasm.dart';
 import 'package:http/http.dart' as http;
+import 'package:sqlite3/wasm.dart';
 import 'package:web/web.dart'
     show document, EventStreamProviders, HTMLDivElement;
 import 'package:web_wasm/initialization_mode.dart';
 import 'package:web_wasm/src/database.dart';
-import 'package:sqlite3/wasm.dart';
 
 const dbName = 'drift_test';
 final sqlite3WasmUri = Uri.parse('sqlite3.wasm');
@@ -32,7 +32,10 @@ void main() {
     driftWorkerUri = Uri.parse('wrong.js');
     return _detectImplementations(arg);
   });
-  _addCallbackForWebDriver('open', _open);
+  _addCallbackForWebDriver('open', (arg) {
+    final decoded = json.decode(arg!);
+    return _open(decoded[0] as String?, decoded[1] as String?);
+  });
   _addCallbackForWebDriver('close', (arg) async {
     await tableUpdates?.cancel();
     await openedDatabase?.close();
@@ -178,7 +181,8 @@ Future<JSString> _detectImplementations(String? _) async {
   }).toJS;
 }
 
-Future<JSAny?> _open(String? implementationName) async {
+Future<JSAny?> _open(
+    String? implementationName, String? preferedImplemetationName) async {
   DatabaseConnection connection;
 
   if (implementationName != null) {
@@ -201,6 +205,8 @@ Future<JSAny?> _open(String? implementationName) async {
       initializeDatabase: _initializeDatabase,
       enableMigrations:
           initializationMode != InitializationMode.noneAndDisableMigrations,
+      preferedImplemetation: WasmStorageImplementation.values
+          .asNameMap()[preferedImplemetationName],
       localSetup: (db) {
         // The worker has a similar setup call that will make database_host
         // return `worker` instead.


### PR DESCRIPTION
This builds ontop of the work started by @Cunibon in https://github.com/simolus3/drift/pull/3695.

The main changes are that this variant:

- Does not expose a general API to move between web storage API implementations, only for IndexedDB to OPFS.
- Copies both the main database and a journal file if it exists.
- Copies on the client side before opening the database instead of doing this via an initialize callback.
- Deletes the old IndexedDB database after moving it to OPFS.

@Cunibon, does this also work for you? Let me know if this API is too restrictive for you. Otherwise I'd release this variant.