### PR TITLE
drift_dev: Added support for dart update placeholder in drift files

### DIFF
--- a/docs/content/sql_api/drift_files.md
+++ b/docs/content/sql_api/drift_files.md
@@ -307,7 +307,7 @@ This feature works for
   will generate a method taking an `OrderingTerm`.
 - whole order-by clauses: `SELECT * FROM todos ORDER BY $order`
 - limit clauses: `SELECT * FROM todos LIMIT $limit`
-- insertables for insert statements: `INSERT INTO todos $row` generates an `Insertable<TodoEntry> row`
+- insertables for insert or update statements: `INSERT INTO todos $row` or `UPDATE todos SET $row` generates an `Insertable<TodoEntry> row`
   parameter
 
 When used as expression, you can also supply a default value in your query:

--- a/drift/lib/src/drift3_preview/src/database/connection_user.dart
+++ b/drift/lib/src/drift3_preview/src/database/connection_user.dart
@@ -738,6 +738,20 @@ abstract base class DatabaseConnectionUser {
     compiler.addInsertFromValues(InsertFromValues.create(table, insertable)!);
     return compiler.statement;
   }
+
+  /// Writes column names and values for an update statement.
+  ///
+  /// Used by generated code.
+  @protected
+  StatementBuffer $writeUpdateInsertable(
+    GeneratedTable table,
+    Insertable insertable, {
+    int? startIndex,
+  }) {
+    final compiler = dialect.createCompiler();
+    compiler.addUpdateValues(insertable.toColumns(true));
+    return compiler.statement;
+  }
 }
 
 final class _ScopedDatabaseSession {

--- a/drift/lib/src/drift3_preview/src/query_builder/compiler.dart
+++ b/drift/lib/src/drift3_preview/src/query_builder/compiler.dart
@@ -526,18 +526,7 @@ abstract base class StatementCompiler {
       statement.hasMultipleTables = true;
     }
 
-    var first = true;
-    update.updatedColumns.forEach((name, variable) {
-      if (!first) {
-        statement.comma();
-      } else {
-        first = false;
-      }
-
-      addReference(name);
-      statement.buffer.write(' = ');
-      variable.compileWith(this);
-    });
+    addUpdateValues(update.updatedColumns);
 
     if (update.fromClause case final fromClause?) {
       fromClause.compileWith(this);
@@ -1102,13 +1091,7 @@ abstract base class StatementCompiler {
     statement.buffer.write(' DO UPDATE SET ');
 
     final updateSet = clause.createInsertable(table).toColumns(true);
-    for (final (i, update) in updateSet.entries.indexed) {
-      if (i != 0) statement.comma();
-
-      addReference(update.key);
-      statement.buffer.write(' = ');
-      update.value.compileWith(this);
-    }
+    addUpdateValues(updateSet);
 
     if (clause.buildWhereClause(table) case final where?) {
       statement.space();
@@ -1241,5 +1224,20 @@ abstract base class StatementCompiler {
         entry.compileWith(this);
       }
     }
+  }
+
+  void addUpdateValues(Map<String, Expression> columns) {
+    var first = true;
+    columns.forEach((name, variable) {
+      if (!first) {
+        statement.comma();
+      } else {
+        first = false;
+      }
+
+      addReference(name);
+      statement.buffer.write(' = ');
+      variable.compileWith(this);
+    });
   }
 }

--- a/drift/lib/src/runtime/api/connection_user.dart
+++ b/drift/lib/src/runtime/api/connection_user.dart
@@ -696,6 +696,27 @@ abstract class DatabaseConnectionUser {
     return context;
   }
 
+  /// Writes column names and values for an update statement.
+  ///
+  /// Used by generated code.
+  @protected
+  GenerationContext $writeUpdateInsertable(
+    TableInfo table,
+    Insertable insertable, {
+    int? startIndex,
+  }) {
+    final context = GenerationContext.fromDb(this)
+      ..explicitVariableIndex = startIndex;
+
+    table.validateIntegrity(insertable, isInserting: false);
+    UpdateStatement(
+      this,
+      table,
+    ).writeInsertable(context, insertable.toColumns(true));
+
+    return context;
+  }
+
   /// Used by generated code to expand array variables.
   String $expandVar(int start, int amount) {
     final buffer = StringBuffer();

--- a/drift/lib/src/runtime/query_builder/statements/update.dart
+++ b/drift/lib/src/runtime/query_builder/statements/update.dart
@@ -14,20 +14,7 @@ class UpdateStatement<T extends Table, D> extends Query<T, D>
 
     ctx.buffer.write('UPDATE ${table.tableWithAlias} SET ');
 
-    var first = true;
-    _updatedFields.forEach((columnName, variable) {
-      if (!first) {
-        ctx.buffer.write(', ');
-      } else {
-        first = false;
-      }
-
-      ctx.buffer
-        ..write(ctx.identifier(columnName))
-        ..write(' = ');
-
-      variable.writeInto(ctx);
-    });
+    writeInsertable(ctx, _updatedFields);
   }
 
   Future<int> _performQuery() async {
@@ -163,5 +150,27 @@ class UpdateStatement<T extends Table, D> extends Query<T, D>
     if (dontExecute) return false;
     final updatedRows = await _performQuery();
     return updatedRows != 0;
+  }
+
+  /// Write column names and values from the map
+  @internal
+  void writeInsertable(
+    GenerationContext ctx,
+    Map<String, Expression> insertable,
+  ) {
+    var first = true;
+    insertable.forEach((columnName, variable) {
+      if (!first) {
+        ctx.buffer.write(', ');
+      } else {
+        first = false;
+      }
+
+      ctx.buffer
+        ..write(ctx.identifier(columnName))
+        ..write(' = ');
+
+      variable.writeInto(ctx);
+    });
   }
 }

