### PR TITLE
Fix read pool starting dequeued selects in the wrong zone

### DIFF
--- a/drift/lib/src/runtime/executor/connection_pool.dart
+++ b/drift/lib/src/runtime/executor/connection_pool.dart
@@ -27,11 +27,20 @@ sealed class MultiExecutor extends QueryExecutor {
 
 class _PendingSelect {
   _PendingSelect(this.statement, this.args)
-    : completer = Completer<List<Map<String, Object?>>>();
+    : completer = Completer<List<Map<String, Object?>>>(),
+      zone = Zone.current;
 
   final String statement;
   final List<Object?> args;
   final Completer<List<Map<String, Object?>>> completer;
+
+  /// The zone from which the select was issued.
+  ///
+  /// When this select is dequeued after waiting for an executor, it must be
+  /// started in this zone: Drift's cancellation tokens are zone-scoped, and
+  /// the dequeueing [_QueryExecutorPool._run] call runs in the zone of
+  /// whichever earlier select happened to free up the executor.
+  final Zone zone;
 }
 
 class _QueryExecutorPool {
@@ -77,15 +86,20 @@ class _QueryExecutorPool {
     _running.add(completer);
 
     completer.completer.complete(
-      Future.sync(() async {
-        try {
-          return await executor.runSelect(completer.statement, completer.args);
-        } finally {
-          _running.remove(completer);
-          _idleExecutors.add(executor);
-          _run();
-        }
-      }),
+      completer.zone.run(
+        () => Future.sync(() async {
+          try {
+            return await executor.runSelect(
+              completer.statement,
+              completer.args,
+            );
+          } finally {
+            _running.remove(completer);
+            _idleExecutors.add(executor);
+            _run();
+          }
+        }),
+      ),
     );
   }
 }

--- a/drift/test/engines/connection_pool_test.dart
+++ b/drift/test/engines/connection_pool_test.dart
@@ -1,4 +1,7 @@
+import 'dart:async';
+
 import 'package:drift/drift.dart';
+import 'package:drift/src/runtime/cancellation_zone.dart';
 import 'package:mockito/mockito.dart';
 import 'package:test/test.dart';
 
@@ -130,5 +133,95 @@ void main() {
     await multi.ensureOpen(db);
 
     expect(multi.runSelect('select 1', []), throwsA(isA<String>()));
+  });
+
+  group('with cancellation zones', () {
+    // https://github.com/simolus3/drift/issues/3824
+    late MockExecutor read2;
+
+    setUp(() {
+      read2 = MockExecutor();
+      multi = MultiExecutor.withReadPool(reads: [read, read2], write: write);
+      db = TodoDb(multi);
+    });
+
+    /// Stubs selects on [executor] to respect cancellations like a real
+    /// executor would.
+    ///
+    /// Selects for statements in [pending] complete when the completer
+    /// returned for them is completed, all other selects complete directly.
+    Map<String, Completer<List<Map<String, Object?>>>> stubSelects(
+      MockExecutor executor,
+      List<String> pending,
+    ) {
+      final completers = {
+        for (final statement in pending)
+          statement: Completer<List<Map<String, Object?>>>(),
+      };
+
+      when(executor.runSelect(any, any)).thenAnswer((invocation) {
+        checkIfCancelled();
+        final statement = invocation.positionalArguments[0] as String;
+        return completers[statement]?.future ??
+            Future.value([
+              {'answer': 42},
+            ]);
+      });
+
+      return completers;
+    }
+
+    test('does not leak them into unrelated queued selects', () async {
+      await multi.ensureOpen(db);
+      final firstPending = stubSelects(read, ['slow1']);
+      final secondPending = stubSelects(read2, ['slow2']);
+
+      // Occupy both readers with selects running in their own cancellation
+      // zones, like stream query fetches would.
+      runCancellable(() => multi.runSelect('slow1', []));
+      final second = runCancellable(() => multi.runSelect('slow2', []));
+
+      // With the pool saturated, this unrelated select gets queued. It is
+      // not issued from a cancellation zone, so nothing may cancel it.
+      final queued = multi.runSelect('queued', []);
+
+      // Cancel the second select and let its statement finish, which makes
+      // the pool dequeue the queued select. That select must not be affected
+      // by the cancelled zone of the select that freed up the reader.
+      second.cancel();
+      secondPending['slow2']!.complete(const []);
+
+      expect(await queued, [
+        {'answer': 42},
+      ]);
+
+      firstPending['slow1']!.complete(const []);
+      await pumpEventQueue();
+    });
+
+    test('still cancels queued selects issued inside of them', () async {
+      await multi.ensureOpen(db);
+      final firstPending = stubSelects(read, ['slow1']);
+      final secondPending = stubSelects(read2, ['slow2']);
+
+      // Occupy both readers with selects that don't support cancellation.
+      final slow1 = multi.runSelect('slow1', []);
+      final slow2 = multi.runSelect('slow2', []);
+
+      // Queue a select from a cancellation zone, then cancel it before a
+      // reader becomes available.
+      final cancelled = runCancellable(() => multi.runSelect('queued', []));
+      cancelled.cancel();
+
+      // When a reader frees up and the queued select is started, it should
+      // be cancelled just like it would have been without the pool.
+      firstPending['slow1']!.complete(const []);
+
+      expect(cancelled.result, throwsA(isA<CancellationException>()));
+
+      secondPending['slow2']!.complete(const []);
+      await slow1;
+      await slow2;
+    });
   });
 }


### PR DESCRIPTION
## What this fixes

`_QueryExecutorPool._run()` starts a queued select from the `finally` block of whichever select freed up the executor. That `finally` continuation runs in the *previous* select's zone, so the dequeued select executed under a foreign zone. Since drift's cancellation tokens are zone-scoped, this had two consequences:

- A plain awaited select (`.get()`, `.getSingle()`, ...) queued behind a saturated read pool could fail with `CancellationException` when an unrelated stream query subscription was cancelled mid-fetch, completing futures that application code is awaiting (see #3824 for a deterministic repro and full trace).
- Conversely, a queued select issued from a zone that *was* cancelled escaped its own cancellation, because its token was no longer in scope when the select started.

## The fix

`_PendingSelect` now captures `Zone.current` at enqueue time, and `_run()` starts dequeued work via `zone.run(...)`. This restores the invariant that dart:async callbacks maintain everywhere else — work runs in the zone it was registered from — and makes the queued path behave exactly as if an executor had been free at enqueue time. Queued selects that belong to a cancellable stream fetch keep responding to their own token; unrelated selects are no longer affected by foreign tokens.

## Tests

Two regression tests in `connection_pool_test.dart`, using mock executors that check for cancellation like real executors do:

- a select queued outside any cancellation zone completes normally even when the select that freed the reader had its zone cancelled (failed with `CancellationException` before this fix, with the same stack trace as the issue);
- a queued select issued from a cancelled zone is still cancelled once it starts (silently ran to completion before this fix).

Also verified against the deterministic isolate repro from #3824 (fails on every run before, passes on every run after, control unchanged) and the full drift VM test suite (899 passed).

Closes #3824