### PR TITLE
Fix typos in docs and contributing guide

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -16,7 +16,7 @@ most certainly helps to resolve the issue quickly.
 All kinds of pull requests are absolutely appreciated! Before working on bigger changes, it
 can be helpful to create an issue describing your plans to help coordination.
 
-When working on drift, its recommended to fork the `develop` branch and also target that
+When working on drift, it's recommended to fork the `develop` branch and also target that
 branch for PRs. When possible, we only use the `latest_release` branch to reflect the state
 that's been released to pub.
 
@@ -90,7 +90,7 @@ Minor changes will be published directly, no special steps are necessary. For ma
 updates that span multiple versions, we should follow these steps
 
 1. Changelogs: The changelog of `drift_dev` should only mention changes to the generator,
-   most changes shuold be in `drift/CHANGELOG.md`.
+   most changes should be in `drift/CHANGELOG.md`.
 2. Make sure each package has the correct dependencies: `drift_dev` version `1.x` should depend
    on `drift` `1.x` as well to ensure users will always `dart pub get` drift packages that are compatible
    with each other.
@@ -102,4 +102,4 @@ The `sqlparser` library can be published independently of drift.
 ### Building the documentation
 
 We use `build_runner` to build the documentation. The [readme](docs/README.md) contains everything
-you need to know go get started.
+you need to know to get started.

--- a/docs/content/dart_api/expressions.md
+++ b/docs/content/dart_api/expressions.md
@@ -132,7 +132,7 @@ a todo item with this query:
 
 <Snippet href="/lib/src/snippets/dart_api/expressions.dart" name="averageItemLength" />
 
