### PR TITLE
Fix DataClass.parseJson missing import prefix in modular mode

### DIFF
--- a/drift_dev/lib/src/writer/tables/data_class_writer.dart
+++ b/drift_dev/lib/src/writer/tables/data_class_writer.dart
@@ -193,10 +193,11 @@ class DataClassWriter {
 
     if (scope.writer.options.generateFromJsonStringConstructor) {
       // also generate a constructor that only takes a json string
+      final dataClassType = _emitter.drift('DataClass');
       _buffer.write('factory $dataClassName.fromJsonString(String encodedJson, '
           '{$serializerType serializer}) => '
           '$dataClassName.fromJson('
-          'DataClass.parseJson(encodedJson) as Map<String, dynamic>, '
+          '$dataClassType.parseJson(encodedJson) as Map<String, dynamic>, '
           'serializer: serializer);');
     }
   }


### PR DESCRIPTION
## Problem

When using `write_from_json_string_constructor: true` with `drift_dev:modular` mode, the generated `fromJsonString` constructor contains a bare `DataClass.parseJson(...)` reference without the import alias prefix (e.g. `i0.`), causing a compile error.

This is because `data_class_writer.dart` hard-codes the string `DataClass` instead of using `_emitter.drift('DataClass')` like the rest of the file does.

## Fix

Use `_emitter.drift('DataClass')` to generate the correctly prefixed reference. This produces `i0.DataClass.parseJson(...)` in modular mode and `DataClass.parseJson(...)` in non-modular mode - both correct.

## Reproduction

`build.yaml`:
```yaml
drift_dev:modular:
  enabled: true
  options:
    write_from_json_string_constructor: true
```

**Before fix** (generated code, will not compile):
```dart
factory XxxData.fromJsonString(String encodedJson, ...) =>
    XxxData.fromJson(DataClass.parseJson(encodedJson) as Map<String, dynamic>, ...);
//                   ^^^^^^^^^ unresolved - drift is imported as i0
```

**After fix**:
```dart
factory XxxData.fromJsonString(String encodedJson, ...) =>
    XxxData.fromJson(i0.DataClass.parseJson(encodedJson) as Map<String, dynamic>, ...);
```

Closes https://github.com/simolus3/drift/issues/3774