### PR TITLE
Managers: Generate entrypoint for accessors

### DIFF
--- a/drift/test/generated/todos.g.dart
+++ b/drift/test/generated/todos.g.dart
@@ -6019,4 +6019,19 @@ mixin _$SomeDaoMixin on DatabaseAccessor<TodoDb> {
           users,
         }).asyncMap(todosTable.mapFromRow);
   }
+
+  SomeDaoManager get managers => SomeDaoManager(this);
+}
+
+class SomeDaoManager {
+  final _$SomeDaoMixin _db;
+  SomeDaoManager(this._db);
+  $$UsersTableTableManager get users =>
+      $$UsersTableTableManager(_db.attachedDatabase, _db.users);
+  $$CategoriesTableTableManager get categories =>
+      $$CategoriesTableTableManager(_db.attachedDatabase, _db.categories);
+  $$TodosTableTableTableManager get todosTable =>
+      $$TodosTableTableTableManager(_db.attachedDatabase, _db.todosTable);
+  $$SharedTodosTableTableManager get sharedTodos =>
+      $$SharedTodosTableTableManager(_db.attachedDatabase, _db.sharedTodos);
 }

--- a/drift_dev/CHANGELOG.md
+++ b/drift_dev/CHANGELOG.md
@@ -1,6 +1,7 @@
-## 2.30.1-dev
+## 2.31.0-dev
 
 - `make_migrations`: Don't generate schema test helpers when `--no-test` is set.
+- Generate managers entrypoint for `@DriftAccessor`s as well.
 
 ## 2.30.0
 

--- a/drift_dev/lib/src/writer/drift_accessor_writer.dart
+++ b/drift_dev/lib/src/writer/drift_accessor_writer.dart
@@ -1,5 +1,6 @@
 import '../analysis/results/results.dart';
 import 'database_writer.dart';
+import 'manager/database_manager_writer.dart';
 import 'modules.dart';
 import 'queries/query_writer.dart';
 import 'writer.dart';