-__Note__: We're using `selectOnly` instead of `select` because we're not interested in any colum that
+__Note__: We're using `selectOnly` instead of `select` because we're not interested in any column that
 `todos` provides - we only care about the average length. More details are available
 [here](select.md#group-by).
 

--- a/docs/content/dart_api/manager.md
+++ b/docs/content/dart_api/manager.md
@@ -53,7 +53,7 @@ If there were 1000 todos, this would issue 1000 queries to fetch the category fo
 
     <h4>How does this affect me?</h4>
 
-    If you have foreign keys contraints enabled (`PRAGMA foreign_keys = ON`) this won't affect you. The database will enfore that the `id` column on the `categories` table is the same as the `category` column on the `todos` table.
+    If you have foreign keys constraints enabled (`PRAGMA foreign_keys = ON`) this won't affect you. The database will enforce that the `id` column on the `categories` table is the same as the `category` column on the `todos` table.
 
     If you don't have foreign key constraints enabled, you should be aware that the above query will not check that the category with `id` 1 exists. It will only check that the `category` column on the `todos` table is 1.
 

--- a/docs/content/dart_api/schema_inspection.md
+++ b/docs/content/dart_api/schema_inspection.md
@@ -62,7 +62,7 @@ In a database or database accessor class, the method can then be called like thi
 <Snippet href="/lib/src/snippets/modular/schema_inspection.dart" name="updateTodo" />
 
 Hopefully, this page gives you some pointers to start reflectively inspecting your drift databases.
-The linked Dart documentation also expains the concepts in more detail.
+The linked Dart documentation also explains the concepts in more detail.
 If you have questions about this, or have a suggestion for more examples to include on this page, feel free to [start a discussion](https://github.com/simolus3/drift/discussions/new?category=q-a) about this.
 
 [ResultSetImplementation]: https://drift.simonbinder.eu/api/drift/resultsetimplementation-class

--- a/docs/content/dart_api/streams.md
+++ b/docs/content/dart_api/streams.md
@@ -93,7 +93,7 @@ It's also possible to mark a table as updated manually:
 
 ## Caveats
 
-While streams are useful to automically get updates for whatever queries you're running, it's
+While streams are useful to automatically get updates for whatever queries you're running, it's
 important to understand their functionality and limitations.
 Stream queries are implemented as a heuristic in drift: For each active stream, drift tracks
 which tables it's listening on (information that is available from the query builder).

--- a/docs/content/examples/index.md
+++ b/docs/content/examples/index.md
@@ -33,7 +33,7 @@ Additional examples from our awesome community are available as well:
 - The [clean architecture](https://github.com/rodydavis/clean_architecture_todo_app) example app written by [Rody Davis](https://github.com/rodydavis) shows how to use drift
   in a more complex architecture.
 - [Abdelrahman Mostafa Elmarakby](https://github.com/abdelrahmanelmarakby) wrote an animated version of the todo app available [here](https://github.com/abdelrahmanelmarakby/todo_with_moor_and_animation).
-- [Abdelrahman Mostafa Elmarakby](https://github.com/abdelrahmanelmarakby) wrote an hotel booking app with GetX version with diffrent relationships available [here](https://github.com/abdelrahmanelmarakby/hotels_booking).
+- [Abdelrahman Mostafa Elmarakby](https://github.com/abdelrahmanelmarakby) wrote an hotel booking app with GetX version with different relationships available [here](https://github.com/abdelrahmanelmarakby/hotels_booking).
 - [BingeTube](https://bingetube.io/) is an app letting you watch YouTube channels in chronological order. It is [open source](https://github.com/mohansella/BingeTube) and uses
   drift for persistence.
 - The [HackerNews reader app](https://github.com/filiph/hn_app) from the [Boring Flutter Show](https://www.youtube.com/playlist?list=PLjxrf2q8roU3ahJVrSgAnPjzkpGmL9Czl)

--- a/docs/content/guides/upgrading.md
+++ b/docs/content/guides/upgrading.md
@@ -61,7 +61,7 @@ maintain and to unblock upcoming new features. This release also provides some
 new features, like nested transactions or support for `RETURNING` for updates
 and deletes in the dart_api.
 We hope the upgrade is worthwhile. If you run into any issues, please do not
-hesistate to [start a new discussion](https://github.com/simolus3/drift/discussions)
+hesitate to [start a new discussion](https://github.com/simolus3/drift/discussions)
 or to [open an issue](https://github.com/simolus3/drift/issues).
 Thanks for using drift!
 

--- a/docs/content/platforms/index.md
+++ b/docs/content/platforms/index.md
@@ -43,7 +43,7 @@ They use Flutter's package channels and support both Android and iOS. They don't
 projects not using flutter.
 
 For new projects, we generally recommend the newer ffi-based implementation, but `drift_sqflite`
-is maintaned and supported too.
+is maintained and supported too.
 
 ### using `drift/native`
 

--- a/docs/content/platforms/postgres.md
+++ b/docs/content/platforms/postgres.md
@@ -125,4 +125,4 @@ by SQLite, only a tiny subset of PostgreSQL's advanced operators and functions a
 
 If you're running into problems or bugs with the postgres database, please let us know by creating an issue
 or a discussion.
-Contributions expanding wrappers around PosgreSQL functions are also much appreciated.
+Contributions expanding wrappers around PostgreSQL functions are also much appreciated.

--- a/docs/content/platforms/web.md
+++ b/docs/content/platforms/web.md
@@ -99,7 +99,7 @@ web/
 #### Additional headers
 
 On browsers that support it, drift uses the origin-private part of the [FileSystem Access API](https://developer.mozilla.org/en-US/docs/Web/API/File_System_Access_API) to store databases efficiently.
-As parts of that API are asynchronous, and since sqlite3 expectes a synchronous file system, we need to
+As parts of that API are asynchronous, and since sqlite3 expects a synchronous file system, we need to
 use two workers with shared memory and `Atomics.wait`/`notify`.
 Just like the official sqlite3 port to the web, __this requires your website to be served with two special headers__:
 
@@ -369,7 +369,7 @@ Be aware that `dart2js` needs to be used as a compiler. `dartdevc` generates mod
 for workers without additional setup.
 
 Compiling the `sqlite3.wasm` file requires a C toolchain capable of compiling to WebAssembly.
-On Arch Linux, I'm using `clang` with the `wasi-compiler-rt` and `wasi-libc` pacakges.
+On Arch Linux, I'm using `clang` with the `wasi-compiler-rt` and `wasi-libc` packages.
 Depending on your distribution, you may have to compile the [wasi-sdk](https://github.com/WebAssembly/wasi-sdk) or
 another toolchain yourself.
 Finally, we're also using [binaryen](https://github.com/WebAssembly/binaryen) as an optimizer.


### PR DESCRIPTION
## What changed

Docs-only cleanup across the contributing guide and nine docs pages:

- CONTRIBUTING.md: "its recommended" -> "it's recommended"
- CONTRIBUTING.md: "most changes shuold be" -> "most changes should be"
- CONTRIBUTING.md: "you need to know go get started" -> "you need to know to get started"
- dart_api/manager.md: "contraints" -> "constraints", "enfore" -> "enforce"
- dart_api/schema_inspection.md: "expains" -> "explains"
- dart_api/expressions.md: "any colum that" -> "any column that"
- dart_api/streams.md: "automically" -> "automatically"
- examples/index.md: "with diffrent relationships" -> "with different relationships"
- guides/upgrading.md: "hesistate" -> "hesitate"
- platforms/index.md: "is maintaned" -> "is maintained"
- platforms/postgres.md: "PosgreSQL" -> "PostgreSQL"
- platforms/web.md: "expectes" -> "expects"
- platforms/web.md: "wasi-libc` pacakges" -> "wasi-libc` packages"

## Why

Self-found during a docs cleanup pass; there is no tracking issue.

Each fix is a plain spelling or wording typo in the repo's own English prose, so nothing about the meaning changes.

## How to verify

Docs-only text changes.

No Dart code, commands, or code fences are touched, so the docs build and Dart CI are unaffected:

```
git fetch https://github.com/olitreadwell/drift.git docs/fix-typos
git checkout FETCH_HEAD
```
