### PR TITLE
Escape reserved Dart keywords in SQL column names

### DIFF
--- a/drift_dev/CHANGELOG.md
+++ b/drift_dev/CHANGELOG.md
@@ -1,3 +1,9 @@
+## 2.34.5
+
+- Escape SQL column names that are reserved Dart keywords (e.g. `class`) when
+  deriving the Dart getter name, fixing invalid generated code for tables read
+  from SQL (such as the schema snapshots emitted by `make-migrations`).
+
 ## 2.34.4
 
 - Schema verifier: Treat `TRUE`/`FALSE` as equal to `1`/`0`, respectively.

--- a/drift_dev/lib/src/analysis/resolver/drift/table.dart
+++ b/drift_dev/lib/src/analysis/resolver/drift/table.dart
@@ -11,6 +11,7 @@ import '../../driver/state.dart';
 import '../../results/results.dart';
 import '../intermediate_state.dart';
 import '../resolver.dart';
+import '../shared/column_name.dart';
 import '../shared/dart_types.dart';
 import '../shared/data_class.dart';
 import 'element_resolver.dart';
@@ -190,7 +191,7 @@ final class DriftTableResolver
           sqlType: type,
           nullable: nullable,
           nameInSql: column.name,
-          nameInDart: overriddenDartName ?? ReCase(column.name).camelCase,
+          nameInDart: overriddenDartName ?? dartNameForSqlColumn(column.name),
           overriddenJsonName: overriddenJsonName,
           constraints: constraints,
           typeConverter: converter,

--- a/drift_dev/lib/src/analysis/resolver/shared/column_name.dart
+++ b/drift_dev/lib/src/analysis/resolver/shared/column_name.dart
@@ -1,3 +1,4 @@
+import 'package:analyzer/dart/ast/token.dart';
 import 'package:recase/recase.dart';
 
 final _illegalChars = RegExp(r'[^0-9a-zA-Z_]');
@@ -10,6 +11,8 @@ final _leadingDigits = RegExp(r'^\d*');
 ///    identifier.
 ///  - defaulting to `empty` if a column only consists of invalid names.
 ///  - changing the case of the identifier to `camelCase`.
+///  - appending a `$` if the name is a reserved Dart keyword (e.g. `class`),
+///    which cannot be used as an identifier on its own.
 ///
 /// This transformation may map distinct SQL identifiers to the same Dart name
 /// (e.g. `dartNameForSqlColumn('1a') == dartNameForSqlColumn('2a')`). To
@@ -31,6 +34,13 @@ String dartNameForSqlColumn(
   }
 
   escapedName = ReCase(escapedName).camelCase;
+
+  // A reserved keyword like `class` is not a valid Dart identifier, so it can't
+  // be used as a getter, field or parameter name. Append a `$` to make it one.
+  if (Keyword.keywords[escapedName]?.isReservedWord ?? false) {
+    escapedName = '$escapedName\$';
+  }
+
   final potentialAmbiguousName = escapedName;
   var counter = 1;
   while (existingNames.contains(escapedName)) {

--- a/drift_dev/test/analysis/resolver/drift/table_test.dart
+++ b/drift_dev/test/analysis/resolver/drift/table_test.dart
@@ -352,4 +352,29 @@ CREATE TABLE foo (
     final column = table.columns.single;
     expect(column.sqlType.builtin, DriftSqlType.bigInt);
   });
+
+  test('escapes reserved Dart keywords in column names', () async {
+    final state = await TestBackend.inTest({
+      'a|lib/a.drift': '''
+CREATE TABLE foo (
+  class INTEGER,
+  mixin INTEGER,
+  regular INTEGER
+);
+''',
+    });
+
+    final file = await state.analyze('package:a/a.drift');
+    state.expectNoErrors();
+
+    final table = file.analyzedElements.single as DriftTable;
+    final byName = {for (final c in table.columns) c.nameInSql: c};
+
+    // A reserved word can't be used as a Dart identifier, so it's escaped while
+    // the SQL name is preserved.
+    expect(byName['class']!.nameInDart, 'class\$');
+    // Built-in identifiers (like `mixin`) are valid identifiers and left alone.
+    expect(byName['mixin']!.nameInDart, 'mixin');
+    expect(byName['regular']!.nameInDart, 'regular');
+  });
 }


### PR DESCRIPTION
## Problem

A SQL column whose name is a reserved Dart keyword (e.g. `class`) generates invalid Dart. The column name is turned into a Dart identifier via `ReCase(name).camelCase` with no keyword check, so the generator emits code like:

```dart
late final GeneratedColumn<int> class = GeneratedColumn<int>('class', ...);
```

which fails to parse (`Can't have modifier 'late' here`, etc.).

This is most visible through `make-migrations`. The serialized schema snapshot embeds a `fixed_sql` block (the real `CREATE TABLE` statements). When reading it back, `SchemaReader` prefers `fixed_sql` and reconstructs tables directly from SQL (`extractDriftElementsFromSql`), which bypasses the serialized `getter_name`. So even a table defined in Dart as `IntColumn get productClass => integer().named('class')()` — which normally generates fine — crashes when its schema snapshot is turned into a migration test database, because the reconstructed column falls back to the raw SQL name `class`.

Stack (drift_dev 2.33.0, still present on `develop` 2.34.4):

```
Could not format because the source could not be parsed:
line ...: Can't have modifier 'late' here.
  #4 GenerateUtils.generateSchemaCode (.../schema/generate_utils.dart)
  #5 _MigrationTestEmitter.writeTestDatabases (.../make_migrations.dart)
```

## Fix

- `dartNameForSqlColumn` now appends `$` when the derived name is a reserved Dart keyword (`class` → `class$`), using the analyzer's authoritative `Keyword` list. Built-in identifiers (e.g. `mixin`) are valid identifiers and left untouched.
- The drift table resolver (`table.dart`) now routes column names through `dartNameForSqlColumn` instead of calling `ReCase(...).camelCase` directly, so both `.drift` files and SQL-reconstructed schemas produce valid identifiers. Views already used the shared helper.

The SQL column name is unchanged — only the generated Dart getter/field/parameter identifier is escaped.

## Tests

Added a resolver regression test (`test/analysis/resolver/drift/table_test.dart`) covering a `class` column (escaped to `class$`), a built-in identifier (`mixin`, unchanged), and a normal column. Full `test/analysis` and `test/writer` suites pass locally (393 tests).

Also verified end-to-end against a real project: `make-migrations` previously crashed on a `class` column and now completes, and the generated `schema_vN.dart` analyzes clean.