### PR TITLE
added RETURNING only for drift3

### DIFF
--- a/drift/lib/src/drift3_preview/src/query_builder/clauses/returning.dart
+++ b/drift/lib/src/drift3_preview/src/query_builder/clauses/returning.dart
@@ -7,23 +7,10 @@ import '../schema/table.dart';
 
 /// A `RETURNING *` clause that can appear as part of an `INSERT`, `UPDATE` or
 /// `DELETE` statement.
-final class ReturningClause<
-  Row extends Object,
-  RS extends GeneratedTable<Row, RS>
->
-    implements SqlComponent {
+final class ReturningClause implements SqlComponent {
   /// The generated [ResultSetStructure] representing columns for this
   /// `RETURNING` clause.
   final ResultSetStructure structure = ResultSetStructure();
-
-  final ResultSet<Row, RS> _resultSet;
-
-  /// Creates a `RETURNING` clause for the given [ResultSet].
-  ReturningClause(this._resultSet) {
-    // Note: We currently only generate `RETURNING *` clauses returning columns
-    // for a single table.
-    structure.addSelectStarFromSingleTable(_resultSet);
-  }
 
   @override
   void compileWith(StatementCompiler compiler) {
@@ -32,12 +19,29 @@ final class ReturningClause<
 
   /// Maps rows from the given [result] using the result set for this
   /// `RETURNING` clause.
-  List<Row> interpretResults(
+  ///
+  /// [resultSet] must to be added to [structure] before calling this method
+  List<Row>
+  interpretResults<Row extends Object, RS extends GeneratedTable<Row, RS>>(
+    DatabaseConnectionUser database,
+    QueryResult result,
+    ResultSet<Row, RS> resultSet,
+  ) {
+    final mapper = resultSet.createMapperToDart(database.dialect, structure);
+
+    return [for (final row in result.resultSet!) mapper(row)!];
+  }
+
+  /// Maps rows from the given [result] using the expression for this
+  /// `RETURNING` clause.
+  ///
+  /// expressions must to be added to [structure] before calling this method
+  List<DriftRow> interpretExpressionResults(
     DatabaseConnectionUser database,
     QueryResult result,
   ) {
-    final mapper = _resultSet.createMapperToDart(database.dialect, structure);
+    final mapper = structure.createMapperToDriftRow(database.dialect);
 
-    return [for (final row in result.resultSet!) mapper(row)!];
+    return [for (final row in result.resultSet!) mapper(row)];
   }
 }

--- a/drift/lib/src/drift3_preview/src/query_builder/compiler.dart
+++ b/drift/lib/src/drift3_preview/src/query_builder/compiler.dart
@@ -624,8 +624,6 @@ abstract base class StatementCompiler {
   }
 
   void addReturningClause(ReturningClause returning) {
-    // We currently only support the `RETURNING *` format without arbitrary
-    // columns.
     statement.resultSetStructure = returning.structure;
     statement.buffer.write('RETURNING ');
     addResultSetExpressions(returning.structure);

--- a/drift/lib/src/drift3_preview/src/query_builder/results.dart
+++ b/drift/lib/src/drift3_preview/src/query_builder/results.dart
@@ -41,6 +41,11 @@ final class ResultSetStructure {
   }) : expressions = expressions ?? {},
        tables = tables ?? {};
 
+  ColumnPosition get _nextPosition {
+    final index = expressions.length;
+    return ColumnPosition(index);
+  }
+
   /// If an explicit name has been set for the given column position, returns
   /// it.
   ///
@@ -60,18 +65,50 @@ final class ResultSetStructure {
     );
   }
 
-  /// Adds all columns from the given [ResultSet] in order.
-  void addSelectStarFromSingleTable(ResultSet resultSet) {
-    assert(expressions.isEmpty);
+  /// Adds a column to this query.
+  ///
+  /// The column will be evaluated for each row of the expression. To read the
+  /// result of the expression in a row, use [DriftRow.read].
+  void addColumn(Expression expression) {
+    expressions[expression] ??= _nextPosition;
+  }
+
+  /// Adds multiple columns to this query.
+  ///
+  /// The column will be evaluated for each row of the expression. To read the
+  /// result of the expression in a row, use [DriftRow.read].
+  void addColumns(Iterable<Expression> columns) {
+    for (final column in columns) {
+      expressions[column] ??= _nextPosition;
+    }
+  }
+
+  /// Adds all columns from [ResultSet] to this [ResultSetStructure].
+  void addResultSet(ResultSet resultSet) {
+    if (tables.containsKey(resultSet)) {
+      throw StateError(
+        'Result set $resultSet has been added to select multiple times, please use an alias',
+      );
+    }
 
     final positions = <ColumnPosition>[];
-    for (final (i, column) in resultSet.columns.indexed) {
-      final position = ColumnPosition(i);
-      expressions[column] = position;
-      positions.add(position);
+    for (final column in resultSet.columns) {
+      final columnPosition = _nextPosition;
+      positions.add(columnPosition);
+      expressions[column] = columnPosition;
     }
 
     tables[resultSet] = positions;
+  }
+
+  /// Creates a function that, given a [RawRow], extracts the [DriftRow] for [expressions].
+  DriftRow Function(RawRow) createMapperToDriftRow(DriftDialect dialect) {
+    final fakeResultSet = DriftResultSet(
+      this,
+      RawResultSet.fromRows(columnNames: [], rows: []),
+      dialect,
+    );
+    return (row) => DriftRow(fakeResultSet, row);
   }
 
   /// Transforms this [ResultSetStructure] into a new one, mapping values in

--- a/drift/lib/src/drift3_preview/src/query_builder/schema/result_set.dart
+++ b/drift/lib/src/drift3_preview/src/query_builder/schema/result_set.dart
@@ -73,7 +73,7 @@ mixin ResultSet<Row extends Object, Self extends ResultSet<Row, Self>>
       );
     }
 
-    final structure = ResultSetStructure()..addSelectStarFromSingleTable(this);
+    final structure = ResultSetStructure()..addResultSet(this);
     final values = [
       for (final value in asColumnMap.values)
         (value as Variable).resolveValue(database.dialect).rawValue,

--- a/drift/lib/src/drift3_preview/src/query_builder/statements/delete.dart
+++ b/drift/lib/src/drift3_preview/src/query_builder/statements/delete.dart
@@ -1,9 +1,11 @@
+import '../expressions/expression.dart';
 import '../../connection/result_set.dart';
 import '../../connection/streams/update_rules.dart';
 import '../../database/connection_user.dart';
 import '../../database/data_class.dart';
 import '../clauses/returning.dart';
 import '../compiler.dart';
+import '../results.dart';
 import '../schema/table.dart';
 import 'query.dart';
 import 'statement.dart';
@@ -20,7 +22,7 @@ final class DeleteStatement<
   final GeneratedTable<Row, RS> resultSet;
 
   /// An optional `RETURNING` clause part of this statement.
-  ReturningClause<Row, RS>? returning;
+  ReturningClause? returning;
 
   final DatabaseConnectionUser _database;
 
@@ -38,8 +40,13 @@ final class DeleteStatement<
     whereSamePrimaryKey(entity);
   }
 
-  void _addReturning() {
-    returning = ReturningClause(resultSet);
+  void _addReturning({List<Expression>? expressions}) {
+    returning = ReturningClause();
+    if (expressions != null) {
+      returning!.structure.addColumns(expressions);
+    } else {
+      returning!.structure.addResultSet(resultSet);
+    }
   }
 
   @override
@@ -96,7 +103,14 @@ final class DeleteStatement<
 
   Future<List<Row>> _goReturning() async {
     final result = await _run();
-    return returning!.interpretResults(_database, result);
+    return returning!.interpretResults(_database, result, resultSet);
+  }
+
+  /// Like [go], but it also returns [expressions] of all rows affected by this delete operation.
+  Future<List<DriftRow>> goAndReturnOnly(List<Expression> expressions) async {
+    _addReturning(expressions: expressions);
+    final result = await _run();
+    return returning!.interpretExpressionResults(_database, result);
   }
 
   @override

--- a/drift/lib/src/drift3_preview/src/query_builder/statements/insert.dart
+++ b/drift/lib/src/drift3_preview/src/query_builder/statements/insert.dart
@@ -35,7 +35,7 @@ final class InsertStatement<
   UpsertClause<Row, RS>? upsertClause;
 
   /// An optional `RETURNING` clause part of this statement.
-  ReturningClause<Row, RS>? returning;
+  ReturningClause? returning;
 
   /// Constructs an insert statement from the database and the table. Used
   /// internally by drift.
@@ -115,8 +115,13 @@ final class InsertStatement<
     return result;
   }
 
-  void _addReturning() {
-    returning = ReturningClause(table);
+  void _addReturning({List<Expression>? expressions}) {
+    returning = ReturningClause();
+    if (expressions != null) {
+      returning!.structure.addColumns(expressions);
+    } else {
+      returning!.structure.addResultSet(table);
+    }
   }
 
   /// Runs this insert statement with a `RETURNING` clause, returning inserted
@@ -130,7 +135,21 @@ final class InsertStatement<
     _addReturning();
 
     final result = await _run();
-    return returning!.interpretResults(_database, result);
+    return returning!.interpretResults(_database, result, table);
+  }
+
+  /// Runs this insert statement with a `RETURNING` clause, returning [expressions}
+  /// of inserted rows.
+  ///
+  /// This method requires that [source] (and optionally also an [upsertClause])
+  /// have already been set (e.g. through [values]).
+  /// For a method that does all of this, use [insertReturning] or
+  /// [insertReturningOrNull].
+  Future<List<DriftRow>> runReturningOnly(List<Expression> expressions) async {
+    _addReturning(expressions: expressions);
+
+    final result = await _run();
+    return returning!.interpretExpressionResults(_database, result);
   }
 
   /// Inserts a row constructed from the fields in [entity].

--- a/drift/lib/src/drift3_preview/src/query_builder/statements/select.dart
+++ b/drift/lib/src/drift3_preview/src/query_builder/statements/select.dart
@@ -63,18 +63,12 @@ sealed class BaseSelectStatement<
 
   BaseSelectStatement(this._database, {this.distinct = false});
 
-  ColumnPosition get _nextPosition {
-    final index = structure.expressions.length;
-    return ColumnPosition(index);
-  }
-
   /// Adds a column to this query.
   ///
   /// The column will be evaluated for each row of the expression. To read the
   /// result of the expression in a row, use [DriftRow.read].
   SelectStatement addColumn(Expression expression) {
-    return _asSelectStatement()
-      ..structure.expressions[expression] ??= _nextPosition;
+    return _asSelectStatement()..structure.addColumn(expression);
   }
 
   /// Adds multiple columns to this query.
@@ -82,30 +76,13 @@ sealed class BaseSelectStatement<
   /// The column will be evaluated for each row of the expression. To read the
   /// result of the expression in a row, use [DriftRow.read].
   SelectStatement addColumns(Iterable<Expression> expressions) {
-    final stmt = _asSelectStatement();
-    for (final expression in expressions) {
-      stmt.structure.expressions[expression] ??= _nextPosition;
-    }
-    return stmt;
+    return _asSelectStatement()..structure.addColumns(expressions);
   }
 
   /// Adds all columns from [ResultSet] to this query.
   @internal
   void addResultSet(ResultSet resultSet) {
-    if (structure.tables.containsKey(resultSet)) {
-      throw StateError(
-        'Result set $resultSet has been added to select multiple times, please use an alias',
-      );
-    }
-
-    final positions = <ColumnPosition>[];
-    for (final column in resultSet.columns) {
-      final columnPosition = _nextPosition;
-      positions.add(columnPosition);
-      structure.expressions[column] = columnPosition;
-    }
-
-    structure.tables[resultSet] = positions;
+    structure.addResultSet(resultSet);
   }
 
   /// Adds [table] to this query using an `INNER JOIN` operator.
@@ -463,12 +440,7 @@ final class SelectStatement
     DriftDialect dialect,
     ResultSetStructure structure,
   ) {
-    final fakeResultSet = DriftResultSet(
-      structure,
-      RawResultSet.fromRows(columnNames: [], rows: []),
-      _database.dialect,
-    );
-    return (row) => DriftRow(fakeResultSet, row);
+    return structure.createMapperToDriftRow(dialect);
   }
 }
 
