### PR TITLE
sqlparser: added alter table add/drop constraint 

### DIFF
--- a/sqlparser/CHANGELOG.md
+++ b/sqlparser/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.44.5 (unreleased)
+
+- Support `ALTER TABLE ADD/DROP CONSTRAINT` statements. 
+
 ## 0.44.4
 
 - Support `ALTER TABLE ALTER COLUMN` statements.

--- a/sqlparser/lib/src/ast/statements/alter.dart
+++ b/sqlparser/lib/src/ast/statements/alter.dart
@@ -126,6 +126,44 @@ final class AlterColumn extends AlterTableInstruction {
   }
 }
 
+/// An `ALTER TABLE ADD CONSTRAINT` statement added in SQLite version 3.53.0.
+final class AddConstraint extends AlterTableInstruction {
+  CheckTable checkTable;
+
+  AddConstraint({required this.checkTable});
+
+  @override
+  R accept<A, R>(AstVisitor<A, R> visitor, A arg) {
+    return visitor.visitAddConstraint(this, arg);
+  }
+
+  @override
+  Iterable<AstNode> get childNodes => [checkTable];
+
+  @override
+  void transformChildren<A>(Transformer<A> transformer, A arg) {
+    checkTable = transformer.transformChild(checkTable, this, arg);
+  }
+}
+
+/// An `ALTER TABLE Drop CONSTRAINT` statement added in SQLite version 3.53.0.
+final class DropConstraint extends AlterTableInstruction {
+  final String name;
+
+  DropConstraint({required this.name});
+
+  @override
+  R accept<A, R>(AstVisitor<A, R> visitor, A arg) {
+    return visitor.visitDropConstraint(this, arg);
+  }
+
+  @override
+  Iterable<AstNode> get childNodes => const [];
+
+  @override
+  void transformChildren<A>(Transformer<A> transformer, A arg) {}
+}
+
 /// An instruction that appears in an [AlterColumn] instruction.
 sealed class AlterColumnInstruction extends AstNode {}
 

--- a/sqlparser/lib/src/ast/visitor.dart
+++ b/sqlparser/lib/src/ast/visitor.dart
@@ -117,6 +117,8 @@ abstract class AstVisitor<A, R> {
   R visitAlterColumn(AlterColumn e, A arg);
   R visitAlterColumnSetNotNull(AlterColumnSetNotNull e, A arg);
   R visitAlterColumnDropNotNull(AlterColumnDropNotNull e, A arg);
+  R visitAddConstraint(AddConstraint e, A arg);
+  R visitDropConstraint(DropConstraint e, A arg);
 
   R visitDriftSpecificNode(DriftSpecificNode e, A arg);
 }
