### PR TITLE
Added UPDATE FROM to drift3

### DIFF
--- a/drift/lib/src/drift3_preview/CHANGELOG.md
+++ b/drift/lib/src/drift3_preview/CHANGELOG.md
@@ -11,3 +11,5 @@
 - Drift manager is now a standalone package, `drift_manager`.
 - Add `TransactionOptions`, which can be used to request read-only transactions.
 - `Selectable.watch` now returns a `QueryStream`, which can be used to track which tables it watches.
+- DML statements now support `RETURNING` partial rows.   
+- `FROM` can now be added to `UpdateStatement`

--- a/drift/lib/src/drift3_preview/src/database/connection_user.dart
+++ b/drift/lib/src/drift3_preview/src/database/connection_user.dart
@@ -429,7 +429,7 @@ abstract base class DatabaseConnectionUser {
       includeJoinsByDefault: false,
       distinct: distinct,
     );
-    statement.from.add(FromResultSet(table));
+    statement.fromClause.addResultSet(table);
     return statement;
   }
 

--- a/drift/lib/src/drift3_preview/src/query_builder.dart
+++ b/drift/lib/src/drift3_preview/src/query_builder.dart
@@ -5,6 +5,7 @@ export 'query_builder/clauses/group_by.dart';
 export 'query_builder/clauses/order_by.dart';
 export 'query_builder/clauses/returning.dart';
 export 'query_builder/clauses/where.dart';
+export 'query_builder/clauses/from.dart';
 
 export 'query_builder/expressions/aggregate.dart';
 export 'query_builder/expressions/algebra.dart';

--- a/drift/lib/src/drift3_preview/src/query_builder/clauses/from.dart
+++ b/drift/lib/src/drift3_preview/src/query_builder/clauses/from.dart
@@ -1,0 +1,133 @@
+import '../../dsl/table.dart';
+import '../../query_builder/expressions/expression.dart';
+import '../../query_builder/schema/result_set.dart';
+import '../compiler.dart';
+
+/// A `FROM` clause providing the tables in SQL.
+final class FromClause implements SqlComponent {
+  /// List of all [FromClauseElement] added to this `FROM` clause.
+  final List<FromClauseElement> elements = [];
+
+  /// Adds a join to this `FROM` clause.
+  void addJoin(Join join) {
+    elements.add(join);
+  }
+
+  /// Adds multiple joins to this `FROM` clause.
+  void addJoins(Iterable<Join> joins) {
+    elements.addAll(joins);
+  }
+
+  /// Adds a result set to this `FROM` clause.
+  void addResultSet(ResultSet resultSet) {
+    elements.add(FromResultSet(resultSet));
+  }
+
+  @override
+  void compileWith(StatementCompiler compiler) {
+    compiler.addFromClause(this);
+  }
+}
+
+/// A source for from clauses
+sealed class FromClauseElement implements SqlComponent {}
+
+/// An operator used to compose joins, see [Join].
+enum JoinOperator implements SqlComponent {
+  /// Perform an `INNER` join.
+  inner('INNER JOIN'),
+
+  /// Perform a `LEFT OUTER` join.
+  leftOuter('LEFT OUTER JOIN'),
+
+  /// Perform a `RIGHT OUTER` join.
+  rightOuter('RIGHT OUTER JOIN'),
+
+  /// Perform a `FULL OUTER` join.
+  fullOuter('FULL OUTER JOIN'),
+
+  /// Perform a `CROSS` join.
+  cross('CROSS JOIN');
+
+  /// The default lexeme to generate for this join operator. Some SQL dialects
+  /// may choose to override this.
+  final String defaultLexeme;
+
+  const JoinOperator(this.defaultLexeme);
+
+  @override
+  void compileWith(StatementCompiler compiler) {
+    compiler.addJoinOperator(this);
+  }
+}
+
+/// Represents a join of a [table] to a query.
+///
+/// This allows applying a [JoinOperator] and optionally also an [on] condition.
+final class Join extends FromClauseElement {
+  /// The [JoinOperator] to use for this join.
+  final JoinOperator operator;
+
+  /// The [ResultSet] that will be added to the query.
+  final FromResultSet table;
+
+  /// For joins that aren't [JoinOperator.cross], contains an additional predicate
+  /// that must be matched for the join.
+  final Expression<bool>? on;
+
+  /// Whether [table] should appear in the result set (defaults to true).
+  /// Default value can be changed by `includeJoinedTableColumns` in
+  /// `selectOnly` statements.
+  ///
+  /// It can be useful to exclude some tables. Sometimes, tables are used in a
+  /// join only to run aggregate functions on them.
+  final bool? includeInResult;
+
+  /// Create a join clause with the given [operator] and [table].
+  Join(this.operator, ResultSetDsl table, {this.on, this.includeInResult})
+    : table = FromResultSet(ResultSet.fromDsl(table));
+
+  /// Create an `INNER JOIN` for the [table].
+  Join.inner(ResultSetDsl table, {this.on, this.includeInResult})
+    : operator = JoinOperator.inner,
+      table = FromResultSet(ResultSet.fromDsl(table));
+
+  /// Create an `LEFT OUTER JOIN` for the [table].
+  Join.leftOuter(ResultSetDsl table, {this.on, this.includeInResult})
+    : operator = JoinOperator.leftOuter,
+      table = FromResultSet(ResultSet.fromDsl(table));
+
+  /// Create an `RIGHT OUTER JOIN` for the [table].
+  Join.rightOuter(ResultSetDsl table, {this.on, this.includeInResult})
+    : operator = JoinOperator.rightOuter,
+      table = FromResultSet(ResultSet.fromDsl(table));
+
+  /// Create an `FULL OUTER JOIN` for the [table].
+  Join.fullOuter(ResultSetDsl table, {this.on, this.includeInResult})
+    : operator = JoinOperator.fullOuter,
+      table = FromResultSet(ResultSet.fromDsl(table));
+
+  /// Create a `CROSS JOIN` for the [table].
+  Join.cross(ResultSetDsl table, {this.on, this.includeInResult})
+    : operator = JoinOperator.cross,
+      table = FromResultSet(ResultSet.fromDsl(table));
+
+  @override
+  void compileWith(StatementCompiler compiler) {
+    compiler.addJoin(this);
+  }
+}
+
+/// Select from a generated table or view.
+final class FromResultSet extends FromClauseElement {
+  /// The result set to select from.
+  final ResultSet resultSet;
+
+  /// @nodoc
+  FromResultSet(this.resultSet);
+
+  @override
+  void compileWith(StatementCompiler compiler) {
+    compiler.addFromResultSet(this);
+  }
+}