@@ -500,7 +472,7 @@ final class SingleTableSelectStatement<
     this.resultSet, {
     super.distinct,
   }) {
-    structure.addSelectStarFromSingleTable(resultSet);
+    structure.addResultSet(resultSet);
     from.add(FromResultSet(resultSet));
   }
 

--- a/drift/lib/src/drift3_preview/src/query_builder/statements/update.dart
+++ b/drift/lib/src/drift3_preview/src/query_builder/statements/update.dart
@@ -8,6 +8,7 @@ import '../../database/data_class.dart';
 import '../clauses/returning.dart';
 import '../compiler.dart';
 import '../expressions/expression.dart';
+import '../results.dart';
 import '../schema/column_constraints.dart';
 import '../schema/table.dart';
 import 'query.dart';
@@ -26,7 +27,7 @@ final class UpdateStatement<
   final DatabaseConnectionUser _database;
 
   /// An optional `RETURNING` clause part of this statement.
-  ReturningClause<Row, RS>? returning;
+  ReturningClause? returning;
 
   /// The columns set by this update statement.
   final Map<String, Expression> updatedColumns = {};
@@ -54,6 +55,15 @@ final class UpdateStatement<
     updatedColumns
       ..clear()
       ..addAll(entity.toColumns(nullToAbsent));