@@ -664,27 +666,27 @@ class RecursiveVisitor<A, R> implements AstVisitor<A, R?> {
 
   @override
   R? visitRenameTo(RenameTo e, A arg) {
-    return defaultAlterTableInstructrion(e, arg);
+    return defaultAlterTableInstruction(e, arg);
   }
 
   @override
   R? visitRenameColumnTo(RenameColumnTo e, A arg) {
-    return defaultAlterTableInstructrion(e, arg);
+    return defaultAlterTableInstruction(e, arg);
   }
 
   @override
   R? visitAddColumn(AddColumn e, A arg) {
-    return defaultAlterTableInstructrion(e, arg);
+    return defaultAlterTableInstruction(e, arg);
   }
 
   @override
   R? visitDropColumn(DropColumn e, A arg) {
-    return defaultAlterTableInstructrion(e, arg);
+    return defaultAlterTableInstruction(e, arg);
   }
 
   @override
   R? visitAlterColumn(AlterColumn e, A arg) {
-    return defaultAlterTableInstructrion(e, arg);
+    return defaultAlterTableInstruction(e, arg);
   }
 
   @override
@@ -697,7 +699,17 @@ class RecursiveVisitor<A, R> implements AstVisitor<A, R?> {
     return defaultNode(e, arg);
   }
 
-  R? defaultAlterTableInstructrion(AlterTableInstruction e, A arg) {
+  @override
+  R? visitAddConstraint(AddConstraint e, A arg) {
+    return defaultNode(e, arg);
+  }
+
+  @override
+  R? visitDropConstraint(DropConstraint e, A arg) {
+    return defaultNode(e, arg);
+  }
+
+  R? defaultAlterTableInstruction(AlterTableInstruction e, A arg) {
     return defaultNode(e, arg);
   }
 

--- a/sqlparser/lib/src/reader/parser.dart
+++ b/sqlparser/lib/src/reader/parser.dart
@@ -2381,14 +2381,30 @@ extension Parser on ParserState {
 
     if (_matchOne(TokenType.add)) {
       final first = _previous;
+
+      final constraint = tableConstraintOrNull(parseOnlyCheckConstraints: true);
+      if (constraint != null) {
+        return AddConstraint(checkTable: constraint as CheckTable)
+          ..setSpan(first, _previous);
+      }
+
       _matchOne(TokenType.column);
       return AddColumn(_columnDefinition())..setSpan(first, _previous);
     }
 
     if (_matchOne(TokenType.drop)) {
       final first = _previous;
+
+      final constraintName = _constraintNameOrNull();
+      if (constraintName != null) {
+        return DropConstraint(name: constraintName.identifier)
+          ..setSpan(first, _previous);
+      }
+
       _matchOne(TokenType.column);
-      final name = _consumeIdentifier('Expected column to drop');
+      final name = _consumeIdentifier(
+        'Expected column to drop or CONSTRAINT keyword',
+      );
       return DropColumn(Reference.fromTokens(columnName: name))
         ..setSpan(first, _previous);
     }
@@ -2630,13 +2646,21 @@ extension Parser on ParserState {
     _error('Expected a constraint (primary key, nullability, etc.)');
   }
 
-  TableConstraint? tableConstraintOrNull({bool requireConstraint = false}) {
+  TableConstraint? tableConstraintOrNull({
+    bool requireConstraint = false,
+    bool parseOnlyCheckConstraints = false,
+  }) {
     final first = _peek;
     final nameToken = _constraintNameOrNull();
     final name = nameToken?.identifier;
 
     TableConstraint? result;
-    if (_match([TokenType.unique, TokenType.primary])) {
+    if (_matchOne(TokenType.check)) {
+      final expr = _expressionInParentheses();
+      result = CheckTable(name, expr);
+    } else if (parseOnlyCheckConstraints) {
+      return null;
+    } else if (_match([TokenType.unique, TokenType.primary])) {
       final isPrimaryKey = _previous.type == TokenType.primary;
 
       if (isPrimaryKey) {
@@ -2660,9 +2684,6 @@ extension Parser on ParserState {
         columns: columns,
         onConflict: conflictClause,
       );
-    } else if (_matchOne(TokenType.check)) {
-      final expr = _expressionInParentheses();
-      result = CheckTable(name, expr);
     } else if (_matchOne(TokenType.foreign)) {
       _consume(TokenType.key, 'Expected KEY to start FOREIGN KEY clause');
       final columns = _listColumnsInParentheses(allowEmpty: false);

--- a/sqlparser/lib/src/utils/ast_equality.dart
+++ b/sqlparser/lib/src/utils/ast_equality.dart
@@ -927,6 +927,18 @@ class EqualityEnforcingVisitor implements AstVisitor<void, void> {
     _currentAs<AlterColumnDropNotNull>(e);
   }
 
+  @override
+  void visitAddConstraint(AddConstraint e, void arg) {
+    _currentAs<AddConstraint>(e);
+    _checkChildren(e);
+  }
+
+  @override
+  void visitDropConstraint(DropConstraint e, void arg) {
+    final current = _currentAs<DropConstraint>(e);
+    _assert(current.name == e.name, e);
+  }
+
   void _assert(bool contentEqual, AstNode context) {
     if (!contentEqual) _notEqual(context);
   }

--- a/sqlparser/lib/utils/node_to_text.dart
+++ b/sqlparser/lib/utils/node_to_text.dart
@@ -1523,6 +1523,19 @@ base class NodeSqlBuilder extends AstVisitor<void, void> {
     keyword(TokenType.$null);
   }
 
+  @override
+  void visitAddConstraint(AddConstraint e, void arg) {
+    keyword(TokenType.add);
+    visitTableConstraint(e.checkTable, arg);
+  }
+
+  @override
+  void visitDropConstraint(DropConstraint e, void arg) {
+    keyword(TokenType.drop);
+    keyword(TokenType.constraint);
+    identifier(e.name);
+  }
+
   void _conflictClause(ConflictClause? clause) {
     if (clause != null) {
       keyword(TokenType.on);

--- a/sqlparser/lib/utils/schema_buffer.dart
+++ b/sqlparser/lib/utils/schema_buffer.dart
@@ -286,6 +286,83 @@ final class SchemaBuffer {
             ),
           );
         }
+      case AddConstraint(checkTable: final checkTable):
+        if (checkTable.name != null) {
+          for (final tableConstraint in element._tableConstraints) {
+            if (checkTable.name == tableConstraint.constraint.name) {
+              errors.add(
+                AnalysisError(
+                  type: AnalysisErrorType.other,
+                  relevantNode: instruction,
+                  message: 'constraint ${checkTable.name} already exists',
+                ),
+              );
+              return;
+            }
+          }
+
+          for (final column in element._columns) {
+            for (final columnConstraint in column.constraints) {
+              if (checkTable.name == columnConstraint.constraint.name) {
+                errors.add(
+                  AnalysisError(
+                    type: AnalysisErrorType.other,
+                    relevantNode: instruction,
+                    message: 'constraint ${checkTable.name} already exists',
+                  ),
+                );
+                return;
+              }
+            }
+          }
+        }
+
+        element.addConstraint(statement, checkTable);
+      case DropConstraint(name: final name):
+        for (final tableConstraint in element._tableConstraints) {
+          if (name == tableConstraint.constraint.name) {
+            if (tableConstraint.constraint is! CheckTable) {
+              errors.add(
+                AnalysisError(
+                  type: AnalysisErrorType.other,
+                  relevantNode: tableConstraint.constraint,
+                  message: 'constraint may not be dropped: $name',
+                ),
+              );
+              return;
+            }
+            element.dropConstraint(tableConstraint);
+            return;
+          }
+        }
+
+        for (final column in element._columns) {
+          for (final columnConstraint in column.constraints) {
+            if (name == columnConstraint.constraint.name) {
+              if (columnConstraint.constraint is! CheckColumn &&
+                  columnConstraint.constraint is! NotNull) {
+                errors.add(
+                  AnalysisError(
+                    type: AnalysisErrorType.other,
+                    relevantNode: columnConstraint.constraint,
+                    message: 'constraint may not be dropped: $name',
+                  ),
+                );
+                return;
+              }
+              column.dropConstraint(columnConstraint);
+              return;
+            }
+          }
+        }
+
+        errors.add(
+          AnalysisError(
+            type: AnalysisErrorType.other,
+            relevantNode: instruction,
+            message: 'no such constraint: $name',
+          ),
+        );
     }
   }
 }
@@ -306,6 +383,7 @@ final class _TableSchemaElement extends _SchemaElement {
   String lowercaseName;
   late _SourceElement name;
   final List<_ColumnDefinition> _columns = [];
+  final List<_TableConstraint> _tableConstraints = [];
 
   _TableSchemaElement(this.originalStatement)
     : lowercaseName = originalStatement.createdName {
@@ -327,6 +405,13 @@ final class _TableSchemaElement extends _SchemaElement {
       );
 
       _columns.add(columnDef);
+    }
+
+    for (final constraint in originalStatement.tableConstraints) {
+      final before = fromText.elementUntil(constraint.firstPosition);
+      final constraintDef = fromText._readTableConstraint(before, constraint);
+
+      _tableConstraints.add(constraintDef);
     }
 
     // Add remaining text from the CREATE TABLE statement.
@@ -368,6 +453,38 @@ final class _TableSchemaElement extends _SchemaElement {
     }
 
     _columns.remove(definition);
+  }
+
+  void addConstraint(AstNode originalStatement, CheckTable checkTable) {
+    final _SourceElement precedingComma;
+
+    if (_tableConstraints.lastOrNull case final lastConstraint?) {
+      precedingComma =
+          lastConstraint.precedingComma?.clone() ?? _SourceElement(', ');
+
+      lastConstraint.source.insertAfter(precedingComma);
+    } else if (_columns.lastOrNull case final lastColumn?) {
+      precedingComma =
+          lastColumn.precedingComma?.clone() ?? _SourceElement(', ');
+
+      lastColumn.end.insertAfter(precedingComma);
+    } else {
+      throw UnsupportedError('TODO: Adding constraint to empty table');
+    }
+
+    final text = originalStatement.span!.text;
+    final startOffset = originalStatement.firstPosition;
+    final fromText = _SourceFromText(text, startOffset, precedingComma);
+    fromText.currentPosition = checkTable.firstPosition;
+    _tableConstraints.add(
+      fromText._readTableConstraint(precedingComma, checkTable),
+    );
+  }
+
+  void dropConstraint(_TableConstraint tableConstraint) {
+    _tableConstraints.remove(tableConstraint);
+    tableConstraint.precedingComma?.unlink();
+    tableConstraint.source.unlink();
   }
 
   @override
@@ -428,6 +545,19 @@ final class _ColumnDefinition {
       return false;
     });
   }
+
+  void dropConstraint(_ColumnConstraint columnConstraint) {
+    constraints.remove(columnConstraint);
+    columnConstraint.source.unlink();
+  }
+}
+
+final class _TableConstraint {
+  final TableConstraint constraint;
+  final _SourceElement source;
+  final _SourceElement? precedingComma;
+
+  _TableConstraint(this.precedingComma, this.constraint, this.source);
 }
 
 /// Any schema element that isn't a (non-virtual) table.
@@ -530,7 +660,18 @@ final class _SourceFromText {
       name,
       column.columnName.toLowerCase(),
       typeName,
-      [],
+      constraints,
+    );
+  }
+
+  _TableConstraint _readTableConstraint(
+    _SourceElement? precedingComma,
+    TableConstraint tableConstraint,
+  ) {
+    return _TableConstraint(
+      precedingComma,
+      tableConstraint,
+      elementUntil(tableConstraint.lastPosition)!,
     );
   }
 }

