### PR TITLE
docs: mention CLI and DevTools tools in FAQ

### DIFF
--- a/docs/content/faq.md
+++ b/docs/content/faq.md
@@ -183,4 +183,6 @@ Yes! Drift stores its data in a sqlite3 database file that can be extracted from
 To inspect a drift database directly in your app, you can use the [`drift_db_viewer`](https://pub.dev/packages/drift_db_viewer)
 package by Koen Van Looveren.
 
-There is also an under-development DevTools Extension that comes when you add `drift` to your app. Open DevTools and try it out! Contributions and feedback are definitely welcome!
+There is also a [DevTools extension](tools/devtools.md) that comes when you add `drift` to your app. Open DevTools and try it out! Contributions and feedback are definitely welcome!
+
+Don't forget to take a look at the pages for our tools: [CLI](tools/index.md) and [DevTools extension](tools/devtools.md)!


### PR DESCRIPTION
## Summary
- Link the FAQ DevTools mention to `tools/devtools.md`
- Add a short end-of-FAQ pointer to the CLI and DevTools extension pages, as suggested in #3530

## Test plan
- [ ] Preview FAQ page and confirm both tool links resolve
- [ ] Confirm wording matches the existing FAQ tone

Fixes #3530