+  }
+
+  void _addReturning({List<Expression>? expressions}) {
+    returning = ReturningClause();
+    if (expressions != null) {
+      returning!.structure.addColumns(expressions);
+    } else {
+      returning!.structure.addResultSet(resultSet);
+    }
   }
 
   /// Sets the `SET` components used for this update statement to the columns
@@ -104,10 +114,30 @@ final class UpdateStatement<
       return const [];
     }
 
-    returning = ReturningClause(resultSet);
+    _addReturning();
 
     final result = await _run();
-    return returning!.interpretResults(_database, result);
+    return returning!.interpretResults(_database, result, resultSet);
+  }
+
+  /// Applies the updates from [entity] to all rows matching the applied `where`
+  /// clause and returns [expressions] of the affected rows _after the update_.
+  ///
+  /// For more details on writing entries, see [write].
+  /// Note that this requires sqlite 3.35 or later.
+  Future<List<DriftRow>> writeReturningOnly(
+    Insertable<Row> entity,
+    List<Expression> expressions,
+  ) async {
+    _applyColumns(entity, true);
+    if (updatedColumns.isEmpty) {
+      return const [];
+    }
+
+    _addReturning(expressions: expressions);
+
+    final result = await _run();
+    return returning!.interpretExpressionResults(_database, result);
   }
 
   /// Update this statement to generate the SQL for a [replace] call.

