### PR TITLE
Make sure to honor moveExistingIndexedDbToOpfs bool

### DIFF
--- a/drift/lib/wasm.dart
+++ b/drift/lib/wasm.dart
@@ -180,7 +180,8 @@ class WasmDatabase extends DelegatedDatabase {
     if (currentDb != null && currentDb != selectedImplementation.storageApi) {
       // ... except if we want to move from IndexedDB to OPFS
       var didMove = false;
-      if (currentDb == WebStorageApi.indexedDb &&
+      if (moveExistingIndexedDbToOpfs &&
+          currentDb == WebStorageApi.indexedDb &&
           selectedImplementation.storageApi == WebStorageApi.opfs) {
         try {
           await probed.moveFromIndexedDBToOpfs(databaseName);


### PR DESCRIPTION
I noticed we define the moveExistingIndexedDbToOpfs bool but dont acutally use it in the code, so currently all drift users would automatically move to OPFS if their browser allows it.