--- a/sqlparser/test/parser/alter_table_test.dart
+++ b/sqlparser/test/parser/alter_table_test.dart
@@ -55,7 +55,7 @@ void main() {
     );
   });
 
-  test('add column', () {
+  test('drop column', () {
     testStatement(
       'ALTER TABLE foo DROP bar',
       AlterTableStatement(
@@ -88,6 +88,49 @@ void main() {
         TableReference('foo'),
         AlterColumn(columnName: 'bar', instruction: AlterColumnDropNotNull()),
       ),
+    );
+  });
+
+  test('add constraint', () {
+    testStatement(
+      'ALTER TABLE foo ADD CONSTRAINT bar CHECK (foo >= 18);',
+      AlterTableStatement(
+        TableReference('foo'),
+        AddConstraint(
+          checkTable: CheckTable(
+            "bar",
+            BinaryExpression(
+              Reference(columnName: 'foo'),
+              token(TokenType.moreEqual),
+              NumericLiteral(18),
+            ),
+          ),
+        ),
+      ),
+    );
+
+    testStatement(
+      'ALTER TABLE foo ADD CHECK (foo != 18);',
+      AlterTableStatement(
+        TableReference('foo'),
+        AddConstraint(
+          checkTable: CheckTable(
+            null,
+            BinaryExpression(
+              Reference(columnName: 'foo'),
+              token(TokenType.exclamationEqual),
+              NumericLiteral(18),
+            ),
+          ),
+        ),
+      ),
+    );
+  });
+
+  test('DROP CONSTRAINT', () {
+    testStatement(
+      'ALTER TABLE foo DROP CONSTRAINT bar;',
+      AlterTableStatement(TableReference('foo'), DropConstraint(name: 'bar')),
     );
   });
 }

--- a/sqlparser/test/utils/node_to_text_test.dart
+++ b/sqlparser/test/utils/node_to_text_test.dart
@@ -266,6 +266,12 @@ CREATE UNIQUE INDEX my_idx ON t1 (c1, c2, c3) WHERE c1 < c3;
         'ALTER TABLE foo ALTER COLUMN bar SET NOT NULL ON CONFLICT FAIL',
       );
     });