--- a/future/drift3/test/database/tables_test.dart
+++ b/future/drift3/test/database/tables_test.dart
@@ -52,8 +52,7 @@ void main() {
       'status': null,
     };
 
-    final structure = ResultSetStructure()
-      ..addSelectStarFromSingleTable(db.todosTable);
+    final structure = ResultSetStructure()..addResultSet(db.todosTable);
     final resultSet = DriftResultSet(
       structure,
       RawResultSet.fromRows(

--- a/future/drift3/test/query_builder/statements/delete_test.dart
+++ b/future/drift3/test/query_builder/statements/delete_test.dart
@@ -106,6 +106,33 @@ void main() {
         );
         expect(streamQueries.recordedUpdates, isEmpty);
       });
+
+      test('only', () async {
+        when(session.execute(any)).thenAnswer((_) {
+          return Future.value(
+            queryResult(const [
+              {'name': 'foo', 'id': 1},
+              {'name': 'bar', 'id': 2},
+            ], affectedRows: 2),
+          );
+        });
+
+        final rows = await db.delete(db.users).goAndReturnOnly([
+          db.users.name,
+          db.users.id,
+        ]);
+
+        expect(rows.map((s) => s.raw), const [
+          ["foo", 1],
+          ["bar", 2],
+        ]);
+        verify(
+          session.executeSql('DELETE FROM "users" RETURNING "name","id";', []),
+        );
+        expect(streamQueries.recordedUpdates, {
+          TableUpdate.onTable(db.users, kind: UpdateKind.delete),
+        });
+      });
     });
   });
 

