### PR TITLE
fix(sqlparser): colon in line comment no longer breaks drift file parsing

### DIFF
--- a/sqlparser/lib/src/reader/tokenizer/scanner.dart
+++ b/sqlparser/lib/src/reader/tokenizer/scanner.dart
@@ -536,6 +536,8 @@ class Scanner {
 
   static final _importComment = RegExp(r'^\s*import.*;', caseSensitive: false);
   // match `foo:` or `myQuery (:variable AS TEXT):`
+  // The colon must be at the end of the line to avoid matching regular
+  // comments that happen to contain colons (e.g. `-- VIEW : description`).
   static final _statementMeta =
-      RegExp(r'^\s*\w+\s*(?:\(.*\)\s*)?:', caseSensitive: false);
+      RegExp(r'^\s*\w+\s*(?:\(.*\)\s*)?:\s*$', caseSensitive: false);
 }

--- a/sqlparser/test/parser/drift_file_test.dart
+++ b/sqlparser/test/parser/drift_file_test.dart
@@ -300,6 +300,29 @@ SELECT * FROM todos WHERE $predicate;
       ]);
     });
 
+    test('colon in comment does not break parsing', () {
+      // Regression test for https://github.com/simolus3/drift/issues/3763
+      final driftFile = _engine.parse(ParserEntrypoint.driftFile, r'''
+-- import 'status.dart';
+
+-- VIEW : For Definitions (handles the JSON ordering)
+CREATE VIEW definitions_json_view AS
+  SELECT 1;
+
+-- deleteById:
+DELETE FROM todos WHERE id = :id;
+''').rootNode;
+
+      final stmts = driftFile.statements;
+      expect(stmts, [
+        isA<ImportStatement>(),
+        isA<CreateViewStatement>()
+            .having((e) => e.viewName, 'viewName', 'definitions_json_view'),
+        isA<DeclaredStatement>()
+            .having((e) => e.identifier.name, 'identifier.name', 'deleteById'),
+      ]);
+    });
+
     test('keeps comments in definitions', () {
       final driftFile = _engine.parse(ParserEntrypoint.driftFile, r'''
 -- import 'status.dart';


### PR DESCRIPTION
## Summary

Fixes #3763.

A colon inside a line comment (e.g. `-- VIEW : For Definitions`) was incorrectly matched by the `_statementMeta` regex as a named statement header. This caused the scanner to truncate the comment and parse the remaining text as SQL tokens, which broke all subsequent table/view definitions in the file.

The `_statementMeta` regex now requires the colon to be the last non-whitespace character on the line (`\s*$`), so regular comments containing colons are no longer mistaken for named statements.

## What changed

**`sqlparser/lib/src/reader/tokenizer/scanner.dart`** - one line: added `\s*$` to the regex

Before: `^\s*\w+\s*(?:\(.*\)\s*)?:`
After: `^\s*\w+\s*(?:\(.*\)\s*)?:\s*$`

## Test plan

- Added regression test with a comment containing a colon before a `CREATE VIEW`
- All 726 existing sqlparser tests pass
- `dart format` and `dart analyze` clean