--- a/drift/lib/src/drift3_preview/src/query_builder/compiler.dart
+++ b/drift/lib/src/drift3_preview/src/query_builder/compiler.dart
@@ -4,6 +4,7 @@ import 'package:collection/collection.dart';
 
 import '../connection/connection.dart';
 import '../connection/streams/update_rules.dart';
+import 'clauses/from.dart';
 import 'clauses/group_by.dart';
 import 'clauses/limit.dart';
 import 'clauses/order_by.dart';
@@ -520,6 +521,11 @@ abstract base class StatementCompiler {
     );
     statement.buffer.write(' SET ');
 
+    // hasMultipleTable must be set before adding the values in case a table is referenced
+    if (update.fromClause?.elements.isNotEmpty == true) {
+      statement.hasMultipleTables = true;
+    }
+
     var first = true;
     update.updatedColumns.forEach((name, variable) {
       if (!first) {
@@ -532,6 +538,10 @@ abstract base class StatementCompiler {
       statement.buffer.write(' = ');
       variable.compileWith(this);
     });
+
+    if (update.fromClause case final fromClause?) {
+      fromClause.compileWith(this);
+    }
 
     if (update.whereClause case final where?) {
       statement.space();
@@ -659,7 +669,7 @@ abstract base class StatementCompiler {
       statement.buffer.write('DISTINCT ');
     }
 
-    statement.hasMultipleTables |= select.from.length > 1;
+    statement.hasMultipleTables |= select.fromClause.elements.length > 1;
 
     if (!_ignoreResultSet) {
       addResultSetExpressions(select.structure);
@@ -669,20 +679,7 @@ abstract base class StatementCompiler {
 
     _ignoreResultSet = false;
 
-    if (select.from case [final first, ...final rest]) {
-      statement.buffer.write(' FROM ');
-      first.compileWith(this);
-
-      for (final entry in rest) {
-        if (entry is! Join) {
-          statement.buffer.write(', ');
-        } else {
-          statement.space();
-        }
-
-        entry.compileWith(this);
-      }
-    }
+    select.fromClause.compileWith(this);
 
     if (select.whereClause case final where?) {
       statement.space();
@@ -1227,4 +1224,22 @@ abstract base class StatementCompiler {
   void addUnixTimestampToDateTime(UnixTimestampToDateTime e);
 
   void addDateExtractionOperator(DateExtractionOperator e);
+
+  void addFromClause(FromClause fromClause) {
+    if (fromClause.elements case [final first, ...final rest]) {
+      statement.buffer.write(' FROM ');
+      first.compileWith(this);
+
+      for (final entry in rest) {
+        switch (entry) {
+          case Join():
+            statement.space();
+          case FromResultSet():
+            statement.buffer.write(', ');
+        }
+
+        entry.compileWith(this);
+      }
+    }
+  }
 }

--- a/drift/lib/src/drift3_preview/src/query_builder/statements/select.dart
+++ b/drift/lib/src/drift3_preview/src/query_builder/statements/select.dart
@@ -6,6 +6,7 @@ import '../../connection/streams/update_rules.dart';
 import '../../database/connection_user.dart';
 import '../../database/selectable.dart';
 import '../../dsl/table.dart';
+import '../clauses/from.dart';
 import '../clauses/group_by.dart';
 import '../clauses/limit.dart';
 import '../clauses/order_by.dart';
@@ -38,8 +39,8 @@ sealed class BaseSelectStatement<
   /// rows would be removed.
   final bool distinct;
 
-  /// All tables that this statement selects from.
-  final List<FromClauseElement> from = [];
+  /// The from clause of select statement.
+  final fromClause = FromClause();
 
   /// The filtering `WHERE` clause of this select statement.
   WhereClause? whereClause;
@@ -337,7 +338,7 @@ final class SelectStatement
     addResultSet(other.resultSet);
 
     assert(distinct == other.distinct);
-    from.addAll(other.from);
+    fromClause.elements.addAll(other.fromClause.elements);
     whereClause = other.whereClause;
     groupByClause = other.groupByClause;
     orderByClause = other.orderByClause;
@@ -382,7 +383,7 @@ final class SelectStatement
   SelectStatement _asSelectStatement() => this;
 
   void _addJoin(Join join) {
-    from.add(join);
+    fromClause.addJoin(join);
     if (join.includeInResult ?? _includeJoinsByDefault) {
       addResultSet(join.table.resultSet);
     }
@@ -474,7 +475,7 @@ final class SingleTableSelectStatement<
     super.distinct,
   }) {
     structure.addResultSet(resultSet);
-    from.add(FromResultSet(resultSet));
+    fromClause.addResultSet(resultSet);
   }
 
   /// Orders the result by the given clauses. The clauses coming first in the
@@ -519,109 +520,6 @@ final class SingleTableSelectStatement<
   @override
   SelectStatement _asSelectStatement() {
     return SelectStatement(_database, distinct: distinct).._applyFrom(this);
-  }
-}
-
-/// A source for from clauses
-sealed class FromClauseElement implements SqlComponent {}
-
-/// An operator used to compose joins, see [Join].
-enum JoinOperator implements SqlComponent {
-  /// Perform an `INNER` join.
-  inner('INNER JOIN'),
-
-  /// Perform a `LEFT OUTER` join.
-  leftOuter('LEFT OUTER JOIN'),
-
-  /// Perform a `RIGHT OUTER` join.
-  rightOuter('RIGHT OUTER JOIN'),
-
-  /// Perform a `FULL OUTER` join.
-  fullOuter('FULL OUTER JOIN'),
-
-  /// Perform a `CROSS` join.
-  cross('CROSS JOIN');
-
-  /// The default lexeme to generate for this join operator. Some SQL dialects
-  /// may choose to override this.
-  final String defaultLexeme;
-
-  const JoinOperator(this.defaultLexeme);
-
-  @override
-  void compileWith(StatementCompiler compiler) {
-    compiler.addJoinOperator(this);
-  }
-}
-
-/// Represents a join of a [table] to a query.
-///
-/// This allows applying a [JoinOperator] and optionally also an [on] condition.
-final class Join extends FromClauseElement {
-  /// The [JoinOperator] to use for this join.
-  final JoinOperator operator;
-
-  /// The [ResultSet] that will be added to the query.
-  final FromResultSet table;
-
-  /// For joins that aren't [JoinOperator.cross], contains an additional predicate
-  /// that must be matched for the join.
-  final Expression<bool>? on;
-
-  /// Whether [table] should appear in the result set (defaults to true).
-  /// Default value can be changed by `includeJoinedTableColumns` in
-  /// `selectOnly` statements.
-  ///
-  /// It can be useful to exclude some tables. Sometimes, tables are used in a
-  /// join only to run aggregate functions on them.
-  final bool? includeInResult;
-
-  /// Create a join clause with the given [operator] and [table].
-  Join(this.operator, ResultSetDsl table, {this.on, this.includeInResult})
-    : table = FromResultSet(ResultSet.fromDsl(table));
-
-  /// Create an `INNER JOIN` for the [table].
-  Join.inner(ResultSetDsl table, {this.on, this.includeInResult})
-    : operator = JoinOperator.inner,
-      table = FromResultSet(ResultSet.fromDsl(table));
-
-  /// Create an `LEFT OUTER JOIN` for the [table].
-  Join.leftOuter(ResultSetDsl table, {this.on, this.includeInResult})
-    : operator = JoinOperator.leftOuter,
-      table = FromResultSet(ResultSet.fromDsl(table));
-
-  /// Create an `RIGHT OUTER JOIN` for the [table].
-  Join.rightOuter(ResultSetDsl table, {this.on, this.includeInResult})
-    : operator = JoinOperator.rightOuter,
-      table = FromResultSet(ResultSet.fromDsl(table));
-
-  /// Create an `FULL OUTER JOIN` for the [table].
-  Join.fullOuter(ResultSetDsl table, {this.on, this.includeInResult})
-    : operator = JoinOperator.fullOuter,
-      table = FromResultSet(ResultSet.fromDsl(table));
-
-  /// Create a `CROSS JOIN` for the [table].
-  Join.cross(ResultSetDsl table, {this.on, this.includeInResult})
-    : operator = JoinOperator.cross,
-      table = FromResultSet(ResultSet.fromDsl(table));
-
-  @override
-  void compileWith(StatementCompiler compiler) {
-    compiler.addJoin(this);
-  }
-}
-
-/// Select from a generated table or view.
-final class FromResultSet extends FromClauseElement {
-  /// The result set to select from.
-  final ResultSet resultSet;
-
-  /// @nodoc
-  FromResultSet(this.resultSet);
-
-  @override
-  void compileWith(StatementCompiler compiler) {
-    compiler.addFromResultSet(this);
   }
 }
 

--- a/drift/lib/src/drift3_preview/src/query_builder/statements/update.dart
+++ b/drift/lib/src/drift3_preview/src/query_builder/statements/update.dart
@@ -4,11 +4,13 @@ import '../../connection/result_set.dart';
 import '../../connection/streams/update_rules.dart';
 import '../../database/connection_user.dart';
 import '../../database/data_class.dart';
+import '../clauses/from.dart';
 import '../clauses/returning.dart';
 import '../compiler.dart';
 import '../expressions/expression.dart';
 import '../results.dart';
 import '../schema/column_constraints.dart';
+import '../schema/result_set.dart';
 import '../schema/table.dart';
 import 'query.dart';
 
@@ -26,6 +28,9 @@ final class UpdateStatement<
 
   /// The columns set by this update statement.
   final Map<String, Expression> updatedColumns = {};
+
+  /// The fromClause of this update statement
+  FromClause? fromClause;
 
   /// Used internally by drift to construct an update statement
   UpdateStatement(this._database, super.table);
@@ -61,6 +66,16 @@ final class UpdateStatement<
     _applyColumns(entity, true);
   }
 
+  /// Adds a [Table] or [Subquery] to the from clause of this update statement
+  void from(ResultSet resultSet) {
+    (fromClause ??= FromClause()).addResultSet(resultSet);
+  }
+
+  /// Adds joins to the from claus of this update statement
+  void join(Iterable<Join> joins) {
+    (fromClause ??= FromClause()).addJoins(joins);
+  }
+
   /// Writes all non-null fields from [entity] into the columns of all rows
   /// that match the [where] clause. Warning: That also means that, when you're
   /// not setting a where clause explicitly, this method will update all rows in
@@ -82,6 +97,23 @@ final class UpdateStatement<
 
     if (updatedColumns.isEmpty) {
       // nothing to update, we're done
+      return Future.value(0);
+    }
+
+    final result = await _run();
+    return result.affectedRows!;
+  }
+
+  /// Updates all columns provided in [expressions] keys with the corresponding [Expression].
+  ///
+  /// This is useful in combination with [from] and [join] to set columns based on other tables.
+  /// For all other use cases see [write].
+  Future<int> writeExpressions(Map<String, Expression> expressions) async {
+    updatedColumns
+      ..clear()
+      ..addAll(expressions);
+
+    if (updatedColumns.isEmpty) {
       return Future.value(0);
     }
 

--- a/future/drift3/test/query_builder/statements/update_test.dart
+++ b/future/drift3/test/query_builder/statements/update_test.dart
@@ -304,4 +304,117 @@ void main() {
 
     verifyNever(executor.execute(any));
   });
+
+  group('generates update from statements', () {
+    test('regular', () async {
+      await (db.update(db.todosTable)
+            ..from(db.sharedTodos)
+            ..where((s) => s.id.equalsExp(db.sharedTodos.todo)))
+          .write(const TodosTableCompanion(title: Value('Changed title')));
+
+      verify(
+        executor.executeSql(
+          'UPDATE "todos" SET "title" = ?1 FROM "shared_todos" WHERE "todos"."id" = "shared_todos"."todo";',
+          ['Changed title'],
+        ),
+      );
+    });
+
+    test('subquery', () async {
+      final subquery = Subquery(
+        db.selectOnly(db.sharedTodos)..addColumns([db.sharedTodos.todo]),
+        's',
+      );
+      await (db.update(db.todosTable)
+            ..from(subquery)
+            ..where((s) => s.id.equalsExp(subquery.ref(db.sharedTodos.todo))))
+          .write(const TodosTableCompanion(title: Value('Changed title')));
+      verify(
+        executor.executeSql(
+          'UPDATE "todos" SET "title" = ?1 FROM (SELECT "shared_todos"."todo" AS "c0" FROM "shared_todos") "s" WHERE "todos"."id" = "s"."c0";',
+          ['Changed title'],
+        ),
+      );
+    });
+
+    test('join', () async {
+      final subquery = Subquery(
+        db.selectOnly(db.todosTable)..addColumns([db.todosTable.id]),
+        's',
+      );
+      await (db.update(db.categories)
+            ..from(subquery)
+            ..join([
+              Join.inner(
+                db.sharedTodos,
+                on: subquery
+                    .ref(db.todosTable.id)
+                    .equalsExp(db.sharedTodos.todo),
+              ),
+              Join.inner(
+                db.users,
+                on: db.users.id.equalsExp(db.sharedTodos.user),
+              ),
+            ])
+            ..where((s) => s.id.equalsExp(subquery.ref(db.todosTable.id))))
+          .write(
+            const CategoriesCompanion(description: Value('New description')),
+          );
+      verify(
+        executor.executeSql(
+          'UPDATE "categories" SET "desc" = ?1 FROM (SELECT "todos"."id" AS "c0" FROM "todos") "s" INNER JOIN "shared_todos" ON "s"."c0" = "shared_todos"."todo" INNER JOIN "users" ON "users"."id" = "shared_todos"."user" WHERE "categories"."id" = "s"."c0";',
+          ['New description'],
+        ),
+      );
+    });
+
+    test('multiple from tables', () async {
+      final subquery = Subquery(
+        db.selectOnly(db.todosTable)..addColumns([db.todosTable.id]),
+        's',
+      );
+      final shared1 = db.sharedTodos.withAlias('shared1');
+      final shared2 = db.sharedTodos.withAlias('shared2');
+      await (db.update(db.categories)
+            ..from(shared1)
+            ..join([
+              Join.inner(
+                subquery,
+                on: subquery.ref(db.todosTable.id).equalsExp(shared1.todo),
+              ),
+            ])
+            ..from((shared2))
+            ..join([
+              Join.inner(db.users, on: db.users.id.equalsExp(shared2.user)),
+            ])
+            ..where(
+              (s) =>
+                  s.id.equalsExp(subquery.ref(db.todosTable.id)) &
+                  shared2.todo.equalsExp(shared1.todo) &
+                  shared2.user.equalsExp(shared1.user),
+            ))
+          .write(
+            const CategoriesCompanion(description: Value('New description')),
+          );
+      verify(
+        executor.executeSql(
+          'UPDATE "categories" SET "desc" = ?1 FROM "shared_todos" AS "shared1" INNER JOIN (SELECT "todos"."id" AS "c0" FROM "todos") "s" ON "s"."c0" = "shared1"."todo", "shared_todos" AS "shared2" INNER JOIN "users" ON "users"."id" = "shared2"."user" WHERE ("categories"."id" = "s"."c0" AND "shared2"."todo" = "shared1"."todo") AND "shared2"."user" = "shared1"."user";',
+          ['New description'],
+        ),
+      );
+    });
+
+    test('writeExpression', () async {
+      await (db.update(db.todosTable)
+            ..from(db.sharedTodos)
+            ..where((s) => s.id.equalsExp(db.sharedTodos.todo)))
+          .writeExpressions({db.todosTable.title.name: db.sharedTodos.todo});
+      verify(
+        executor.executeSql(
+          'UPDATE "todos" SET "title" = "shared_todos"."todo" FROM "shared_todos" WHERE "todos"."id" = "shared_todos"."todo";',
+          [],
+        ),
+      );
+    });
+  });
 }


### PR DESCRIPTION
closes #3690 

Added the possibility to reference columns from other tables/joins in `UpateStatements`
Added `writeExpressions` in `UpdateStatements` to make it possible to set columns based on other tables.

If you have a better idea for `writeExpression` than a `Map<String, Expression` let me now.