--- a/future/drift3/test/query_builder/statements/insert_test.dart
+++ b/future/drift3/test/query_builder/statements/insert_test.dart
@@ -594,36 +594,70 @@ void main() {
     );
   });
 
-  test('generates RETURNING clauses', () async {
-    when(session.execute(any)).thenAnswer(
-      (_) => Future.value(
-        queryResult([
-          {
-            'id': 1,
-            'desc': 'description',
-            'priority': 1,
-            'description_in_upper_case': 'DESCRIPTION',
-          },
-        ]),
-      ),
-    );
+  group('generates RETURNING', () {
+    test('for one row', () async {
+      when(session.execute(any)).thenAnswer(
+        (_) => Future.value(
+          queryResult([
+            {
+              'id': 1,
+              'desc': 'description',
+              'priority': 1,
+              'description_in_upper_case': 'DESCRIPTION',
+            },
+          ]),
+        ),
+      );
 
-    await db
-        .into(db.categories)
-        .insertReturning(
-          CategoriesCompanion.insert(
-            description: 'description',
-            priority: const Value(CategoryPriority.medium),
-          ),
-        );
+      await db
+          .into(db.categories)
+          .insertReturning(
+            CategoriesCompanion.insert(
+              description: 'description',
+              priority: const Value(CategoryPriority.medium),
+            ),
+          );
 
-    verify(
-      session.executeSql(
-        'INSERT INTO "categories" ("desc","priority") VALUES (?1,?2) '
-        'RETURNING "id","desc","priority","description_in_upper_case"',
-        ['description', 1],
-      ),
-    );
+      verify(
+        session.executeSql(
+          'INSERT INTO "categories" ("desc","priority") VALUES (?1,?2) '
+          'RETURNING "id","desc","priority","description_in_upper_case"',
+          ['description', 1],
+        ),
+      );
+    });
+
+    test('only', () async {
+      when(session.execute(any)).thenAnswer(
+        (_) => Future.value(
+          queryResult(const [
+            {'desc': 'description'},
+          ]),
+        ),
+      );
+
+      final result = await db
+          .into(db.categories)
+          .values(
+            CategoriesCompanion.insert(
+              description: 'description',
+              priority: const Value(CategoryPriority.medium),
+            ),
+          )
+          .runReturningOnly([db.categories.description]);
+
+      expect(result.map((s) => s.raw), const [
+        ['description'],
+      ]);
+
+      verify(
+        session.executeSql(
+          'INSERT INTO "categories" ("desc","priority") VALUES (?1,?2) '
+          'RETURNING "desc"',
+          ['description', 1],
+        ),
+      );
+    });
   });
 
   group('insert from select', () {

--- a/future/drift3/test/query_builder/statements/update_test.dart
+++ b/future/drift3/test/query_builder/statements/update_test.dart
@@ -208,43 +208,77 @@ void main() {
     });
   });
 
-  test('RETURNING', () async {
-    when(executor.execute(any)).thenAnswer((_) {
-      return Future.value(
-        queryResult([
-          {
-            'id': 3,
-            'desc': 'test',
-            'priority': 0,
-            'description_in_upper_case': 'TEST',
-          },
-        ], affectedRows: 1),
+  group('RETURNING', () {
+    test('for one row', () async {
+      when(executor.execute(any)).thenAnswer((_) {
+        return Future.value(
+          queryResult([
+            {
+              'id': 3,
+              'desc': 'test',
+              'priority': 0,
+              'description_in_upper_case': 'TEST',
+            },
+          ], affectedRows: 1),
+        );
+      });
+
+      final rows = await db
+          .update(db.categories)
+          .writeReturning(
+            const CategoriesCompanion(description: Value('test')),
+          );
+
+      verify(
+        executor.executeSql(
+          'UPDATE "categories" SET "desc" = ?1 RETURNING '
+          '"id","desc","priority","description_in_upper_case";',
+          ['test'],
+        ),
       );
+      expect(streamQueries.recordedUpdates, {
+        TableUpdate.onTable(db.categories, kind: UpdateKind.update),
+      });
+
+      expect(rows, const [
+        Category(
+          id: RowId(3),
+          description: 'test',
+          priority: CategoryPriority.low,
+          descriptionInUpperCase: 'TEST',
+        ),
+      ]);
     });
 
-    final rows = await db
-        .update(db.categories)
-        .writeReturning(const CategoriesCompanion(description: Value('test')));
+    test('only', () async {
+      when(executor.execute(any)).thenAnswer((_) {
+        return Future.value(
+          queryResult([
+            {'description_in_upper_case': 'TEST'},
+          ], affectedRows: 1),
+        );
+      });
 
-    verify(
-      executor.executeSql(
-        'UPDATE "categories" SET "desc" = ?1 RETURNING '
-        '"id","desc","priority","description_in_upper_case";',
-        ['test'],
-      ),
-    );
-    expect(streamQueries.recordedUpdates, {
-      TableUpdate.onTable(db.categories, kind: UpdateKind.update),
+      final rows = await db.update(db.categories).writeReturningOnly(
+        const CategoriesCompanion(priority: Value(CategoryPriority.high)),
+        [db.categories.descriptionInUpperCase],
+      );
+
+      verify(
+        executor.executeSql(
+          'UPDATE "categories" SET "priority" = ?1 RETURNING '
+          '"description_in_upper_case";',
+          [2],
+        ),
+      );
+      expect(streamQueries.recordedUpdates, {
+        TableUpdate.onTable(db.categories, kind: UpdateKind.update),
+      });
+
+      expect(rows.map((s) => s.raw), const [
+        ['TEST'],
+      ]);
     });
-
-    expect(rows, const [
-      Category(
-        id: RowId(3),
-        description: 'test',
-        priority: CategoryPriority.low,
-        descriptionInUpperCase: 'TEST',
-      ),
-    ]);
   });
 
   test('can use empty companion for update', () async {


### PR DESCRIPTION
closes #3806.

Added the possibility to pass `List<Expression>` to `ReturningClause`, to be able to return partial rows in insert, delete, and update statements.
Added `interpretExpressionResults` to get the result as a `List<DriftRow>` instead of the complete `Row`.

Moved some methods from `BaseSelectStatement` to `ResultSetStructure`, to be able to reuse them for the returning clause.

Adding it to the current Drift version would be possible as well, but the new `ResultSetStructure` makes it a bit cleaner than adding a mixin or something to try and reuse the implementation from `SelectStatement`.