+
+    test('alter constraint', () {
+      testFormat('ALTER TABLE foo ADD CHECK (x != 1)');
+      testFormat('ALTER TABLE foo ADD CONSTRAINT bar CHECK (x != 1)');
+      testFormat('ALTER TABLE foo DROP CONSTRAINT bar');
+    });
   });
 
   group('query statements', () {

--- a/sqlparser/test/utils/schema_buffer_test.dart
+++ b/sqlparser/test/utils/schema_buffer_test.dart
@@ -226,5 +226,179 @@ CREATE TABLE tbl (
         ),
       ]);
     });
+
+    group('add constraint', () {
+      test('no existing constraint', () {
+        process('CREATE TABLE original (a INTEGER);');
+        process('ALTER TABLE original ADD CHECK (a >= 0);');
+
+        expect(buffer.definitions, {
+          'original': 'CREATE TABLE original (a INTEGER, CHECK (a >= 0));',
+        });
+      });
+
+      test('existing table constraint', () {
+        process(
+          'CREATE TABLE original (a INTEGER, CONSTRAINT smaller_zero CHECK (a < 0));',
+        );
+        process(
+          'ALTER TABLE original ADD CONSTRAINT check_constraint CHECK (a >= 0);',
+        );
+
+        expect(buffer.definitions, {
+          'original':
+              'CREATE TABLE original (a INTEGER, CONSTRAINT smaller_zero CHECK (a < 0), CONSTRAINT check_constraint CHECK (a >= 0));',
+        });
+      });
+
+      test('existing column constraint', () {
+        process(
+          'CREATE TABLE original (a INTEGER CONSTRAINT smaller_zero CHECK (a < 0));',
+        );
+        process('ALTER TABLE original ADD CHECK (a >= 0);');
+
+        expect(buffer.definitions, {
+          'original':
+              'CREATE TABLE original (a INTEGER CONSTRAINT smaller_zero CHECK (a < 0), CHECK (a >= 0));',
+        });
+      });
+
+      group('constraint name already exists', () {
+        test('in column', () {
+          process(
+            'CREATE TABLE original (a INTEGER CONSTRAINT check_constraint CHECK (id > 0));',
+          );
+
+          expect(
+            processWithErrors(
+              'ALTER TABLE original ADD CONSTRAINT check_constraint CHECK (a >= 0);',
+            ),
+            [
+              analysisErrorWith(
+                type: AnalysisErrorType.other,
+                lexeme: 'ADD CONSTRAINT check_constraint CHECK (a >= 0)',
+                message: 'constraint check_constraint already exists',
+              ),
+            ],
+          );
+        });
+
+        test('in table', () {
+          process(
+            'CREATE TABLE original (a INTEGER, CONSTRAINT check_constraint CHECK (a >=0));',
+          );
+          expect(
+            processWithErrors(
+              'ALTER TABLE original ADD CONSTRAINT check_constraint CHECK (a >= 0);',
+            ),
+            [
+              analysisErrorWith(
+                type: AnalysisErrorType.other,
+                lexeme: 'ADD CONSTRAINT check_constraint CHECK (a >= 0)',
+                message: 'constraint check_constraint already exists',
+              ),
+            ],
+          );
+        });
+      });
+    });
+
+    group("drop constraint", () {
+      test("table constraint", () {
+        process(
+          'CREATE TABLE original (a INTEGER, CONSTRAINT check_constraint CHECK (a > 0));',
+        );
+        process('ALTER TABLE original DROP CONSTRAINT check_constraint;');
+
+        expect(buffer.definitions, {
+          'original': 'CREATE TABLE original (a INTEGER);',
+        });
+      });
+
+      test("check", () {
+        process(
+          'CREATE TABLE original (a INTEGER CONSTRAINT check_constraint CHECK (a > 0));',
+        );
+        process('ALTER TABLE original DROP CONSTRAINT check_constraint;');
+
+        expect(buffer.definitions, {
+          'original': 'CREATE TABLE original (a INTEGER );',
+        });
+      });
+
+      test("not null", () {
+        process(
+          'CREATE TABLE original (a INTEGER CONSTRAINT not_null NOT NULL);',
+        );
+        process('ALTER TABLE original DROP CONSTRAINT not_null;');
+
+        expect(buffer.definitions, {
+          'original': 'CREATE TABLE original (a INTEGER );',
+        });
+      });
+
+      test("multiple", () {
+        process(
+          'CREATE TABLE original (a INTEGER, CONSTRAINT check_constraint CHECK (a > 0), CHECK (a != 5));',
+        );
+        process('ALTER TABLE original DROP CONSTRAINT check_constraint;');
+
+        expect(buffer.definitions, {
+          'original': 'CREATE TABLE original (a INTEGER, CHECK (a != 5));',
+        });
+      });
+
+      test("name doesn't exists", () {
+        process(
+          'CREATE TABLE original (a INTEGER CONSTRAINT not_null NOT NULL, CHECK (a >=0));',
+        );
+        expect(
+          processWithErrors(
+            'ALTER TABLE original DROP CONSTRAINT check_constraint;',
+          ),
+          [
+            analysisErrorWith(
+              type: AnalysisErrorType.other,
+              lexeme: 'DROP CONSTRAINT check_constraint',
+              message: 'no such constraint: check_constraint',
+            ),
+          ],
+        );
+      });
+
+      test("may not be dropped", () {
+        process(
+          'CREATE TABLE original (a INTEGER CONSTRAINT unique_constraint UNIQUE, CONSTRAINT primary_constraint PRIMARY KEY (a));',
+        );
+
+        // check column constraint
+        expect(
+          processWithErrors(
+            'ALTER TABLE original DROP CONSTRAINT unique_constraint;',
+          ),
+          [
+            analysisErrorWith(
+              type: AnalysisErrorType.other,
+              lexeme: 'CONSTRAINT unique_constraint UNIQUE',
+              message: 'constraint may not be dropped: unique_constraint',
+            ),
+          ],
+        );
+
+        // check table constraint
+        expect(
+          processWithErrors(
+            'ALTER TABLE original DROP CONSTRAINT primary_constraint;',
+          ),
+          [
+            analysisErrorWith(
+              type: AnalysisErrorType.other,
+              lexeme: 'CONSTRAINT primary_constraint PRIMARY KEY (a)',
+              message: 'constraint may not be dropped: primary_constraint',
+            ),
+          ],
+        );
+      });
+    });
   });
 }


### PR DESCRIPTION
Fixes #3801

Added support for the new SQLITE 3.53 `ADD CONSTRAINT` and `DROP CONSTRAINT` syntax.

`ADD CONSTRAINT` can add named/unnamed `CHECK` constraints to the table constraints.
`DROP CONSTRAINT` can drop named `CHECK` or `NOT NULL` constraints.

---

In the sqlite documentation `ADD CHECK` has an optional conflict clause.
The sqlite repl doesn't throw an error adding the conflict clause but it seems to be ignored and would always ABORT on conflict.
I ignored the conflict clause for the time being, but can add it if you want.

I don't really like `parseOnlyCheckConstraints` in `Parser`. Wanted to reuse the existing code to parse table constraints, but 
add constraint only supports check constraint.

In `SchemaBuffer` the code to search for a constraint in the table and column constraints is kinda duplicated.
Didn't had a good idea to merge it because `_TableConstraint` and `_ColumnConstraint` are completely different Objects.

Should the `ReferenceResolver` resolve the columns in the check constraint expression?
It doesn't at the moment. Seems the table is not added to the `StatementScope`.