### PR TITLE
fix(streams): emit DatabaseDisconnectedException before closing watch() streams

### DIFF
--- a/drift/lib/src/runtime/exceptions.dart
+++ b/drift/lib/src/runtime/exceptions.dart
@@ -44,6 +44,24 @@ class DriftWrappedException implements Exception {
   }
 }
 
+/// Exception thrown on active [watch()] streams when the database is closed.
+///
+/// When a database is closed while a [watch()] stream has active listeners,
+/// drift emits this exception before sending the done event. This lets callers
+/// distinguish a database shutdown from a normal stream completion and
+/// re-subscribe after the database is reopened.
+///
+/// In Flutter, check for this in [StreamBuilder] via
+/// `snapshot.hasError && snapshot.error is DatabaseDisconnectedException`.
+class DatabaseDisconnectedException implements Exception {
+  /// Constant constructor.
+  const DatabaseDisconnectedException();
+
+  @override
+  String toString() => 'DatabaseDisconnectedException: '
+      'The database was closed while this stream was still active.';
+}
+
 /// Exception thrown by drift when rolling back a transaction fails.
 ///
 /// When using a `transaction` block, transactions are automatically rolled back

--- a/drift/lib/src/runtime/executor/stream_queries.dart
+++ b/drift/lib/src/runtime/executor/stream_queries.dart
@@ -363,8 +363,17 @@ class QueryStream<Rows extends Object> {
   Future<void> close() async {
     _isClosed = true;
 
-    final listenersDone = Future.wait(
-        [for (final listener in _listeners) listener.controller.close()]);
+    // Emit an error before closing so callers can distinguish a database
+    // shutdown from a normal stream completion and re-subscribe if needed.
+    // See https://github.com/simolus3/drift/issues/3782
+    const disconnected = DatabaseDisconnectedException();
+    final listenersDone = Future.wait([
+      for (final listener in _listeners)
+        Future.sync(() {
+          listener.controller.addError(disconnected);
+          return listener.controller.close();
+        }),
+    ]);
     _listeners.clear();
     await listenersDone;
   }


### PR DESCRIPTION
Fixes #3782

## Problem

When a database is closed while `watch()` streams have active listeners, `QueryStream.close()` called `controller.close()` directly. This sent a `done` event with no error, making it impossible for `StreamBuilder` (or any other consumer) to distinguish a database shutdown from a normal stream completion. The widget silently froze on stale data.

## Fix

Two changes:

1. **`drift/lib/src/runtime/exceptions.dart`** — add `DatabaseDisconnectedException`, a new public exception class that callers can check against.
2. **`drift/lib/src/runtime/executor/stream_queries.dart`** — in `QueryStream.close()`, call `controller.addError(const DatabaseDisconnectedException())` on each `MultiStreamController` before calling `controller.close()`.

Callers can now detect shutdown via:

```dart
if (snapshot.hasError && snapshot.error is DatabaseDisconnectedException) {
  // database was closed; re-subscribe after reopening
}
```

The existing `done`-event behavior is preserved — the stream still closes. Only the distinguishable error is added before it.

*AI-assisted — authored with Claude, reviewed by Komada.*