@@ -13,12 +14,14 @@ class AccessorWriter {
   void write() {
     final classScope = scope.child();
     final isModular = scope.generationOptions.isModular;
+    final elements = input.resolvedAccessor.availableElements;
 
     final daoName = input.accessor.declaration.name!;
 
     final prefix = isModular ? '' : r'_';
+    final mixinName = '$prefix\$${daoName}Mixin';
     classScope.leaf()
-      ..write('mixin $prefix\$${daoName}Mixin on ')
+      ..write('mixin $mixinName on ')
       ..writeDriftRef('DatabaseAccessor<')
       ..writeDart(input.accessor.databaseClass)
       ..writeln('> {');
@@ -50,6 +53,17 @@ class AccessorWriter {
         classScope.writeGetterForIncludedDriftFile(import, input.driver!,
             isAccessor: true);
       }
+    }
+
+    if (scope.options.generateManager) {
+      final managerWriter = DatabaseManagerWriter(scope.child(), daoName,
+          accessorMixin: mixinName);
+      for (var table in elements.whereType<DriftTable>()) {
+        managerWriter.addTable(table);
+      }
+
+      managerWriter.writeDatabaseManager();
+      classScope.leaf().writeln(managerWriter.databaseManagerGetter);
     }
 
     classScope.leaf().write('}');

--- a/drift_dev/lib/src/writer/manager/database_manager_writer.dart
+++ b/drift_dev/lib/src/writer/manager/database_manager_writer.dart
@@ -11,13 +11,14 @@ class DatabaseManagerWriter {
   final Scope _scope;
   final String _dbClassName;
   final List<DriftTable> _addedTables = [];
+  final String? accessorMixin;
 
   /// Tables which may be referenced in added tables, but for which no code
   /// should be generated.
   final List<DriftTable> _additionalTables = [];
 
   /// Class used to write a manager for a database
-  DatabaseManagerWriter(this._scope, this._dbClassName);
+  DatabaseManagerWriter(this._scope, this._dbClassName, {this.accessorMixin});
 
   _ManagerCodeTemplates get _templates => _ManagerCodeTemplates(_scope);
 
@@ -54,21 +55,27 @@ class DatabaseManagerWriter {
     }
   }
 
+  String get _databaseManagerName =>
+      _templates.databaseManagerName(_dbClassName);
+
   /// The code for the database manager getter which will be added to the main database class
   ///
   /// E.g. `AppDatabase get managers => AppDatabaseManager(this);`
-  String get databaseManagerGetter =>
-      '${_templates.databaseManagerName(_dbClassName)} get managers => ${_templates.databaseManagerName(_dbClassName)}(this);';
+  String get databaseManagerGetter {
+    final managerName = _databaseManagerName;
+    return '$managerName get managers => $managerName(this);';
+  }
 
   /// Write the database manager class
   void writeDatabaseManager() {
     final leaf = _scope.leaf();
+    final managerName = _databaseManagerName;
 
     // Write the database manager class with the required getters
     leaf
-      ..writeln('class ${_templates.databaseManagerName(_dbClassName)} {')
-      ..writeln('final $_dbClassName _db;')
-      ..writeln('${_templates.databaseManagerName(_dbClassName)}(this._db);');
+      ..writeln('class $managerName {')
+      ..writeln('final ${accessorMixin ?? _dbClassName} _db;')
+      ..writeln('$managerName(this._db);');
 
     for (final table in _addedTables) {
       // Get the name of the table manager class
@@ -76,8 +83,10 @@ class DatabaseManagerWriter {
           _templates.rootTableManagerWithPrefix(table, leaf);
 
       /// Write the getter for the table manager
+      final databaseInstance =
+          accessorMixin != null ? '_db.attachedDatabase' : '_db';
       leaf.writeln(
-          '$rootTableManagerClass get ${table.dbGetterName} => $rootTableManagerClass(_db, _db.${table.dbGetterName});');
+          '$rootTableManagerClass get ${table.dbGetterName} => $rootTableManagerClass($databaseInstance, _db.${table.dbGetterName});');
     }
     leaf.writeln('}');
   }

--- a/examples/modular/lib/accessor.drift.dart
+++ b/examples/modular/lib/accessor.drift.dart
@@ -28,4 +28,14 @@ mixin $MyAccessorMixin on i0.DatabaseAccessor<i1.Database> {
   i4.UserQueriesDrift get userQueriesDrift =>
       i3.ReadDatabaseContainer(attachedDatabase)
           .accessor<i4.UserQueriesDrift>(i4.UserQueriesDrift.new);
+  MyAccessorManager get managers => MyAccessorManager(this);
+}
+
+class MyAccessorManager {
+  final $MyAccessorMixin _db;
+  MyAccessorManager(this._db);
+  i2.$UsersTableManager get users =>
+      i2.$UsersTableManager(_db.attachedDatabase, _db.users);
+  i2.$FollowsTableManager get follows =>
+      i2.$FollowsTableManager(_db.attachedDatabase, _db.follows);
 }

--- a/examples/with_built_value/lib/database.g.dart
+++ b/examples/with_built_value/lib/database.g.dart
@@ -11,19 +11,15 @@ class _$Foo extends Foo {
   final User driftGeneratedField;
 
   factory _$Foo([void Function(FooBuilder)? updates]) =>
-      (new FooBuilder()..update(updates))._build();
+      (FooBuilder()..update(updates))._build();
 
-  _$Foo._({required this.driftGeneratedField}) : super._() {
-    BuiltValueNullFieldError.checkNotNull(
-        driftGeneratedField, r'Foo', 'driftGeneratedField');
-  }
-
+  _$Foo._({required this.driftGeneratedField}) : super._();
   @override
   Foo rebuild(void Function(FooBuilder) updates) =>
       (toBuilder()..update(updates)).build();
 
   @override
-  FooBuilder toBuilder() => new FooBuilder()..replace(this);
+  FooBuilder toBuilder() => FooBuilder()..replace(this);
 
   @override
   bool operator ==(Object other) {
@@ -68,7 +64,6 @@ class FooBuilder implements Builder<Foo, FooBuilder> {
 
   @override
   void replace(Foo other) {
-    ArgumentError.checkNotNull(other, 'other');
     _$v = other as _$Foo;
   }
 
@@ -82,7 +77,7 @@ class FooBuilder implements Builder<Foo, FooBuilder> {
 
   _$Foo _build() {
     final _$result = _$v ??
-        new _$Foo._(
+        _$Foo._(
           driftGeneratedField: BuiltValueNullFieldError.checkNotNull(
               driftGeneratedField, r'Foo', 'driftGeneratedField'),
         );


### PR DESCRIPTION
This generates a `managers` getter for `@DriftAccessor` classes exposing a subset of tables from the database. This ensures that `.managers` is consistently callable from every place one might want to write drift queries from.

Closes https://github.com/simolus3/drift/issues/3735.

@dickermoshe let me know if you want to have a quick look at this.