--- a/drift/test/generated/custom_tables.g.dart
+++ b/drift/test/generated/custom_tables.g.dart
@@ -2173,6 +2173,30 @@ abstract class _$CustomTablesDb extends GeneratedDatabase {
     ).then((rows) => Future.wait(rows.map(config.mapFromRow)));
   }
 
+  Future<int> updateAll({
+    required Insertable<Config> all,
+    required UpdateAll$key key,
+  }) {
+    var $arrayStartIndex = 1;
+    final generatedall = $writeUpdateInsertable(
+      this.config,
+      all,
+      startIndex: $arrayStartIndex,
+    );
+    $arrayStartIndex += generatedall.amountOfVariables;
+    final generatedkey = $write(key(this.config), startIndex: $arrayStartIndex);
+    $arrayStartIndex += generatedkey.amountOfVariables;
+    return customUpdate(
+      'UPDATE config SET ${generatedall.sql} WHERE ${generatedkey.sql}',
+      variables: [
+        ...generatedall.introducedVariables,
+        ...generatedkey.introducedVariables,
+      ],
+      updates: {config},
+      updateKind: UpdateKind.update,
+    );
+  }
+
   Selectable<NestedResult> nested(String? var1) {
     return customSelect(
       'SELECT"defaults"."a" AS "nested_0.a", "defaults"."b" AS "nested_0.b", defaults.b AS "\$n_0" FROM with_defaults AS defaults WHERE a = ?1',
@@ -3392,6 +3416,7 @@ class ReadRowIdResult extends CustomResultSet {
 
 typedef ReadRowId$expr = Expression<int> Function(ConfigTable config);
 typedef ReadView$where = Expression<bool> Function(MyView my_view);
+typedef UpdateAll$key = Expression<bool> Function(ConfigTable config);
 
 class NestedResult extends CustomResultSet {
   final WithDefault defaults;

--- a/drift/test/generated/tables.drift
+++ b/drift/test/generated/tables.drift
@@ -95,6 +95,7 @@ cfeTest: WITH RECURSIVE
 
 nullableQuery: SELECT MAX(oid) FROM config;
 addConfig: INSERT INTO config $value RETURNING *;
+updateAll: UPDATE config SET $all WHERE $key;
 
 nested: SELECT defaults.**, LIST(SELECT * FROM with_constraints c WHERE c.b = defaults.b)
   FROM with_defaults defaults

--- a/drift/test/generated/todos.mocks.dart
+++ b/drift/test/generated/todos.mocks.dart
@@ -1353,6 +1353,37 @@ class MockTodoDb extends _i1.Mock implements _i3.TodoDb {
           as _i2.GenerationContext);
 
   @override
+  _i2.GenerationContext $writeUpdateInsertable(
+    _i2.TableInfo<_i2.Table, dynamic>? table,
+    _i2.Insertable<dynamic>? insertable, {
+    int? startIndex,
+  }) =>
+      (super.noSuchMethod(
+            Invocation.method(
+              #$writeUpdateInsertable,
+              [table, insertable],
+              {#startIndex: startIndex},
+            ),
+            returnValue: _FakeGenerationContext_34(
+              this,
+              Invocation.method(
+                #$writeUpdateInsertable,
+                [table, insertable],
+                {#startIndex: startIndex},
+              ),
+            ),
+            returnValueForMissingStub: _FakeGenerationContext_34(
+              this,
+              Invocation.method(
+                #$writeUpdateInsertable,
+                [table, insertable],
+                {#startIndex: startIndex},
+              ),
+            ),
+          )
+          as _i2.GenerationContext);
+
+  @override
   String $expandVar(int? start, int? amount) =>
       (super.noSuchMethod(
             Invocation.method(#$expandVar, [start, amount]),

--- a/drift/test/integration_tests/drift_files_integration_test.dart
+++ b/drift/test/integration_tests/drift_files_integration_test.dart
@@ -216,4 +216,33 @@ void main() {
     );
     expect(row.nested, hasLength(1));
   });
+
+  test('can run updateQuery with Insertable', () async {
+    await db.addConfig(
+      value: ConfigCompanion.insert(
+        configKey: 'updateKey',
+        configValue: Value(DriftAny(1)),
+        syncState: Value(null),
+        syncStateImplicit: Value(null),
+      ),
+    );
+    await db.updateAll(
+      all: ConfigCompanion(
+        configValue: Value(DriftAny(2)),
+        syncState: Value(SyncType.locallyCreated),
+      ),
+      key: (config) => config.configKey.equals('updateKey'),
+    );
+
+    final config = await db.readConfig('updateKey').getSingle();
+
+    expect(
+      config,
+      Config(
+        configKey: 'updateKey',
+        configValue: DriftAny(2),
+        syncState: SyncType.locallyCreated,
+      ),
+    );
+  });
 }

--- a/drift_dev/CHANGELOG.md
+++ b/drift_dev/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 2.35.0 (unreleased)
+
+- Drift files: Support for dart placeholder in `update` statements to reference companions 
+
 ## 2.34.1+1
 
 - Require analyzer version 13.

--- a/drift_dev/lib/src/analysis/resolver/queries/query_analyzer.dart
+++ b/drift_dev/lib/src/analysis/resolver/queries/query_analyzer.dart
@@ -1,4 +1,5 @@
 import 'package:analyzer/dart/ast/ast.dart' as dart;
+import 'package:collection/collection.dart';
 import 'package:drift/drift.dart' as drift;
 import 'package:recase/recase.dart';
 import 'package:sqlparser/sqlparser.dart' hide ResultColumn;
@@ -758,9 +759,11 @@ class QueryAnalyzer {
   ) {
     final name = placeholder.name;
 
-    final type = placeholder.when(
-      isExpression: (e) {
-        final foundType = context.typeOf(e);
+    final DartPlaceholderType type;
+
+    switch (placeholder) {
+      case DartExpressionPlaceholder():
+        final foundType = context.typeOf(placeholder);
         ColumnType? columnType;
         if (foundType.type != null) {
           columnType = typeMapping.sqlTypeToDrift(foundType.type);
@@ -769,23 +772,45 @@ class QueryAnalyzer {
         final defaultValue =
             context.stmtOptions.defaultValuesForPlaceholder[name];
 
-        return ExpressionDartPlaceholderType(columnType, defaultValue);
-      },
-      isLimit: (_) =>
-          SimpleDartPlaceholderType(SimpleDartPlaceholderKind.limit),
-      isOrderBy: (_) =>
-          SimpleDartPlaceholderType(SimpleDartPlaceholderKind.orderBy),
-      isOrderingTerm: (_) =>
-          SimpleDartPlaceholderType(SimpleDartPlaceholderKind.orderByTerm),
-      isInsertable: (_) {
-        final insert = placeholder.parents.whereType<InsertStatement>().first;
-        final table = insert.table.resultSet;
-
-        return InsertableDartPlaceholderType(
-          table is Table ? _lookupReference(table.name) as DriftTable : null,
+        type = ExpressionDartPlaceholderType(columnType, defaultValue);
+      case DartLimitPlaceholder():
+        type = SimpleDartPlaceholderType(SimpleDartPlaceholderKind.limit);
+      case DartOrderByPlaceholder():
+        type = SimpleDartPlaceholderType(SimpleDartPlaceholderKind.orderBy);
+      case DartOrderingTermPlaceholder():
+        type = SimpleDartPlaceholderType(SimpleDartPlaceholderKind.orderByTerm);
+      case DartInsertablePlaceholder():
+        final parentStatement = placeholder.parents.firstWhereOrNull(
+          (s) => s is InsertStatement || s is UpdateStatement,
         );
-      },
-    );
+
+        final (table, isInsert) = switch (parentStatement) {
+          InsertStatement() => (parentStatement.table, true),
+          UpdateStatement() => (parentStatement.table, false),
+          null => (null, true),
+          _ => throw AssertionError(
+            "Expected InsertableDartPlaceholderType to have an InsertStatement or UpdateStatement parent",
+          ),
+        };
+
+        DriftTable? driftTable;
+        if (table?.resultSet case Table table) {
+          driftTable = _lookupReference(table.name);
+        }
+
+        if (driftTable == null) {
+          lints.add(
+            AnalysisError(
+              type: AnalysisErrorType.other,
+              message:
+                  "Placeholder expects a Table but got ${table?.resultSet.runtimeType}",
+              relevantNode: placeholder,
+            ),
+          );
+        }
+
+        type = InsertableDartPlaceholderType(driftTable, isInsert);
+    }
 
     final availableResults = placeholder.statementScope.allAvailableResultSets;
     final availableDriftResults = <AvailableDriftResultSet>[];
@@ -817,7 +842,7 @@ class QueryAnalyzer {
       );
     }
 
-    return FoundDartPlaceholder(type!, name, availableDriftResults)
+    return FoundDartPlaceholder(type, name, availableDriftResults)
       ..astNode = placeholder;
   }
 

--- a/drift_dev/lib/src/analysis/results/query.dart
+++ b/drift_dev/lib/src/analysis/results/query.dart
@@ -1145,7 +1145,10 @@ class ExpressionDartPlaceholderType extends DartPlaceholderType {
 class InsertableDartPlaceholderType extends DartPlaceholderType {
   final DriftTable? table;
 
-  InsertableDartPlaceholderType(this.table);
+  /// Whether this placeholder was used in an [InsertStatement] or an [UpdateStatement]
+  final bool isInsert;
+
+  InsertableDartPlaceholderType(this.table, this.isInsert);
 
   @override
   int get hashCode => table.hashCode;

--- a/drift_dev/lib/src/writer/queries/query_writer.dart
+++ b/drift_dev/lib/src/writer/queries/query_writer.dart
@@ -1032,8 +1032,13 @@ class _ExpandedDeclarationWriter {
     if (type is InsertableDartPlaceholderType) {
       final table = type.table;
 
+      if (type.isInsert) {
+        _buffer.write(r'$writeInsertable(this.');
+      } else {
+        _buffer.write(r'$writeUpdateInsertable(this.');
+      }
+
       _buffer
-        ..write(r'$writeInsertable(this.')
         ..write(table?.computeDbGetterName(options))
         ..write(', ')
         ..write(useExpression())

--- a/future/drift3/test/generated/custom_tables.g.dart
+++ b/future/drift3/test/generated/custom_tables.g.dart
@@ -2044,6 +2044,27 @@ abstract base class _$CustomTablesDb extends GeneratedDatabase {
     });
   }
 
+  Future<int> updateAll({
+    required Insertable<Config> all,
+    required UpdateAll$key key,
+  }) {
+    var $arrayStartIndex = 0;
+    final generatedall = $writeUpdateInsertable(
+      this.config,
+      all,
+      startIndex: $arrayStartIndex,
+    );
+    $arrayStartIndex += generatedall.variables.length;
+    final generatedkey = $write(key(this.config), startIndex: $arrayStartIndex);
+    $arrayStartIndex += generatedkey.variables.length;
+    return customUpdate(
+      'UPDATE config SET ${generatedall.buffer} WHERE ${generatedkey.buffer}',
+      variables: [...generatedall.variables, ...generatedkey.variables],
+      updates: {config},
+      updateKind: UpdateKind.update,
+    );
+  }
+
   Selectable<NestedResult> nested(String? var1) {
     return customSelectMappedAsync<NestedResult>(
       query: switch (dialect.known) {
@@ -2274,6 +2295,7 @@ final class ReadRowIdResult extends CustomResultSet {
 
 typedef ReadRowId$expr = Expression<int> Function(ConfigTable config);
 typedef ReadView$where = Expression<bool> Function(MyView my_view);
+typedef UpdateAll$key = Expression<bool> Function(ConfigTable config);
 
 final class NestedResult extends CustomResultSet {
   final WithDefault defaults;

--- a/future/drift3/test/generated/tables.drift
+++ b/future/drift3/test/generated/tables.drift
@@ -95,6 +95,7 @@ cfeTest: WITH RECURSIVE
 
 nullableQuery: SELECT MAX(oid) FROM config;
 addConfig: INSERT INTO config $value RETURNING *;
+updateAll: UPDATE config SET $all WHERE $key;
 
 nested: SELECT defaults.**, LIST(SELECT * FROM with_constraints c WHERE c.b = defaults.b)
   FROM with_defaults defaults

--- a/future/drift3/test/integration_tests/drift_files_integration_test.dart
+++ b/future/drift3/test/integration_tests/drift_files_integration_test.dart
@@ -239,4 +239,33 @@ void main() {
     );
     expect(row.nested, hasLength(1));
   });
+
+  test('can run updateQuery with Insertable', () async {
+    await db.addConfig(
+      value: ConfigCompanion.insert(
+        configKey: 'updateKey',
+        configValue: Value(DriftAny(1)),
+        syncState: Value(null),
+        syncStateImplicit: Value(null),
+      ),
+    );
+    await db.updateAll(
+      all: ConfigCompanion(
+        configValue: Value(DriftAny(2)),
+        syncState: Value(SyncType.locallyCreated),
+      ),
+      key: (config) => config.configKey.equals('updateKey'),
+    );
+
+    final config = await db.readConfig('updateKey').getSingle();
+
+    expect(
+      config,
+      Config(
+        configKey: 'updateKey',
+        configValue: DriftAny(2),
+        syncState: SyncType.locallyCreated,
+      ),
+    );
+  });
 }

--- a/sqlparser/lib/src/ast/drift/inline_dart.dart
+++ b/sqlparser/lib/src/ast/drift/inline_dart.dart
@@ -14,7 +14,7 @@ import '../ast.dart';
 ///  drift.
 ///  4. A list of order-by clauses, which will be exposed as a `OrderBy` from
 ///  drift.
-abstract class DartPlaceholder extends AstNode implements DriftSpecificNode {
+sealed class DartPlaceholder extends AstNode implements DriftSpecificNode {
   final String name;
 
   DollarSignVariableToken? token;
@@ -30,28 +30,6 @@ abstract class DartPlaceholder extends AstNode implements DriftSpecificNode {
   @override
   R accept<A, R>(AstVisitor<A, R> visitor, A arg) {
     return visitor.visitDriftSpecificNode(this, arg);
-  }
-
-  T? when<T>({
-    T Function(DartExpressionPlaceholder)? isExpression,
-    T Function(DartLimitPlaceholder)? isLimit,
-    T Function(DartOrderingTermPlaceholder)? isOrderingTerm,
-    T Function(DartOrderByPlaceholder)? isOrderBy,
-    T Function(DartInsertablePlaceholder)? isInsertable,
-  }) {
-    if (this is DartExpressionPlaceholder) {
-      return isExpression?.call(this as DartExpressionPlaceholder);
-    } else if (this is DartLimitPlaceholder) {
-      return isLimit?.call(this as DartLimitPlaceholder);
-    } else if (this is DartOrderingTermPlaceholder) {
-      return isOrderingTerm?.call(this as DartOrderingTermPlaceholder);
-    } else if (this is DartOrderByPlaceholder) {
-      return isOrderBy?.call(this as DartOrderByPlaceholder);
-    } else if (this is DartInsertablePlaceholder) {
-      return isInsertable?.call(this as DartInsertablePlaceholder);
-    }
-
-    throw AssertionError('Invalid placeholder: $runtimeType');
   }
 }
 
@@ -73,6 +51,10 @@ class DartOrderByPlaceholder extends DartPlaceholder implements OrderByBase {
 }
 
 class DartInsertablePlaceholder extends DartPlaceholder
-    implements InsertSource {
+    implements InsertSource, SetComponent {
   DartInsertablePlaceholder({required String name}) : super._(name);
+
+  /// Placeholders in [UpdateStatement] will generate columns dynamically at runtime.
+  @override
+  List<Reference> get columns => const [];
 }

--- a/sqlparser/lib/src/reader/parser.dart
+++ b/sqlparser/lib/src/reader/parser.dart
@@ -1409,6 +1409,15 @@ extension Parser on ParserState {
   }
 
   List<SetComponent> _setComponents() {
+    if (enableDriftExtensions && _matchOne(TokenType.dollarSignVariable)) {
+      final token = _previous as DollarSignVariableToken;
+      final placeholder = DartInsertablePlaceholder(name: token.name)
+        ..token = token
+        ..setSpan(token, token);
+
+      return [placeholder];
+    }
+
     final set = <SetComponent>[];
     do {
       if (_check(TokenType.leftParen)) {

--- a/sqlparser/lib/utils/node_to_text.dart
+++ b/sqlparser/lib/utils/node_to_text.dart
@@ -459,13 +459,17 @@ base class NodeSqlBuilder extends AstVisitor<void, void> {
   @override
   void visitDriftSpecificNode(DriftSpecificNode e, void arg) {
     if (e is DartPlaceholder) {
-      e.when(
-        isLimit: (_) => keyword(TokenType.limit),
-        isOrderBy: (_) {
+      switch (e) {
+        case DartLimitPlaceholder():
+          keyword(TokenType.limit);
+        case DartOrderByPlaceholder():
           keyword(TokenType.order);
           keyword(TokenType.by);
-        },
-      );
+        case DartExpressionPlaceholder():
+        case DartOrderingTermPlaceholder():
+        case DartInsertablePlaceholder():
+          break;
+      }
 
       symbol(r'$', spaceBefore: true);
       symbol(e.name, spaceAfter: true);


### PR DESCRIPTION
closes #3516 

Similar to insert statements, it is now possible to reference insertables in update statements.

```sql
updateUser: UPDATE users SET $changes
```
will generate
```dart
updateUser(Insertable<User> changes);
```
Initially, I had the update placeholder as a separate placeholder type, but since the implementation was practically the same, I merged them.

Should `$writeUpdateInsertable` also be merged into `writeInsertable` with a `isInsert` argument?
Should `DartPlaceholder`  be refactored into a `sealed class`?