### PR TITLE
fix: don't report a boolean default TRUE/1 as a schema difference (#3738)

### DIFF
--- a/drift_dev/CHANGELOG.md
+++ b/drift_dev/CHANGELOG.md
@@ -1,9 +1,6 @@
 ## 2.34.4
 
-- Fix `VerifySelf.validateDatabaseSchema` (and `SchemaVerifier`) reporting a
-  spurious difference for boolean columns with a default value, where an older
-  schema snapshot serialized the default as `TRUE`/`FALSE` and a newer drift
-  version renders it as `(1)`/`(0)` ([#3738](https://github.com/simolus3/drift/issues/3738)).
+- Schema verifier: Treat `TRUE`/`FALSE` as equal to `1`/`0`, respectively.
 
 ## 2.34.3
 

--- a/drift_dev/CHANGELOG.md
+++ b/drift_dev/CHANGELOG.md
@@ -1,3 +1,10 @@
+## 2.34.4
+
+- Fix `VerifySelf.validateDatabaseSchema` (and `SchemaVerifier`) reporting a
+  spurious difference for boolean columns with a default value, where an older
+  schema snapshot serialized the default as `TRUE`/`FALSE` and a newer drift
+  version renders it as `(1)`/`(0)` ([#3738](https://github.com/simolus3/drift/issues/3738)).
+
 ## 2.34.3
 
 - Fix a bug introduced in version 2.24.2 where deserializing cached elements could cause

--- a/drift_dev/lib/src/services/schema/find_differences.dart
+++ b/drift_dev/lib/src/services/schema/find_differences.dart
@@ -187,19 +187,73 @@ class FindSchemaDifferences {
       );
     }
 
-    if (options.validateColumnConstraints) {
-      try {
-        enforceEqualIterable(ref.constraints, act.constraints);
-      } catch (e) {
-        final firstSpan = ref.constraints.spanOrNull?.text ?? '';
-        final secondSpan = act.constraints.spanOrNull?.text ?? '';
-        return FoundDifference(
-          'Not equal: `$firstSpan` (expected) and `$secondSpan` (actual)',
-        );
-      }
+    if (options.validateColumnConstraints &&
+        !_columnConstraintsMatch(ref.constraints, act.constraints)) {
+      final firstSpan = ref.constraints.spanOrNull?.text ?? '';
+      final secondSpan = act.constraints.spanOrNull?.text ?? '';
+      return FoundDifference(
+        'Not equal: `$firstSpan` (expected) and `$secondSpan` (actual)',
+      );
     }
 
     return const Success();
+  }
+
+  /// Compares two column constraint lists like [enforceEqualIterable], but
+  /// tolerates a boolean default (`TRUE`/`FALSE`) being written as its
+  /// equivalent integer (`1`/`0`), optionally wrapped in parentheses.
+  ///
+  /// Booleans are stored as integers in SQLite, so a `DEFAULT TRUE` emitted by
+  /// an older drift version and a `DEFAULT (1)` emitted by a newer one describe
+  /// the same column and must not be reported as a schema difference.
+  /// See https://github.com/simolus3/drift/issues/3738.
+  bool _columnConstraintsMatch(
+    List<ColumnConstraint> reference,
+    List<ColumnConstraint> actual,
+  ) {
+    if (reference.length != actual.length) return false;
+
+    for (var i = 0; i < reference.length; i++) {
+      final ref = reference[i];
+      final act = actual[i];
+
+      // Only treat a boolean/integer default mismatch as equal when the two
+      // constraints are otherwise identical, including an optional
+      // `CONSTRAINT <name>`. Differing names fall through to enforceEqual.
+      if (ref is Default && act is Default && ref.name == act.name) {
+        final refValue = _booleanOrNumericLiteral(ref.expression);
+        final actValue = _booleanOrNumericLiteral(act.expression);
+
+        if (refValue != null && actValue != null) {
+          if (refValue != actValue) return false;
+          continue;
+        }
+      }
+
+      try {
+        enforceEqual(ref, act);
+      } catch (_) {
+        return false;
+      }
+    }
+
+    return true;
+  }
+
+  /// Interprets [e] as a boolean or numeric literal, unwrapping parentheses,
+  /// and returns its numeric value (`true` -> 1, `false` -> 0). Returns `null`
+  /// if [e] is not a simple boolean or numeric literal.
+  static num? _booleanOrNumericLiteral(Expression e) {
+    var expression = e;
+    while (expression is Parentheses) {
+      expression = expression.expression;
+    }
+
+    return switch (expression) {
+      BooleanLiteral(:final value) => value ? 1 : 0,
+      NumericLiteral(:final value) => value,
+      _ => null,
+    };
   }
 
   CompareResult _compareByAst(AstNode reference, AstNode actual) {

--- a/drift_dev/test/services/schema/find_differences_test.dart
+++ b/drift_dev/test/services/schema/find_differences_test.dart
@@ -90,6 +90,62 @@ void main() {
         );
       });
 
+      test('with a boolean default written as an integer', () {
+        // Booleans are stored as integers in SQLite, so a `DEFAULT TRUE`
+        // written by an older drift version and a `DEFAULT (1)` emitted by a
+        // newer one describe the same column.
+        // https://github.com/simolus3/drift/issues/3738
+        final result = compare(
+          Input('a', 'CREATE TABLE a (b INTEGER NOT NULL DEFAULT TRUE);'),
+          Input('a', 'CREATE TABLE a (b INTEGER NOT NULL DEFAULT (1));'),
+        );
+
+        expect(result, hasNoChanges);
+      });
+
+      test('with a boolean default and a check (as reported in #3738)', () {
+        final result = compare(
+          Input(
+            'a',
+            'CREATE TABLE a (is_first_login INTEGER NOT NULL DEFAULT TRUE '
+                'CHECK (is_first_login IN (0, 1)));',
+          ),
+          Input(
+            'a',
+            'CREATE TABLE a (is_first_login INTEGER NOT NULL DEFAULT (1) '
+                'CHECK ("is_first_login" IN (0, 1)));',
+          ),
+        );
+
+        expect(result, hasNoChanges);
+      });
+
+      test('with a genuinely different default', () {
+        final result = compare(
+          Input('a', 'CREATE TABLE a (b INTEGER NOT NULL DEFAULT TRUE);'),
+          Input('a', 'CREATE TABLE a (b INTEGER NOT NULL DEFAULT (0));'),
+        );
+
+        expect(result, hasChanges);
+      });
+
+      test('with a boolean default under a different constraint name', () {
+        // The default values are equivalent, but a named constraint differs,
+        // so this is a real schema difference and must still be reported.
+        final result = compare(
+          Input(
+            'a',
+            'CREATE TABLE a (b INTEGER NOT NULL CONSTRAINT x DEFAULT TRUE);',
+          ),
+          Input(
+            'a',
+            'CREATE TABLE a (b INTEGER NOT NULL CONSTRAINT y DEFAULT (1));',
+          ),
+        );
+
+        expect(result, hasChanges);
+      });
+
       test('ignored column constraints diff', () {
         final result = compare(
           Input('a', 'CREATE TABLE a (id INTEGER PRIMARY KEY NOT NULL);'),

--- a/future/drift_sqlite/lib/src/schema_verifier/find_differences.dart
+++ b/future/drift_sqlite/lib/src/schema_verifier/find_differences.dart
@@ -267,19 +267,73 @@ final class _FindSchemaDifferences {
       );
     }
 
-    if (options.validateColumnConstraints) {
-      try {
-        enforceEqualIterable(ref.constraints, act.constraints);
-      } catch (e) {
-        final firstSpan = ref.constraints.spanOrNull?.text ?? '';
-        final secondSpan = act.constraints.spanOrNull?.text ?? '';
-        return _FoundDifference(
-          'Not equal: `$firstSpan` (expected) and `$secondSpan` (actual)',
-        );
-      }
+    if (options.validateColumnConstraints &&
+        !_columnConstraintsMatch(ref.constraints, act.constraints)) {
+      final firstSpan = ref.constraints.spanOrNull?.text ?? '';
+      final secondSpan = act.constraints.spanOrNull?.text ?? '';
+      return _FoundDifference(
+        'Not equal: `$firstSpan` (expected) and `$secondSpan` (actual)',
+      );
     }
 
     return const _Success();
+  }
+
+  /// Compares two column constraint lists like [enforceEqualIterable], but
+  /// tolerates a boolean default (`TRUE`/`FALSE`) being written as its
+  /// equivalent integer (`1`/`0`), optionally wrapped in parentheses.
+  ///
+  /// Booleans are stored as integers in SQLite, so a `DEFAULT TRUE` emitted by
+  /// an older drift version and a `DEFAULT (1)` emitted by a newer one describe
+  /// the same column and must not be reported as a schema difference.
+  /// See https://github.com/simolus3/drift/issues/3738.
+  bool _columnConstraintsMatch(
+    List<ColumnConstraint> reference,
+    List<ColumnConstraint> actual,
+  ) {
+    if (reference.length != actual.length) return false;
+
+    for (var i = 0; i < reference.length; i++) {
+      final ref = reference[i];
+      final act = actual[i];
+
+      // Only treat a boolean/integer default mismatch as equal when the two
+      // constraints are otherwise identical, including an optional
+      // `CONSTRAINT <name>`. Differing names fall through to enforceEqual.
+      if (ref is Default && act is Default && ref.name == act.name) {
+        final refValue = _booleanOrNumericLiteral(ref.expression);
+        final actValue = _booleanOrNumericLiteral(act.expression);
+
+        if (refValue != null && actValue != null) {
+          if (refValue != actValue) return false;
+          continue;
+        }
+      }
+
+      try {
+        enforceEqual(ref, act);
+      } catch (_) {
+        return false;
+      }
+    }
+
+    return true;
+  }
+
+  /// Interprets [e] as a boolean or numeric literal, unwrapping parentheses,
+  /// and returns its numeric value (`true` -> 1, `false` -> 0). Returns `null`
+  /// if [e] is not a simple boolean or numeric literal.
+  static num? _booleanOrNumericLiteral(Expression e) {
+    var expression = e;
+    while (expression is Parentheses) {
+      expression = expression.expression;
+    }
+
+    return switch (expression) {
+      BooleanLiteral(:final value) => value ? 1 : 0,
+      NumericLiteral(:final value) => value,
+      _ => null,
+    };
   }
 
   CompareResult _compareByAst(AstNode reference, AstNode actual) {

--- a/future/drift_sqlite/test/schema_verifier/find_differences_test.dart
+++ b/future/drift_sqlite/test/schema_verifier/find_differences_test.dart
@@ -132,6 +132,78 @@ void main() {
         );
       });
 
+      test('with a boolean default written as an integer', () {
+        // Booleans are stored as integers in SQLite, so a `DEFAULT TRUE`
+        // written by an older drift version and a `DEFAULT (1)` emitted by a
+        // newer one describe the same column.
+        // https://github.com/simolus3/drift/issues/3738
+        final result = compare(
+          SyntacticSchemaElement(
+            name: 'a',
+            create: 'CREATE TABLE a (b INTEGER NOT NULL DEFAULT TRUE);',
+          ),
+          SyntacticSchemaElement(
+            name: 'a',
+            create: 'CREATE TABLE a (b INTEGER NOT NULL DEFAULT (1));',
+          ),
+        );
+
+        expect(result, hasNoChanges);
+      });
+
+      test('with a boolean default and a check (as reported in #3738)', () {
+        final result = compare(
+          SyntacticSchemaElement(
+            name: 'a',
+            create:
+                'CREATE TABLE a (is_first_login INTEGER NOT NULL DEFAULT TRUE '
+                'CHECK (is_first_login IN (0, 1)));',
+          ),
+          SyntacticSchemaElement(
+            name: 'a',
+            create:
+                'CREATE TABLE a (is_first_login INTEGER NOT NULL DEFAULT (1) '
+                'CHECK ("is_first_login" IN (0, 1)));',
+          ),
+        );
+
+        expect(result, hasNoChanges);
+      });
+
+      test('with a genuinely different default', () {
+        final result = compare(
+          SyntacticSchemaElement(
+            name: 'a',
+            create: 'CREATE TABLE a (b INTEGER NOT NULL DEFAULT TRUE);',
+          ),
+          SyntacticSchemaElement(
+            name: 'a',
+            create: 'CREATE TABLE a (b INTEGER NOT NULL DEFAULT (0));',
+          ),
+        );
+
+        expect(result, hasChanges);
+      });
+
+      test('with a boolean default under a different constraint name', () {
+        // The default values are equivalent, but a named constraint differs,
+        // so this is a real schema difference and must still be reported.
+        final result = compare(
+          SyntacticSchemaElement(
+            name: 'a',
+            create:
+                'CREATE TABLE a (b INTEGER NOT NULL CONSTRAINT x DEFAULT TRUE);',
+          ),
+          SyntacticSchemaElement(
+            name: 'a',
+            create:
+                'CREATE TABLE a (b INTEGER NOT NULL CONSTRAINT y DEFAULT (1));',
+          ),
+        );
+
+        expect(result, hasChanges);
+      });
+
       test('ignored column constraints diff', () {
         final result = compare(
           SyntacticSchemaElement(


### PR DESCRIPTION
A boolean column with a default value fails `SchemaVerifier.migrateAndValidate`, even though the schema is semantically identical:

```
Not equal: `NOT NULL DEFAULT TRUE CHECK (is_first_login IN (0, 1))` (expected)
       and `NOT NULL DEFAULT (1) CHECK ("is_first_login" IN (0, 1))` (actual)
```

Booleans are stored as integers in SQLite, so a `DEFAULT TRUE` emitted by one schema snapshot and a `DEFAULT 1` emitted by another describe the same column. But `find_differences` compared the default expressions textually and flagged a spurious difference, which breaks migration tests for any table with a boolean default (#3738).

### Fix

When comparing column constraints, a boolean default written as `TRUE`/`FALSE` is now treated as equal to the same value written in its integer form `1`/`0`. Genuinely different defaults are still reported as differences.

### Tests

Added cases to `find_differences_test.dart`: a boolean default written as an integer, the exact #3738 scenario (boolean default + `IN (0, 1)` check), and a guard that a *genuinely* different default is still detected as a change. Reverting the fix makes the first two fail; with the fix the whole `find_differences` suite passes.

Closes #3738.
