### PR TITLE
Fix: TableInfo equality is wrong if used across multiple databases.

### DIFF
--- a/drift/CHANGELOG.md
+++ b/drift/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## 2.34.0 (unreleased)
 
 - Use `BEGIN IMMEDIATE` to start transactions.
+- Make `TableInfo`'s `==` and `hashCode` take into account the database its attached to.
 
 ## 2.33.0
 

--- a/drift/lib/src/runtime/query_builder/schema/table_info.dart
+++ b/drift/lib/src/runtime/query_builder/schema/table_info.dart
@@ -99,16 +99,16 @@ mixin TableInfo<TableDsl extends Table, D> on Table
 
   @override
   bool operator ==(Object other) {
-    // tables are singleton instances except for aliases
+    // Tables are singletons within the databases they're attached to (except for aliases).
     if (other is TableInfo) {
       return other.runtimeType == runtimeType &&
-          other.aliasedName == aliasedName;
+          other.aliasedName == aliasedName && other.attachedDatabase == attachedDatabase;
     }
     return false;
   }
 
   @override
-  int get hashCode => Object.hash(aliasedName, actualTableName);
+  int get hashCode => Object.hash(aliasedName, actualTableName, attachedDatabase);
 }
 
 /// Additional interface for tables in a drift file that have been created with

--- a/drift/lib/src/runtime/query_builder/schema/table_info.dart
+++ b/drift/lib/src/runtime/query_builder/schema/table_info.dart
@@ -102,13 +102,15 @@ mixin TableInfo<TableDsl extends Table, D> on Table
     // Tables are singletons within the databases they're attached to (except for aliases).
     if (other is TableInfo) {
       return other.runtimeType == runtimeType &&
-          other.aliasedName == aliasedName && other.attachedDatabase == attachedDatabase;
+          other.aliasedName == aliasedName &&
+          other.attachedDatabase == attachedDatabase;
     }
     return false;
   }
 
   @override
-  int get hashCode => Object.hash(aliasedName, actualTableName, attachedDatabase);
+  int get hashCode =>
+      Object.hash(aliasedName, actualTableName, attachedDatabase);
 }
 
 /// Additional interface for tables in a drift file that have been created with

--- a/drift/test/database/database_test.dart
+++ b/drift/test/database/database_test.dart
@@ -111,6 +111,36 @@ void main() {
     verifyNever(ex2.runSelect(any, any));
   });
 
+  test('database tables can be equated', () {
+    final ex1 = MockExecutor();
+
+    final db1 = TodoDb(ex1);
+
+    addTearDown(db1.close);
+
+    final reference1 = db1.todosTable;
+    final reference2 = db1.todosTable;
+
+    expect(reference1, equals(reference1));
+    expect(reference1.hashCode, equals(reference2.hashCode));
+  });
+
+  test(
+    'database tables from different databases with same names are unequal',
+    () {
+      final ex1 = MockExecutor();
+      final ex2 = MockExecutor();
+
+      final db1 = TodoDb(ex1);
+      final db2 = TodoDb(ex2);
+
+      addTearDown(db1.close);
+      addTearDown(db2.close);
+
+      expect(db1.todosTable, isNot(equals(db2.todosTable)));
+    },
+  );
+
   test('disallows zero as a schema version', () async {
     var db = TodoDb(MockExecutor(OpeningDetails(null, 0)))..schemaVersion = 0;
     await expectLater(db.customSelect('SELECT 1').get(), throwsStateError);


### PR DESCRIPTION
In the old equality code:

```dart
  @override
  bool operator ==(Object other) {
    // tables are singleton instances except for aliases
    if (other is TableInfo) {
      return other.runtimeType == runtimeType &&
          other.aliasedName == aliasedName;
    }
    return false;
  }

  @override
  int get hashCode => Object.hash(aliasedName, actualTableName);
```

If you:
* Closed your old database
* Still held a reference to a TableInfo attached to that closed database 
        * (In my case, that reference was held by a Riverpod provider family)
* And then did equality between that old TableInfo and a new TableInfo, 
* Even if both TableInfos are attached to completely different databases, if both TableInfos had the same table name, the equality would wrongly say they're equal.

This fixes that by checking if the Table infos have the same [attachedDatabase], too!