### PR TITLE
Clarify definition of todo_items table in docs

### DIFF
--- a/docs/content/dart_api/tables.md
+++ b/docs/content/dart_api/tables.md
@@ -30,7 +30,7 @@ Drift will warn you if you forget them.
 
 Note that columns are non-nullable by default. Using `nullable()` allows storing `null` values.
 
-This defines two tables: `todo_items` with columns `id`, `title`, `category`, and `created_at`; and `todo_category` with columns `id` and `description`.
+This defines the `todo_items` table with columns `id`, `title`, `category`, and `created_at`.
 
 The SQL equivalent of this table would be:
 


### PR DESCRIPTION
Removed reference to the 'todo_category' table in documentation.