### PR TITLE
Add `upsertsWriteNullValues` option so upserts don't treat nulls as absent (#2998)

### DIFF
--- a/docs/content/generation_options/index.md
+++ b/docs/content/generation_options/index.md
@@ -77,6 +77,15 @@ At the moment, drift supports these options:
   The function has a parameter for each table that is available in the query, making it easier to get aliases right when using
   Dart placeholders.
 - `store_date_time_values_as_text`: Whether date-time columns should be stored as ISO 8601 string instead of a unix timestamp.
+- `upserts_write_null_values` (defaults to `false`): Controls how the `DO UPDATE SET` clause of an upsert
+  (e.g. `insertOnConflictUpdate`, or `insert` with a `DoUpdate` clause) handles columns that are `null`.
+  By default, drift treats `null` values as absent and leaves those columns out of the update clause, so a
+  conflicting row keeps whatever value it had before. That means the same upsert produces a different row
+  depending on whether it inserted or updated. With this option enabled, `null` values are written out
+  explicitly (`SET "col" = NULL`), so the resulting row always matches the row that was passed to the insert.
+  This only affects insertables that distinguish `null` from absent by value (like generated row classes) -
+  companions always write exactly the values that are `present`, with or without this option.
+  See [issue 2998](https://github.com/simolus3/drift/issues/2998) for context.
   For more information on these modes, see [datetime options](../dart_api/tables.md#datetime-options).
 - `case_from_dart_to_sql` (defaults to `snake_case`): Controls how the table and column names are re-cased from the Dart identifiers.
   The possible values are `preserve`, `camelCase`, `CONSTANT_CASE`, `snake_case`, `PascalCase`, `lowercase` and `UPPERCASE` (default: `snake_case`).

--- a/drift/CHANGELOG.md
+++ b/drift/CHANGELOG.md
@@ -1,3 +1,10 @@
+## 2.34.5-wip
+
+- Add `DriftDatabaseOptions.upsertsWriteNullValues`, an opt-in option making the
+  `DO UPDATE SET` clause of upserts write `null` values instead of treating them
+  as absent. This makes an upsert yield the row that was passed to it regardless
+  of whether it inserted or updated (#2998).
+
 ## 2.34.4
 
 - Allow using `rowid` extension on virtual tables, as they usually provide rowids as well.

--- a/drift/lib/src/runtime/api/options.dart
+++ b/drift/lib/src/runtime/api/options.dart
@@ -12,6 +12,40 @@ class DriftDatabaseOptions {
 
   final bool _storeDateTimeAsText;
 
+  /// Whether the `DO UPDATE SET` clause of an upsert should assign columns
+  /// holding a `null` value instead of leaving them out of the statement.
+  ///
+  /// By default (and for backwards-compatibility), drift builds the update
+  /// clause of an upsert by treating `null` values as absent. So for an
+  /// [Insertable] describing a row with a `null` column, that column is
+  /// omitted from `DO UPDATE SET` entirely, meaning that a conflicting row
+  /// keeps whatever value it had before:
+  ///
+  /// ```sql
+  /// -- with upsertsWriteNullValues: false (the default)
+  /// INSERT INTO "users" ("id", "name", "nickname") VALUES (?, ?, NULL)
+  ///   ON CONFLICT("id") DO UPDATE SET "id" = ?, "name" = ?
+  /// ```
+  ///
+  /// This is a sensible default for partial updates, but it is surprising for
+  /// upserts: the row that was inserted and the row that was updated no longer
+  /// describe the same data. When this option is enabled, `null` values are
+  /// written out explicitly, so that a conflicting row ends up matching the row
+  /// that was passed to the insert:
+  ///
+  /// ```sql
+  /// -- with upsertsWriteNullValues: true
+  /// INSERT INTO "users" ("id", "name", "nickname") VALUES (?, ?, NULL)
+  ///   ON CONFLICT("id") DO UPDATE SET "id" = ?, "name" = ?, "nickname" = NULL
+  /// ```
+  ///
+  /// Note that this only affects columns that are explicitly set to `null`.
+  /// Columns that are absent from the [Insertable] (e.g. a `Value.absent()` in
+  /// a companion) are never written, regardless of this option.
+  ///
+  /// See also: https://github.com/simolus3/drift/issues/2998
+  final bool upsertsWriteNullValues;
+
   /// Creates database-specific database options.
   ///
   /// When [storeDateTimeAsText] is enabled (it defaults to `false` for
@@ -20,13 +54,19 @@ class DriftDatabaseOptions {
   ///
   /// For details on how datetimes can be stored, see [the documentation].
   ///
+  /// When [upsertsWriteNullValues] is enabled (it defaults to `false` for
+  /// backwards-compatibility), `null` values are written into the
+  /// `DO UPDATE SET` clause of upserts instead of being treated as absent.
+  ///
   /// [the documentation]: https://drift.simonbinder.eu/docs/getting-started/advanced_dart_tables/#supported-column-types
-  const DriftDatabaseOptions({bool storeDateTimeAsText = false})
-    : _storeDateTimeAsText = storeDateTimeAsText,
-      // ignore: deprecated_member_use_from_same_package
-      types = storeDateTimeAsText
-          ? const SqlTypes(true)
-          : const SqlTypes(false);
+  const DriftDatabaseOptions({
+    bool storeDateTimeAsText = false,
+    this.upsertsWriteNullValues = false,
+  }) : _storeDateTimeAsText = storeDateTimeAsText,
+       // ignore: deprecated_member_use_from_same_package
+       types = storeDateTimeAsText
+           ? const SqlTypes(true)
+           : const SqlTypes(false);
 
   /// Creates a type mapping suitable for these options and the given [dialect].
   SqlTypes createTypeMapping(SqlDialect dialect) {

--- a/drift/lib/src/runtime/query_builder/statements/insert.dart
+++ b/drift/lib/src/runtime/query_builder/statements/insert.dart
@@ -389,7 +389,14 @@ class InsertStatement<T extends Table, D> {
             .throwIfInvalid(upsertInsertable);
       }
 
-      final updateSet = upsertInsertable.toColumns(true);
+      // Unless `upsertsWriteNullValues` is enabled, `null` values are treated
+      // as absent here, which means that they are left out of the update
+      // clause entirely. That keeps the previous value of a conflicting row
+      // instead of overwriting it with `null`.
+      // https://github.com/simolus3/drift/issues/2998
+      final updateSet = upsertInsertable.toColumns(
+        !ctx.options.upsertsWriteNullValues,
+      );
 
       writeOnConflictConstraint(
         onConflict.target,

--- a/drift/test/database/statements/upsert_null_values_test.dart
+++ b/drift/test/database/statements/upsert_null_values_test.dart
@@ -1,0 +1,200 @@
+@TestOn('vm')
+library;
+
+import 'package:drift/drift.dart' hide isNull;
+import 'package:mockito/mockito.dart';
+import 'package:test/test.dart';
+
+import '../../generated/todos.dart';
+import '../../test_utils/test_utils.dart';
+
+/// Tests for [DriftDatabaseOptions.upsertsWriteNullValues].
+///
+/// Without the option, the `DO UPDATE SET` clause of an upsert treats `null`
+/// values as absent, so a conflicting row keeps whatever value it had before.
+/// That makes `INSERT ... ON CONFLICT DO UPDATE` behave differently depending
+/// on whether the row already existed, see
+/// https://github.com/simolus3/drift/issues/2998.
+void main() {
+  group('SQL generation', () {
+    late TodoDb db;
+    late MockExecutor executor;
+
+    setUp(() {
+      executor = MockExecutor();
+      db = TodoDb(createConnection(executor, MockStreamQueries()));
+    });
+
+    /// A full row with `null` in every nullable column.
+    const entry = TodoEntry(id: RowId(3), content: 'content');
+
+    group('with the default options', () {
+      test('drops null columns from the update clause', () async {
+        await db.into(db.todosTable).insertOnConflictUpdate(entry);
+
+        verify(
+          executor.runInsert(
+            'INSERT INTO "todos" ("id", "content") VALUES (?, ?) '
+            'ON CONFLICT("id") DO UPDATE SET "id" = ?, "content" = ?',
+            [3, 'content', 3, 'content'],
+          ),
+        );
+      });
+
+      test('drops null columns for an explicit DoUpdate clause', () async {
+        await db
+            .into(db.todosTable)
+            .insert(entry, onConflict: DoUpdate((_) => entry));
+
+        verify(
+          executor.runInsert(
+            'INSERT INTO "todos" ("id", "content") VALUES (?, ?) '
+            'ON CONFLICT("id") DO UPDATE SET "id" = ?, "content" = ?',
+            [3, 'content', 3, 'content'],
+          ),
+        );
+      });
+    });
+
+    group('with upsertsWriteNullValues', () {
+      setUp(() {
+        db.options = const DriftDatabaseOptions(upsertsWriteNullValues: true);
+      });
+
+      test('writes null columns into the update clause', () async {
+        await db.into(db.todosTable).insertOnConflictUpdate(entry);
+
+        verify(
+          executor.runInsert(
+            'INSERT INTO "todos" ("id", "content") VALUES (?, ?) '
+            'ON CONFLICT("id") DO UPDATE SET '
+            '"id" = ?, "title" = ?, "content" = ?, '
+            '"target_date" = ?, "category" = ?, "status" = ?',
+            [3, 'content', 3, null, 'content', null, null, null],
+          ),
+        );
+      });
+
+      test('writes null columns for an explicit DoUpdate clause', () async {
+        await db
+            .into(db.todosTable)
+            .insert(entry, onConflict: DoUpdate((_) => entry));
+
+        verify(
+          executor.runInsert(
+            'INSERT INTO "todos" ("id", "content") VALUES (?, ?) '
+            'ON CONFLICT("id") DO UPDATE SET '
+            '"id" = ?, "title" = ?, "content" = ?, '
+            '"target_date" = ?, "category" = ?, "status" = ?',
+            [3, 'content', 3, null, 'content', null, null, null],
+          ),
+        );
+      });
+
+      test('does not change the INSERT part of the statement', () async {
+        await db.into(db.todosTable).insertOnConflictUpdate(entry);
+
+        final sql =
+            verify(executor.runInsert(captureAny, any)).captured.single
+                as String;
+        expect(sql, startsWith('INSERT INTO "todos" ("id", "content")'));
+      });
+
+      test('leaves absent companion values out of the update clause', () async {
+        // Companions distinguish between `Value.absent()` and `Value(null)`,
+        // so they must not be affected by this option at all.
+        await db
+            .into(db.todosTable)
+            .insertOnConflictUpdate(
+              const TodosTableCompanion(
+                id: Value(RowId(3)),
+                content: Value('content'),
+                title: Value(null),
+              ),
+            );
+
+        verify(
+          executor.runInsert(
+            'INSERT INTO "todos" ("id", "title", "content") '
+            'VALUES (?, ?, ?) '
+            'ON CONFLICT("id") DO UPDATE SET '
+            '"id" = ?, "title" = ?, "content" = ?',
+            [3, null, 'content', 3, null, 'content'],
+          ),
+        );
+      });
+
+      test('does not affect DoNothing clauses', () async {
+        await db.into(db.todosTable).insert(entry, onConflict: DoNothing());
+
+        verify(
+          executor.runInsert(
+            'INSERT INTO "todos" ("id", "content") VALUES (?, ?) '
+            'ON CONFLICT("id") DO NOTHING',
+            [3, 'content'],
+          ),
+        );
+      });
+    });
+  });
+
+  group('against a real database', () {
+    late TodoDb db;
+
+    setUp(() => db = TodoDb(testInMemoryDatabase()));
+    tearDown(() => db.close());
+
+    Future<TodoEntry> insertInitialRow() async {
+      await db
+          .into(db.todosTable)
+          .insert(
+            TodosTableCompanion.insert(
+              content: 'initial content',
+              title: const Value('initial title'),
+              status: const Value(TodoStatus.open),
+            ),
+          );
+      return db.select(db.todosTable).getSingle();
+    }
+
+    test('keeps stale values by default', () async {
+      final row = await insertInitialRow();
+
+      // Upsert the same row, but with the nullable columns cleared.
+      final cleared = TodoEntry(id: row.id, content: 'new content');
+      await db.into(db.todosTable).insertOnConflictUpdate(cleared);
+
+      final updated = await db.select(db.todosTable).getSingle();
+      expect(updated.content, 'new content');
+      // The bug: the row that comes back does not match the row we upserted.
+      expect(updated.title, 'initial title');
+      expect(updated.status, TodoStatus.open);
+      expect(updated, isNot(cleared));
+    });
+
+    test('writes nulls with upsertsWriteNullValues', () async {
+      final row = await insertInitialRow();
+      db.options = const DriftDatabaseOptions(upsertsWriteNullValues: true);
+
+      final cleared = TodoEntry(id: row.id, content: 'new content');
+      await db.into(db.todosTable).insertOnConflictUpdate(cleared);
+
+      final updated = await db.select(db.todosTable).getSingle();
+      expect(updated.content, 'new content');
+      expect(updated.title, null);
+      expect(updated.status, null);
+      // The whole point: an upsert now yields the row that was passed in,
+      // regardless of whether it inserted or updated.
+      expect(updated, cleared);
+    });
+
+    test('upserting a new row is unaffected by the option', () async {
+      db.options = const DriftDatabaseOptions(upsertsWriteNullValues: true);
+
+      const fresh = TodoEntry(id: RowId(1), content: 'content');
+      await db.into(db.todosTable).insertOnConflictUpdate(fresh);
+
+      expect(await db.select(db.todosTable).getSingle(), fresh);
+    });
+  });
+}

--- a/drift_dev/CHANGELOG.md
+++ b/drift_dev/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 2.34.7-wip
+
+- Add the `upserts_write_null_values` build option, enabling
+  `DriftDatabaseOptions.upsertsWriteNullValues` on generated databases (#2998).
+
 ## 2.34.6
 
 - Remove legacy command used to migrate from `moor` from `drift`.

--- a/drift_dev/lib/src/analysis/options.dart
+++ b/drift_dev/lib/src/analysis/options.dart
@@ -135,6 +135,13 @@ class DriftOptions {
   @JsonKey(defaultValue: false)
   final bool storeDateTimeValuesAsText;
 
+  /// Whether the `DO UPDATE SET` clause of an upsert should assign columns
+  /// holding a `null` value instead of treating them as absent.
+  ///
+  /// See `DriftDatabaseOptions.upsertsWriteNullValues` for details.
+  @JsonKey(name: 'upserts_write_null_values', defaultValue: false)
+  final bool upsertsWriteNullValues;
+
   @JsonKey(name: 'case_from_dart_to_sql', defaultValue: CaseFromDartToSql.snake)
   final CaseFromDartToSql caseFromDartToSql;
 
@@ -185,6 +192,7 @@ class DriftOptions {
     this.modules = const [],
     this.sqliteAnalysisOptions,
     this.storeDateTimeValuesAsText = false,
+    this.upsertsWriteNullValues = false,
     this.dialect = const DialectOptions(null, [SqlDialect.sqlite], null),
     this.caseFromDartToSql = CaseFromDartToSql.snake,
     this.preamble,
@@ -221,6 +229,7 @@ class DriftOptions {
     required this.modules,
     required this.sqliteAnalysisOptions,
     required this.storeDateTimeValuesAsText,
+    required this.upsertsWriteNullValues,
     required this.caseFromDartToSql,
     required this.writeToColumnsMixins,
     required this.fatalWarnings,

--- a/drift_dev/lib/src/generated/analysis/options.g.dart
+++ b/drift_dev/lib/src/generated/analysis/options.g.dart
@@ -37,6 +37,7 @@ DriftOptions _$DriftOptionsFromJson(Map json) => $checkedCreate(
         'named_parameters_always_required',
         'scoped_dart_components',
         'store_date_time_values_as_text',
+        'upserts_write_null_values',
         'case_from_dart_to_sql',
         'write_to_columns_mixins',
         'assume_correct_reference',
@@ -141,6 +142,10 @@ DriftOptions _$DriftOptionsFromJson(Map json) => $checkedCreate(
         'store_date_time_values_as_text',
         (v) => v as bool? ?? false,
       ),
+      upsertsWriteNullValues: $checkedConvert(
+        'upserts_write_null_values',
+        (v) => v as bool? ?? false,
+      ),
       caseFromDartToSql: $checkedConvert(
         'case_from_dart_to_sql',
         (v) =>
@@ -215,6 +220,7 @@ DriftOptions _$DriftOptionsFromJson(Map json) => $checkedCreate(
     'modules': 'sqlite_modules',
     'sqliteAnalysisOptions': 'sqlite',
     'storeDateTimeValuesAsText': 'store_date_time_values_as_text',
+    'upsertsWriteNullValues': 'upserts_write_null_values',
     'caseFromDartToSql': 'case_from_dart_to_sql',
     'writeToColumnsMixins': 'write_to_columns_mixins',
     'fatalWarnings': 'fatal_warnings',
@@ -259,6 +265,7 @@ Map<String, dynamic> _$DriftOptionsToJson(
   'named_parameters_always_required': instance.namedParametersAlwaysRequired,
   'scoped_dart_components': instance.scopedDartComponents,
   'store_date_time_values_as_text': instance.storeDateTimeValuesAsText,
+  'upserts_write_null_values': instance.upsertsWriteNullValues,
   'case_from_dart_to_sql':
       _$CaseFromDartToSqlEnumMap[instance.caseFromDartToSql]!,
   'write_to_columns_mixins': instance.writeToColumnsMixins,

--- a/drift_dev/lib/src/writer/database_writer.dart
+++ b/drift_dev/lib/src/writer/database_writer.dart
@@ -172,15 +172,21 @@ class DatabaseWriter {
         ..writeln('int get schemaVersion => $version;');
     }
 
-    if (scope.options.storeDateTimeValuesAsText) {
-      // Override database options to reflect that DateTimes are stored as text.
+    // Override database options to reflect build options changing the runtime
+    // behavior of the generated database.
+    final optionArguments = [
+      if (scope.options.storeDateTimeValuesAsText) 'storeDateTimeAsText: true',
+      if (scope.options.upsertsWriteNullValues) 'upsertsWriteNullValues: true',
+    ];
+
+    if (optionArguments.isNotEmpty) {
       final options = schemaScope.drift('DriftDatabaseOptions');
 
       schemaScope
         ..writeln('@override')
         ..writeln(
           '$options get options => '
-          'const $options(storeDateTimeAsText: true);',
+          'const $options(${optionArguments.join(', ')});',
         );
     }
 

--- a/drift_dev/test/writer/upserts_write_null_values_test.dart
+++ b/drift_dev/test/writer/upserts_write_null_values_test.dart
@@ -1,0 +1,80 @@
+import 'package:build/build.dart';
+import 'package:build_test/build_test.dart';
+import 'package:test/test.dart';
+
+import '../utils.dart';
+
+void main() {
+  const input = {
+    'a|lib/main.dart': r'''
+import 'package:drift/drift.dart';
+
+part 'main.drift.dart';
+
+class TodoItems extends Table {
+  IntColumn get id => integer().autoIncrement()();
+  TextColumn get description => text().nullable()();
+}
+
+@DriftDatabase(tables: [TodoItems])
+class Database extends _$Database {}
+''',
+  };
+
+  test('does not override options by default', () async {
+    final result = await emulateDriftBuild(inputs: input);
+
+    checkOutputs(
+      {
+        'a|lib/main.drift.dart': decodedMatches(
+          isNot(contains('upsertsWriteNullValues')),
+        ),
+      },
+      result.dartOutputs,
+      result.writer,
+    );
+  }, tags: 'analyzer');
+
+  test('overrides options with the build option', () async {
+    final result = await emulateDriftBuild(
+      inputs: input,
+      options: BuilderOptions({'upserts_write_null_values': true}),
+    );
+
+    checkOutputs(
+      {
+        'a|lib/main.drift.dart': decodedMatches(
+          contains('DriftDatabaseOptions(upsertsWriteNullValues: true)'),
+        ),
+      },
+      result.dartOutputs,
+      result.writer,
+    );
+  }, tags: 'analyzer');
+
+  test('combines with store_date_time_values_as_text', () async {
+    final result = await emulateDriftBuild(
+      inputs: input,
+      options: BuilderOptions({
+        'store_date_time_values_as_text': true,
+        'upserts_write_null_values': true,
+      }),
+    );
+
+    checkOutputs(
+      {
+        'a|lib/main.drift.dart': decodedMatches(
+          // The generated file is formatted, so the arguments may be wrapped
+          // across lines.
+          allOf(
+            contains('DriftDatabaseOptions get options =>'),
+            contains('storeDateTimeAsText: true'),
+            contains('upsertsWriteNullValues: true'),
+          ),
+        ),
+      },
+      result.dartOutputs,
+      result.writer,
+    );
+  }, tags: 'analyzer');
+}


### PR DESCRIPTION
Closes #2998.

## The problem

The `DO UPDATE SET` clause of an upsert is built with `toColumns(true)` — `nullToAbsent` — so columns holding `null` are dropped from the statement entirely and a conflicting row keeps whatever value it had before:

```sql
-- upserting a row whose `title` is null
INSERT INTO "todos" ("id", "content") VALUES (?, ?)
  ON CONFLICT("id") DO UPDATE SET "id" = ?, "content" = ?
--                                ^ "title" is absent, so the old title survives
```

`INSERT ... ON CONFLICT DO UPDATE` therefore yields a *different row* depending on whether it inserted or updated. Passing a complete row and getting a half-updated one back is surprising, and it's the behavior reported in #2998.

This only affects insertables that distinguish `null` from absent *by value* — generated row classes and `RawValuesInsertable`. Companions are unaffected either way: their generated `toColumns` ignores `nullToAbsent` and writes exactly the fields that are `present`.

## The change

A new `DriftDatabaseOptions.upsertsWriteNullValues`, defaulting to `false`, so **behavior is unchanged unless opted in**. When enabled:

```sql
INSERT INTO "todos" ("id", "content") VALUES (?, ?)
  ON CONFLICT("id") DO UPDATE SET "id" = ?, "title" = ?, "content" = ?,
                                  "target_date" = ?, "category" = ?, "status" = ?
```

The runtime change is one expression in `insert.dart`:

```dart
final updateSet = upsertInsertable.toColumns(
  !ctx.options.upsertsWriteNullValues,
);
```

It's enabled declaratively through a new `upserts_write_null_values` build option, which makes `drift_dev` emit the `options` override on the generated database — reusing the mechanism `store_date_time_values_as_text` already uses, and composing with it:

```yaml
targets:
  $default:
    builders:
      drift_dev:
        options:
          upserts_write_null_values: true
```

I went with an opt-in flag rather than just changing the default, since the current behavior is observable and someone may well be relying on it. Happy to flip it to a default (or a breaking change slated for drift 3) if you'd prefer — the flag plumbing is the same either way.

## Results

### Before — the same assertions against `develop` unmodified

The new test file with the three `upsertsWriteNullValues: true` lines removed (the API doesn't exist yet); everything else byte-identical.

```
00:00 +0: SQL generation with the default options drops null columns from the update clause
00:00 +1: SQL generation with the default options drops null columns for an explicit DoUpdate clause
00:00 +2 -1: SQL generation DESIRED behaviour writes null columns into the update clause [E]
  No matching calls. All calls: ... MockExecutor.runInsert(
    'INSERT INTO "todos" ("id", "content") VALUES (?, ?)
     ON CONFLICT("id") DO UPDATE SET "id" = ?, "content" = ?', [3, content, 3, content])

00:00 +2 -2: SQL generation DESIRED behaviour writes null columns for an explicit DoUpdate clause [E]
  No matching calls. ... (same truncated update clause)

00:00 +6 -3: against a real database DESIRED: writes nulls on upsert [E]
  Expected: <null>
    Actual: 'initial title'

00:00 +7 -3: Some tests failed.
```

**7 passed, 3 failed.** The integration failure (`Expected: <null>  Actual: 'initial title'`) is #2998 reproduced against a real sqlite3 database.

### After

```
00:00 +0: SQL generation with the default options drops null columns from the update clause
00:00 +1: SQL generation with the default options drops null columns for an explicit DoUpdate clause
00:00 +2: SQL generation with upsertsWriteNullValues writes null columns into the update clause
00:00 +3: SQL generation with upsertsWriteNullValues writes null columns for an explicit DoUpdate clause
00:00 +4: SQL generation with upsertsWriteNullValues does not change the INSERT part of the statement
00:00 +5: SQL generation with upsertsWriteNullValues leaves absent companion values out of the update clause
00:00 +6: SQL generation with upsertsWriteNullValues does not affect DoNothing clauses
00:00 +7: against a real database keeps stale values by default
00:00 +8: against a real database writes nulls with upsertsWriteNullValues
00:00 +9: against a real database upserting a new row is unaffected by the option
00:00 +10: All tests passed!
```

**10 passed.** The two "with the default options" tests pass in *both* runs — that's the backwards-compatibility guarantee: with the flag off the emitted SQL is unchanged.

### Generator tests

```
00:00 +0: does not override options by default
00:02 +1: overrides options with the build option
00:02 +2: combines with store_date_time_values_as_text
00:02 +3: All tests passed!
```

### Full suites

| Suite | Result |
| --- | --- |
| `drift` | **909 passed**, 5 skipped, 0 failed |
| `drift_dev` | **510 passed**, 1 skipped, 0 failed |
| `dart analyze --fatal-infos` (both) | No issues found |
| `dart format` (changed files) | Clean |

## Scope / notes

- The `INSERT` half of the statement is untouched; only `DO UPDATE SET` changes.
- `DoNothing` and `DoUpdate.withExcluded` are unaffected — both covered by tests.
- `drift3_preview`'s compiler has the same `toColumns(true)` in `addDoUpdate` (`drift/lib/src/drift3_preview/src/query_builder/compiler.dart:1096`), but there's no `DriftDatabaseOptions` equivalent in that runtime to read the flag from. I left it alone rather than introducing a database-options concept to the preview package unilaterally — glad to follow up if you'd like it covered, and if so, guidance on where you'd want those options to live would help.
